### PR TITLE
fix(sugar): align match pattern constructors after bind_program

### DIFF
--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -157,9 +157,10 @@ def bind_sterm(t: STerm, subs: RenamingSubstitions) -> STerm:
                     nb, branch_subs = check_name(b, branch_subs)
                     renamed_binders.append(nb)
                 n_body = bind_sterm(br.body, branch_subs)
-                n_branches.append(
-                    type(br)(constructor=br.constructor, binders=renamed_binders, body=n_body, loc=br.loc)
-                )
+                # Align pattern constructor names with the `Name` ids assigned while
+                # binding inductive constructor definitions (see `bind_program`).
+                ctor = apply_subs_name(subs, br.constructor)
+                n_branches.append(type(br)(constructor=ctor, binders=renamed_binders, body=n_body, loc=br.loc))
             return SMatch(n_scrutinee, n_branches, loc=loc)
         case SLet(name, body, cont, loc=loc):
             name, nsubs = check_name(name, subs)

--- a/tests/match_inductive_test.py
+++ b/tests/match_inductive_test.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from aeon.sugar.bind import bind_program
 from aeon.sugar.desugar import desugar
-from aeon.sugar.parser import parse_program
+from aeon.sugar.parser import parse_main_program, parse_program
 
 
 def test_match_lowering_intlist():
@@ -28,5 +29,29 @@ def test_match_lowering_intlist():
     # Lowering should remove SMatch nodes and use the generated eliminator.
     dumped = str(desugared.program)
     # Our surface AST pretty-print includes "match ... with" for SMatch.
+    assert "SMatch" not in dumped
+    assert "IntList_rec" in dumped
+
+
+def test_match_lowering_intlist_after_bind_program():
+    """`bind_program` renames inductive constructors; match branches must use the same names."""
+    src = """
+        inductive IntList
+        | empty : IntList
+        | cons (hd:Int) (tl:IntList) : IntList
+        def mk (l:IntList) : IntList {
+            match l with
+            | empty => l
+            | cons hd tl => l
+        }
+        def main (args:Int) : Int {
+            0
+        }
+    """
+
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    dumped = str(desugared.program)
     assert "SMatch" not in dumped
     assert "IntList_rec" in dumped


### PR DESCRIPTION
## Summary

- **Bug:** After `bind_program`, inductive constructor `Name`s get fresh ids, but `SMatch` branch constructors kept the parser ids. `lower_match_to_inductive_rec` compares constructors with `Name` equality, failed to pick an inductive, and left `SMatch` in the program. Typechecking then failed with errors like `Variable (match …) does not exist in context`.
- **Fix:** When binding `SMatch`, resolve each branch’s constructor with `apply_subs_name(subs, br.constructor)` so it matches the entries in the inductive declaration snapshot.
- **Test:** Regression test runs `bind_program` before `desugar` and asserts `SMatch` is gone and `IntList_rec` appears.

## Notes

End-to-end typechecking of eliminator handlers that use nested `\` abstractions is still a separate limitation; this change only fixes match lowering after bind.

Made with [Cursor](https://cursor.com)