### PR TITLE
Moving the error locations to the right place.

### DIFF
--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -106,12 +106,13 @@ class LiquidTypeCheckingFailedRelation(CoreTypeCheckingError):
     term: Term
     type: Type
     vc: Constraint
+    loc: Location | None = None
 
     def __str__(self) -> str:
         return f"Failed to prove ({pretty_print_constraint(self.vc)}) in {self.position()}"
 
     def position(self) -> Location:
-        return self.term.loc
+        return self.loc if self.loc is not None else self.term.loc
 
 
 @dataclass

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -60,8 +60,10 @@ from aeon.verification.vcs import Conjunction
 from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import LiquidConstraint
 from aeon.verification.horn import solve
+from aeon.utils.location import Location
 from aeon.utils.name import Name, fresh_counter
 from aeon.verification.helpers import (
+    constraint_location,
     remove_unrelated_context,
     simplify_constraint,
     conjunctive_normal_form,
@@ -270,14 +272,14 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             (c2, t2) = synth(nctx, body)
             term_vars = type_free_term_vars(t1)
             assert t.var_name not in term_vars
-            r = (Conjunction(c1, implication_constraint(var_name, t1, c2)), t2)
+            r = (Conjunction(c1, implication_constraint(var_name, t1, c2, body.loc)), t2)
             return r
         case Rec(var_name, var_type, var_value, body):
             nrctx: TypingContext = ctx.with_var(var_name, var_type)
             c1 = check(nrctx, var_value, var_type)
             (c2, t2) = synth(nrctx, body)
-            c1 = implication_constraint(var_name, var_type, c1)
-            c2 = implication_constraint(var_name, var_type, c2)
+            c1 = implication_constraint(var_name, var_type, c1, var_value.loc)
+            c2 = implication_constraint(var_name, var_type, c2, body.loc)
             return Conjunction(c1, c2), t2
         case Annotation(expr, ty):
             nty = fresh(ctx, ty)
@@ -319,19 +321,19 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
         case Abstraction(name, body), AbstractionType(var_name, var_type, ret):
             ret = substitution_in_type(ret, Var(name), var_name)
             c = check(ctx.with_var(name, var_type), body, ret)
-            return implication_constraint(name, var_type, c)
+            return implication_constraint(name, var_type, c, body.loc)
         case Let(name, val, body), _:
             (c1, t1) = synth(ctx, val)
             nctx: TypingContext = ctx.with_var(name, t1)
             c2 = check(nctx, body, ty)
-            return Conjunction(c1, implication_constraint(name, t1, c2))
+            return Conjunction(c1, implication_constraint(name, t1, c2, body.loc))
         case Rec(var_name, var_type, var_value, body), _:
             t1 = fresh(ctx, var_type)
             nrctx: TypingContext = ctx.with_var(var_name, t1)
             c1 = check(nrctx, var_value, var_type)
             c2 = check(nrctx, body, ty)
-            c1 = implication_constraint(var_name, t1, c1)
-            c2 = implication_constraint(var_name, t1, c2)
+            c1 = implication_constraint(var_name, t1, c1, var_value.loc)
+            c2 = implication_constraint(var_name, t1, c2, body.loc)
             return Conjunction(c1, c2)
         case If(cond, then, otherwise), _:
             y = Name("_cond", fresh_counter.fresh())
@@ -345,12 +347,14 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
                 y,
                 RefinedType(name_pos, t_int, liq_cond),
                 check(ctx, then, ty),
+                then.loc,
             )
             name_neg = Name("branch_neg", fresh_counter.fresh())
             c2 = implication_constraint(
                 y,
                 RefinedType(name_neg, t_int, LiquidApp(Name("!", 0), [liq_cond])),
                 check(ctx, otherwise, ty),
+                otherwise.loc,
             )
             return Conjunction(c0, Conjunction(c1, c2))
         case TypeAbstraction(name, kind, body), TypePolymorphism(var_name, var_kind, var_body):
@@ -365,7 +369,7 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
             return check(ctx.with_typevar(name, var_kind), body, itype)
         case _:
             (c, s) = synth(ctx, t)
-            cp = sub(ctx, s, ty)
+            cp = sub(ctx, s, ty, t.loc)
             if cp == LiquidConstraint(LiquidLiteralBool(False)):
                 raise CoreSubtypingError(ctx, t, s, ty)
             return Conjunction(c, cp)
@@ -385,14 +389,17 @@ def check_type(ctx: TypingContext, t: Term, ty: Type = top) -> bool:
         return False
 
 
-def constraint_to_parts(c: Constraint) -> Iterable[Constraint]:
-    """Prepares a constraint into a list of sub-problems for error messages"""
+def constraint_to_parts(c: Constraint) -> Iterable[tuple[Constraint, Location | None]]:
+    """Prepares a constraint into a list of sub-problems for error messages.
+    Yields (constraint, location) pairs where location is the AST location
+    associated with the failing constraint part."""
     for cons in conjunctive_normal_form(c):
         if not is_implication_true(cons):
             if not solve(cons):
                 cons_simp = simplify_constraint(cons)
                 cons_clean, _ = remove_unrelated_context(cons_simp, ignore_vars=set())
-                yield cons_clean
+                loc = constraint_location(cons_clean)
+                yield cons_clean, loc
 
 
 def check_type_errors(
@@ -411,8 +418,8 @@ def check_type_errors(
             case False:
                 full_constraint = entailment_context(ctx, constraint)
                 return [
-                    LiquidTypeCheckingFailedRelation(ctx, term, expected_type, v)
-                    for v in constraint_to_parts(full_constraint)
+                    LiquidTypeCheckingFailedRelation(ctx, term, expected_type, vc, loc)
+                    for vc, loc in constraint_to_parts(full_constraint)
                 ]
     except CoreTypeCheckingError as e:
         return [e]

--- a/aeon/verification/helpers.py
+++ b/aeon/verification/helpers.py
@@ -19,7 +19,21 @@ from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import Implication
 from aeon.verification.vcs import LiquidConstraint
 from aeon.verification.vcs import UninterpretedFunctionDeclaration
+from aeon.utils.location import Location
 from aeon.utils.name import Name, fresh_counter
+
+
+def constraint_location(c: Constraint) -> Location | None:
+    """Recursively extracts the first non-None location from a constraint."""
+    if isinstance(c, LiquidConstraint):
+        return c.loc
+    elif isinstance(c, Implication):
+        return c.loc or constraint_location(c.seq)
+    elif isinstance(c, Conjunction):
+        return c.loc or constraint_location(c.c1) or constraint_location(c.c2)
+    elif isinstance(c, UninterpretedFunctionDeclaration):
+        return constraint_location(c.seq)
+    return None
 
 
 def parse_liquid(t: str) -> LiquidTerm | None:
@@ -133,17 +147,17 @@ def substitution_in_constraint(c: Constraint, rep: LiquidTerm, name: Name) -> Co
     """Substitues a LiquidVar by another expression within a constraint."""
     match c:
         case LiquidConstraint(expr):
-            return LiquidConstraint(substitution_in_liquid(expr, rep, name))
+            return LiquidConstraint(substitution_in_liquid(expr, rep, name), loc=c.loc)
         case Conjunction(c1, c2):
             left = substitution_in_constraint(c1, rep, name)
             right = substitution_in_constraint(c2, rep, name)
-            return Conjunction(left, right)
+            return Conjunction(left, right, loc=c.loc)
         case Implication(name, base, pred, seq):
             if c.name == name:
                 return c
             else:
                 nseq = substitution_in_constraint(seq, rep, name)
-                return Implication(name, base, substitution_in_liquid(pred, rep, name), nseq)
+                return Implication(name, base, substitution_in_liquid(pred, rep, name), nseq, loc=c.loc)
         case UninterpretedFunctionDeclaration(name, type, seq):
             nseq = substitution_in_constraint(seq, rep, name)
             return UninterpretedFunctionDeclaration(name, type, nseq)
@@ -185,7 +199,9 @@ def simplify_constraint(c: Constraint) -> Constraint:
             rep = c.pred.args[1].args[1]
             subs_pred = substitution_in_liquid(c.pred.args[0], rep, c.name)
             subs_seq = substitution_in_constraint(c.seq, rep, c.name)
-            rc = simplify_constraint(Implication(Name("_", fresh_counter.fresh()), t_bool, subs_pred, subs_seq))
+            rc = simplify_constraint(
+                Implication(Name("_", fresh_counter.fresh()), t_bool, subs_pred, subs_seq, loc=c.loc)
+            )
             return rc
 
         cont = simplify_constraint(c.seq)
@@ -195,7 +211,7 @@ def simplify_constraint(c: Constraint) -> Constraint:
         if not is_used(c.name, cont) and not other_used_vars:
             return c.seq
 
-        return Implication(c.name, c.base, s, cont)
+        return Implication(c.name, c.base, s, cont, loc=c.loc)
     elif isinstance(c, UninterpretedFunctionDeclaration):
         cont = simplify_constraint(c.seq)
         return UninterpretedFunctionDeclaration(c.name, c.type, cont)
@@ -211,7 +227,7 @@ def conjunctive_normal_form(c: Constraint) -> Generator[Constraint, None, None]:
         yield from conjunctive_normal_form(c.c2)
     elif isinstance(c, Implication):
         for inner in conjunctive_normal_form(c.seq):
-            yield Implication(c.name, c.base, c.pred, inner)
+            yield Implication(c.name, c.base, c.pred, inner, loc=c.loc)
 
     elif isinstance(c, UninterpretedFunctionDeclaration):
         for inner in conjunctive_normal_form(c.seq):
@@ -277,7 +293,7 @@ def remove_unrelated_context(c: Constraint, ignore_vars: set[Name]) -> tuple[Con
     elif isinstance(c, Conjunction):
         (p1, vs1) = remove_unrelated_context(c.c1, ignore_vars)
         (p2, vs2) = remove_unrelated_context(c.c2, ignore_vars)
-        return (c, vs1.union(vs2))
+        return (Conjunction(p1, p2, loc=c.loc), vs1.union(vs2))
     else:
         assert False
 

--- a/aeon/verification/sub.py
+++ b/aeon/verification/sub.py
@@ -14,6 +14,7 @@ from aeon.core.types import Type
 from aeon.core.types import TypePolymorphism
 from aeon.core.types import t_unit
 from aeon.typechecking.context import TypingContext
+from aeon.utils.location import Location
 from aeon.verification.vcs import Conjunction, UninterpretedFunctionDeclaration
 from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import Implication
@@ -72,17 +73,17 @@ def lower_constraint_type(ttype: Type) -> Type:
             assert False, f"Unsupport type in constraint {ttype} ({type(ttype)})"
 
 
-def implication_constraint(name: Name, ty: Type, c: Constraint) -> Constraint:
+def implication_constraint(name: Name, ty: Type, c: Constraint, loc: Location | None = None) -> Constraint:
     match ty:
         case Top() | TypeVar(_) | TypeConstructor(_, _):
             basety = lower_constraint_type(ty)
             assert isinstance(basety, TypeConstructor)
-            return Implication(name, basety, LiquidLiteralBool(True), c)
+            return Implication(name, basety, LiquidLiteralBool(True), c, loc=loc)
         case RefinedType(tname, ttype, tref):
             ref_subs = substitution_in_liquid(tref, LiquidVar(name), tname)
             ltype = lower_constraint_type(ttype)
             assert isinstance(ltype, TypeConstructor) or isinstance(ltype, TypeVar)
-            return Implication(name, ltype, ref_subs, c)
+            return Implication(name, ltype, ref_subs, c, loc=loc)
         case AbstractionType(_, _, _):
             # TODO Poly Refl: instead of true, reflect the implementation of the function?
             if is_first_order_function(ty):
@@ -97,7 +98,7 @@ def implication_constraint(name: Name, ty: Type, c: Constraint) -> Constraint:
             assert False
 
 
-def sub(ctx: TypingContext, t1: Type, t2: Type) -> Constraint:
+def sub(ctx: TypingContext, t1: Type, t2: Type, loc: Location | None = None) -> Constraint:
     if t2 == Top():
         return ctrue
     match (ensure_refined(t1), ensure_refined(t2)):
@@ -114,7 +115,7 @@ def sub(ctx: TypingContext, t1: Type, t2: Type) -> Constraint:
             r1_ = substitution_in_liquid(r1, LiquidVar(new_name), n1)
             lowert = lower_constraint_type(ty1)
             assert isinstance(lowert, TypeConstructor)
-            rconstraint = Implication(new_name, lowert, r1_, LiquidConstraint(r2_))
+            rconstraint = Implication(new_name, lowert, r1_, LiquidConstraint(r2_, loc=loc), loc=loc)
 
             return rconstraint
         case TypePolymorphism(_, _, _), _:
@@ -122,11 +123,11 @@ def sub(ctx: TypingContext, t1: Type, t2: Type) -> Constraint:
         case AbstractionType(a1, t1, rt1), AbstractionType(a2, t2, rt2):
             new_name_a: Name = Name(a1.name + a2.name, fresh_counter.fresh())
 
-            c0 = sub(ctx, t2, t1)
+            c0 = sub(ctx, t2, t1, loc)
             rt1_ = substitution_in_type(rt1, Var(new_name_a), a1)
             rt2_ = substitution_in_type(rt2, Var(new_name_a), a2)
-            c1 = sub(ctx, rt1_, rt2_)
-            return Conjunction(c0, implication_constraint(new_name_a, t2, c1))
+            c1 = sub(ctx, rt1_, rt2_, loc)
+            return Conjunction(c0, implication_constraint(new_name_a, t2, c1, loc))
         case TypeConstructor(name1, args1), TypeConstructor(name2, args2):
             if name1 != name2:
                 return cfalse

--- a/aeon/verification/vcs.py
+++ b/aeon/verification/vcs.py
@@ -11,6 +11,7 @@ from aeon.core.liquid import LiquidTerm
 from aeon.core.liquid import LiquidVar
 from aeon.core.types import AbstractionType, Top, TypeVar
 from aeon.core.types import TypeConstructor
+from aeon.utils.location import Location
 from aeon.utils.name import Name
 
 
@@ -21,6 +22,7 @@ class Constraint:
 @dataclass
 class LiquidConstraint(Constraint):
     expr: LiquidTerm
+    loc: Location | None = None
 
     def __repr__(self):
         return repr(self.expr)
@@ -30,6 +32,7 @@ class LiquidConstraint(Constraint):
 class Conjunction(Constraint):
     c1: Constraint
     c2: Constraint
+    loc: Location | None = None
 
     def __repr__(self):
         return f"({self.c1}) ∧ ({self.c2})"
@@ -51,6 +54,7 @@ class Implication(Constraint):
     base: TypeConstructor | TypeVar | Top
     pred: LiquidTerm
     seq: Constraint
+    loc: Location | None = None
 
     def __post_init__(self):
         assert isinstance(self.name, Name)

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
-from aeon.sugar.parser import parse_type
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.facade.api import LiquidTypeCheckingFailedRelation
+from aeon.frontend.anf_converter import ensure_anf
 from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import DesugaredProgram, desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_main_program, parse_type
+from aeon.typechecking.typeinfer import check_type_errors
+from aeon.utils.location import FileLocation
 from tests.driver import check_compile_expr
 
 
@@ -48,3 +58,59 @@ def test_annotation_anf2():
 def test_annotation_anf3():
     source = r"""3 % 2"""
     assert check_compile_expr(source, parse_type("{x:Int | x == 1}"), 1)
+
+
+def _check_refinement_error_location(
+    source: str, filename: str, expected_line: int, expected_col_min: int, expected_col_max: int
+) -> None:
+    """Helper: parse source, get refinement errors, assert location points to expected range."""
+    prog = parse_main_program(source.strip(), filename=filename)
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(progt, ctx, desugared.metadata)
+
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    core_ast_anf = ensure_anf(core_ast)
+
+    errors = list(check_type_errors(typing_ctx, core_ast_anf, top))
+
+    assert len(errors) >= 1, "Expected at least one type error"
+    liquid_errors = [e for e in errors if isinstance(e, LiquidTypeCheckingFailedRelation)]
+    assert liquid_errors, "Expected LiquidTypeCheckingFailedRelation when refinement fails"
+
+    loc = liquid_errors[0].position()
+    assert isinstance(loc, FileLocation)
+    assert loc.file == filename
+    assert loc.start[0] == expected_line
+    assert expected_col_min <= loc.start[1] <= expected_col_max, (
+        f"Expected column in [{expected_col_min}, {expected_col_max}], got {loc.start[1]}"
+    )
+
+
+def test_horn_solver_error_location():
+    """When the Horn solver fails, the error location should point to the AST element
+    being checked as the subtype (e.g. the argument in f(-3)), not the top-level program."""
+    source = """
+def f (x: {a:Int | a > 0}) : Int { x }
+
+def k : Int = f (-3);
+"""
+    _check_refinement_error_location(source, "test_error.ae", expected_line=3, expected_col_min=14, expected_col_max=22)
+
+
+def test_horn_solver_error_location_positive_arg():
+    """Calling a function that expects negative with a positive argument fails;
+    error location should point to the argument expression (2 + 40)."""
+    source = """
+def g (x: {a:Int | a < 0}) : Int { x }
+
+def k : Int = g (2 + 40);
+"""
+    # Line 3: "def k : Int = g (2 + 40);" - argument "(2 + 40)" is around columns 14-23
+    _check_refinement_error_location(
+        source, "test_refinement.ae", expected_line=3, expected_col_min=14, expected_col_max=24
+    )


### PR DESCRIPTION
VCs are now annotated with the expression that generate them, so error messages have better locations.