### PR TITLE
Add coin change puzzle example

### DIFF
--- a/examples/synthesis/coin.ae
+++ b/examples/synthesis/coin.ae
@@ -1,0 +1,43 @@
+# Coin Change - from https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/
+#
+# Find the minimum number of coins needed to reach a target value of 37,
+# using denominations of 1, 5, and 10.
+#
+# Constraints:
+#   coins_1 * 1 + coins_5 * 5 + coins_10 * 10 == 37
+#   all coin counts >= 0
+#
+# Expected solution: 2 coins of 1, 1 coin of 5, 3 coins of 10 (6 coins total)
+
+type CoinChange;
+
+def coins_1  : (c:CoinChange) -> Int = uninterpreted;
+def coins_5  : (c:CoinChange) -> Int = uninterpreted;
+def coins_10 : (c:CoinChange) -> Int = uninterpreted;
+
+def coinchange_mk
+    (c1  : {n:Int | n >= 0})
+    (c5  : {n:Int | n >= 0})
+    (c10 : {n:Int | n >= 0}) :
+    {c:CoinChange |
+        (coins_1 c == c1) &&
+        (coins_5 c == c5) &&
+        (coins_10 c == c10)
+    } { native "[c1, c5, c10]" }
+
+@minimize_int(1)
+def coin_solution_hole : {c:CoinChange |
+    (coins_1 c >= 0) &&
+    (coins_5 c >= 0) &&
+    (coins_10 c >= 0) &&
+    (coins_1 c + coins_5 c * 5 + coins_10 c * 10 == 37)
+} = ?hole;
+
+# Verification: the known optimal solution should type-check
+# 2 coins of 1 + 1 coin of 5 + 3 coins of 10 = 2 + 5 + 30 = 37
+def coin_solution : {c:CoinChange |
+    (coins_1 c >= 0) &&
+    (coins_5 c >= 0) &&
+    (coins_10 c >= 0) &&
+    (coins_1 c + coins_5 c * 5 + coins_10 c * 10 == 37)
+} = coinchange_mk 2 1 3;

--- a/examples/synthesis/coin.ae
+++ b/examples/synthesis/coin.ae
@@ -25,7 +25,9 @@ def coinchange_mk
         (coins_10 c == c10)
     } { native "[c1, c5, c10]" }
 
-@minimize_int(1)
+def total_coins (c:CoinChange) : Int { native "c[0] + c[1] + c[2]" }
+
+@minimize_int((total_coins coin_solution_hole))
 def coin_solution_hole : {c:CoinChange |
     (coins_1 c >= 0) &&
     (coins_5 c >= 0) &&


### PR DESCRIPTION
## Summary
- Adds `examples/synthesis/coin.ae` — a coin change optimization problem inspired by https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/
- Find minimum number of coins (denominations 1, 5, 10) to make 37
- Includes both a synthesis hole and a verification definition with the known optimal solution (2×1 + 1×5 + 3×10 = 6 coins)

## Test plan
- [ ] `uv run python -m aeon --no-main examples/synthesis/coin.ae` typechecks successfully
- [ ] `run_examples.sh` passes (already covers `examples/synthesis/*.ae`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)