### PR TITLE
context has repeated type

### DIFF
--- a/aeon/sugar/lifting.py
+++ b/aeon/sugar/lifting.py
@@ -1,4 +1,3 @@
-from typing import TypeVar
 from aeon.core.liquid import (
     LiquidApp,
     LiquidLiteralBool,
@@ -22,7 +21,7 @@ from aeon.core.terms import (
     TypeAbstraction,
     TypeApplication,
 )
-from aeon.core.types import AbstractionType, RefinedType, Top, Type, TypeConstructor, TypePolymorphism
+from aeon.core.types import AbstractionType, RefinedType, Top, Type, TypeConstructor, TypePolymorphism, TypeVar
 from aeon.sugar.program import (
     STerm,
     SLiteral,

--- a/aeon/typechecking/context.py
+++ b/aeon/typechecking/context.py
@@ -73,7 +73,9 @@ class TypingContext:
 
     def __post_init__(self):
         for bt in builtin_core_types[::-1]:
-            self.entries.insert(0, TypeConstructorBinder(bt.name, []))
+            temp = TypeConstructorBinder(bt.name, [])
+            if temp not in self.entries:
+                self.entries.insert(0, temp)
 
     def __repr__(self):
         fields = "; ".join(map(repr, self.entries))


### PR DESCRIPTION
In the previous version each time a TypingContext was created, it would insert the core types, which caused the context to contain multiple repeated core types like int and float.