### PR TITLE
feat: decreasing_by termination metrics (LH-style)

### DIFF
--- a/aeon/backend/evaluator.py
+++ b/aeon/backend/evaluator.py
@@ -75,7 +75,7 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
             return e
         case Let(var_name, var_value, body):
             return eval(body, ctx.with_var(var_name, eval(var_value, ctx)))
-        case Rec(var_name, _, var_value, body):
+        case Rec(var_name, _, var_value, body, _, _):
             if isinstance(var_value, Abstraction):
                 fun = var_value
 

--- a/aeon/core/bind.py
+++ b/aeon/core/bind.py
@@ -175,9 +175,16 @@ def bind_term(t: Term, subs: RenamingSubstitions) -> Term:
         case Let(name, body, cont, loc):
             name, nsubs = check_name(name, subs)
             return Let(name, bind_term(body, subs), bind_term(cont, nsubs), loc)
-        case Rec(name, ty, body, cont, loc):
+        case Rec(name, ty, body, cont, decreasing_by, loc):
             name, subs = check_name(name, subs)
-            return Rec(name, bind_type(ty, subs), bind_term(body, subs), bind_term(cont, subs), loc)
+            return Rec(
+                name,
+                bind_type(ty, subs),
+                bind_term(body, subs),
+                bind_term(cont, subs),
+                decreasing_by=tuple(bind_term(m, subs) for m in decreasing_by),
+                loc=loc,
+            )
         case _:
             assert False, f"Unique not supported for {t} ({type(t)})"
 

--- a/aeon/core/equality.py
+++ b/aeon/core/equality.py
@@ -99,12 +99,14 @@ def core_term_equality(term1: Term, term2: Term, rename_left: dict[Name, Name] |
             return core_term_equality(aval, bval, rename_left) and core_term_equality(
                 acont, bcont, rename_left | {aname: bname}
             )
-        case Rec(aname, atype, aval, acont), Rec(bname, btype, bval, bcont):
+        case Rec(aname, atype, aval, acont, adecr), Rec(bname, btype, bval, bcont, bdecr):
             nrename = rename_left | {aname: bname}
             return (
                 core_term_equality(aval, bval, nrename)
                 and core_type_equality(atype, btype, rename_left)
                 and core_term_equality(acont, bcont, nrename)
+                and len(adecr) == len(bdecr)
+                and all(core_term_equality(x, y, nrename) for x, y in zip(adecr, bdecr, strict=True))
             )
         case If(ac, at, ao), If(bc, bt, bo):
             return (

--- a/aeon/core/liquid_ops.py
+++ b/aeon/core/liquid_ops.py
@@ -43,3 +43,14 @@ def mk_liquid_and(e1: LiquidTerm, e2: LiquidTerm):
         return e2
     else:
         return LiquidApp(Name("&&", 0), [e1, e2])
+
+
+def mk_liquid_or(e1: LiquidTerm, e2: LiquidTerm) -> LiquidTerm:
+    if e1 == LiquidLiteralBool(True) or e2 == LiquidLiteralBool(True):
+        return LiquidLiteralBool(True)
+    elif e1 == LiquidLiteralBool(False):
+        return e2
+    elif e2 == LiquidLiteralBool(False):
+        return e1
+    else:
+        return LiquidApp(Name("||", 0), [e1, e2])

--- a/aeon/core/parser.py
+++ b/aeon/core/parser.py
@@ -85,7 +85,7 @@ class TreeToCore(Transformer):
         return Let(Name(args[0]), args[1], args[2])
 
     def rec_e(self, args):
-        return Rec(Name(args[0]), args[1], args[2], args[3])
+        return Rec(Name(args[0]), args[1], args[2], args[3], decreasing_by=())
 
     def if_e(self, args):
         return If(args[0], args[1], args[2])

--- a/aeon/core/pprint.py
+++ b/aeon/core/pprint.py
@@ -124,7 +124,7 @@ def custom_preludes_ops_representation(term: Term, counter: int = 0) -> tuple[st
             body_str, counter = custom_preludes_ops_representation(body, counter)
             return f"""(let {var_name} {var_value_prefix}{var_value_str} in\n {body_str})""", counter
 
-        case Rec(var_name=var_name, var_type=var_type, var_value=var_value, body=body):
+        case Rec(var_name=var_name, var_type=var_type, var_value=var_value, body=body, decreasing_by=_):
             var_value_str, counter = custom_preludes_ops_representation(var_value, counter)
             body_str, counter = custom_preludes_ops_representation(body, counter)
             return f"""(let {var_name} : {var_type} = {var_value_str} in\n {body_str})""", counter

--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -81,11 +81,11 @@ def substitute_vartype_in_term(t: Term, rep: Type, name: Name) -> Term:
             n_value = rec(var_value)
             n_body = rec(body)
             return Let(var_name, n_value, n_body, loc=loc)
-        case Rec(var_name, var_type, var_value, body, loc):
+        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
             n_value = rec(var_value)
             n_type = substitute_vartype(var_type, rep, name)
             n_body = rec(body)
-            return Rec(var_name, n_type, n_value, n_body, loc=loc)
+            return Rec(var_name, n_type, n_value, n_body, decreasing_by=decreasing_by, loc=loc)
         case Annotation(expr, type, loc):
             n_type = substitute_vartype(type, rep, name)
             return Annotation(rec(expr), n_type, loc=loc)
@@ -341,9 +341,9 @@ def substitution_liquid_in_term(t: Term, rep: LiquidTerm, name: Name) -> Term:
             return Abstraction(var_name, rec(body), loc=loc)
         case Let(var_name, var_value, body, loc):
             return Let(var_name, rec(var_value), rec(body), loc=loc)
-        case Rec(var_name, var_type, var_value, body, loc):
+        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
             n_type = substitution_liquid_in_type(var_type, rep, name)
-            return Rec(var_name, n_type, rec(var_value), rec(body), loc=loc)
+            return Rec(var_name, n_type, rec(var_value), rec(body), decreasing_by=decreasing_by, loc=loc)
         case Annotation(expr, ty, loc):
             n_type = substitution_liquid_in_type(ty, rep, name)
             return Annotation(rec(expr), n_type, loc=loc)
@@ -421,14 +421,14 @@ def substitution(t: Term, rep: Term, name: Name) -> Term:
                 n_value = rec(val)
                 n_body = rec(body)
             return Let(tname, n_value, n_body, loc=loc)
-        case Rec(tname, ty, val, body, loc):
+        case Rec(tname, ty, val, body, decreasing_by, loc):
             if tname == name:
                 n_value = val
                 n_body = body
             else:
                 n_value = rec(val)
                 n_body = rec(body)
-            return Rec(tname, ty, n_value, n_body, loc=loc)
+            return Rec(tname, ty, n_value, n_body, decreasing_by=decreasing_by, loc=loc)
         case Annotation(body, ty, loc):
             return Annotation(rec(body), ty, loc=loc)
         case If(cond, then, otherwise, loc):
@@ -450,7 +450,7 @@ def inline_lets(t: Term) -> Term:
     match t:
         case Let(var_name, var_value, body):
             return inline_lets(substitution(body, var_value, var_name))
-        case Rec(var_name, _, var_value, body):
+        case Rec(var_name, _, var_value, body, _, _):
             return inline_lets(substitution(body, var_value, var_name))
         case Application(Annotation(Abstraction(var_name, body), _), arg):
             return inline_lets(substitution(body, arg, var_name))
@@ -562,7 +562,7 @@ def liquefy(rep: Term) -> LiquidTerm | None:
             return LiquidHornApplication(name, argtypes=[], loc=loc)
         case Let(_, _, _):
             return liquefy_let(rep)
-        case Rec(_, _, _, _):
+        case Rec(_, _, _, _, _):
             return liquefy_rec(rep)
         case If(_, _, _):
             return liquefy_if(rep)

--- a/aeon/core/terms.py
+++ b/aeon/core/terms.py
@@ -142,6 +142,7 @@ class Rec(Term):
     var_type: Type
     var_value: Term
     body: Term
+    decreasing_by: tuple[Term, ...] = field(default_factory=tuple)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __repr__(self):
@@ -162,6 +163,7 @@ class Rec(Term):
             and self.var_type == other.var_type
             and self.var_value == other.var_value
             and self.body == other.body
+            and self.decreasing_by == other.decreasing_by
         )
 
 

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -85,7 +85,7 @@ def elaborate_foralls(e: STerm) -> STerm:
             | SRefinementApplication(_, _)
         ):
             return e
-        case SRec(_, _, _, _, loc):
+        case SRec(_, _, _, _, _, loc):
             e1: SRec = e
             if len(get_type_vars(e.var_type)) > 0:
                 nt = e.var_type
@@ -102,7 +102,7 @@ def elaborate_foralls(e: STerm) -> STerm:
                         body=nv,
                     )
 
-                e1 = SRec(e.var_name, nt, nv, e.body, loc=loc)
+                e1 = SRec(e.var_name, nt, nv, e.body, decreasing_by=e.decreasing_by, loc=loc)
             return e1
         case _:
             assert False, f"Could not elaborate {e} ({type(e)})"
@@ -314,7 +314,10 @@ def elaborate_synth(ctx: ElaborationTypingContext, t: STerm) -> tuple[STerm, STy
                             return SApplication(nfun, narg), return_type
                         case _:
                             nname = Name("_anf", fresh_counter.fresh())
-                            return SRec(nname, arg_type, narg, SApplication(nfun, SVar(nname)), loc=loc), return_type
+                            return (
+                                SRec(nname, arg_type, narg, SApplication(nfun, SVar(nname)), decreasing_by=(), loc=loc),
+                                return_type,
+                            )
                 case _:
                     assert False, f"Expected an abstraction type, but got {nfun_type} for {nfun}."
         case _:
@@ -333,11 +336,11 @@ def elaborate_check(ctx: ElaborationTypingContext, t: STerm, ty: SType) -> STerm
             nctx = ctx.with_var(name, u)
             nbody = elaborate_check(nctx, body, ty)
             return SLet(name, nval, nbody, loc=loc)
-        case (SRec(name, vty, val, body, loc=loc), _):
+        case (SRec(name, vty, val, body, decreasing_by, loc=loc), _):
             nctx = ctx.with_var(name, vty)
             nval = elaborate_check(nctx, val, vty)
             nbody = elaborate_check(nctx, body, ty)
-            return SRec(name, vty, nval, nbody, loc=loc)
+            return SRec(name, vty, nval, nbody, decreasing_by=decreasing_by, loc=loc)
         case (SIf(cond, then, otherwise, loc=loc), _):
             ncond = elaborate_check(ctx, cond, st_bool)
             nthen = elaborate_check(ctx, then, ty)
@@ -505,12 +508,17 @@ def elaborate_remove_unification(ctx: ElaborationTypingContext, t: STerm) -> STe
         case SLet(name, val, body, loc=loc):
             nctx = ctx.with_var(t.var_name, st_unit)  # TODO poly: Unit??
             return SLet(name, elaborate_remove_unification(ctx, val), elaborate_remove_unification(nctx, body), loc=loc)
-        case SRec(name, ty, val, body, loc=loc):
+        case SRec(name, ty, val, body, decreasing_by, loc=loc):
             nty = handle_unification_in_type(ctx, ty)
             nt = remove_unions_and_intersections(ctx, ty)
             nctx = ctx.with_var(t.var_name, t.var_type)
             return SRec(
-                name, nty, elaborate_remove_unification(nctx, val), elaborate_remove_unification(nctx, body), loc=loc
+                name,
+                nty,
+                elaborate_remove_unification(nctx, val),
+                elaborate_remove_unification(nctx, body),
+                decreasing_by=decreasing_by,
+                loc=loc,
             )
 
         case SIf(cond, then, otherwise, loc=loc):

--- a/aeon/frontend/anf_converter.py
+++ b/aeon/frontend/anf_converter.py
@@ -63,17 +63,24 @@ class ANFConverter:
                         vvalue = self.convert(vvalue)
                         vbody = self.convert(vbody)
                         return Let(vname, vvalue, self.convert(Let(name, vbody, body, loc=loc)), loc=iloc)
-                    case Rec(var_name=vname, var_type=vtype, var_value=vvalue, body=vbody, loc=loc):
+                    case Rec(var_name=vname, var_type=vtype, var_value=vvalue, body=vbody, decreasing_by=db, loc=loc):
                         assert name != vname
                         vvalue = self.convert(vvalue)
                         vbody = self.convert(vbody)
-                        return Rec(vname, vtype, vvalue, self.convert(Let(name, vbody, body, loc=loc)), loc=loc)
+                        return Rec(
+                            vname,
+                            vtype,
+                            vvalue,
+                            self.convert(Let(name, vbody, body, loc=loc)),
+                            decreasing_by=db,
+                            loc=loc,
+                        )
                     case _:
                         return Let(name, value, body, loc=loc)
-            case Rec(var_name=name, var_type=type, var_value=value, body=body, loc=loc):
+            case Rec(var_name=name, var_type=type, var_value=value, body=body, decreasing_by=db, loc=loc):
                 value = self.convert(value)
                 body = self.convert(body)
-                return Rec(name, type, value, body, loc=loc)
+                return Rec(name, type, value, body, decreasing_by=db, loc=loc)
             case Abstraction(var_name=name, body=body, loc=loc):
                 body = self.convert(body)
                 return Abstraction(var_name=name, body=body, loc=loc)

--- a/aeon/optimization/normal_form.py
+++ b/aeon/optimization/normal_form.py
@@ -133,8 +133,8 @@ def nf(t: Term) -> Term:
             return Application(nf(fun), nf(arg))
         case Let(var_name, var_value, body):
             return substitution(body, nf(var_value), var_name)
-        case Rec(var_name, var_type, var_value, body):
-            return Rec(var_name, var_type, nf(var_value), nf(body))
+        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
+            return Rec(var_name, var_type, nf(var_value), nf(body), decreasing_by=decreasing_by, loc=loc)
 
         case If(cond, then, otherwise):
             return If(nf(cond), nf(then), nf(otherwise))

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -25,8 +25,10 @@ def : soft_constraint "def" ID ":" type "=" expression ";"                  -> d
     | soft_constraint "def" ID  args ":" type decreasing_by_opt "{" expression "}"     -> def_fun
     | soft_constraint "def" ID  args ":" type decreasing_by_opt "=" expression ";"     -> def_fun_eq
 
-decreasing_by_opt: "decreasing_by" "[" expression "]" -> decreasing_by_one
+decreasing_by_opt: "decreasing_by" "[" decreasing_exprs "]" -> decreasing_by_list
                  | -> decreasing_by_none
+
+decreasing_exprs: expression ("," expression)* -> decreasing_exprs
 
 
 soft_constraint :                      -> empty_list

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -22,8 +22,11 @@ measures : measure_rule*                                  -> list
 measure_rule : "+" ID args ":" type                        -> def_ind_cons
 
 def : soft_constraint "def" ID ":" type "=" expression ";"                  -> def_cons
-    | soft_constraint "def" ID  args ":" type "{" expression "}"     -> def_fun
-    | soft_constraint "def" ID  args ":" type "=" expression ";"     -> def_fun_eq
+    | soft_constraint "def" ID  args ":" type decreasing_by_opt "{" expression "}"     -> def_fun
+    | soft_constraint "def" ID  args ":" type decreasing_by_opt "=" expression ";"     -> def_fun_eq
+
+decreasing_by_opt: "decreasing_by" "[" expression "]" -> decreasing_by_one
+                 | -> decreasing_by_none
 
 
 soft_constraint :                      -> empty_list

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -165,9 +165,12 @@ def bind_sterm(t: STerm, subs: RenamingSubstitions) -> STerm:
         case SLet(name, body, cont, loc=loc):
             name, nsubs = check_name(name, subs)
             return SLet(name, bind_sterm(body, subs), bind_sterm(cont, nsubs), loc=loc)
-        case SRec(name, ty, body, cont, loc=loc):
+        case SRec(name, ty, body, cont, decreasing_by, loc=loc):
             name, subs = check_name(name, subs)
-            return SRec(name, bind_stype(ty, subs), bind_sterm(body, subs), bind_sterm(cont, subs), loc=loc)
+            nd = tuple(bind_sterm(m, subs) for m in decreasing_by)
+            return SRec(
+                name, bind_stype(ty, subs), bind_sterm(body, subs), bind_sterm(cont, subs), decreasing_by=nd, loc=loc
+            )
         case _:
             assert False, f"Unique not supported for {t} ({type(t)})"
 
@@ -190,12 +193,15 @@ def _bind_definition(
         nname, nsubs = check_name(pname, nsubs)
         rforalls.append((nname, bind_stype(psort, nsubs)))
     ntype = bind_stype(df.type, nsubs)
+    decreasing = [bind_sterm(m, nsubs) for m in df.decreasing_by]
     body = bind_sterm(df.body, nsubs)
     decorators = []
     for dec in df.decorators:
         dargs = [bind_sterm(da, subs) for da in dec.macro_args]
         decorators.append(Decorator(dec.name, dargs))
-    return Definition(name, foralls, args, ntype, body, decorators, rforalls, loc=df.loc), nsubs
+    return Definition(
+        name, foralls, args, ntype, body, decorators, rforalls, decreasing_by=decreasing, loc=df.loc
+    ), nsubs
 
 
 def bind_program(p: Program, subs: RenamingSubstitions) -> Program:

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -157,9 +157,10 @@ def bind_sterm(t: STerm, subs: RenamingSubstitions) -> STerm:
                     nb, branch_subs = check_name(b, branch_subs)
                     renamed_binders.append(nb)
                 n_body = bind_sterm(br.body, branch_subs)
-                n_branches.append(
-                    type(br)(constructor=br.constructor, binders=renamed_binders, body=n_body, loc=br.loc)
-                )
+                # Align pattern constructor names with the `Name` ids assigned while
+                # binding inductive constructor definitions (see `bind_program`).
+                ctor = apply_subs_name(subs, br.constructor)
+                n_branches.append(type(br)(constructor=ctor, binders=renamed_binders, body=n_body, loc=br.loc))
             return SMatch(n_scrutinee, n_branches, loc=loc)
         case SLet(name, body, cont, loc=loc):
             name, nsubs = check_name(name, subs)

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 from pathlib import Path
 from typing import NamedTuple
 
@@ -55,6 +56,59 @@ from aeon.sugar.ast_helpers import st_int, st_string
 from aeon.facade.api import ImportError
 
 
+def _stype_base_int(ty: SType) -> bool:
+    match ty:
+        case SRefinedType(_, inner, _):
+            return _stype_base_int(inner)
+        case STypeConstructor(Name("Int", _), _):
+            return True
+        case _:
+            return False
+
+
+def _sugar_contains_recursive_call(t: STerm, fname: Name) -> bool:
+    def is_call_tree(node: STerm) -> bool:
+        cur = node
+        while isinstance(cur, SApplication):
+            cur = cur.fun
+        return isinstance(cur, SVar) and cur == fname
+
+    def walk(node: STerm) -> bool:
+        if isinstance(node, SApplication) and is_call_tree(node):
+            return True
+        match node:
+            case SApplication(fun, arg, _):
+                return walk(fun) or walk(arg)
+            case SAbstraction(_, body, _):
+                return walk(body)
+            case SLet(_, val, body, _):
+                return walk(val) or walk(body)
+            case SRec(_, _, val, body, _, _):
+                return walk(val) or walk(body)
+            case SIf(c, th, el, _):
+                return walk(c) or walk(th) or walk(el)
+            case SAnnotation(e, _, _):
+                return walk(e)
+            case SMatch(s, brs, _):
+                return walk(s) or any(walk(b.body) for b in brs)
+            case _:
+                return False
+
+    return walk(t)
+
+
+def definition_with_inferred_decreasing(d: Definition) -> Definition:
+    """If omitted, use the sole ``Int`` parameter as the metric for unary self-recursion."""
+    if d.decreasing_by or len(d.args) != 1:
+        return d
+    pname, pty = d.args[0]
+    if not _stype_base_int(pty):
+        return d
+    if not _sugar_contains_recursive_call(d.body, d.name):
+        return d
+    return replace(d, decreasing_by=[SVar(pname)])
+
+
 class DesugaredProgram(NamedTuple):
     program: STerm
     elabcontext: ElaborationTypingContext
@@ -106,7 +160,7 @@ def lower_match_to_inductive_rec(prog: STerm, inductive_decls: list[InductiveDec
             # Each constructor is represented as a Definition in sugar, where `args`
             # already carries the types we need to place the bound variables.
             match cons:
-                case Definition(cname, _, cargs, _, _, _, _):
+                case Definition(cname, _, cargs, _, _, _, _, _, _):
                     cons_map[cname] = cargs
         inductive_info[decl.name] = cons_map
 
@@ -145,7 +199,7 @@ def lower_match_to_inductive_rec(prog: STerm, inductive_decls: list[InductiveDec
                         continue
                     for cons_def in decl.constructors:
                         match cons_def:
-                            case Definition(cname, _, cargs, _, _, _, _):
+                            case Definition(cname, _, cargs, _, _, _, _, _, _):
                                 # Find the matching branch, if missing use a hole-like undefined.
                                 branch_expr = None
                                 for b in lowered_branches:
@@ -178,8 +232,9 @@ def lower_match_to_inductive_rec(prog: STerm, inductive_decls: list[InductiveDec
                 return SAbstraction(name, lower_term(body), loc=loc)
             case SLet(name, val, body, loc=loc):
                 return SLet(name, lower_term(val), lower_term(body), loc=loc)
-            case SRec(name, ty, val, body, loc=loc):
-                return SRec(name, ty, lower_term(val), lower_term(body), loc=loc)
+            case SRec(name, ty, val, body, decreasing_by, loc=loc):
+                nd = tuple(lower_term(m) for m in decreasing_by)
+                return SRec(name, ty, lower_term(val), lower_term(body), decreasing_by=nd, loc=loc)
             case SIf(cond, then, otherwise, loc=loc):
                 return SIf(lower_term(cond), lower_term(then), lower_term(otherwise), loc=loc)
             case SAnnotation(expr, ty, loc=loc):
@@ -211,7 +266,7 @@ def expand_inductive_decls(p: Program) -> Program:
 
                 for measure in measures:
                     match measure:
-                        case Definition(mname, mforalls, margs, mrtype, _, _, _, mloc):
+                        case Definition(mname, mforalls, margs, mrtype, _, _, _, _, mloc):
                             de = Definition(mname, mforalls, margs, mrtype, uninterpreted_lit, loc=mloc)
                             defs.append(de)
 
@@ -220,7 +275,7 @@ def expand_inductive_decls(p: Program) -> Program:
 
                 for constructor in constructors:
                     match constructor:
-                        case Definition(cname, cforalls, cargs, crtype, _, _, _, cloc):
+                        case Definition(cname, cforalls, cargs, crtype, _, _, _, _, cloc):
                             arg_s = ", ".join(str(arg.name) for (arg, _) in cargs)
                             mk_tuple = SApplication(
                                 SVar(Name("native", 0)), SLiteral(f"('{key_for(name, cname)}', {arg_s})", st_string)
@@ -268,6 +323,7 @@ def expand_inductive_decls(p: Program) -> Program:
                     type=return_type,
                     body=rec_body,
                     rforalls=[],
+                    decreasing_by=[],
                     loc=loc,
                 )
                 defs.append(rec_de)
@@ -283,7 +339,7 @@ def introduce_forall_in_types(defs: list[Definition], type_decls: list[TypeDecl]
     ndefs = []
     for d in defs:
         match d:
-            case Definition(name, foralls, args, rtype, body, decorators, rforalls, loc):
+            case Definition(name, foralls, args, rtype, body, decorators, rforalls, decreasing_by, loc):
                 new_foralls: list[tuple[Name, Kind]] = []
 
                 tlst: list[SType] = [ty for _, ty in args] + [rtype]
@@ -303,6 +359,7 @@ def introduce_forall_in_types(defs: list[Definition], type_decls: list[TypeDecl]
                         body,
                         decorators,
                         rforalls,
+                        decreasing_by,
                         loc,
                     )
                 )
@@ -355,7 +412,7 @@ def introduce_rforall_in_types(defs: list[Definition]) -> list[Definition]:
     ndefs: list[Definition] = []
     for d in defs:
         match d:
-            case Definition(name, foralls, args, rtype, body, decorators, rforalls, loc):
+            case Definition(name, foralls, args, rtype, body, decorators, rforalls, decreasing_by, loc):
                 acc: dict[Name, SType] = {}
                 tlst: list[SType] = [ty for _, ty in args] + [rtype]
                 for ty in tlst:
@@ -386,6 +443,7 @@ def introduce_rforall_in_types(defs: list[Definition]) -> list[Definition]:
                         body,
                         decorators,
                         final_rforalls,
+                        decreasing_by,
                         loc,
                     )
                 )
@@ -492,7 +550,7 @@ def replace_concrete_types(
 
 def type_of_definition(d: Definition) -> SType:
     match d:
-        case Definition(_, foralls, args, rtype, _, _, rforalls, loc):
+        case Definition(_, foralls, args, rtype, _, _, rforalls, _, loc):
             ntype = rtype
             for name, atype in reversed(args):
                 ntype = SAbstractionType(name, atype, ntype, loc)
@@ -506,8 +564,9 @@ def type_of_definition(d: Definition) -> SType:
 
 
 def convert_definition_to_srec(prog: STerm, d: Definition) -> STerm:
+    d = definition_with_inferred_decreasing(d)
     match d:
-        case Definition(dname, foralls, args, rtype, body, _, rforalls, loc):
+        case Definition(dname, foralls, args, rtype, body, _, rforalls, decreasing_by, loc):
             ntype = rtype
             nbody = body
             for name, atype in reversed(args):
@@ -519,7 +578,7 @@ def convert_definition_to_srec(prog: STerm, d: Definition) -> STerm:
             for name, kind in reversed(foralls):
                 ntype = STypePolymorphism(name, kind, ntype, loc=loc)
                 nbody = STypeAbstraction(name, kind, nbody, loc=loc)
-            return SRec(dname, ntype, nbody, prog, loc=loc)
+            return SRec(dname, ntype, nbody, prog, decreasing_by=tuple(decreasing_by), loc=loc)
         case _:
             assert False, f"{d} is not a definition"
 

--- a/aeon/sugar/equality.py
+++ b/aeon/sugar/equality.py
@@ -70,12 +70,14 @@ def term_equality(a: STerm, b: STerm, rename_left: dict[Name, Name] | None = Non
             return term_equality(abody, bbody, rename_left | {an: bn})
         case SLet(aname, aval, acont), SLet(bname, bval, bcont):
             return term_equality(aval, bval, rename_left) and term_equality(acont, bcont, rename_left | {aname: bname})
-        case SRec(aname, atype, aval, acont), SRec(bname, btype, bval, bcont):
+        case SRec(aname, atype, aval, acont, adecr), SRec(bname, btype, bval, bcont, bdecr):
             nrename = rename_left | {aname: bname}
             return (
                 term_equality(aval, bval, nrename)
                 and type_equality(atype, btype, rename_left)
                 and term_equality(acont, bcont, nrename)
+                and len(adecr) == len(bdecr)
+                and all(term_equality(x, y, nrename) for x, y in zip(adecr, bdecr, strict=True))
             )
         case SAnnotation(ae, at), SAnnotation(be, bt):
             return term_equality(ae, be, rename_left) and type_equality(at, bt, rename_left)

--- a/aeon/sugar/lifting.py
+++ b/aeon/sugar/lifting.py
@@ -119,8 +119,15 @@ def lift(t: Term) -> STerm:
             return SAbstraction(var_name, lift(body), loc=loc)
         case Let(var_name, var_value, body, loc):
             return SLet(var_name, lift(var_value), lift(body), loc=loc)
-        case Rec(var_name, var_type, var_value, body, loc):
-            return SRec(var_name, lift_type(var_type), lift(var_value), lift(body), loc=loc)
+        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
+            return SRec(
+                var_name,
+                lift_type(var_type),
+                lift(var_value),
+                lift(body),
+                decreasing_by=tuple(lift(m) for m in decreasing_by),
+                loc=loc,
+            )
         case If(cond, then, otherwise, loc):
             return SIf(lift(cond), lift(then), lift(otherwise), loc=loc)
         case TypeAbstraction(name, kind, body, loc):

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -164,7 +164,7 @@ def liquefy(t: STerm, available_vars: list[tuple[Name, TypeConstructor | TypeVar
             if lval and lbody:
                 return substitution_in_liquid(lbody, lval, name)
             return None
-        case SRec(name, _, val, body):
+        case SRec(name, _, val, body, _, _):
             lval = liquefy(val, available_vars)  # TODO: induction?
             lbody = liquefy(body, available_vars)
             if lval and lbody:
@@ -249,8 +249,15 @@ def lower_to_core(t: STerm) -> Term:
             return Application(lower_to_core(fun), lower_to_core(arg), loc=loc)
         case SLet(name, val, body, loc):
             return Let(name, lower_to_core(val), lower_to_core(body), loc=loc)
-        case SRec(name, ty, val, body, loc):
-            return Rec(name, type_to_core(ty), lower_to_core(val), lower_to_core(body), loc=loc)
+        case SRec(name, ty, val, body, decreasing_by, loc):
+            return Rec(
+                name,
+                type_to_core(ty),
+                lower_to_core(val),
+                lower_to_core(body),
+                decreasing_by=tuple(lower_to_core(m) for m in decreasing_by),
+                loc=loc,
+            )
         case SAnnotation(expr, ty, loc):
             return Annotation(lower_to_core(expr), type_to_core(ty), loc=loc)
         case SAbstraction(name, body, loc):

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -323,9 +323,12 @@ class TreeToSugar(Transformer):
     def decreasing_by_none(self, args):
         return []
 
+    def decreasing_exprs(self, args):
+        return list(args)
+
     @v_args(meta=True)
-    def decreasing_by_one(self, meta, args):
-        return [args[0]]
+    def decreasing_by_list(self, meta, args):
+        return args[0]
 
     @v_args(meta=True)
     def def_fun(self, meta, args):

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -130,13 +130,13 @@ class TreeToSugar(Transformer):
 
     @v_args(meta=True)
     def rec_e(self, meta, args):
-        return SRec(Name(args[0]), args[1], args[2], args[3], loc=self._loc(meta))
+        return SRec(Name(args[0]), args[1], args[2], args[3], decreasing_by=(), loc=self._loc(meta))
 
     @v_args(meta=True)
     def rec_refined_e(self, meta, args):
         name = Name(args[0])
         refined_type = SRefinedType(name, args[1], args[2])
-        return SRec(name, refined_type, args[3], args[4], loc=self._loc(meta))
+        return SRec(name, refined_type, args[3], args[4], decreasing_by=(), loc=self._loc(meta))
 
     @v_args(meta=True)
     def if_e(self, meta, args):
@@ -320,13 +320,40 @@ class TreeToSugar(Transformer):
     def def_ind_cons(self, meta, args):
         return Definition(Name(args[0]), [], args[1], args[2], SLiteral(None, st_unit), loc=self._loc(meta))
 
+    def decreasing_by_none(self, args):
+        return []
+
+    @v_args(meta=True)
+    def decreasing_by_one(self, meta, args):
+        return [args[0]]
+
     @v_args(meta=True)
     def def_fun(self, meta, args):
-        if len(args) == 4:
-            return Definition(Name(args[0]), [], args[1], args[2], args[3], loc=self._loc(meta))
-        else:
-            decorators = args[0]
-            return Definition(Name(args[1]), [], args[2], args[3], args[4], decorators, loc=self._loc(meta))
+        if len(args) == 5:
+            name, fn_args, rtype, decr, body = args
+            return Definition(
+                Name(name),
+                [],
+                fn_args,
+                rtype,
+                body,
+                decreasing_by=ensure_list(decr),
+                loc=self._loc(meta),
+            )
+        if len(args) == 6:
+            decorators, name, fn_args, rtype, decr, body = args
+            return Definition(
+                Name(name),
+                [],
+                fn_args,
+                rtype,
+                body,
+                decorators,
+                [],
+                decreasing_by=ensure_list(decr),
+                loc=self._loc(meta),
+            )
+        raise AssertionError(f"def_fun: unexpected args {args!r}")
 
     @v_args(meta=True)
     def def_cons(self, meta, args):

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -137,6 +137,7 @@ class SRec(STerm):
     var_type: SType
     var_value: STerm
     body: STerm
+    decreasing_by: tuple[STerm, ...] = field(default_factory=tuple)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __repr__(self):
@@ -157,6 +158,7 @@ class SRec(STerm):
             and self.var_type == other.var_type
             and self.var_value == other.var_value
             and self.body == other.body
+            and self.decreasing_by == other.decreasing_by
         )
 
 
@@ -319,6 +321,7 @@ class Definition(Node):
     body: STerm
     decorators: list[Decorator] = field(default_factory=list)
     rforalls: list[tuple[Name, SType]] = field(default_factory=list)
+    decreasing_by: list[STerm] = field(default_factory=list)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __post_init__(self):

--- a/aeon/sugar/substitutions.py
+++ b/aeon/sugar/substitutions.py
@@ -124,11 +124,12 @@ def substitution_sterm_in_sterm(t: STerm, beta: STerm, alpha: Name) -> STerm:
                 return SLet(vname, rec(vvalue), body, loc=loc)
             else:
                 return SLet(vname, rec(vvalue), rec(body), loc=loc)
-        case SRec(vname, vty, vvalue, body, loc):
+        case SRec(vname, vty, vvalue, body, decreasing_by, loc):
+            nd = tuple(rec(m) for m in decreasing_by)
             if vname == alpha:
-                return SRec(vname, rect(vty), rec(vvalue), body, loc=loc)
+                return SRec(vname, rect(vty), rec(vvalue), body, decreasing_by=nd, loc=loc)
             else:
-                return SRec(vname, rect(vty), rec(vvalue), rec(body), loc=loc)
+                return SRec(vname, rect(vty), rec(vvalue), rec(body), decreasing_by=nd, loc=loc)
         case SAnnotation(expr, ty, loc):
             return SAnnotation(rec(expr), rect(ty), loc=loc)
         case SIf(cond, then, otherwise, loc):
@@ -205,8 +206,11 @@ def substitution_svartype_in_sterm(t: STerm, rep: SType, name: Name) -> STerm:
             return SAbstraction(aname, rec(body), loc=loc)
         case SLet(vname, vvalue, body, loc):
             return SLet(vname, rec(vvalue), rec(body), loc=loc)
-        case SRec(vname, vtype, vvalue, body, loc):
-            return SRec(vname, substitute_svartype_in_stype(vtype, rep, name), rec(vvalue), rec(body), loc=loc)
+        case SRec(vname, vtype, vvalue, body, decreasing_by, loc):
+            nd = tuple(rec(m) for m in decreasing_by)
+            return SRec(
+                vname, substitute_svartype_in_stype(vtype, rep, name), rec(vvalue), rec(body), decreasing_by=nd, loc=loc
+            )
         case SAnnotation(expr, ty, loc):
             return SAnnotation(rec(expr), substitute_svartype_in_stype(ty, rep, name), loc=loc)
         case SIf(cond, then, otherwise, loc):

--- a/aeon/synthesis/fitness.py
+++ b/aeon/synthesis/fitness.py
@@ -97,6 +97,7 @@ def generate_term(
             var_type=fitness_return_type,
             var_value=fitness_terms[0],
             body=SVar(rec_name),
+            decreasing_by=(),
         )
     else:
         raise NotImplementedError("Not yet supported")

--- a/aeon/synthesis/identification.py
+++ b/aeon/synthesis/identification.py
@@ -84,7 +84,7 @@ def get_holes_info(
                 ctx = ctx.with_var(vname, t1)
                 hs2 = get_holes_info(ctx, t.body, ty, targets, refined_types)
             return hs1 | hs2
-        case Rec(var_name=vname, var_type=vtype, var_value=value, body=body):
+        case Rec(var_name=vname, var_type=vtype, var_value=value, body=body, decreasing_by=_):
             vtype = vtype if refined_types else refined_to_unrefined_type(vtype)
             if isinstance(vtype, AbstractionType) or isinstance(vtype, TypePolymorphism):
                 hs1 = get_holes_info(ctx.with_var(vname, vtype), value, vtype, targets, refined_types)
@@ -136,8 +136,9 @@ def get_holes(term: Term) -> list[Name]:
             return get_holes(body)
         case Let(var_name=_, var_value=value, body=body):
             return get_holes(value) + get_holes(body)
-        case Rec(var_name=_, var_type=_, var_value=value, body=body):
-            return get_holes(value) + get_holes(body)
+        case Rec(var_name=_, var_type=_, var_value=value, body=body, decreasing_by=decr):
+            nested = [h for m in decr for h in get_holes(m)]
+            return get_holes(value) + get_holes(body) + nested
         case TypeApplication(body=body, type=_):
             return get_holes(body)
         case TypeAbstraction(name=_, kind=_, body=body):

--- a/aeon/typechecking/qualifiers.py
+++ b/aeon/typechecking/qualifiers.py
@@ -86,7 +86,7 @@ def _collect_from_term(t: Term, sink: set[LiquidTerm]) -> None:
         case Let(_, v, b):
             _collect_from_term(v, sink)
             _collect_from_term(b, sink)
-        case Rec(_, vty, vv, b):
+        case Rec(_, vty, vv, b, _, _):
             _collect_from_type(vty, sink)
             _collect_from_term(vv, sink)
             _collect_from_term(b, sink)

--- a/aeon/typechecking/termination.py
+++ b/aeon/typechecking/termination.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidTerm, LiquidVar
-from aeon.core.types import LiquidHornApplication
-from aeon.core.substitutions import inline_lets, liquefy, substitution
+from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidLiteralInt, LiquidTerm, LiquidVar
+from aeon.core.liquid_ops import mk_liquid_and, mk_liquid_or
+from aeon.core.substitutions import inline_lets, liquefy, substitution, substitution_in_liquid
 from aeon.core.terms import (
     Abstraction,
     Annotation,
@@ -19,26 +19,12 @@ from aeon.core.terms import (
     TypeApplication,
     Var,
 )
+from aeon.core.types import AbstractionType, RefinedType, Type
 from aeon.utils.location import Location
 from aeon.utils.name import Name
 from aeon.verification.vcs import Conjunction, Constraint, LiquidConstraint
 
 ctrue = LiquidConstraint(LiquidLiteralBool(True))
-
-
-def _liquid_var_names_only(t: LiquidTerm | None) -> set[str]:
-    """Variable names appearing as ``LiquidVar`` (not operator symbols in ``LiquidApp``)."""
-    if t is None:
-        return set()
-    match t:
-        case LiquidVar(n):
-            return {n.name}
-        case LiquidApp(_, args, _):
-            return set().union(*(_liquid_var_names_only(a) for a in args))
-        case LiquidHornApplication(_, argtypes, _):
-            return set().union(*(_liquid_var_names_only(a) for a, _ in argtypes))
-        case _:
-            return set()
 
 
 def peel_abstractions(t: Term) -> tuple[list[Name], Term]:
@@ -48,6 +34,41 @@ def peel_abstractions(t: Term) -> tuple[list[Name], Term]:
         names.append(cur.var_name)
         cur = cur.body
     return names, cur
+
+
+def peel_type_formal_names(ty: Type) -> list[Name]:
+    names: list[Name] = []
+    cur: Type = ty
+    while isinstance(cur, AbstractionType):
+        names.append(cur.var_name)
+        cur = cur.type
+    return names
+
+
+def entry_refinement_liquids(
+    fn_arrow_type: Type, term_formals: list[Name], type_formals: list[Name]
+) -> list[LiquidTerm]:
+    """Opened refinement predicates for each curried ``RefinedType`` parameter (entry guards)."""
+    out: list[LiquidTerm] = []
+    cur: Type = fn_arrow_type
+    while isinstance(cur, AbstractionType):
+        match cur.var_type:
+            case RefinedType(bname, _bty, ref):
+                opened = substitution_in_liquid(ref, LiquidVar(cur.var_name), bname)
+                out.append(align_liquid_to_type_formals(opened, term_formals, type_formals))
+            case _:
+                pass
+        cur = cur.type
+    return out
+
+
+def align_liquid_to_type_formals(liq: LiquidTerm, term_names: list[Name], type_names: list[Name]) -> LiquidTerm:
+    """VCs use ``AbstractionType`` binders; liquefy may use distinct ``Name`` ids from lambdas."""
+    out = liq
+    for t_n, ty_n in zip(term_names, type_names, strict=True):
+        if t_n != ty_n:
+            out = substitution_in_liquid(out, LiquidVar(ty_n), t_n)
+    return out
 
 
 def peel_application_chain(t: Term) -> tuple[Term, list[Term]]:
@@ -61,50 +82,119 @@ def peel_application_chain(t: Term) -> tuple[Term, list[Term]]:
     return cur, args
 
 
-def collect_recursive_calls(fn: Name, arity: int, t: Term) -> list[tuple[list[Term], Location | None]]:
-    """All maximal application chains headed by ``Var(fn)`` with exactly ``arity`` arguments."""
-    found: list[tuple[list[Term], Location | None]] = []
+def _term_bool_not(cond: Term) -> Term:
+    """Surface ``!cond`` as a core application (see parser ``nnot``)."""
+    return Application(Var(Name("!", 0), loc=cond.loc), cond, loc=cond.loc)
 
-    def walk(tt: Term) -> None:
+
+def collect_recursive_calls_with_paths(
+    fn: Name, arity: int, t: Term
+) -> list[tuple[list[Term], Location | None, tuple[Term, ...]]]:
+    """Self-calls with ``arity`` args and a conjunction of branch conditions along ``If`` paths."""
+    found: list[tuple[list[Term], Location | None, tuple[Term, ...]]] = []
+
+    def walk(tt: Term, path: tuple[Term, ...]) -> None:
         match tt:
             case Application(_, _, _):
                 head, args = peel_application_chain(tt)
                 if isinstance(head, Var) and head.name == fn and len(args) == arity:
-                    found.append((args, tt.loc))
+                    found.append((args, tt.loc, path))
             case _:
                 pass
         match tt:
             case Application(fun, arg, _):
-                walk(fun)
-                walk(arg)
+                walk(fun, path)
+                walk(arg, path)
             case Abstraction(_, body, _):
-                walk(body)
+                walk(body, path)
             case Let(_, val, body, _):
-                walk(val)
-                walk(body)
+                walk(val, path)
+                walk(body, path)
             case Rec(_, _, val, body, _, _):
-                walk(val)
-                walk(body)
+                walk(val, path)
+                walk(body, path)
             case Annotation(expr, _, _):
-                walk(expr)
+                walk(expr, path)
             case If(cond, then, otherwise, _):
-                walk(cond)
-                walk(then)
-                walk(otherwise)
+                walk(cond, path)
+                walk(then, path + (cond,))
+                walk(otherwise, path + (_term_bool_not(cond),))
             case TypeApplication(body, _, _):
-                walk(body)
+                walk(body, path)
             case TypeAbstraction(_, _, body, _):
-                walk(body)
+                walk(body, path)
             case RefinementApplication(body, refinement, _):
-                walk(body)
-                walk(refinement)
+                walk(body, path)
+                walk(refinement, path)
             case RefinementAbstraction(_, _, body, _):
-                walk(body)
+                walk(body, path)
             case _:
                 pass
 
-    walk(t)
+    walk(t, ())
     return found
+
+
+def _full_path_guard_liquid(
+    entry_refs: list[LiquidTerm],
+    path: tuple[Term, ...],
+    formals: list[Name],
+    type_formals: list[Name],
+) -> LiquidTerm | None:
+    parts: list[LiquidTerm] = list(entry_refs)
+    if path:
+        pl = _liquefy_path_conjuncts(path, formals, type_formals)
+        if pl is None:
+            return None
+        if pl != LiquidLiteralBool(True):
+            parts.append(pl)
+    if not parts:
+        return LiquidLiteralBool(True)
+    acc = parts[0]
+    for p in parts[1:]:
+        acc = mk_liquid_and(acc, p)
+    return acc
+
+
+def _liquefy_path_conjuncts(path: tuple[Term, ...], formals: list[Name], type_formals: list[Name]) -> LiquidTerm | None:
+    if not path:
+        return LiquidLiteralBool(True)
+    parts: list[LiquidTerm] = []
+    for g in path:
+        liq = liquefy(inline_lets(g))
+        if liq is None:
+            return None
+        parts.append(align_liquid_to_type_formals(liq, formals, type_formals))
+    acc = parts[0]
+    for p in parts[1:]:
+        acc = mk_liquid_and(acc, p)
+    return acc
+
+
+def _metric_call_non_negative(call_ms: list[LiquidTerm]) -> LiquidTerm:
+    acc = LiquidApp(Name(">=", 0), [call_ms[0], LiquidLiteralInt(0)])
+    for m in call_ms[1:]:
+        acc = mk_liquid_and(acc, LiquidApp(Name(">=", 0), [m, LiquidLiteralInt(0)]))
+    return acc
+
+
+def _termination_obligation(
+    path: tuple[Term, ...],
+    lex: LiquidTerm,
+    call_ms: list[LiquidTerm],
+    formals: list[Name],
+    type_formals: list[Name],
+    entry_refs: list[LiquidTerm],
+) -> Constraint:
+    r"""``(entry /\ branch) => (lex and metric(call) >= 0)`` when guarded; else ``lex`` only."""
+    needs_call_nonneg = bool(path) or bool(entry_refs)
+    oblig = mk_liquid_and(lex, _metric_call_non_negative(call_ms)) if needs_call_nonneg else lex
+    full = _full_path_guard_liquid(entry_refs, path, formals, type_formals)
+    if full is None:
+        return LiquidConstraint(LiquidLiteralBool(False))
+    if full == LiquidLiteralBool(True):
+        return LiquidConstraint(oblig)
+    return LiquidConstraint(LiquidApp(Name("-->", 0), [full, oblig]))
 
 
 def substitute_formals(template: Term, formals: list[Name], args: list[Term]) -> Term:
@@ -114,35 +204,90 @@ def substitute_formals(template: Term, formals: list[Name], args: list[Term]) ->
     return out
 
 
+def _liquefy_metric_at(
+    metric: Term,
+    formals: list[Name],
+    type_formals: list[Name],
+    call_args: list[Term] | None,
+) -> LiquidTerm | None:
+    t = inline_lets(metric)
+    if call_args is not None:
+        t = substitute_formals(t, formals, [inline_lets(a) for a in call_args])
+        t = inline_lets(t)
+    liq = liquefy(t)
+    if liq is None:
+        return None
+    return align_liquid_to_type_formals(liq, formals, type_formals)
+
+
+def _fold_or(terms: list[LiquidTerm]) -> LiquidTerm:
+    acc = terms[0]
+    for t in terms[1:]:
+        acc = mk_liquid_or(acc, t)
+    return acc
+
+
+def _lexicographic_less(call_ms: list[LiquidTerm], entry_ms: list[LiquidTerm]) -> LiquidTerm:
+    """Strict lexicographic decrease (Liquid Haskell ``/ [m0, m1, …]``)."""
+    assert len(call_ms) == len(entry_ms) and len(call_ms) >= 1
+    k = len(call_ms)
+    disjuncts: list[LiquidTerm] = []
+    for j in range(k):
+        step_lt = LiquidApp(Name("<", 0), [call_ms[j], entry_ms[j]])
+        if j == 0:
+            disjuncts.append(step_lt)
+        else:
+            prefix = LiquidApp(Name("==", 0), [call_ms[0], entry_ms[0]])
+            for i in range(1, j):
+                prefix = mk_liquid_and(prefix, LiquidApp(Name("==", 0), [call_ms[i], entry_ms[i]]))
+            disjuncts.append(mk_liquid_and(prefix, step_lt))
+    return _fold_or(disjuncts)
+
+
 def termination_metric_constraints(rec: Rec) -> Constraint:
-    """For a single Int-valued metric, emit ``m(call) < m(params)`` at each self-call (LH-style)."""
+    r"""Lexicographic ``m(call) <* m(entry)`` (Liquid Haskell ``/ [m0, m1, …]``).
+
+    For self-calls under ``if`` branches, obligations are guarded:
+    ``branch => (lex and m(call) >= 0)``, e.g. ``fact (n-1)`` in the ``n != 0`` branch.
+    Entry refinements (``Nat``) stay as implication premises from typing.
+    """
     if not rec.decreasing_by:
         return ctrue
-    if len(rec.decreasing_by) != 1:
-        return LiquidConstraint(LiquidLiteralBool(False))
-    metric = rec.decreasing_by[0]
+    metrics = list(rec.decreasing_by)
     formals, inner = peel_abstractions(rec.var_value)
+    type_formals = peel_type_formal_names(rec.var_type)
+    if len(type_formals) != len(formals):
+        return LiquidConstraint(LiquidLiteralBool(False))
+    entry_refs = entry_refinement_liquids(rec.var_type, formals, type_formals)
+    # ANF introduces `let anf = …` around sub-expressions; inlining exposes call
+    # arguments in terms of parameters so liquefy does not mention ANF temps.
+    inner = inline_lets(inner)
     arity = len(formals)
-    calls = collect_recursive_calls(rec.var_name, arity, inner)
+    calls = collect_recursive_calls_with_paths(rec.var_name, arity, inner)
     if not calls:
         return ctrue
 
     parts: list[Constraint] = []
-    for call_args, _loc in calls:
+    for call_args, _loc, path in calls:
         if len(call_args) != arity:
             parts.append(LiquidConstraint(LiquidLiteralBool(False)))
             continue
-        m_entry = liquefy(inline_lets(metric))
-        m_call = liquefy(inline_lets(substitute_formals(metric, formals, call_args)))
-        if m_entry is None or m_call is None:
+        entry_ms: list[LiquidTerm] = []
+        call_ms: list[LiquidTerm] = []
+        bad = False
+        for metric in metrics:
+            m_entry = _liquefy_metric_at(metric, formals, type_formals, None)
+            m_call = _liquefy_metric_at(metric, formals, type_formals, call_args)
+            if m_entry is None or m_call is None:
+                bad = True
+                break
+            entry_ms.append(m_entry)
+            call_ms.append(m_call)
+        if bad:
             parts.append(LiquidConstraint(LiquidLiteralBool(False)))
             continue
-        allowed_names = {f.name for f in formals}
-        call_vars = _liquid_var_names_only(m_call)
-        if not call_vars.issubset(allowed_names):
-            # ANF temporaries in call arguments are not yet in VC scope; skip (see driver ANF order).
-            continue
-        parts.append(LiquidConstraint(LiquidApp(Name("<", 0), [m_call, m_entry])))
+        lex = _lexicographic_less(call_ms, entry_ms)
+        parts.append(_termination_obligation(path, lex, call_ms, formals, type_formals, entry_refs))
 
     if not parts:
         return ctrue

--- a/aeon/typechecking/termination.py
+++ b/aeon/typechecking/termination.py
@@ -1,0 +1,152 @@
+"""Termination metrics (Liquid Haskell-style) for recursive definitions."""
+
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidTerm, LiquidVar
+from aeon.core.types import LiquidHornApplication
+from aeon.core.substitutions import inline_lets, liquefy, substitution
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    If,
+    Let,
+    Rec,
+    RefinementAbstraction,
+    RefinementApplication,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+    Var,
+)
+from aeon.utils.location import Location
+from aeon.utils.name import Name
+from aeon.verification.vcs import Conjunction, Constraint, LiquidConstraint
+
+ctrue = LiquidConstraint(LiquidLiteralBool(True))
+
+
+def _liquid_var_names_only(t: LiquidTerm | None) -> set[str]:
+    """Variable names appearing as ``LiquidVar`` (not operator symbols in ``LiquidApp``)."""
+    if t is None:
+        return set()
+    match t:
+        case LiquidVar(n):
+            return {n.name}
+        case LiquidApp(_, args, _):
+            return set().union(*(_liquid_var_names_only(a) for a in args))
+        case LiquidHornApplication(_, argtypes, _):
+            return set().union(*(_liquid_var_names_only(a) for a, _ in argtypes))
+        case _:
+            return set()
+
+
+def peel_abstractions(t: Term) -> tuple[list[Name], Term]:
+    names: list[Name] = []
+    cur = t
+    while isinstance(cur, Abstraction):
+        names.append(cur.var_name)
+        cur = cur.body
+    return names, cur
+
+
+def peel_application_chain(t: Term) -> tuple[Term, list[Term]]:
+    """Left-associate application: ((f x) y) -> f, [x, y]."""
+    args: list[Term] = []
+    cur = t
+    while isinstance(cur, Application):
+        args.append(cur.arg)
+        cur = cur.fun
+    args.reverse()
+    return cur, args
+
+
+def collect_recursive_calls(fn: Name, arity: int, t: Term) -> list[tuple[list[Term], Location | None]]:
+    """All maximal application chains headed by ``Var(fn)`` with exactly ``arity`` arguments."""
+    found: list[tuple[list[Term], Location | None]] = []
+
+    def walk(tt: Term) -> None:
+        match tt:
+            case Application(_, _, _):
+                head, args = peel_application_chain(tt)
+                if isinstance(head, Var) and head.name == fn and len(args) == arity:
+                    found.append((args, tt.loc))
+            case _:
+                pass
+        match tt:
+            case Application(fun, arg, _):
+                walk(fun)
+                walk(arg)
+            case Abstraction(_, body, _):
+                walk(body)
+            case Let(_, val, body, _):
+                walk(val)
+                walk(body)
+            case Rec(_, _, val, body, _, _):
+                walk(val)
+                walk(body)
+            case Annotation(expr, _, _):
+                walk(expr)
+            case If(cond, then, otherwise, _):
+                walk(cond)
+                walk(then)
+                walk(otherwise)
+            case TypeApplication(body, _, _):
+                walk(body)
+            case TypeAbstraction(_, _, body, _):
+                walk(body)
+            case RefinementApplication(body, refinement, _):
+                walk(body)
+                walk(refinement)
+            case RefinementAbstraction(_, _, body, _):
+                walk(body)
+            case _:
+                pass
+
+    walk(t)
+    return found
+
+
+def substitute_formals(template: Term, formals: list[Name], args: list[Term]) -> Term:
+    out = template
+    for formal, arg in zip(formals, args, strict=True):
+        out = substitution(out, arg, formal)
+    return out
+
+
+def termination_metric_constraints(rec: Rec) -> Constraint:
+    """For a single Int-valued metric, emit ``m(call) < m(params)`` at each self-call (LH-style)."""
+    if not rec.decreasing_by:
+        return ctrue
+    if len(rec.decreasing_by) != 1:
+        return LiquidConstraint(LiquidLiteralBool(False))
+    metric = rec.decreasing_by[0]
+    formals, inner = peel_abstractions(rec.var_value)
+    arity = len(formals)
+    calls = collect_recursive_calls(rec.var_name, arity, inner)
+    if not calls:
+        return ctrue
+
+    parts: list[Constraint] = []
+    for call_args, _loc in calls:
+        if len(call_args) != arity:
+            parts.append(LiquidConstraint(LiquidLiteralBool(False)))
+            continue
+        m_entry = liquefy(inline_lets(metric))
+        m_call = liquefy(inline_lets(substitute_formals(metric, formals, call_args)))
+        if m_entry is None or m_call is None:
+            parts.append(LiquidConstraint(LiquidLiteralBool(False)))
+            continue
+        allowed_names = {f.name for f in formals}
+        call_vars = _liquid_var_names_only(m_call)
+        if not call_vars.issubset(allowed_names):
+            # ANF temporaries in call arguments are not yet in VC scope; skip (see driver ANF order).
+            continue
+        parts.append(LiquidConstraint(LiquidApp(Name("<", 0), [m_call, m_entry])))
+
+    if not parts:
+        return ctrue
+    acc: Constraint = parts[0]
+    for p in parts[1:]:
+        acc = Conjunction(acc, p)
+    return acc

--- a/aeon/typechecking/termination.py
+++ b/aeon/typechecking/termination.py
@@ -20,6 +20,7 @@ from aeon.core.terms import (
     Var,
 )
 from aeon.core.types import AbstractionType, RefinedType, Type
+from aeon.typechecking.context import TypingContext
 from aeon.utils.location import Location
 from aeon.utils.name import Name
 from aeon.verification.vcs import Conjunction, Constraint, LiquidConstraint
@@ -45,6 +46,17 @@ def peel_type_formal_names(ty: Type) -> list[Name]:
     return names
 
 
+def _opened_refinement_liquid(
+    var_type: Type, binder_name: Name, term_formals: list[Name], type_formals: list[Name]
+) -> LiquidTerm | None:
+    match var_type:
+        case RefinedType(bname, _bty, ref):
+            opened = substitution_in_liquid(ref, LiquidVar(binder_name), bname)
+            return align_liquid_to_type_formals(opened, term_formals, type_formals)
+        case _:
+            return None
+
+
 def entry_refinement_liquids(
     fn_arrow_type: Type, term_formals: list[Name], type_formals: list[Name]
 ) -> list[LiquidTerm]:
@@ -52,12 +64,9 @@ def entry_refinement_liquids(
     out: list[LiquidTerm] = []
     cur: Type = fn_arrow_type
     while isinstance(cur, AbstractionType):
-        match cur.var_type:
-            case RefinedType(bname, _bty, ref):
-                opened = substitution_in_liquid(ref, LiquidVar(cur.var_name), bname)
-                out.append(align_liquid_to_type_formals(opened, term_formals, type_formals))
-            case _:
-                pass
+        liq = _opened_refinement_liquid(cur.var_type, cur.var_name, term_formals, type_formals)
+        if liq is not None:
+            out.append(liq)
         cur = cur.type
     return out
 
@@ -87,61 +96,106 @@ def _term_bool_not(cond: Term) -> Term:
     return Application(Var(Name("!", 0), loc=cond.loc), cond, loc=cond.loc)
 
 
-def collect_recursive_calls_with_paths(
-    fn: Name, arity: int, t: Term
-) -> list[tuple[list[Term], Location | None, tuple[Term, ...]]]:
-    """Self-calls with ``arity`` args and a conjunction of branch conditions along ``If`` paths."""
-    found: list[tuple[list[Term], Location | None, tuple[Term, ...]]] = []
+def _synth_type(ctx: TypingContext, t: Term) -> Type | None:
+    """Lazy import: ``typeinfer`` imports this module at load time."""
+    try:
+        from aeon.typechecking.typeinfer import synth
 
-    def walk(tt: Term, path: tuple[Term, ...]) -> None:
+        return synth(ctx, t)[1]
+    except Exception:
+        return None
+
+
+def collect_recursive_calls_with_paths(
+    fn: Name,
+    arity: int,
+    t: Term,
+    typing_ctx: TypingContext | None,
+    inner_expect_ty: Type | None,
+    term_formals: list[Name],
+    type_formals: list[Name],
+) -> list[tuple[list[Term], Location | None, tuple[Term, ...], tuple[LiquidTerm, ...]]]:
+    """Self-calls with ``arity`` args, ``If`` path guards, and nested binder refinements (e.g. match)."""
+    found: list[tuple[list[Term], Location | None, tuple[Term, ...], tuple[LiquidTerm, ...]]] = []
+
+    def walk(
+        tt: Term,
+        path: tuple[Term, ...],
+        nested_refs: tuple[LiquidTerm, ...],
+        ctx: TypingContext | None,
+        expect_ty: Type | None,
+    ) -> None:
         match tt:
             case Application(_, _, _):
                 head, args = peel_application_chain(tt)
                 if isinstance(head, Var) and head.name == fn and len(args) == arity:
-                    found.append((args, tt.loc, path))
+                    found.append((args, tt.loc, path, nested_refs))
             case _:
                 pass
         match tt:
             case Application(fun, arg, _):
-                walk(fun, path)
-                walk(arg, path)
-            case Abstraction(_, body, _):
-                walk(body, path)
+                f_ty = _synth_type(ctx, fun) if ctx is not None else None
+                walk(fun, path, nested_refs, ctx, f_ty)
+                arg_ty: Type | None = None
+                match f_ty:
+                    case AbstractionType(_, vt, _):
+                        arg_ty = vt
+                walk(arg, path, nested_refs, ctx, arg_ty)
+            case Abstraction(name, body, _):
+                if isinstance(expect_ty, AbstractionType):
+                    vty = expect_ty.var_type
+                    new_ctx = ctx.with_var(name, vty) if ctx is not None else None
+                    ref_l = _opened_refinement_liquid(vty, name, term_formals, type_formals)
+                    nrefs = nested_refs + (ref_l,) if ref_l is not None else nested_refs
+                    walk(body, path, nrefs, new_ctx, expect_ty.type)
+                else:
+                    walk(body, path, nested_refs, ctx, None)
             case Let(_, val, body, _):
-                walk(val, path)
-                walk(body, path)
+                walk(val, path, nested_refs, ctx, None)
+                walk(body, path, nested_refs, ctx, None)
             case Rec(_, _, val, body, _, _):
-                walk(val, path)
-                walk(body, path)
+                walk(val, path, nested_refs, ctx, None)
+                walk(body, path, nested_refs, ctx, None)
             case Annotation(expr, _, _):
-                walk(expr, path)
+                walk(expr, path, nested_refs, ctx, expect_ty)
             case If(cond, then, otherwise, _):
-                walk(cond, path)
-                walk(then, path + (cond,))
-                walk(otherwise, path + (_term_bool_not(cond),))
+                walk(cond, path, nested_refs, ctx, None)
+                walk(then, path + (cond,), nested_refs, ctx, expect_ty)
+                walk(otherwise, path + (_term_bool_not(cond),), nested_refs, ctx, expect_ty)
             case TypeApplication(body, _, _):
-                walk(body, path)
+                walk(body, path, nested_refs, ctx, expect_ty)
             case TypeAbstraction(_, _, body, _):
-                walk(body, path)
+                walk(body, path, nested_refs, ctx, expect_ty)
             case RefinementApplication(body, refinement, _):
-                walk(body, path)
-                walk(refinement, path)
+                walk(body, path, nested_refs, ctx, expect_ty)
+                walk(refinement, path, nested_refs, ctx, None)
             case RefinementAbstraction(_, _, body, _):
-                walk(body, path)
+                walk(body, path, nested_refs, ctx, expect_ty)
             case _:
                 pass
 
-    walk(t, ())
+    walk(t, (), (), typing_ctx, inner_expect_ty)
     return found
+
+
+def _inner_ctx_and_expect_ty(nrctx: TypingContext, var_type: Type, formals: list[Name]) -> tuple[TypingContext, Type]:
+    ctx = nrctx
+    cur_ty = var_type
+    for nm in formals:
+        assert isinstance(cur_ty, AbstractionType)
+        ctx = ctx.with_var(nm, cur_ty.var_type)
+        cur_ty = cur_ty.type
+    return ctx, cur_ty
 
 
 def _full_path_guard_liquid(
     entry_refs: list[LiquidTerm],
+    nested_refs: tuple[LiquidTerm, ...],
     path: tuple[Term, ...],
     formals: list[Name],
     type_formals: list[Name],
 ) -> LiquidTerm | None:
-    parts: list[LiquidTerm] = list(entry_refs)
+    parts: list[LiquidTerm] = list(entry_refs) + list(nested_refs)
     if path:
         pl = _liquefy_path_conjuncts(path, formals, type_formals)
         if pl is None:
@@ -185,11 +239,12 @@ def _termination_obligation(
     formals: list[Name],
     type_formals: list[Name],
     entry_refs: list[LiquidTerm],
+    nested_refs: tuple[LiquidTerm, ...],
 ) -> Constraint:
-    r"""``(entry /\ branch) => (lex and metric(call) >= 0)`` when guarded; else ``lex`` only."""
-    needs_call_nonneg = bool(path) or bool(entry_refs)
+    r"""``(entry /\ nested /\ branch) => (lex and metric(call) >= 0)`` when guarded; else ``lex`` only."""
+    needs_call_nonneg = bool(path) or bool(entry_refs) or bool(nested_refs)
     oblig = mk_liquid_and(lex, _metric_call_non_negative(call_ms)) if needs_call_nonneg else lex
-    full = _full_path_guard_liquid(entry_refs, path, formals, type_formals)
+    full = _full_path_guard_liquid(entry_refs, nested_refs, path, formals, type_formals)
     if full is None:
         return LiquidConstraint(LiquidLiteralBool(False))
     if full == LiquidLiteralBool(True):
@@ -244,12 +299,12 @@ def _lexicographic_less(call_ms: list[LiquidTerm], entry_ms: list[LiquidTerm]) -
     return _fold_or(disjuncts)
 
 
-def termination_metric_constraints(rec: Rec) -> Constraint:
+def termination_metric_constraints(rec: Rec, typing_ctx: TypingContext | None = None) -> Constraint:
     r"""Lexicographic ``m(call) <* m(entry)`` (Liquid Haskell ``/ [m0, m1, …]``).
 
-    For self-calls under ``if`` branches, obligations are guarded:
-    ``branch => (lex and m(call) >= 0)``, e.g. ``fact (n-1)`` in the ``n != 0`` branch.
-    Entry refinements (``Nat``) stay as implication premises from typing.
+    With ``typing_ctx`` (the context used to check ``rec.var_value``), also accumulate
+    refinements from **nested** abstractions—typically pattern binders after ``match`` lowers
+    to an eliminator—so constructor argument refinements guard termination obligations.
     """
     if not rec.decreasing_by:
         return ctrue
@@ -263,12 +318,18 @@ def termination_metric_constraints(rec: Rec) -> Constraint:
     # arguments in terms of parameters so liquefy does not mention ANF temps.
     inner = inline_lets(inner)
     arity = len(formals)
-    calls = collect_recursive_calls_with_paths(rec.var_name, arity, inner)
+    inner_ctx: TypingContext | None = None
+    inner_expect: Type | None = None
+    if typing_ctx is not None:
+        inner_ctx, inner_expect = _inner_ctx_and_expect_ty(typing_ctx, rec.var_type, formals)
+    calls = collect_recursive_calls_with_paths(
+        rec.var_name, arity, inner, inner_ctx, inner_expect, formals, type_formals
+    )
     if not calls:
         return ctrue
 
     parts: list[Constraint] = []
-    for call_args, _loc, path in calls:
+    for call_args, _loc, path, nested_refs in calls:
         if len(call_args) != arity:
             parts.append(LiquidConstraint(LiquidLiteralBool(False)))
             continue
@@ -287,7 +348,7 @@ def termination_metric_constraints(rec: Rec) -> Constraint:
             parts.append(LiquidConstraint(LiquidLiteralBool(False)))
             continue
         lex = _lexicographic_less(call_ms, entry_ms)
-        parts.append(_termination_obligation(path, lex, call_ms, formals, type_formals, entry_refs))
+        parts.append(_termination_obligation(path, lex, call_ms, formals, type_formals, entry_refs, nested_refs))
 
     if not parts:
         return ctrue

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -58,6 +58,7 @@ from aeon.facade.api import (
 )
 from aeon.typechecking.context import TypingContext
 from aeon.typechecking.entailment import entailment, entailment_context
+from aeon.typechecking.termination import termination_metric_constraints
 from aeon.typechecking.qualifiers import extract_qualifier_atoms
 from aeon.typechecking.well_formed import wellformed
 from aeon.verification.horn import fresh
@@ -289,7 +290,9 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             (c2, t2) = synth(nrctx, body)
             c1 = implication_constraint(var_name, var_type, c1, var_value.loc)
             c2 = implication_constraint(var_name, var_type, c2, body.loc)
-            return Conjunction(c1, c2), t2
+            term_c = termination_metric_constraints(t)
+            term_c = implication_constraint(var_name, var_type, term_c, var_value.loc)
+            return Conjunction(Conjunction(c1, c2), term_c), t2
         case Annotation(expr, ty):
             nty = fresh(ctx, ty)
             c = check(ctx, expr, nty)
@@ -361,7 +364,9 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
             c2 = check(nrctx, body, ty)
             c1 = implication_constraint(var_name, t1, c1, var_value.loc)
             c2 = implication_constraint(var_name, t1, c2, body.loc)
-            return Conjunction(c1, c2)
+            term_c = termination_metric_constraints(t)
+            term_c = implication_constraint(var_name, t1, term_c, var_value.loc)
+            return Conjunction(Conjunction(c1, c2), term_c)
         case If(cond, then, otherwise), _:
             y = Name("_cond", fresh_counter.fresh())
             liq_cond = liquefy(cond)

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -290,7 +290,7 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             (c2, t2) = synth(nrctx, body)
             c1 = implication_constraint(var_name, var_type, c1, var_value.loc)
             c2 = implication_constraint(var_name, var_type, c2, body.loc)
-            term_c = termination_metric_constraints(t)
+            term_c = termination_metric_constraints(t, nrctx)
             term_c = implication_constraint(var_name, var_type, term_c, var_value.loc)
             return Conjunction(Conjunction(c1, c2), term_c), t2
         case Annotation(expr, ty):
@@ -364,7 +364,7 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
             c2 = check(nrctx, body, ty)
             c1 = implication_constraint(var_name, t1, c1, var_value.loc)
             c2 = implication_constraint(var_name, t1, c2, body.loc)
-            term_c = termination_metric_constraints(t)
+            term_c = termination_metric_constraints(t, nrctx)
             term_c = implication_constraint(var_name, t1, term_c, var_value.loc)
             return Conjunction(Conjunction(c1, c2), term_c)
         case If(cond, then, otherwise), _:

--- a/aeon/utils/pprint.py
+++ b/aeon/utils/pprint.py
@@ -508,7 +508,7 @@ def sterm_pretty(sterm: STerm, context: ParenthesisContext = None, depth: int = 
                 binding = concat([pretty_var_name, text(" = "), pretty_var_value])
                 return group(concat([text("let "), binding, text(" in"), line(), pretty_body]))
 
-        case SRec(var_name=var_name, var_type=var_type, var_value=var_value, body=body):  # refazer rec
+        case SRec(var_name=var_name, var_type=var_type, var_value=var_value, body=body, decreasing_by=_):  # refazer rec
             pretty_var_name = text(var_name.pretty())
             pretty_var_type = pretty_stype_with_parens(var_type, ParenthesisContext(Precedence.ANNOTATION, Side.RIGHT))
             pretty_var_value = pretty_sterm_with_parens(
@@ -657,7 +657,7 @@ def normalize_term(term: STerm, context: dict[Name, STerm] = None, seen: set[Nam
                         var_value=normalize_term(var_value, context, seen),
                         body=normalize_term(body, context, seen),
                     )
-        case SRec(var_name=var_name, var_type=var_type, var_value=var_value, body=body):
+        case SRec(var_name=var_name, var_type=var_type, var_value=var_value, body=body, decreasing_by=db):
             if var_name.pretty() == "anf":
                 context_copy = context.copy()
                 context_copy[var_name] = normalize_term(var_value, context, seen)
@@ -670,6 +670,7 @@ def normalize_term(term: STerm, context: dict[Name, STerm] = None, seen: set[Nam
                         var_type=var_type,
                         var_value=normalize_term(var_value, context, seen),
                         body=SVar(name=name),
+                        decreasing_by=tuple(normalize_term(m, context, seen) for m in db),
                     )
                 case _:
                     return SRec(
@@ -677,6 +678,7 @@ def normalize_term(term: STerm, context: dict[Name, STerm] = None, seen: set[Nam
                         var_type=var_type,
                         var_value=normalize_term(var_value, context, seen),
                         body=normalize_term(body, context, seen),
+                        decreasing_by=tuple(normalize_term(m, context, seen) for m in db),
                     )
         case STypeAbstraction(name=name, kind=kind, body=body):
             simplified_body = normalize_term(body, context, seen)

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -41,6 +41,7 @@ from aeon.core.types import AbstractionType, RefinedType, Top, TypePolymorphism
 from aeon.core.types import Type
 from aeon.core.types import TypeVar
 from aeon.core.types import t_bool, t_int, t_float, t_string, t_unit
+from aeon.verification.sub import lower_constraint_type
 from aeon.verification.vcs import Conjunction
 from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import Implication
@@ -131,6 +132,28 @@ class SMTContext:
         return SMTContext(self.sorts, self.functions, self.variables, self.premises + [p])
 
 
+def _ctx_with_curried_formals(ctx: SMTContext, fun_ty: AbstractionType) -> SMTContext:
+    """Add Z3-scalar bindings for each curried parameter of ``fun_ty`` (for UFD / recursion VCs)."""
+    out = ctx
+    cur: Type = fun_ty
+    while isinstance(cur, AbstractionType):
+        base = lower_constraint_type(cur.var_type)
+        match base:
+            case TypeVar(iname):
+                base_tc = TypeConstructor(iname)
+            case TypeConstructor(iname, []):
+                base_tc = base
+            case TypeConstructor(iname, args):
+                mangle_name = str(iname) + "_" + "_".join(str(a) for a in args)
+                nname = Name(mangle_name, fresh_counter.fresh())
+                base_tc = TypeConstructor(nname)
+            case _:
+                assert False, f"{base} ({type(base)}) is not a base type for curried formal."
+        out = out.with_var(cur.var_name, base_tc)
+        cur = cur.type
+    return out
+
+
 @dataclass(init=False)
 class CanonicConstraint:
     """Represents SMT-valid constraints."""
@@ -199,7 +222,8 @@ def flatten(c: Constraint, ctx: SMTContext | None = None) -> Generator[CanonicCo
             yield from flatten(seq, ctx.with_var(name, base).with_premise(pred))
         case UninterpretedFunctionDeclaration(name, ty, seq):
             assert isinstance(c, UninterpretedFunctionDeclaration)
-            yield from flatten(seq, ctx.with_function(name, ty))
+            nctx = _ctx_with_curried_formals(ctx, ty)
+            yield from flatten(seq, nctx.with_function(name, ty))
         case _:
             assert False, f"Cannot flatten {c}."
 

--- a/examples/syntax/ackermann_decreasing.ae
+++ b/examples/syntax/ackermann_decreasing.ae
@@ -1,0 +1,9 @@
+# Lexicographic termination: ``decreasing_by [m, n]`` matches Liquid Haskell ``/ [m, n]``.
+# Use refinements so ``m >= 0`` and ``n >= 0`` appear as VC premises (well-founded ``Nat^2``).
+
+def ack (m:Int | m >= 0)(n:Int | n >= 0) : Int decreasing_by [m, n] =
+  if m == 0 then n + 1 else (if n == 0 then ack (m - 1) 1 else ack m (n - 1));
+
+def main (_:Int) : Int {
+  ack 2 3
+}

--- a/examples/syntax/factorial_decreasing.ae
+++ b/examples/syntax/factorial_decreasing.ae
@@ -1,0 +1,10 @@
+# Unary recursion with an explicit Liquid Haskell-style metric (single Int).
+# The checker emits ``m(call) < m(params)`` at self-calls when the metric at the
+# call site liquefies to variables drawn only from the function parameters (so
+# ANF temporaries in complex call expressions may skip the check until VC scope improves).
+
+def fact (n:Int) : Int decreasing_by [n] = if n == 0 then 1 else n * fact (n - 1);
+
+def main (_:Int) : Int {
+  fact 5
+}

--- a/examples/syntax/factorial_decreasing.ae
+++ b/examples/syntax/factorial_decreasing.ae
@@ -1,9 +1,8 @@
 # Unary recursion with an explicit Liquid Haskell-style metric (single Int).
-# The checker emits ``m(call) < m(params)`` at self-calls when the metric at the
-# call site liquefies to variables drawn only from the function parameters (so
-# ANF temporaries in complex call expressions may skip the check until VC scope improves).
+# Path-sensitive VCs: in the ``n != 0`` branch we prove ``(n-1) >= 0`` and decrease; use ``Nat``.
+# For lexicographic ``[m0, m1, …]``, see ``ackermann_decreasing.ae``.
 
-def fact (n:Int) : Int decreasing_by [n] = if n == 0 then 1 else n * fact (n - 1);
+def fact (n:Int | n >= 0) : Int decreasing_by [n] = if n == 0 then 1 else n * fact (n - 1);
 
 def main (_:Int) : Int {
   fact 5

--- a/tests/decreasing_by_test.py
+++ b/tests/decreasing_by_test.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from aeon.sugar.bind import bind_program
+from aeon.sugar.parser import parse_main_program
+from aeon.sugar.program import SVar
+
+
+def test_parse_decreasing_by_on_definition():
+    src = """
+        def f (n:Int) : Int decreasing_by [n] = n;
+        def main (_:Int) : Int { 0 }
+    """
+    p = parse_main_program(src, filename="<test>")
+    p = bind_program(p, [])
+    fdef = p.definitions[0]
+    assert len(fdef.decreasing_by) == 1
+    assert isinstance(fdef.decreasing_by[0], SVar)

--- a/tests/decreasing_by_test.py
+++ b/tests/decreasing_by_test.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
-from aeon.sugar.bind import bind_program
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.frontend.anf_converter import ensure_anf
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import DesugaredProgram, desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
 from aeon.sugar.parser import parse_main_program
 from aeon.sugar.program import SVar
+from aeon.typechecking.typeinfer import check_type_errors
 
 
 def test_parse_decreasing_by_on_definition():
@@ -15,3 +23,56 @@ def test_parse_decreasing_by_on_definition():
     fdef = p.definitions[0]
     assert len(fdef.decreasing_by) == 1
     assert isinstance(fdef.decreasing_by[0], SVar)
+
+
+def test_parse_decreasing_by_lex_list():
+    src = """
+        def g (m:Int)(n:Int) : Int decreasing_by [m, n] = m;
+        def main (_:Int) : Int { 0 }
+    """
+    p = parse_main_program(src, filename="<test>")
+    p = bind_program(p, [])
+    gdef = p.definitions[0]
+    assert len(gdef.decreasing_by) == 2
+    assert isinstance(gdef.decreasing_by[0], SVar)
+    assert isinstance(gdef.decreasing_by[1], SVar)
+
+
+def test_factorial_nat_path_sensitive_terminates():
+    src = """
+        def fact (n:Int | n >= 0) : Int decreasing_by [n] =
+          if n == 0 then 1 else n * fact (n - 1);
+        def main (_:Int) : Int { fact 5 }
+    """
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(progt, ctx, desugared.metadata)
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    core_ast_anf = ensure_anf(core_ast)
+    errors = list(check_type_errors(typing_ctx, core_ast_anf, top))
+    assert errors == [], [type(e).__name__ for e in errors]
+
+
+def test_lexicographic_ackermann_typechecks():
+    src = """
+        def ack (m:Int | m >= 0)(n:Int | n >= 0) : Int decreasing_by [m, n] =
+          if m == 0 then n + 1 else (if n == 0 then ack (m - 1) 1 else ack m (n - 1));
+        def main (_:Int) : Int { ack 2 3 }
+    """
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(progt, ctx, desugared.metadata)
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    core_ast_anf = ensure_anf(core_ast)
+    errors = list(check_type_errors(typing_ctx, core_ast_anf, top))
+    assert errors == [], [type(e).__name__ for e in errors]

--- a/tests/match_inductive_test.py
+++ b/tests/match_inductive_test.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from aeon.sugar.bind import bind_program
 from aeon.sugar.desugar import desugar
-from aeon.sugar.parser import parse_program
+from aeon.sugar.parser import parse_main_program, parse_program
 
 
 def test_match_lowering_intlist():
@@ -28,5 +29,29 @@ def test_match_lowering_intlist():
     # Lowering should remove SMatch nodes and use the generated eliminator.
     dumped = str(desugared.program)
     # Our surface AST pretty-print includes "match ... with" for SMatch.
+    assert "SMatch" not in dumped
+    assert "IntList_rec" in dumped
+
+
+def test_match_lowering_intlist_after_bind_program():
+    """`bind_program` renames inductive constructors; match branches must use the same names."""
+    src = """
+        inductive IntList
+        | empty : IntList
+        | cons (hd:Int) (tl:IntList) : IntList
+        def mk (l:IntList) : IntList {
+            match l with
+            | empty => l
+            | cons hd tl => l
+        }
+        def main (args:Int) : Int {
+            0
+        }
+    """
+
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    dumped = str(desugared.program)
     assert "SMatch" not in dumped
     assert "IntList_rec" in dumped


### PR DESCRIPTION
## Summary

- **Syntax:** Optional `decreasing_by [e]` after the return type on `def` (both `{ ... }` and `= ... ;` forms), per earlier design discussion (Lean-style name, Liquid Haskell-style `/ [e]` semantics).
- **Pipeline:** `Definition.decreasing_by` → `SRec` / core `Rec.decreasing_by`, through bind, elaboration, lowering, ANF, etc.
- **Default metric:** Unary `Int` recursion with no explicit metric and a self-call in the body defaults to `[n]` for the lone parameter.
- **VCs:** `aeon/typechecking/termination.py` emits `m(call) < m(params)` for a single metric when liquefaction succeeds; call sites are skipped if the metric mentions ANF temporaries not in scope for standalone SMT translation (documented in the factorial example).
- **Example:** `examples/syntax/factorial_decreasing.ae` (picked up by existing `run_examples.sh` `syntax` folder).
- **Test:** `tests/decreasing_by_test.py` asserts parse + bind of `decreasing_by`.

## Note

This branch also contains commit `8a3c9fe` (match + `bind_program` constructor alignment). If `master` already has that via another PR, rebase this branch onto `master` before merge to avoid duplication.

Made with [Cursor](https://cursor.com)