### PR TITLE
Fix off-by-one in LSP semantic error line numbers

### DIFF
--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -130,8 +130,8 @@ async def _parse(
             error_end_line, error_end_character = error_position.get_end()
 
             error_range = Range(
-                start=Position(line=error_start_line, character=error_start_character),
-                end=Position(line=error_end_line, character=error_end_character),
+                start=Position(line=max(0, error_start_line - 1), character=max(0, error_start_character - 1)),
+                end=Position(line=max(0, error_end_line - 1), character=max(0, error_end_character - 1)),
             )
 
             diagnostics.append(

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -21,7 +21,7 @@ def test_literal():
     assert weval(parse_term("1.0")) == 1.0
     assert weval(parse_term(""" "hello"  """)) == "hello"
 
-    assert weval(Literal(value=(2, 3), type=TypeConstructor("Tuple"))) == (2, 3)
+    assert weval(Literal(value=(2, 3), type=TypeConstructor(Name("Tuple")))) == (2, 3)
 
 
 def test_application():
@@ -74,5 +74,5 @@ def test_rec():
 
 def test_type_abs_app():
     tabs = TypeAbstraction(Name("t"), BaseKind(), parse_term("1"))
-    tapp = TypeApplication(tabs, TypeConstructor("Int"))
+    tapp = TypeApplication(tabs, TypeConstructor(Name("Int")))
     assert weval(tapp) == 1


### PR DESCRIPTION
## Summary
- Lark produces 1-indexed line/column positions, but LSP `Position` expects 0-indexed
- Parse errors (`UnexpectedToken`) were already correctly converted with `- 1`, but semantic errors (type checking, elaboration, etc.) were passed through without adjustment
- This caused semantic errors to appear one line too low in the editor
- Added `max(0, ...)` clamping to safely handle `SynthesizedLocation` which returns `(0, 0)`

## Test plan
- [x] All 31 LSP tests pass (`pytest tests/lsp_test.py`)
- [ ] Manual verification: open a file with a type error in VS Code and confirm the error underline appears on the correct line

🤖 Generated with [Claude Code](https://claude.com/claude-code)