### PR TITLE
Cleaning Repetitions of TypeConstructor

### DIFF
--- a/aeon/core/liquid_ops.py
+++ b/aeon/core/liquid_ops.py
@@ -11,7 +11,7 @@ def tv(name: str) -> TypeVar:
     return TypeVar(Name(name))
 
 
-liquid_prelude: dict[Name, list[TypeConstructor | TypeVar | TypeConstructor]] = {
+liquid_prelude: dict[Name, list[TypeConstructor | TypeVar]] = {
     Name("==", 0): [tv("a"), tv("a"), t_bool],
     Name("!=", 0): [tv("a"), tv("a"), t_bool],
     Name("<", 0): [tv("a"), tv("a"), t_bool],  # TODO typeclasses: order

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -101,7 +101,7 @@ class AbstractionType(Type):
 @dataclass
 class RefinedType(Type):
     name: Name
-    type: TypeConstructor | TypeVar | TypeConstructor
+    type: TypeConstructor | TypeVar
     refinement: LiquidTerm
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
@@ -171,7 +171,7 @@ top = Top()
 @dataclass
 class LiquidHornApplication(LiquidTerm):
     name: Name
-    argtypes: list[tuple[LiquidTerm, TypeConstructor | TypeVar | TypeConstructor]]
+    argtypes: list[tuple[LiquidTerm, TypeConstructor | TypeVar]]
 
     def __post_init__(self):
         assert isinstance(self.name, Name)
@@ -200,7 +200,7 @@ class LiquidHornApplication(LiquidTerm):
 liq_true = LiquidLiteralBool(True)
 
 
-def extract_parts(t: Type) -> tuple[Name, TypeConstructor | TypeVar | TypeConstructor, LiquidTerm]:
+def extract_parts(t: Type) -> tuple[Name, TypeConstructor | TypeVar, LiquidTerm]:
     assert (
         isinstance(t, TypeConstructor)
         or isinstance(t, RefinedType)

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -98,9 +98,7 @@ def liquefy_app(app: SApplication) -> LiquidApp | None:
             raise LiquefactionException(f"{app} is not a valid predicate.")
 
 
-def liquefy(
-    t: STerm, available_vars: list[tuple[Name, TypeConstructor | TypeVar | TypeConstructor]] | None = None
-) -> LiquidTerm:
+def liquefy(t: STerm, available_vars: list[tuple[Name, TypeConstructor | TypeVar]] | None = None) -> LiquidTerm:
     """Converts Surface Terms into Liquid Terms"""
     match t:
         case SLiteral(val, STypeConstructor(Name("Bool", _)), loc):

--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -42,12 +42,12 @@ class LiquidTypeCheckException(Exception):
 @dataclass
 class LiquidTypeCheckingContext:
     known_types: list[TypeConstructor]
-    variables: dict[Name, TypeConstructor | TypeVar | TypeConstructor]
-    functions: dict[Name, list[TypeConstructor | TypeVar | TypeConstructor]]
+    variables: dict[Name, TypeConstructor | TypeVar]
+    functions: dict[Name, list[TypeConstructor | TypeVar]]
 
 
-def lower_abstraction_type(ty: Type) -> list[TypeConstructor | TypeVar | TypeConstructor]:
-    args: list[TypeConstructor | TypeVar | TypeConstructor] = []
+def lower_abstraction_type(ty: Type) -> list[TypeConstructor | TypeVar]:
+    args: list[TypeConstructor | TypeVar] = []
     while True:
         match ty:
             # TODO: Should these be removed?
@@ -89,7 +89,7 @@ def flatten(xs: list[list[T]]) -> list[T]:
 
 def lower_context(ctx: TypingContext) -> LiquidTypeCheckingContext:
     known_types: list[Name] = native_types + []
-    variables: dict[Name, TypeConstructor | TypeVar | TypeConstructor] = {}
+    variables: dict[Name, TypeConstructor | TypeVar] = {}
     functions = {}
 
     for entry in ctx.entries[::-1]:

--- a/aeon/verification/horn.py
+++ b/aeon/verification/horn.py
@@ -168,7 +168,7 @@ def mk_arg(i: int) -> Name:
     return Name(f"arg_{i}", 0)
 
 
-def get_possible_args(vars: list[tuple[LiquidTerm, TypeConstructor | TypeVar | TypeConstructor]], arity: int):
+def get_possible_args(vars: list[tuple[LiquidTerm, TypeConstructor | TypeVar]], arity: int):
     if arity == 0:
         yield []
     else:


### PR DESCRIPTION
Cleaning repetitions of `TypeConstructor` on files from a serach and replace that made redundant uses of type