### PR TITLE
Expose tdsyn on the public synthesizer list; default to tdsyn_enumerative

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -75,8 +75,12 @@ def _parse_common_arguments(parser: ArgumentParser):
         "-s",
         "--synthesizer",
         type=str,
-        default="gp",
-        help="Select a synthesizer for synthesis(gp for Genetic programming(Defaut), synquid for Synquid, random_search for Random Search, enumerative for Enumerative Search, hc for Hill Climbing, and 1p1 for One Plus One)",
+        default="tdsyn_enumerative",
+        help=(
+            "Select a synthesizer: tdsyn_enumerative (default, type-directed BFS), tdsyn (same as tdsyn_enumerative), "
+            "tdsyn_random (type-directed random walk), gp, synquid, random_search, enumerative (grammar enumeration), "
+            "hc, 1p1, smt, decision_tree, llm"
+        ),
     )
 
     parser.add_argument(

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -36,7 +36,19 @@ from pygls.lsp.server import LanguageServer
 
 from aeon.facade.driver import AeonDriver
 
-SYNTHESIZERS = ["gp", "enumerative", "random_search", "synquid", "hc", "1p1", "smt", "decision_tree", "llm"]
+SYNTHESIZERS = [
+    "tdsyn_enumerative",
+    "tdsyn",
+    "gp",
+    "enumerative",
+    "random_search",
+    "synquid",
+    "hc",
+    "1p1",
+    "smt",
+    "decision_tree",
+    "llm",
+]
 SYNTHESIZE_COMMAND = "aeon.synthesize"
 
 

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -4,6 +4,7 @@ from aeon.synthesis.modules.synquid.synthesizer import SynquidSynthesizer
 from aeon.synthesis.modules.llm import LLMSynthesizer
 from aeon.synthesis.modules.decision_tree import DecisionTreeSynthesizer
 from aeon.synthesis.modules.smt_synthesizer import SMTSynthesizer
+from aeon.synthesis.modules.tdsyn.synthesizer import TDSynSynthesizer
 
 
 def make_synthesizer(module: str) -> Synthesizer:
@@ -26,5 +27,9 @@ def make_synthesizer(module: str) -> Synthesizer:
             return DecisionTreeSynthesizer()
         case "smt":
             return SMTSynthesizer()
+        case "tdsyn" | "tdsyn_enumerative":
+            return TDSynSynthesizer(mode="enumerative")
+        case "tdsyn_random":
+            return TDSynSynthesizer(mode="random")
         case _:
             assert False, f"Not supported synthesizer with name {module}"

--- a/aeon/synthesis/modules/tdsyn/actions.py
+++ b/aeon/synthesis/modules/tdsyn/actions.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidTerm, LiquidVar
+from aeon.core.substitutions import substitution_in_liquid
+from aeon.core.terms import Abstraction, Application, If, Literal, Term, Var
+from aeon.core.types import (
+    AbstractionType,
+    RefinedType,
+    Type,
+    TypeConstructor,
+    TypePolymorphism,
+    RefinementPolymorphism,
+    t_bool,
+    t_float,
+    t_int,
+)
+from aeon.synthesis.modules.tdsyn.helpers import (
+    base_type_of,
+    bases_match,
+    get_param_types,
+    get_return_type,
+    is_subtype,
+    monomorphize,
+)
+from aeon.synthesis.modules.tdsyn.worklist import TypedHole, fresh_hole
+from aeon.typechecking.context import TypingContext
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name
+
+_loc = SynthesizedLocation("tdsyn")
+
+
+def get_applicable_functions(
+    ctx: TypingContext,
+    skip: Callable[[Name], bool],
+) -> list[tuple[Term, Type]]:
+    """Get all applicable functions from context, monomorphizing polymorphic ones.
+
+    Returns list of (term, monomorphic_function_type) pairs where term is
+    Var(f) for monomorphic functions or TypeApplication(Var(f), T) for
+    instantiated polymorphic ones.
+    """
+    results: list[tuple[Term, Type]] = []
+    for name, ty in ctx.vars():
+        if skip(name):
+            continue
+        if isinstance(ty, (TypePolymorphism, RefinementPolymorphism)):
+            for term, mono_ty in monomorphize(name, ty, ctx):
+                if isinstance(mono_ty, AbstractionType):
+                    results.append((term, mono_ty))
+        elif isinstance(ty, AbstractionType):
+            results.append((Var(name, _loc), ty))
+    return results
+
+
+def _extract_refinement(ty: Type) -> tuple[Name, LiquidTerm] | None:
+    """Extract (binder_name, refinement) from a refined type, or None."""
+    match ty:
+        case RefinedType(binder, _, refinement):
+            if refinement != LiquidLiteralBool(True):
+                return (binder, refinement)
+        case _:
+            pass
+    return None
+
+
+def _build_liquid_app(fun_name: Name, hole_names: list[Name]) -> LiquidTerm:
+    """Build a liquid application term: f(h1, h2, ..., hn) for constraint propagation."""
+    if len(hole_names) == 0:
+        return LiquidVar(fun_name)
+    return LiquidApp(fun_name, [LiquidVar(h) for h in hole_names])
+
+
+def _propagate_constraints(
+    hole: TypedHole,
+    fun_name: Name,
+    new_holes: list[TypedHole],
+) -> None:
+    """Propagate refinement constraints from parent hole to parameter holes.
+
+    If the parent hole expects {x:T | R(x)} and we're applying f(h1, h2, ...),
+    the constraint R(f(h1, h2, ...)) is added to all parameter holes.
+    """
+    ref_info = _extract_refinement(hole.expected_type)
+    if ref_info is None:
+        # Also propagate any existing constraints from parent hole
+        if hole.constraints:
+            for h in new_holes:
+                h.constraints.extend(hole.constraints)
+        return
+
+    binder, refinement = ref_info
+    # Build liquid expression: f(h1, h2, ...)
+    hole_names = [h.name for h in new_holes]
+    liquid_expr = _build_liquid_app(fun_name, hole_names)
+
+    # Substitute: R(x) becomes R(f(h1, h2, ...))
+    propagated = substitution_in_liquid(refinement, liquid_expr, binder)
+
+    # Attach constraint to all parameter holes
+    for h in new_holes:
+        h.constraints.append(propagated)
+        # Also propagate parent's accumulated constraints
+        h.constraints.extend(hole.constraints)
+
+
+def _get_operator_name(f_term: Term) -> Name | None:
+    """Extract the function name from a term (Var or TypeApplication(Var, ...))."""
+    match f_term:
+        case Var(name, _):
+            return name
+        case _:
+            # For TypeApplication(Var(name), type), walk down
+            t = f_term
+            from aeon.core.terms import TypeApplication as TA
+
+            while isinstance(t, TA):
+                t = t.body
+            if isinstance(t, Var):
+                return t.name
+            return None
+
+
+def _build_application(
+    f_term: Term,
+    param_types: list[tuple[Name, Type]],
+    hole: TypedHole,
+) -> tuple[Term, list[TypedHole]]:
+    """Build a curried application f(h1)(h2)...(hn) with fresh holes for each parameter.
+
+    Propagates refinement constraints from the parent hole to parameter holes.
+    """
+    new_holes: list[TypedHole] = []
+    result = f_term
+    for _, param_type in param_types:
+        hole_term, typed_hole = fresh_hole(param_type, hole.context)
+        result = Application(result, hole_term, _loc)
+        new_holes.append(typed_hole)
+
+    # Propagate constraints
+    fun_name = _get_operator_name(f_term)
+    if fun_name is not None:
+        _propagate_constraints(hole, fun_name, new_holes)
+
+    return result, new_holes
+
+
+def backward_candidates(
+    hole: TypedHole,
+    skip: Callable[[Name], bool],
+) -> list[tuple[Term, list[TypedHole]]]:
+    """Backward action: from expected type, find terms that produce a subtype.
+
+    Given hole expecting type T:
+    1. If T is a function type, produce an abstraction
+    2. Generate literals for base types
+    3. Look up variables with matching types
+    4. Find functions whose return type matches T
+    5. Generate if-then-else
+    """
+    T = hole.expected_type
+    ctx = hole.context
+    candidates: list[tuple[Term, list[TypedHole]]] = []
+
+    # 1. Abstraction for function types
+    match T:
+        case AbstractionType(var_name, var_type, body_type):
+            body_hole_term, body_typed_hole = fresh_hole(body_type, ctx.with_var(var_name, var_type))
+            candidates.append((Abstraction(var_name, body_hole_term, _loc), [body_typed_hole]))
+            return candidates  # For function types, only produce abstractions
+        case _:
+            pass
+
+    # 2. Literals
+    base = base_type_of(T)
+    if base is not None:
+        match base:
+            case TypeConstructor(Name("Int", _)):
+                for ival in range(-2, 11):
+                    candidates.append((Literal(ival, t_int, _loc), []))
+            case TypeConstructor(Name("Bool", _)):
+                candidates.append((Literal(True, t_bool, _loc), []))
+                candidates.append((Literal(False, t_bool, _loc), []))
+            case TypeConstructor(Name("Float", _)):
+                for fval in [-1.0, -0.5, 0.0, 0.5, 1.0, 2.0]:
+                    candidates.append((Literal(fval, t_float, _loc), []))
+            case _:
+                pass
+
+    # 3. Variables (non-function types)
+    for name, var_type in ctx.vars():
+        if skip(name):
+            continue
+        if isinstance(var_type, (AbstractionType, TypePolymorphism, RefinementPolymorphism)):
+            continue
+        if bases_match(var_type, T):
+            if is_subtype(ctx, var_type, T):
+                candidates.append((Var(name, _loc), []))
+
+    # 4. Function applications (monomorphic + polymorphic)
+    for f_term, f_type in get_applicable_functions(ctx, skip):
+        assert isinstance(f_type, AbstractionType)
+        ret_type = get_return_type(f_type)
+        if bases_match(ret_type, T):
+            params = get_param_types(f_type)
+            app_term, new_holes = _build_application(f_term, params, hole)
+            candidates.append((app_term, new_holes))
+
+    # 5. If-then-else
+    cond_hole_term, cond_typed_hole = fresh_hole(t_bool, ctx)
+    then_hole_term, then_typed_hole = fresh_hole(T, ctx)
+    else_hole_term, else_typed_hole = fresh_hole(T, ctx)
+    candidates.append(
+        (
+            If(cond_hole_term, then_hole_term, else_hole_term, _loc),
+            [cond_typed_hole, then_typed_hole, else_typed_hole],
+        )
+    )
+
+    return candidates
+
+
+def forward_candidates(
+    hole: TypedHole,
+    skip: Callable[[Name], bool],
+) -> list[tuple[Term, list[TypedHole]]]:
+    """Forward action: from variables in scope, find functions that consume them.
+
+    Given hole expecting type T, for each variable v:A in scope, find functions
+    f:(x:A)->B where A is compatible with v's type, and produce f(v) with
+    remaining holes if needed.
+    """
+    T = hole.expected_type
+    ctx = hole.context
+    candidates: list[tuple[Term, list[TypedHole]]] = []
+
+    # Collect concrete (non-function) variables
+    concrete_vars: list[tuple[Name, Type]] = []
+    for name, var_type in ctx.vars():
+        if skip(name):
+            continue
+        if isinstance(var_type, (AbstractionType, TypePolymorphism, RefinementPolymorphism)):
+            continue
+        concrete_vars.append((name, var_type))
+
+    # For each variable, find functions that accept it
+    for v_name, v_type in concrete_vars:
+        for f_term, f_type in get_applicable_functions(ctx, skip):
+            assert isinstance(f_type, AbstractionType)
+            first_param_type = f_type.var_type
+
+            if not bases_match(v_type, first_param_type):
+                continue
+            if not is_subtype(ctx, v_type, first_param_type):
+                continue
+
+            # Apply f to v
+            applied = Application(f_term, Var(v_name, _loc), _loc)
+            remaining_type = f_type.type
+
+            if isinstance(remaining_type, AbstractionType):
+                # Multi-argument function: create holes for remaining args
+                remaining_params = get_param_types(remaining_type)
+                final_ret = get_return_type(remaining_type)
+                if not bases_match(final_ret, T):
+                    continue
+                result, new_holes = _build_application(applied, remaining_params, hole)
+                candidates.append((result, new_holes))
+            else:
+                # Single-argument or final application
+                if bases_match(remaining_type, T):
+                    candidates.append((applied, []))
+
+    return candidates

--- a/aeon/synthesis/modules/tdsyn/helpers.py
+++ b/aeon/synthesis/modules/tdsyn/helpers.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from aeon.core.instantiation import type_substitution
+from aeon.core.terms import Term, TypeApplication, Var
+from aeon.core.types import (
+    AbstractionType,
+    RefinementPolymorphism,
+    Type,
+    TypeConstructor,
+    TypePolymorphism,
+    refined_to_unrefined_type,
+    t_bool,
+    t_float,
+    t_int,
+    t_string,
+)
+from aeon.decorators.api import Metadata
+from aeon.typechecking.context import TypingContext
+from aeon.typechecking.entailment import entailment
+from aeon.utils.name import Name
+from aeon.verification.sub import sub
+
+
+def is_subtype(ctx: TypingContext, t1: Type, t2: Type) -> bool:
+    """Check if t1 is a subtype of t2 using SMT-based verification."""
+    constraint = sub(ctx, t1, t2)
+    return entailment(ctx, constraint)
+
+
+def base_type_of(ty: Type) -> TypeConstructor | None:
+    """Strip refinements to get the base TypeConstructor, or None if not a base type."""
+    unrefined = refined_to_unrefined_type(ty)
+    match unrefined:
+        case TypeConstructor():
+            return unrefined
+        case _:
+            return None
+
+
+def get_return_type(ty: Type) -> Type:
+    """Get the final return type of a (possibly multi-argument) function type."""
+    t = ty
+    while isinstance(t, AbstractionType):
+        t = t.type
+    return t
+
+
+def get_param_types(ty: Type) -> list[tuple[Name, Type]]:
+    """Extract (name, type) for each parameter of a function type."""
+    params: list[tuple[Name, Type]] = []
+    t = ty
+    while isinstance(t, AbstractionType):
+        params.append((t.var_name, t.var_type))
+        t = t.type
+    return params
+
+
+def bases_match(t1: Type, t2: Type) -> bool:
+    """Fast structural pre-check: do the base type constructors match?"""
+    b1 = base_type_of(t1)
+    b2 = base_type_of(t2)
+    if b1 is None or b2 is None:
+        return False
+    return b1.name.name == b2.name.name
+
+
+def should_skip(name: Name, fun_name: Name, metadata: Metadata, is_recursion_allowed: bool) -> bool:
+    """Check if a variable should be skipped during synthesis."""
+    if name == fun_name:
+        return not is_recursion_allowed
+    current_metadata = metadata.get(fun_name, {})
+    vars_to_ignore = current_metadata.get("hide", [])
+    if name in vars_to_ignore:
+        return True
+    if name.name.startswith("__internal__"):
+        return True
+    if name.name in ["native", "native_import", "print"]:
+        return True
+    return False
+
+
+BUILTIN_BASE_TYPES: list[TypeConstructor] = [t_int, t_bool, t_float, t_string]
+
+
+def _collect_concrete_types(ctx: TypingContext) -> list[TypeConstructor]:
+    """Collect all concrete base types from context plus built-ins."""
+    types: set[str] = set()
+    result: list[TypeConstructor] = []
+    for tc in BUILTIN_BASE_TYPES:
+        if tc.name.name not in types:
+            types.add(tc.name.name)
+            result.append(tc)
+    for _, t in ctx.concrete_vars():
+        bt = base_type_of(t)
+        if bt is not None and bt.name.name not in types and bt != TypeConstructor(Name("Unit", 0)):
+            types.add(bt.name.name)
+            result.append(bt)
+    return result
+
+
+def monomorphize(name: Name, ty: Type, ctx: TypingContext) -> list[tuple[Term, Type]]:
+    """Generate all monomorphic instantiations of a (possibly polymorphic) type.
+
+    Returns list of (term, monomorphic_type) pairs.
+    For non-polymorphic types, returns [(Var(name), ty)].
+    For polymorphic types, instantiates type variables with concrete types from context.
+    """
+    match ty:
+        case TypePolymorphism(var_name, _, body):
+            concrete_types = _collect_concrete_types(ctx)
+            results: list[tuple[Term, Type]] = []
+            for concrete_type in concrete_types:
+                substituted = type_substitution(body, var_name, concrete_type)
+                term = TypeApplication(Var(name), concrete_type)
+                if isinstance(substituted, TypePolymorphism):
+                    # Nested polymorphism: recurse (need a fresh name for the intermediate)
+                    for sub_term, sub_type in _monomorphize_term(term, substituted, ctx):
+                        results.append((sub_term, sub_type))
+                else:
+                    results.append((term, substituted))
+            return results
+        case RefinementPolymorphism():
+            return []
+        case _:
+            return [(Var(name), ty)]
+
+
+def _monomorphize_term(base_term: Term, ty: Type, ctx: TypingContext) -> list[tuple[Term, Type]]:
+    """Continue monomorphizing an already partially applied term."""
+    match ty:
+        case TypePolymorphism(var_name, _, body):
+            concrete_types = _collect_concrete_types(ctx)
+            results: list[tuple[Term, Type]] = []
+            for concrete_type in concrete_types:
+                substituted = type_substitution(body, var_name, concrete_type)
+                term = TypeApplication(base_term, concrete_type)
+                if isinstance(substituted, TypePolymorphism):
+                    for sub_term, sub_type in _monomorphize_term(term, substituted, ctx):
+                        results.append((sub_term, sub_type))
+                else:
+                    results.append((term, substituted))
+            return results
+        case _:
+            return [(base_term, ty)]
+
+
+def make_skip_fn(fun_name: Name, metadata: Metadata) -> Callable[[Name], bool]:
+    """Create a skip function for use in actions."""
+    current_metadata = metadata.get(fun_name, {})
+    is_recursion_allowed = current_metadata.get("recursion", False)
+
+    def skip(name: Name) -> bool:
+        return should_skip(name, fun_name, metadata, is_recursion_allowed)
+
+    return skip

--- a/aeon/synthesis/modules/tdsyn/smt_solve.py
+++ b/aeon/synthesis/modules/tdsyn/smt_solve.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+
+from z3 import Or, Solver, sat
+from z3.z3 import ModelRef
+
+from aeon.core.liquid import LiquidLiteralBool, LiquidVar
+from aeon.core.substitutions import substitution_in_liquid
+from aeon.core.terms import Literal, Term
+from aeon.core.types import (
+    RefinedType,
+    TypeConstructor,
+    t_bool,
+    t_float,
+    t_int,
+)
+from aeon.synthesis.modules.tdsyn.helpers import base_type_of
+from aeon.synthesis.modules.tdsyn.worklist import TypedHole
+from aeon.typechecking.context import TypingContext, VariableBinder
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name
+from aeon.verification.smt import base_functions, make_variable, translate_liq
+
+_loc = SynthesizedLocation("tdsyn")
+
+
+def _is_leaf_hole(hole: TypedHole) -> bool:
+    """Check if a hole expects a base type (Int, Bool, Float) — i.e., can be filled with a literal."""
+    base = base_type_of(hole.expected_type)
+    if base is None:
+        return False
+    return base.name.name in ("Int", "Bool", "Float")
+
+
+def all_leaf_holes(holes: list[TypedHole]) -> bool:
+    """Check if all holes are leaf-solvable by SMT."""
+    return all(_is_leaf_hole(h) for h in holes)
+
+
+def _collect_context_constraints(
+    ctx: TypingContext,
+    z3_vars: dict[str, object],
+) -> list:
+    """Collect Z3 constraints from typing context variable refinements."""
+    z3_constraints = []
+    for entry in ctx.entries:
+        match entry:
+            case VariableBinder(name, RefinedType(binder, base, refinement)):
+                if isinstance(base, TypeConstructor) and base.name.name in ("Int", "Bool", "Float"):
+                    if refinement != LiquidLiteralBool(True):
+                        # Substitute binder with variable name
+                        ref = substitution_in_liquid(refinement, LiquidVar(name), binder)
+                        # Make sure the context variable has a Z3 var
+                        sname = str(name)
+                        if sname not in z3_vars:
+                            z3_vars[sname] = make_variable(sname, base)
+                        try:
+                            z3_c = translate_liq(ref, z3_vars | base_functions)
+                            if z3_c is not None and z3_c is not True:
+                                z3_constraints.append(z3_c)
+                        except Exception:
+                            pass
+            case _:
+                pass
+    return z3_constraints
+
+
+def solve_literals(
+    holes: list[TypedHole],
+    max_models: int = 5,
+) -> list[dict[Name, Term]]:
+    """Use Z3 to find concrete literal values for all leaf-level holes simultaneously.
+
+    Collects constraints from:
+    1. Each hole's refined expected type
+    2. Each hole's propagated constraints (from parent expansions)
+    3. Typing context variable refinements
+
+    Returns a list of solutions, each mapping hole names to Literal terms.
+    """
+    if not holes:
+        return []
+
+    # Use the first hole's context for context constraints (they share the same scope)
+    ctx = holes[0].context
+
+    # Create Z3 variables for each hole
+    z3_vars: dict[str, object] = {}
+    for hole in holes:
+        hole_base = base_type_of(hole.expected_type)
+        assert hole_base is not None
+        z3_vars[str(hole.name)] = make_variable(str(hole.name), hole_base)
+
+    # Collect constraints from context
+    z3_constraints = _collect_context_constraints(ctx, z3_vars)
+
+    # Collect constraints from each hole's expected type refinement
+    for hole in holes:
+        match hole.expected_type:
+            case RefinedType(binder, _, refinement):
+                if refinement != LiquidLiteralBool(True):
+                    ref = substitution_in_liquid(refinement, LiquidVar(hole.name), binder)
+                    try:
+                        z3_c = translate_liq(ref, z3_vars | base_functions)
+                        if z3_c is not None and z3_c is not True:
+                            z3_constraints.append(z3_c)
+                    except Exception:
+                        pass
+            case _:
+                pass
+
+        # Collect propagated constraints from parent expansions
+        for constraint in hole.constraints:
+            try:
+                z3_c = translate_liq(constraint, z3_vars | base_functions)
+                if z3_c is not None and z3_c is not True:
+                    z3_constraints.append(z3_c)
+            except Exception:
+                pass
+
+    if not z3_constraints:
+        return []
+
+    # Solve
+    solver = Solver()
+    solver.set(timeout=500)
+    for c in z3_constraints:
+        solver.add(c)
+
+    solutions: list[dict[Name, Term]] = []
+
+    for _ in range(max_models):
+        result = solver.check()
+        if result != sat:
+            break
+
+        model = solver.model()
+        solution = _extract_solution(model, holes, z3_vars)
+        if solution is not None:
+            solutions.append(solution)
+
+            # Add blocking clause to get a different solution
+            blocking = []
+            for hole in holes:
+                z3_var = z3_vars[str(hole.name)]
+                val = model[z3_var]
+                if val is not None:
+                    blocking.append(z3_var != val)
+            if blocking:
+                solver.add(Or(*blocking))
+            else:
+                break
+
+    return solutions
+
+
+def _extract_solution(
+    model: ModelRef,
+    holes: list[TypedHole],
+    z3_vars: dict[str, object],
+) -> dict[Name, Term] | None:
+    """Extract concrete Literal terms from a Z3 model."""
+    solution: dict[Name, Term] = {}
+
+    for hole in holes:
+        z3_var = z3_vars[str(hole.name)]
+        val = model[z3_var]
+        base = base_type_of(hole.expected_type)
+        assert base is not None
+
+        if val is None:
+            # Z3 didn't constrain this variable; pick a default
+            match base.name.name:
+                case "Int":
+                    solution[hole.name] = Literal(0, t_int, _loc)
+                case "Bool":
+                    solution[hole.name] = Literal(True, t_bool, _loc)
+                case "Float":
+                    solution[hole.name] = Literal(0.0, t_float, _loc)
+                case _:
+                    return None
+        else:
+            try:
+                match base.name.name:
+                    case "Int":
+                        int_val = val.as_long()
+                        solution[hole.name] = Literal(int_val, t_int, _loc)
+                    case "Bool":
+                        from z3 import is_true
+
+                        bool_val = is_true(val)
+                        solution[hole.name] = Literal(bool_val, t_bool, _loc)
+                    case "Float":
+                        float_val = float(val.as_decimal(10).rstrip("?"))
+                        solution[hole.name] = Literal(float_val, t_float, _loc)
+                    case _:
+                        return None
+            except Exception:
+                return None
+
+    return solution

--- a/aeon/synthesis/modules/tdsyn/synthesizer.py
+++ b/aeon/synthesis/modules/tdsyn/synthesizer.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import random
+from collections import deque
+from time import monotonic_ns
+from typing import Callable
+
+from loguru import logger
+
+from aeon.core.terms import Abstraction, Term
+from aeon.core.types import AbstractionType, Type
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import Synthesizer
+from aeon.synthesis.modules.tdsyn.actions import backward_candidates, forward_candidates
+from aeon.synthesis.modules.tdsyn.helpers import make_skip_fn
+from aeon.synthesis.modules.tdsyn.smt_solve import all_leaf_holes, solve_literals
+from aeon.synthesis.modules.tdsyn.worklist import PartialAST, TypedHole, fresh_hole, substitute_hole
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name
+
+MAX_DEPTH = 5
+
+_loc = SynthesizedLocation("tdsyn")
+
+
+def _is_better(v1: list[float], v2: list[float]) -> bool:
+    if not v2:
+        return True
+    return all(x < y for x, y in zip(v1, v2))
+
+
+def _get_elapsed_time(start_time: int) -> float:
+    return (monotonic_ns() - start_time) * 0.000000001
+
+
+def _peel_abstractions(ty: Type, ctx: TypingContext) -> tuple[Term, Type, TypingContext, list[TypedHole]]:
+    """If the target type is a function type, peel off abstractions.
+
+    Returns (wrapper_term_with_hole, inner_type, extended_ctx, [inner_hole]).
+    For non-function types, returns a single hole.
+    """
+    if not isinstance(ty, AbstractionType):
+        hole_term, typed_hole = fresh_hole(ty, ctx)
+        return hole_term, ty, ctx, [typed_hole]
+
+    # Peel all abstractions
+    current_type: Type = ty
+    current_ctx = ctx
+    var_names: list[Name] = []
+
+    while isinstance(current_type, AbstractionType):
+        var_names.append(current_type.var_name)
+        current_ctx = current_ctx.with_var(current_type.var_name, current_type.var_type)
+        current_type = current_type.type
+
+    # Create the innermost hole
+    inner_hole_term, inner_typed_hole = fresh_hole(current_type, current_ctx)
+
+    # Wrap in abstractions (inside-out)
+    term: Term = inner_hole_term
+    for var_name in reversed(var_names):
+        term = Abstraction(var_name, term, _loc)
+
+    return term, current_type, current_ctx, [inner_typed_hole]
+
+
+class TDSynSynthesizer(Synthesizer):
+    """Type-directed synthesizer using backward and forward actions with SMT-based subtyping.
+
+    Supports both enumerative (BFS) and random exploration modes.
+    """
+
+    def __init__(self, mode: str = "enumerative"):
+        assert mode in ("enumerative", "random")
+        self.mode = mode
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+    ) -> Term:
+        assert isinstance(ctx, TypingContext)
+        assert isinstance(type, Type)
+
+        skip = make_skip_fn(fun_name, metadata)
+        start_time = monotonic_ns()
+        best: tuple[list[float], Term | None] = ([], None)
+        ui.register(None, None, 0, True)
+
+        # Peel abstractions from the target type
+        initial_term, inner_type, inner_ctx, initial_holes = _peel_abstractions(type, ctx)
+
+        initial_partial = PartialAST(term=initial_term, holes=initial_holes, depth=0)
+
+        if self.mode == "enumerative":
+            best = self._enumerative_search(initial_partial, skip, validate, evaluate, start_time, budget, ui, best)
+        else:
+            best = self._random_search(initial_partial, skip, validate, evaluate, start_time, budget, ui, best)
+
+        return best[1]
+
+    def _try_complete(
+        self,
+        partial: PartialAST,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        start_time: int,
+        ui: SynthesisUI,
+        best: tuple[list[float], Term | None],
+    ) -> tuple[list[float], Term | None]:
+        """Try to validate and evaluate a complete term."""
+        if not partial.is_complete():
+            return best
+        term = partial.term
+        try:
+            if validate(term):
+                score = evaluate(term)
+                if _is_better(score, best[0]):
+                    best = (score, term)
+                    ui.register(term, score, _get_elapsed_time(start_time), True)
+                else:
+                    ui.register(term, score, _get_elapsed_time(start_time), False)
+            else:
+                ui.register(term, "Invalid", _get_elapsed_time(start_time), False)
+        except Exception:
+            ui.register(term, "Invalid", _get_elapsed_time(start_time), False)
+        return best
+
+    def _try_smt_complete(
+        self,
+        partial: PartialAST,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        start_time: int,
+        ui: SynthesisUI,
+        best: tuple[list[float], Term | None],
+    ) -> tuple[list[float], Term | None, bool]:
+        """Try to complete a partial AST by solving all remaining holes with SMT.
+
+        Returns (best, smt_succeeded). smt_succeeded is True if SMT produced
+        at least one solution attempt (even if validation failed).
+        """
+        if not partial.holes or not all_leaf_holes(partial.holes):
+            return best[0], best[1], False
+
+        solutions = solve_literals(partial.holes)
+        if not solutions:
+            return best[0], best[1], False
+
+        for solution in solutions:
+            # Substitute all holes with their solved values
+            term = partial.term
+            for hole_name, literal_term in solution.items():
+                term = substitute_hole(term, hole_name, literal_term)
+
+            complete = PartialAST(term=term, holes=[], depth=partial.depth)
+            best = self._try_complete(complete, validate, evaluate, start_time, ui, best)
+
+        return best[0], best[1], True
+
+    def _expand_hole(
+        self,
+        partial: PartialAST,
+        hole: TypedHole,
+        skip: Callable[[Name], bool],
+    ) -> list[PartialAST]:
+        """Expand a single hole using backward and forward actions."""
+        results: list[PartialAST] = []
+
+        for action_fn in [backward_candidates, forward_candidates]:
+            try:
+                candidates = action_fn(hole, skip)
+            except Exception as e:
+                logger.debug(f"tdsyn: action failed: {e}")
+                continue
+
+            for replacement, new_holes in candidates:
+                new_term = substitute_hole(partial.term, hole.name, replacement)
+                remaining_holes = [h for h in partial.holes if h.name != hole.name]
+                remaining_holes.extend(new_holes)
+                new_depth = partial.depth + (1 if new_holes else 0)
+                if new_depth <= MAX_DEPTH:
+                    results.append(PartialAST(term=new_term, holes=remaining_holes, depth=new_depth))
+
+        return results
+
+    def _enumerative_search(
+        self,
+        initial: PartialAST,
+        skip: Callable[[Name], bool],
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        start_time: int,
+        budget: float,
+        ui: SynthesisUI,
+        best: tuple[list[float], Term | None],
+    ) -> tuple[list[float], Term | None]:
+        """BFS-based enumerative search."""
+        worklist: deque[PartialAST] = deque([initial])
+
+        while worklist:
+            if _get_elapsed_time(start_time) > budget:
+                break
+
+            partial = worklist.popleft()
+
+            if partial.is_complete():
+                best = self._try_complete(partial, validate, evaluate, start_time, ui, best)
+                continue
+
+            # Try SMT completion if all holes are leaf-solvable
+            best_score, best_term, smt_ok = self._try_smt_complete(partial, validate, evaluate, start_time, ui, best)
+            best = (best_score, best_term)
+
+            # Pick the first unfilled hole
+            hole = partial.holes[0]
+            expanded = self._expand_hole(partial, hole, skip)
+
+            for new_partial in expanded:
+                if _get_elapsed_time(start_time) > budget:
+                    break
+                if new_partial.is_complete():
+                    best = self._try_complete(new_partial, validate, evaluate, start_time, ui, best)
+                else:
+                    # Try SMT on newly expanded partials too
+                    best_score, best_term, smt_ok = self._try_smt_complete(
+                        new_partial, validate, evaluate, start_time, ui, best
+                    )
+                    best = (best_score, best_term)
+                    if not smt_ok:
+                        worklist.append(new_partial)
+
+        return best
+
+    def _random_search(
+        self,
+        initial: PartialAST,
+        skip: Callable[[Name], bool],
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        start_time: int,
+        budget: float,
+        ui: SynthesisUI,
+        best: tuple[list[float], Term | None],
+    ) -> tuple[list[float], Term | None]:
+        """Random exploration search."""
+        rng = random.Random(42)
+
+        while _get_elapsed_time(start_time) < budget:
+            # Start fresh from initial each time for random search
+            partial = PartialAST(term=initial.term, holes=list(initial.holes), depth=initial.depth)
+
+            # Randomly expand holes until complete or stuck
+            attempts = 0
+            while not partial.is_complete() and attempts < MAX_DEPTH * 2:
+                if _get_elapsed_time(start_time) > budget:
+                    break
+
+                # Try SMT completion first
+                best_score, best_term, smt_ok = self._try_smt_complete(
+                    partial, validate, evaluate, start_time, ui, best
+                )
+                best = (best_score, best_term)
+                if smt_ok:
+                    break
+
+                # Pick a random hole
+                hole = rng.choice(partial.holes)
+
+                # Get all candidates from both actions
+                all_candidates: list[PartialAST] = self._expand_hole(partial, hole, skip)
+
+                if not all_candidates:
+                    break
+
+                partial = rng.choice(all_candidates)
+                attempts += 1
+
+            if partial.is_complete():
+                best = self._try_complete(partial, validate, evaluate, start_time, ui, best)
+
+        return best

--- a/aeon/synthesis/modules/tdsyn/worklist.py
+++ b/aeon/synthesis/modules/tdsyn/worklist.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from aeon.core.liquid import LiquidTerm
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    Hole,
+    If,
+    Let,
+    Literal,
+    Rec,
+    RefinementApplication,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+    Var,
+)
+from aeon.core.types import Type
+from aeon.typechecking.context import TypingContext
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name, fresh_counter
+
+
+@dataclass
+class TypedHole:
+    """A hole carrying its expected type and the typing context at its position."""
+
+    name: Name
+    expected_type: Type
+    context: TypingContext
+    constraints: list[LiquidTerm] = field(default_factory=list)
+
+
+@dataclass
+class PartialAST:
+    """A partial term with its unfilled holes and current depth."""
+
+    term: Term
+    holes: list[TypedHole]
+    depth: int
+    constraints: list[LiquidTerm] = field(default_factory=list)
+
+    def is_complete(self) -> bool:
+        return len(self.holes) == 0
+
+
+def fresh_hole(
+    expected_type: Type,
+    context: TypingContext,
+    constraints: list[LiquidTerm] | None = None,
+) -> tuple[Hole, TypedHole]:
+    """Create a fresh hole with a unique name."""
+    name = Name("tdsyn_hole", fresh_counter.fresh())
+    loc = SynthesizedLocation("tdsyn")
+    hole_term = Hole(name, loc)
+    typed_hole = TypedHole(name, expected_type, context, constraints or [])
+    return hole_term, typed_hole
+
+
+def substitute_hole(term: Term, hole_name: Name, replacement: Term) -> Term:
+    """Replace a Hole node with the given name by the replacement term."""
+    match term:
+        case Hole(name, _) if name == hole_name:
+            return replacement
+        case Hole(_, _):
+            return term
+        case Application(fun, arg, loc):
+            return Application(
+                substitute_hole(fun, hole_name, replacement),
+                substitute_hole(arg, hole_name, replacement),
+                loc,
+            )
+        case Abstraction(var_name, body, loc):
+            return Abstraction(var_name, substitute_hole(body, hole_name, replacement), loc)
+        case If(cond, then, otherwise, loc):
+            return If(
+                substitute_hole(cond, hole_name, replacement),
+                substitute_hole(then, hole_name, replacement),
+                substitute_hole(otherwise, hole_name, replacement),
+                loc,
+            )
+        case Annotation(expr, ty, loc):
+            return Annotation(substitute_hole(expr, hole_name, replacement), ty, loc)
+        case Let(var_name, var_value, body, loc):
+            return Let(
+                var_name,
+                substitute_hole(var_value, hole_name, replacement),
+                substitute_hole(body, hole_name, replacement),
+                loc,
+            )
+        case Rec(var_name, var_type, var_value, body, loc):
+            return Rec(
+                var_name,
+                var_type,
+                substitute_hole(var_value, hole_name, replacement),
+                substitute_hole(body, hole_name, replacement),
+                loc,
+            )
+        case TypeApplication(body, ty, loc):
+            return TypeApplication(substitute_hole(body, hole_name, replacement), ty, loc)
+        case TypeAbstraction(name, kind, body, loc):
+            return TypeAbstraction(name, kind, substitute_hole(body, hole_name, replacement), loc)
+        case RefinementApplication(body, refinement, loc):
+            return RefinementApplication(
+                substitute_hole(body, hole_name, replacement),
+                substitute_hole(refinement, hole_name, replacement),
+                loc,
+            )
+        case Literal(_, _, _) | Var(_, _):
+            return term
+        case _:
+            return term

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -309,7 +309,8 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                     raise CoreWrongKindInTypeApplicationError(term=t, type=nty, expected_kind=tabs.kind, actual_kind=k)
                 return (c, s)
             else:
-                assert isinstance(tabs, AbstractionType)
+                if not isinstance(tabs, AbstractionType):
+                    raise CoreInvalidApplicationError(t, tabs)
                 return (c, tabs)
 
         case RefinementApplication(body, refinement):

--- a/tests/lsp_test.py
+++ b/tests/lsp_test.py
@@ -193,6 +193,8 @@ def test_synthesizers_list_non_empty():
 
 
 def test_synthesizers_includes_defaults():
+    assert "tdsyn_enumerative" in SYNTHESIZERS
+    assert "tdsyn" in SYNTHESIZERS
     assert "gp" in SYNTHESIZERS
     assert "enumerative" in SYNTHESIZERS
 


### PR DESCRIPTION
This pull request adds the type-directed `TDSynSynthesizer` backend and wires it into the factory, the LSP `SYNTHESIZERS` list, and the CLI.

**Public list (LSP code actions):** `tdsyn_enumerative` and `tdsyn` are listed first. Both use the same enumerative (BFS) mode so existing `-s tdsyn` expectations from the feature branch stay aligned while the explicit `tdsyn_enumerative` name is the documented default.

**CLI default:** `--synthesizer` now defaults to `tdsyn_enumerative`.

**Also included:** `tdsyn_random` is registered in the factory for type-directed random exploration but is not exposed in the LSP menu. `CoreInvalidApplicationError` is raised instead of an assertion for an invalid type-application target in `synth`, which avoids hard failures on some synthesis paths.

**Tests:** `tests/lsp_test.py` asserts both names appear in `SYNTHESIZERS`; the parametrized LSP synthesis test covers the new entries.

Made with [Cursor](https://cursor.com)