### PR TITLE
PR #166 follow-up: `$` operator + parametric refinements (lint-clean)

### DIFF
--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -144,6 +144,9 @@ class RefinementPolymorphism(Type):
     def __str__(self):
         return f"forall <{self.name}:{self.sort} -> Bool>, {self.body}"
 
+    def __hash__(self) -> int:
+        return hash(self.name) + hash(self.sort) + hash(self.body)
+
 
 @dataclass
 class TypeConstructor(Type):

--- a/aeon/prelude/prelude.py
+++ b/aeon/prelude/prelude.py
@@ -47,8 +47,7 @@ prelude = [
     ("!", "(x:Bool) -> Bool", lambda x: not x),
     (
         "$",
-        "forall a:B, forall b:B, forall <p:a -> Bool>, forall <q:b -> Bool>,"
-        " (f:(x:a<p>) -> b<q>) -> (x:a<p>) -> b<q>",
+        "forall a:B, forall b:B, forall <p:a -> Bool>, forall <q:b -> Bool>, (f:(x:a<p>) -> b<q>) -> (x:a<p>) -> b<q>",
         lambda f: lambda x: f(x),
     ),
 ]

--- a/aeon/prelude/prelude.py
+++ b/aeon/prelude/prelude.py
@@ -45,6 +45,12 @@ prelude = [
     ("&&", "(x:Bool) -> (y:Bool) -> Bool", lambda x: lambda y: x and y),
     ("||", "(x:Bool) -> (y:Bool) -> Bool", lambda x: lambda y: x or y),
     ("!", "(x:Bool) -> Bool", lambda x: not x),
+    (
+        "$",
+        "forall a:B, forall b:B, forall <p:a -> Bool>, forall <q:b -> Bool>,"
+        " (f:(x:a<p>) -> b<q>) -> (x:a<p>) -> b<q>",
+        lambda f: lambda x: f(x),
+    ),
 ]
 
 typing_vars: dict[Name, SType] = {}

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -62,7 +62,10 @@ expression_i : "let" ID "=" expression  ("in"|";") expression           -> let_e
           | "let" ID ":" type _PIPE expression "=" expression  ("in"|";") expression     -> rec_refined_e
           | ID ":" type _PIPE expression "=" expression  ("in"|";") expression     -> rec_refined_e
           | "if" expression "then" expression "else" expression    -> if_e
-          | expression_un                                          -> same
+          | expression_dollar                                      -> same
+
+expression_dollar : expression_un                                    -> same
+                  | expression_un "$" expression_i                  -> binop_dollar
 
 expression_un : expression_bool                                      -> same
            | "!" expression_un                                       -> nnot
@@ -121,7 +124,7 @@ INTLIT : /[0-9][0-9]*/
 FLOATLIT : SIGNED_FLOAT
 
 TYPENAME : /[a-zA-Z0-9]+/
-ID.0 : CNAME | /\([\+=\>\<!\*\-&\|]{1,3}\)/
+ID.0 : CNAME | /\([\+=\>\<!\*\-&\|\$]{1,3}\)/
 
 _PIPE.10 : "where" | "|"
 _DOUBLEPIPE.11 : "||"

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -202,7 +202,8 @@ class TreeToSugar(Transformer):
 
     @v_args(meta=True)
     def binop_dollar(self, meta, args):
-        return self.binop(args, "$", meta)
+        # `$` is syntactic sugar for function application (right-associative by grammar).
+        return SApplication(args[0], args[1], loc=self._loc(meta))
 
     def binop(self, args, op: str, meta):
         return SApplication(

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -200,6 +200,10 @@ class TreeToSugar(Transformer):
     def binop_mod(self, meta, args):
         return self.binop(args, "%", meta)
 
+    @v_args(meta=True)
+    def binop_dollar(self, meta, args):
+        return self.binop(args, "$", meta)
+
     def binop(self, args, op: str, meta):
         return SApplication(
             SApplication(SVar(Name(op, 0), loc=self._loc(meta)), args[0], loc=self._loc(meta)),

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -23,7 +23,7 @@ from aeon.core.liquid import (
 from aeon.core.substitutions import substitution_in_type, substitution_liquid_in_type
 from aeon.core.terms import Abstraction, Annotation, Application, If, Literal
 from aeon.core.terms import Var
-from aeon.core.types import AbstractionType, Type, TypePolymorphism, TypeVar
+from aeon.core.types import AbstractionType, RefinementPolymorphism, Type, TypePolymorphism, TypeVar
 from aeon.core.types import TypeConstructor
 from aeon.core.types import RefinedType
 from aeon.core.types import Top
@@ -388,6 +388,8 @@ def remove_uninterpreted_functions_from_type(ty: Type) -> Type:
                 return RefinedType(name, type, ref_filtered)
         case TypePolymorphism(name, kind, body):
             return TypePolymorphism(name, kind, remove_uninterpreted_functions_from_type(body))
+        case RefinementPolymorphism(_, _, body):
+            return remove_uninterpreted_functions_from_type(body)
         case _:
             assert False, f"Unsupported {ty}"
 

--- a/tests/parametric_refinements_test.py
+++ b/tests/parametric_refinements_test.py
@@ -180,14 +180,27 @@ def main (args:Int) : Unit {{
 
 def test_dollar_preserves_output_refinement():
     source = """
-def inc : (x:Int) -> {y:Int | y > 0} = \\x -> if x > 0 then x + 1 else 1;
+def inc : (x : Int | x > 4) -> {y:Int | y > 0} = \\x -> x + 1;
 
 def main (args:Int) : Unit {
-    r : Int | r > 0 = inc $ 5;
+    n : Int | n > 4 = 5;
+    r : Int | r > 0 = inc $ n;
     print (r)
 }
 """
     assert check_compile(source, st_top)
+
+
+def test_dollar_propagates_argument_refinement_check():
+    source = """
+def inc : (x : Int | x > 4) -> {y:Int | y > 0} = \\x -> x + 1;
+
+def main (args:Int) : Unit {
+    r : Int | r > 0 = inc $ 3;
+    print (r)
+}
+"""
+    assert not check_compile(source, st_top)
 
 
 def test_dollar_right_associative_chain():

--- a/tests/parametric_refinements_test.py
+++ b/tests/parametric_refinements_test.py
@@ -176,3 +176,52 @@ def main (args:Int) : Unit {{
 """
     assert check_compile(source_ok, st_top)
     assert not check_compile(source_bad, st_top)
+
+
+def test_dollar_preserves_output_refinement():
+    source = """
+def inc : (x:Int) -> {y:Int | y > 0} = \\x -> if x > 0 then x + 1 else 1;
+
+def main (args:Int) : Unit {
+    r : Int | r > 0 = inc $ 5;
+    print (r)
+}
+"""
+    assert check_compile(source, st_top)
+
+
+def test_dollar_right_associative_chain():
+    source = """
+def inc : (x:Int) -> {y:Int | y > 0} = \\x -> if x > 0 then x + 1 else 1;
+def dbl : (x:Int) -> {y:Int | y > 0} = \\x -> if x > 0 then x + x else 1;
+
+def main (args:Int) : Unit {
+    r : Int | r > 0 = inc $ dbl $ 3;
+    print (r)
+}
+"""
+    assert check_compile(source, st_top)
+
+
+def test_dollar_rejects_stricter_refinement():
+    source = """
+def inc : (x:Int) -> {y:Int | y > 0} = \\x -> if x > 0 then x + 1 else 1;
+
+def main (args:Int) : Unit {
+    r : Int | r > 100 = inc $ 5;
+    print (r)
+}
+"""
+    assert not check_compile(source, st_top)
+
+
+def test_dollar_lower_precedence_than_plus():
+    source = """
+def inc : (x:Int) -> {y:Int | y > 0} = \\x -> if x > 0 then x + 1 else 1;
+
+def main (args:Int) : Unit {
+    r : Int | r > 0 = inc $ 2 + 3;
+    print (r)
+}
+"""
+    assert check_compile(source, st_top)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR supersedes the integration work for **PR #166** (Haskell-style `$`) on top of **`Parametric-refinements-2.0`**.

### What changed
- Adds `$` parsing/precedence behavior and refinement-focused tests in `tests/parametric_refinements_test.py`.
- **`$` is lowered during parsing to ordinary function application** (`f $ x` → `f x`), so refinement typechecking matches normal application (including domains like `(x : Int | x > 4)`).

### Validation
- `uvx pre-commit run --all-files`
- `uv run pytest -q`

### Notes
- Intended to land after / alongside parametric refinements work; base branch is `Parametric-refinements-2.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bfcc54b-f39d-499e-bed4-80ee58b9d9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bfcc54b-f39d-499e-bed4-80ee58b9d9e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

