### PR TITLE
Correcting Logger to work on Windows

### DIFF
--- a/aeon/logger/logger.py
+++ b/aeon/logger/logger.py
@@ -28,7 +28,7 @@ def setup_logger():
 
 def export_log(logs: list, export_file: bool = False, logfile_name: str = ""):
     if export_file:
-        logfile = f"logs/{logfile_name}_{datetime.datetime.now()}.log"
+        logfile = f"logs/{logfile_name}_{datetime.datetime.now().strftime('%Y_%m_%d %H_%M_%S')}.log"
         return logger.add(logfile, filter=levels_filter(logs))
     else:
         return logger.add(sys.stderr, filter=levels_filter(logs))


### PR DESCRIPTION
Fixing Logger that uses ':' on the time part of the file, when Windows does not support ':' on filenames