### PR TITLE
feat(sugar): inductive abstract refinements and inferred rforalls

### DIFF
--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -14,8 +14,11 @@ type_decl : "type" TYPENAME ";"                            -> type_decl
           | type_def                                           -> same
 
 
-type_def : "inductive" ID iargs constructors measures      -> inductive
+type_def : "inductive" ID iargs inductive_rforalls constructors measures      -> inductive
 iargs: (ID)*                                                -> list
+// Abstract refinements on the datatype (Liquid Haskell ``data T <p :: S -> Bool>``): zero or more ``forall <p : S -> Bool>`` binders shared by all constructors.
+inductive_rforalls: inductive_rforall*                     -> list
+inductive_rforall: "forall" "<" ID ":" type "->" "Bool" ">"   -> inductive_rforall_binding
 constructors : cons_rule*                                  -> list
 cons_rule : _PIPE ID args ":" type                           -> def_ind_cons
 measures : measure_rule*                                  -> list

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -221,6 +221,10 @@ def bind_program(p: Program, subs: RenamingSubstitions) -> Program:
         for aname in ind.args:
             nname, nsubs = check_name(aname, nsubs)
             iargs.append(nname)
+        drfs = []
+        for pname, psort in ind.rforalls:
+            nname, nsubs = check_name(pname, nsubs)
+            drfs.append((nname, bind_stype(psort, nsubs)))
         constructors = []
         for cons in ind.constructors:
             bound_cons, nsubs = _bind_definition(cons, nsubs, subs)
@@ -229,7 +233,7 @@ def bind_program(p: Program, subs: RenamingSubstitions) -> Program:
         for meas in ind.measures:
             bound_meas, nsubs = _bind_definition(meas, nsubs, subs)
             measures.append(bound_meas)
-        inductive_decls.append(InductiveDecl(name, iargs, constructors, measures, loc=ind.loc))
+        inductive_decls.append(InductiveDecl(name, iargs, drfs, constructors, measures, loc=ind.loc))
 
     for df in p.definitions:
         bound_df, nsubs = _bind_definition(df, nsubs, subs)

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -54,6 +54,7 @@ from aeon.utils.name import Name
 from aeon.sugar.ast_helpers import st_int, st_string
 
 from aeon.facade.api import ImportError
+from aeon.sugar.equality import type_equality
 
 
 def _stype_base_int(ty: SType) -> bool:
@@ -121,6 +122,7 @@ def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType]
 
     # We need inductive constructor info to lower `match` expressions.
     # Note: `expand_inductive_decls` clears `p.inductive_decls`, so we snapshot it here.
+    p = infer_inductive_rforall_decls(p)
     inductive_decls_snapshot = list(p.inductive_decls)
 
     p = expand_inductive_decls(p)
@@ -253,6 +255,111 @@ def lower_match_to_inductive_rec(prog: STerm, inductive_decls: list[InductiveDec
     return lower_term(prog)
 
 
+def _merge_inductive_rforalls(
+    dtype_rfs: list[tuple[Name, SType]], local_rfs: list[tuple[Name, SType]]
+) -> list[tuple[Name, SType]]:
+    """Datatype-level abstract refinements (Liquid Haskell ``data T <p>``) scope over every constructor."""
+    seen = {n for n, _ in dtype_rfs}
+    return list(dtype_rfs) + [(n, t) for n, t in local_rfs if n not in seen]
+
+
+def _eligible_refinement_base_for_inductive(ind: InductiveDecl, base: SType) -> bool:
+    """True when an abstract refinement predicate ranges over this datatype or one of its parameters."""
+    match base:
+        case STypeConstructor(n, _):
+            return n == ind.name or n.name == ind.name.name
+        case STypeVar(tv):
+            return any(tv.name == a.name for a in ind.args) or tv.name == ind.name.name
+        case SRefinedType(_, inner, _):
+            return _eligible_refinement_base_for_inductive(ind, inner)
+        case _:
+            return False
+
+
+def _collect_implicit_refinement_params_for_inductive(
+    ind: InductiveDecl, ty: SType, bound_rho: set[Name], acc: dict[Name, SType]
+) -> None:
+    """Like ``_collect_implicit_refinement_params``, but only records predicates over ``ind`` or its type params."""
+
+    def rec(t: SType, rho: set[Name]) -> None:
+        _collect_implicit_refinement_params_for_inductive(ind, t, rho, acc)
+
+    match ty:
+        case SRefinementPolymorphism(rname, sort, body):
+            rec(sort, bound_rho)
+            rec(body, bound_rho | {rname})
+        case STypePolymorphism(_, _, body):
+            rec(body, bound_rho)
+        case SAbstractionType(_, vt, rt):
+            rec(vt, bound_rho)
+            rec(rt, bound_rho)
+        case SRefinedType(binder, base, ref):
+            rec(base, bound_rho)
+            match ref:
+                case SApplication(SVar(p), SVar(b)) if b == binder and p not in bound_rho:
+                    if not _eligible_refinement_base_for_inductive(ind, base):
+                        pass
+                    elif p in acc:
+                        if not type_equality(acc[p], base):
+                            raise TypeError(
+                                f"Inconsistent sorts for inferred datatype refinement {p.name} "
+                                f"on {ind.name.name}: {acc[p]} vs {base}"
+                            )
+                    else:
+                        acc[p] = base
+                case _:
+                    pass
+        case STypeConstructor(_, ty_args):
+            for a in ty_args:
+                rec(a, bound_rho)
+        case STypeVar(_):
+            pass
+        case _:
+            assert False, f"_collect_implicit_refinement_params_for_inductive: unhandled {ty} ({type(ty)})"
+
+
+def infer_inductive_rforall_decls(p: Program) -> Program:
+    """If an inductive omits ``forall <p : …>``, infer datatype ``rforalls`` from refinements in constructor and
+    measure signatures, and from the types of top-level definitions (Liquid Haskell-style abstract refinements).
+    """
+    inferred: list[InductiveDecl] = []
+    for ind in p.inductive_decls:
+        if ind.rforalls:
+            inferred.append(ind)
+            continue
+        acc: dict[Name, SType] = {}
+
+        def scan(ty: SType) -> None:
+            _collect_implicit_refinement_params_for_inductive(ind, ty, set(), acc)
+
+        for cons in ind.constructors:
+            match cons:
+                case Definition(_, _, cargs, crtype, _, _, _, _, _):
+                    for _, at in cargs:
+                        scan(at)
+                    scan(crtype)
+        for meas in ind.measures:
+            match meas:
+                case Definition(_, _, margs, mrtype, _, _, _, _, _):
+                    for _, at in margs:
+                        scan(at)
+                    scan(mrtype)
+        for d in p.definitions:
+            match d:
+                case Definition(_, _, dargs, drtype, _, _, _, _, _):
+                    for _, at in dargs:
+                        scan(at)
+                    scan(drtype)
+
+        if acc:
+            ordered = sorted(acc.items(), key=lambda item: (item[0].name, item[0].id))
+            inferred.append(replace(ind, rforalls=list(ordered)))
+        else:
+            inferred.append(ind)
+
+    return Program(p.imports, p.type_decls, inferred, p.definitions)
+
+
 def expand_inductive_decls(p: Program) -> Program:
     tds: list[TypeDecl] = []
     defs: list[Definition] = []
@@ -261,13 +368,24 @@ def expand_inductive_decls(p: Program) -> Program:
 
     for decl in p.inductive_decls:
         match decl:
-            case InductiveDecl(name, args, constructors, measures, loc):
+            case InductiveDecl(name, args, dtype_rfs, constructors, measures, loc):
                 tds.append(TypeDecl(name, args))
 
                 for measure in measures:
                     match measure:
-                        case Definition(mname, mforalls, margs, mrtype, _, _, _, _, mloc):
-                            de = Definition(mname, mforalls, margs, mrtype, uninterpreted_lit, loc=mloc)
+                        case Definition(mname, mforalls, margs, mrtype, _, mdecs, m_rf, m_decr, mloc):
+                            merged_m_rf = _merge_inductive_rforalls(dtype_rfs, m_rf)
+                            de = Definition(
+                                mname,
+                                mforalls,
+                                margs,
+                                mrtype,
+                                uninterpreted_lit,
+                                mdecs,
+                                merged_m_rf,
+                                m_decr,
+                                loc=mloc,
+                            )
                             defs.append(de)
 
                 def key_for(tyname: Name, constructor_name: Name) -> str:
@@ -275,12 +393,23 @@ def expand_inductive_decls(p: Program) -> Program:
 
                 for constructor in constructors:
                     match constructor:
-                        case Definition(cname, cforalls, cargs, crtype, _, _, _, _, cloc):
+                        case Definition(cname, cforalls, cargs, crtype, _, cdecs, c_rf, c_decr, cloc):
                             arg_s = ", ".join(str(arg.name) for (arg, _) in cargs)
                             mk_tuple = SApplication(
                                 SVar(Name("native", 0)), SLiteral(f"('{key_for(name, cname)}', {arg_s})", st_string)
                             )
-                            de = Definition(cname, cforalls, cargs, crtype, mk_tuple, loc=cloc)
+                            merged_c_rf = _merge_inductive_rforalls(dtype_rfs, c_rf)
+                            de = Definition(
+                                cname,
+                                cforalls,
+                                cargs,
+                                crtype,
+                                mk_tuple,
+                                cdecs,
+                                merged_c_rf,
+                                c_decr,
+                                loc=cloc,
+                            )
                             defs.append(de)
 
                 def curry(args: list[tuple[Name, SType]], rty: SType) -> SType:
@@ -299,7 +428,7 @@ def expand_inductive_decls(p: Program) -> Program:
                     SVar(Name("native", 0)), SLiteral(f"""match this:\n{cases}{catchall}\n""", st_string)
                 )
 
-                foralls: list[tuple[Name, Kind]] = []
+                foralls: list[tuple[Name, Kind]] = [(a, BaseKind()) for a in args]
                 rec_args: list[tuple[Name, SType]] = []
 
                 # Return Type
@@ -308,7 +437,6 @@ def expand_inductive_decls(p: Program) -> Program:
                 foralls.append((return_generic_name, BaseKind()))
 
                 # Target Type (First argument)
-                # foralls.extend([ (arg, BaseKind()) for arg in args ])
                 target_type = STypeConstructor(name, [STypeVar(a) for a in args])
                 rec_args.append((Name("this", -1), target_type))
 
@@ -322,7 +450,8 @@ def expand_inductive_decls(p: Program) -> Program:
                     args=rec_args,
                     type=return_type,
                     body=rec_body,
-                    rforalls=[],
+                    decorators=[],
+                    rforalls=list(dtype_rfs),
                     decreasing_by=[],
                     loc=loc,
                 )
@@ -342,11 +471,12 @@ def introduce_forall_in_types(defs: list[Definition], type_decls: list[TypeDecl]
             case Definition(name, foralls, args, rtype, body, decorators, rforalls, decreasing_by, loc):
                 new_foralls: list[tuple[Name, Kind]] = []
 
+                bound_tvars = {n for n, _ in foralls}
                 tlst: list[SType] = [ty for _, ty in args] + [rtype]
                 for ty in tlst:
                     for t in get_type_vars(ty):
                         tname = t.name
-                        if tname not in types:
+                        if tname not in types and tname not in bound_tvars:
                             entry = (tname, BaseKind())
                             if entry not in new_foralls:
                                 new_foralls.append(entry)

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -310,10 +310,18 @@ class TreeToSugar(Transformer):
     def type_constructor_decl(self, meta, args):
         return TypeDecl(Name(args[0]), [Name(i) for i in args[1:]], loc=self._loc(meta))
 
+    def inductive_rforall_binding(self, args):
+        return (Name(args[0]), args[1])
+
     @v_args(meta=True)
     def inductive(self, meta, args):
         return InductiveDecl(
-            Name(args[0]), [Name(i) for i in args[1]], ensure_list(args[2]), ensure_list(args[3]), loc=self._loc(meta)
+            Name(args[0]),
+            [Name(i) for i in args[1]],
+            ensure_list(args[2]),
+            ensure_list(args[3]),
+            ensure_list(args[4]),
+            loc=self._loc(meta),
         )
 
     @v_args(meta=True)

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -282,8 +282,11 @@ class TypeDecl(Node):
 
 @dataclass
 class InductiveDecl(Node):
+    """Datatype declaration. ``rforalls`` are abstract refinement parameters (Liquid Haskell ``data T a <p :: a -> Bool>``)."""
+
     name: Name
     args: list[Name] = field(default_factory=list)
+    rforalls: list[tuple[Name, SType]] = field(default_factory=list)
     constructors: list[Definition] = field(default_factory=list)
     measures: list[Definition] = field(default_factory=list)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
@@ -296,9 +299,15 @@ class InductiveDecl(Node):
 
     def __str__(self):
         args = " ".join(str(arg) for arg in self.args)
+        rfs = " ".join(f"forall <{n}:{s} -> Bool>" for (n, s) in self.rforalls)
         constructors = " ".join(f"| {cons}" for (cons) in self.constructors)
         measures = " ".join(f"+ {dec}" for dec in self.measures)
-        return f"inductive {self.name} {args} {constructors} {measures}"
+        head = f"inductive {self.name}"
+        if args:
+            head += f" {args}"
+        if rfs:
+            head += f" {rfs}"
+        return f"{head} {constructors} {measures}"
 
 
 @dataclass

--- a/aeon/utils/pprint.py
+++ b/aeon/utils/pprint.py
@@ -725,9 +725,27 @@ def node_pretty(node: Node) -> Doc:
             pretty_macro_args_doc = parens(insert_between(concat([text(","), line()]), pretty_macro_args))
 
             return concat([text("@"), text(name.pretty()), pretty_macro_args_doc])
-        case InductiveDecl(name=name, args=args, constructors=constructors, measures=measures):
+        case InductiveDecl(name=name, args=args, rforalls=rforalls, constructors=constructors, measures=measures):
             pretty_name = concat([text("inductive"), line(), text(name.pretty())])
             pretty_args = group(insert_between(line(), [text(arg.pretty()) for arg in args]))
+            pretty_rforalls = group(
+                insert_between(
+                    line(),
+                    [
+                        concat(
+                            [
+                                text("forall"),
+                                text(" <"),
+                                text(rho.pretty()),
+                                text(" : "),
+                                stype_pretty(sort),
+                                text(" -> Bool>"),
+                            ]
+                        )
+                        for rho, sort in rforalls
+                    ],
+                )
+            )
             pretty_constructors = group(
                 insert_between(line(), [concat([text("| "), node_pretty(cons)]) for cons in constructors])
             )
@@ -735,7 +753,11 @@ def node_pretty(node: Node) -> Doc:
                 insert_between(line(), [concat([text("+ "), node_pretty(meas)]) for meas in measures])
             )
 
-            return group(insert_between(line(), [pretty_name, pretty_args, pretty_constructors, pretty_measures]))
+            chunks = [pretty_name, pretty_args]
+            if rforalls:
+                chunks.append(pretty_rforalls)
+            chunks.extend([pretty_constructors, pretty_measures])
+            return group(insert_between(line(), chunks))
         case Definition(
             name=name,
             foralls=foralls,

--- a/tests/match_inductive_test.py
+++ b/tests/match_inductive_test.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from aeon.sugar.bind import bind_program
-from aeon.sugar.desugar import desugar
+from aeon.sugar.desugar import desugar, expand_inductive_decls, infer_inductive_rforall_decls
 from aeon.sugar.parser import parse_main_program, parse_program
+from aeon.sugar.program import Program
 
 
 def test_match_lowering_intlist():
@@ -55,3 +56,106 @@ def test_match_lowering_intlist_after_bind_program():
     dumped = str(desugared.program)
     assert "SMatch" not in dumped
     assert "IntList_rec" in dumped
+
+
+def test_inductive_abstract_refinement_parameters_parse():
+    """Liquid Haskell-style ``data T <p :: S -> Bool>`` as datatype-level ``forall <p : S -> Bool>``."""
+    src = """
+        inductive Box forall <p : Int -> Bool>
+        | mk (x:Int) : Box
+        def main (args:Int) : Int { 0 }
+    """
+    prog = parse_program(src)
+    ind = prog.inductive_decls[0]
+    assert len(ind.rforalls) == 1
+    pname, psort = ind.rforalls[0]
+    assert pname.name == "p"
+    assert "Int" in str(psort)
+
+
+def test_inductive_rforalls_merge_into_constructors_and_eliminator():
+    src = """
+        inductive Box forall <p : Int -> Bool>
+        | mk (x:Int) : Box
+        def main (args:Int) : Int { 0 }
+    """
+    prog = parse_program(src)
+    expanded = expand_inductive_decls(Program(prog.imports, prog.type_decls, prog.inductive_decls, prog.definitions))
+    mk = next(d for d in expanded.definitions if d.name.name == "mk")
+    rec = next(d for d in expanded.definitions if d.name.name == "Box_rec")
+    assert len(mk.rforalls) == 1
+    assert mk.rforalls[0][0].name == "p"
+    assert len(rec.rforalls) == 1
+    assert rec.rforalls[0][0].name == "p"
+
+
+def test_inductive_rforall_sort_may_use_type_parameter():
+    """Predicate sort ``a -> Bool`` matches LH ``<p :: a -> Bool>`` (domain is the type parameter)."""
+    src = """
+        inductive RList a forall <p : a -> Bool>
+        | rnil : (RList a)
+        def main (args:Int) : Int { 0 }
+    """
+    prog = parse_program(src)
+    ind = prog.inductive_decls[0]
+    assert ind.args[0].name == "a"
+    assert ind.rforalls[0][0].name == "p"
+
+
+def test_infer_inductive_rforall_from_constructor_signature():
+    src = """
+        inductive Box
+        | mk : {b:Box | r b}
+        def main (args:Int) : Int { 0 }
+    """
+    prog = parse_program(src)
+    assert prog.inductive_decls[0].rforalls == []
+    inferred = infer_inductive_rforall_decls(prog)
+    ind = inferred.inductive_decls[0]
+    assert len(ind.rforalls) == 1
+    assert ind.rforalls[0][0].name == "r"
+    expanded = expand_inductive_decls(
+        Program(inferred.imports, inferred.type_decls, inferred.inductive_decls, inferred.definitions)
+    )
+    rec = next(d for d in expanded.definitions if d.name.name == "Box_rec")
+    assert len(rec.rforalls) == 1
+    assert rec.rforalls[0][0].name == "r"
+
+
+def test_infer_inductive_rforall_from_top_level_def_types():
+    src = """
+        inductive Box
+        | mk : Box
+        def use (x:{b:Box | s b}) : Int { 0 }
+        def main (args:Int) : Int { 0 }
+    """
+    prog = parse_program(src)
+    inferred = infer_inductive_rforall_decls(prog)
+    ind = inferred.inductive_decls[0]
+    assert len(ind.rforalls) == 1
+    assert ind.rforalls[0][0].name == "s"
+
+
+def test_infer_inductive_rforall_from_type_parameter_refinement():
+    src = """
+        inductive RList a
+        | rnil : (RList a)
+        | rcons (x:{v:a | q v}) : (RList a)
+        def main (args:Int) : Int { 0 }
+    """
+    prog = parse_program(src)
+    inferred = infer_inductive_rforall_decls(prog)
+    ind = inferred.inductive_decls[0]
+    assert len(ind.rforalls) == 1
+    assert ind.rforalls[0][0].name == "q"
+
+
+def test_infer_inductive_rforall_does_not_lift_predicates_on_other_sorts():
+    src = """
+        inductive Box
+        | mk : {x:Int | p x}
+        def main (args:Int) : Int { 0 }
+    """
+    prog = parse_program(src)
+    inferred = infer_inductive_rforall_decls(prog)
+    assert inferred.inductive_decls[0].rforalls == []


### PR DESCRIPTION
## Summary

- Add optional Liquid Haskell-style datatype parameters: repeated `forall <p : τ -> Bool>` on `inductive` declarations, merged into generated constructors, measures, and `T_rec`.
- Infer omitted datatype `rforalls` from refinements in constructor/measure signatures and from top-level `def` argument/result types (predicates over the datatype head or its type parameters only).
- Give generated eliminators explicit `foralls` for inductive type parameters; avoid duplicating inferred type variables in `introduce_forall_in_types`.

## Test plan

- [x] `uvx pre-commit run --all-files`
- [x] `uv run pytest`

Made with [Cursor](https://cursor.com)