### PR TITLE
Support def with parameters and = body

### DIFF
--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -21,8 +21,8 @@ cons_rule : _PIPE ID args ":" type                           -> def_ind_cons
 measures : measure_rule*                                  -> list
 measure_rule : "+" ID args ":" type                        -> def_ind_cons
 
-def : soft_constraint "def" ID ":" type "=" expression ";"                  -> def_cons
-    | soft_constraint "def" ID  args ":" type "{" expression "}"     -> def_fun
+def : soft_constraint "def" ID  args ":" type "{" expression "}"     -> def_fun
+    | soft_constraint "def" ID  args ":" type "=" expression ";"     -> def_fun_eq
 
 
 soft_constraint :                      -> empty_list

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -297,20 +297,16 @@ class TreeToSugar(Transformer):
         return Definition(Name(args[0]), [], args[1], args[2], SLiteral(None, st_unit), loc=self._loc(meta))
 
     @v_args(meta=True)
-    def def_cons(self, meta, args):
-        if len(args) == 3:
-            return Definition(Name(args[0]), [], [], args[1], args[2], loc=self._loc(meta))
-        else:
-            decorators = args[0]
-            return Definition(Name(args[1]), [], [], args[2], args[3], decorators, loc=self._loc(meta))
-
-    @v_args(meta=True)
     def def_fun(self, meta, args):
         if len(args) == 4:
             return Definition(Name(args[0]), [], args[1], args[2], args[3], loc=self._loc(meta))
         else:
             decorators = args[0]
             return Definition(Name(args[1]), [], args[2], args[3], args[4], decorators, loc=self._loc(meta))
+
+    @v_args(meta=True)
+    def def_fun_eq(self, meta, args):
+        return self.def_fun(meta, args)
 
     def macros(self, args):
         return args


### PR DESCRIPTION
## Summary
- Allow `def fun (a:Int) : Int = a;` — parameters combined with an `=` body, which previously only worked with `{ }` braces.
- Unify the grammar: `def_fun` (braces body) and new `def_fun_eq` (`= expr ;` body) both accept optional args, replacing the separate `def_cons` rule.

## Test plan
- [x] `uv run pytest` — 230 passed, 3 skipped
- [x] Smoke test: parse and run an `.ae` file using the new syntax (`def id (a:Int) : Int = a;`)
- [x] Existing no-arg form `def x : Int = 3;` and braces form `def f (a:Int) : Int { a }` still parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)