### PR TITLE
examples: idiomatic `def … = …;` across the example tree

### DIFF
--- a/examples/PSB2/annotations/fizz_buzz_annotations.ae
+++ b/examples/PSB2/annotations/fizz_buzz_annotations.ae
@@ -12,9 +12,7 @@ def div3 ( n :{x:Int | 1 <= x && x <= 1000000}) : Bool = if ((n % 3) == 0) then 
 def div5 ( n :{x:Int | 1 <= x && x <= 1000000}) : Bool = if ((n % 5) == 0) then true else false;
 def div15 ( n :{x:Int | 1 <= x && x <= 1000000}) : Bool = if ((n % 15) == 0) then true else false;
 
-def FizzBuzz ( n :{x:Int | 1 <= x && x <= 1000000}) : String {
-    if div15 n then "FizzBuzz" else (if ((n % 3) == 0) then "Fizz" else (if ((n % 5) == 0)  then "Buzz" else native "str(n)"))
-}
+def FizzBuzz ( n :{x:Int | 1 <= x && x <= 1000000}) : String = if div15 n then "FizzBuzz" else (if ((n % 3) == 0) then "Fizz" else (if ((n % 5) == 0)  then "Buzz" else native "str(n)"));
 
 def  train: TrainData =  extract_train_data ( load_dataset "fizz-buzz" 200 200);
 
@@ -23,7 +21,4 @@ def  input_list : List =  get_input_list ( unpack_train_data  train);
 def  expected_values : List =  get_output_list ( unpack_train_data  train);
 
 @minimize_float(String_distance ( join_string_list( get_fb_synth_values input_list synth)) ( join_string_list( expected_values)))
-def synth (n : Int) : String {
-    (?hole:String)
-
-}
+def synth (n : Int) : String = (?hole:String);

--- a/examples/PSB2/annotations/middle_char_annotations.ae
+++ b/examples/PSB2/annotations/middle_char_annotations.ae
@@ -8,4 +8,4 @@ def  input_list : List =  get_input_list ( unpack_train_data  train);
 def  expected_values : List =  get_output_list ( unpack_train_data  train);
 
 @minimize_float(String_distance ( join_string_list( get_mc_synth_values  input_list synth)) ( join_string_list( expected_values)))
-def synth (s: String) : String {(?hole:String)}
+def synth (s: String) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/basement.ae
+++ b/examples/PSB2/annotations/multi_objective/basement.ae
@@ -5,10 +5,10 @@ import calculate_basement_errors from "PSB2.ae";
 type List;
 
 def List_size: (l:List) -> Int = uninterpreted;
-def List_len (l:List) : Int  { native "len(l)" }
+def List_len (l:List) : Int  = native "len(l)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
-def List_get (l:List) (i: Int) : Int { native "l[i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
+def List_get (l:List) (i: Int) : Int = native "l[i]";
 
 #PSB2 functions
 
@@ -20,6 +20,4 @@ def train: TrainData = extract_train_data (load_dataset "basement" 200 200);
             calculate_basement_errors)
 @allow_recursion
 @multi_minimize_float(calculate_basement_errors train synth, 1)
-def synth (nums: List) : Int {
-    (?hole : Int)
- }
+def synth (nums: List) : Int = (?hole : Int);

--- a/examples/PSB2/annotations/multi_objective/bouncing_balls.ae
+++ b/examples/PSB2/annotations/multi_objective/bouncing_balls.ae
@@ -17,6 +17,4 @@ def train: TrainData = extract_train_data (load_dataset "bouncing-balls" 200 200
             calculate_bouncing_balls_errors)
 @multi_minimize_float(calculate_bouncing_balls_errors train synth, 1)
 def synth (a:Float) (b:Float) (c:Int) : Float
-    {
-    (?hole: Float)
-    }
+    = (?hole: Float);

--- a/examples/PSB2/annotations/multi_objective/bowling.ae
+++ b/examples/PSB2/annotations/multi_objective/bowling.ae
@@ -41,6 +41,4 @@ def train: TrainData = extract_train_data (load_dataset "bowling" 200 200);
             calculate_bowling_errors)
 @hide_types(TrainData)
 @multi_minimize_float(calculate_bowling_errors train synth, 1)
-def synth (scores: String) : Int {
-    (?hole: Int)
- }
+def synth (scores: String) : Int = (?hole: Int);

--- a/examples/PSB2/annotations/multi_objective/camel_case.ae
+++ b/examples/PSB2/annotations/multi_objective/camel_case.ae
@@ -28,6 +28,4 @@ def train: TrainData = extract_train_data (load_dataset "camel-case" 200 200);
             train,
             calculate_camel_case_errors)
 @multi_minimize_float(calculate_camel_case_errors train synth, 1)
-def synth (s:String) : String {
-    (?hole:String)
-}
+def synth (s:String) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/coin_sum.ae
+++ b/examples/PSB2/annotations/multi_objective/coin_sum.ae
@@ -10,7 +10,7 @@ def List_size : (l:List) -> Int = uninterpreted;
 
 def List_new : {x:List | List_size x == 0} = native "[]" ;
 
-def List_append (l:List) (i:Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i:Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 def train: TrainData = extract_train_data (load_dataset "coin-sums" 200 200);
 
@@ -20,6 +20,4 @@ def train: TrainData = extract_train_data (load_dataset "coin-sums" 200 200);
             calculate_coin_sum_errors
             )
 @multi_minimize_float(calculate_coin_sum_errors train synth, 4)
-def synth (cents: Int) : List {
-  (?hole:List)
- }
+def synth (cents: Int) : List = (?hole:List);

--- a/examples/PSB2/annotations/multi_objective/cut_vector.ae
+++ b/examples/PSB2/annotations/multi_objective/cut_vector.ae
@@ -41,6 +41,4 @@ def calculate_cut_vector_errors : (train : TrainData) -> (f:(a: List) -> List ) 
             train,
             calculate_cut_vector_errors)
 @multi_minimize_float(calculate_cut_vector_errors train cut_vector, 2)
-def cut_vector ( ls : List ) : List {
-    (?hole:List)
-}
+def cut_vector ( ls : List ) : List = (?hole:List);

--- a/examples/PSB2/annotations/multi_objective/dice_game.ae
+++ b/examples/PSB2/annotations/multi_objective/dice_game.ae
@@ -18,6 +18,4 @@ def calculate_dice_game_errors : (train : TrainData) -> (f:(a: Int) -> (b:Int) -
             train,
             calculate_dice_game_errors)
 @multi_minimize_float(calculate_dice_game_errors train synth, 1)
-def synth (n:Int) (m: Int) : Float {
-    (?hole: Float)
-}
+def synth (n:Int) (m: Int) : Float = (?hole: Float);

--- a/examples/PSB2/annotations/multi_objective/find_pair.ae
+++ b/examples/PSB2/annotations/multi_objective/find_pair.ae
@@ -19,7 +19,7 @@ def List_head : (l: List) -> List = \xs -> native "xs[0]";
 def List_size : (l:List) -> Int = uninterpreted;
 def List_length : (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 #PSB2 functions
 
@@ -38,6 +38,4 @@ def calculate_find_pair_errors : (train : TrainData) -> (f:(a: List) -> (b:Int) 
             calculate_find_pair_errors,
             train)
 @multi_minimize_float(calculate_find_pair_errors train synth, 1)
-def synth (numbers: List) (target: Int) : List {
-    (?hole:List)
-    }
+def synth (numbers: List) (target: Int) : List = (?hole:List);

--- a/examples/PSB2/annotations/multi_objective/fizzbuzz.ae
+++ b/examples/PSB2/annotations/multi_objective/fizzbuzz.ae
@@ -22,6 +22,4 @@ def calculate_fizzbuzz_errors : (train : TrainData) -> (f:(a: Int) -> String)  -
             calculate_fizzbuzz_errors,
             train )
 @multi_minimize_float(calculate_fizzbuzz_errors train synth, 1)
-def synth (n:Int) : String {
-    (?hole:String)
-}
+def synth (n:Int) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/fuel_cost.ae
+++ b/examples/PSB2/annotations/multi_objective/fuel_cost.ae
@@ -12,7 +12,7 @@ type List;
 def List_size: (l:List) -> Int = uninterpreted;
 def List_length: (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 def sum: (l:List) -> Int = \xs -> native "sum(xs)";
 def Math_max : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "max(i,j)" ;
@@ -37,6 +37,4 @@ def calculate_fuel_cost_errors : (train : TrainData) -> (f:(a: List) -> Int)  ->
             calculate_fuel_cost_errors,
             train)
 @multi_minimize_float(calculate_fuel_cost_errors train synth, 1)
-def synth  (xs: List) : Int {
-    (?hole: Int)
- }
+def synth  (xs: List) : Int = (?hole: Int);

--- a/examples/PSB2/annotations/multi_objective/gcd.ae
+++ b/examples/PSB2/annotations/multi_objective/gcd.ae
@@ -11,6 +11,4 @@ def calculate_gcd_errors : (train : TrainData) -> (f:(a: Int) -> (b: Int) -> Int
             calculate_fuel_cost_errors)
 #@allow_recursion
 @multi_minimize_float(calculate_gcd_errors train synth, 1)
-def synth (n:Int) (z:Int) : Int {
-    (?hole: Int)
-}
+def synth (n:Int) (z:Int) : Int = (?hole: Int);

--- a/examples/PSB2/annotations/multi_objective/indices_of_substring.ae
+++ b/examples/PSB2/annotations/multi_objective/indices_of_substring.ae
@@ -25,7 +25,4 @@ def calculate_indices_of_substring_errors : (train : TrainData) -> (f:(a: String
             calculate_indices_of_substring_errors,
             train )
 @multi_minimize_float(calculate_indices_of_substring_errors train synth, 1)
-def synth ( text :String) (target: String) : List {
-    (?hole:List)
-
-}
+def synth ( text :String) (target: String) : List = (?hole:List);

--- a/examples/PSB2/annotations/multi_objective/leaders.ae
+++ b/examples/PSB2/annotations/multi_objective/leaders.ae
@@ -26,7 +26,4 @@ def calculate_leaders_errors : (train : TrainData) -> (f:(a: List) -> List ) -> 
             calculate_leaders_errors,
             train )
 @multi_minimize_float(calculate_leaders_errors train synth, 1)
-def synth ( vector : List ) : List {
-    (?hole:List)
-
-}
+def synth ( vector : List ) : List = (?hole:List);

--- a/examples/PSB2/annotations/multi_objective/luhn.ae
+++ b/examples/PSB2/annotations/multi_objective/luhn.ae
@@ -8,7 +8,7 @@ type Map;
 def List_size: (l:List) -> Int = uninterpreted;
 def List_length: (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
 def sum : (l:List) -> Int = \xs -> native "sum(xs)";
@@ -27,9 +27,7 @@ def Range_new : (a:Int) -> (b:Int) -> Range = \a -> \b -> native "range(a,b)";
 
 def even : (n:Int) -> Bool = \n -> n % 2 == 0;
 
-def map_digit (x:Int) (i:Int) : Int {
-    if (i % 2) == 0 then ( if (x * 2) > 9 then ((x * 2) - 9) else ( x * 2 ) : Int) else x
-}
+def map_digit (x:Int) (i:Int) : Int = if (i % 2) == 0 then ( if (x * 2) > 9 then ((x * 2) - 9) else ( x * 2 ) : Int) else x;
 
 
 #PSB2
@@ -44,6 +42,4 @@ def calculate_luhn_errors : (train : TrainData) -> (f:(a: List) -> Int)  -> List
             train )
 @multi_minimize_float(calculate_luhn_errors train synth, 1)
 @disable_control_flow
-def synth (digits: List) : Int {
-    (?hole: Int)
-}
+def synth (digits: List) : Int = (?hole: Int);

--- a/examples/PSB2/annotations/multi_objective/mastermind.ae
+++ b/examples/PSB2/annotations/multi_objective/mastermind.ae
@@ -40,6 +40,4 @@ def calculate_mastermind_errors : (train : TrainData) -> (f:(a: String) -> (b:St
             calculate_mastermind_errors,
             train)
 @multi_minimize_float(calculate_mastermind_errors train synth, 2)
-def synth ( code : String) (guess: String ) : List {
-    (?hole:List)
-}
+def synth ( code : String) (guess: String ) : List = (?hole:List);

--- a/examples/PSB2/annotations/multi_objective/middle_char.ae
+++ b/examples/PSB2/annotations/multi_objective/middle_char.ae
@@ -25,6 +25,4 @@ def calculate_middle_char_errors : (train : TrainData) -> (f:(a: String) -> Stri
             calculate_middle_char_errors,
             train )
 @multi_minimize_float(calculate_middle_char_errors train synth, 1)
-def synth(s: String) : String {
-    (?hole:String)
-}
+def synth(s: String) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/paired_digits.ae
+++ b/examples/PSB2/annotations/multi_objective/paired_digits.ae
@@ -29,6 +29,4 @@ def calculate_paired_digits_errors : (train : TrainData) -> (f:(a: String) -> In
             calculate_paired_digits_errors,
             train )
 @multi_minimize_float(calculate_paired_digits_errors train synth, 1)
-def synth (nums: String) : Int {
-    (?hole:Int)
-}
+def synth (nums: String) : Int = (?hole:Int);

--- a/examples/PSB2/annotations/multi_objective/shopping.ae
+++ b/examples/PSB2/annotations/multi_objective/shopping.ae
@@ -12,7 +12,7 @@ type Map;
 def List_size: (l:List) -> Int = uninterpreted;
 def List_length: (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 def List_sum: (l:List) -> Int = \xs -> native "sum(xs)";
 def Math_max : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "max(i,j)" ;
@@ -37,6 +37,4 @@ def calculate_shopping_errors : (train : TrainData) -> (f:(a: List) -> (b: List)
             calculate_shopping_errors,
             train)
 @multi_minimize_float(calculate_shopping_errors train synth, 1)
-def synth  (prices: List) (discounts: List) : Int {
-    (?hole:Int)
- }
+def synth  (prices: List) (discounts: List) : Int = (?hole:Int);

--- a/examples/PSB2/annotations/multi_objective/snow_day.ae
+++ b/examples/PSB2/annotations/multi_objective/snow_day.ae
@@ -13,6 +13,4 @@ def calculate_snow_day_errors : (train : TrainData) -> (f:(a: Int) -> (b: Float)
             train,
             calculate_snow_day_errors)
 @multi_minimize_float(calculate_snow_day_errors train synth, 1)
-def synth ( n :Int) (m :Float) (t :Float) (p :Float) : Float {
-    (?hole:Float)
-}
+def synth ( n :Int) (m :Float) (t :Float) (p :Float) : Float = (?hole:Float);

--- a/examples/PSB2/annotations/multi_objective/solve_boolean.ae
+++ b/examples/PSB2/annotations/multi_objective/solve_boolean.ae
@@ -26,6 +26,4 @@ def calculate_solve_boolean_errors : (train : TrainData) -> (f:(a: String) -> Bo
             train,
             calculate_solve_boolean_errors)
 @multi_minimize_float(calculate_solve_boolean_errors train synth, 1)
-def synth ( s : String ) : Bool {
-    (?hole:Bool)
-}
+def synth ( s : String ) : Bool = (?hole:Bool);

--- a/examples/PSB2/annotations/multi_objective/spin_words.ae
+++ b/examples/PSB2/annotations/multi_objective/spin_words.ae
@@ -24,6 +24,4 @@ def calculate_spin_words_errors : (train : TrainData) -> (f:(a: String) -> Strin
             calculate_spin_words_errors,
             train )
 @multi_minimize_float(calculate_spin_words_errors train synth, 1)
-def synth (phrase: String) : String {
-    (?hole:String)
-    }
+def synth (phrase: String) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/square_digits.ae
+++ b/examples/PSB2/annotations/multi_objective/square_digits.ae
@@ -18,6 +18,4 @@ def calculate_square_digits_errors : (train : TrainData) -> (f:(a: Int) -> Strin
             load_dataset,
             train)
 @multi_minimize_float(calculate_square_digits_errors train synth, 1)
-def synth ( n : Int) : String {
-    (?hole:String)
-}
+def synth ( n : Int) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/substitution_cipher.ae
+++ b/examples/PSB2/annotations/multi_objective/substitution_cipher.ae
@@ -24,6 +24,4 @@ def calculate_cipher_errors : (train : TrainData) -> (f:(a: String) ->(a: String
             calculate_square_digits_errors,
             train)
 @multi_minimize_float(calculate_cipher_errors train synth, 1)
-def synth (cipher_from: String) (cypher_to: String) (msg: String) : String {
-    (?hole:String)
- }
+def synth (cipher_from: String) (cypher_to: String) (msg: String) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/twitter.ae
+++ b/examples/PSB2/annotations/multi_objective/twitter.ae
@@ -23,6 +23,4 @@ def calculate_twitter_errors : (train : TrainData) -> (f:(a: String) -> String) 
             calculate_twitter_errors,
             train )
 @multi_minimize_float(calculate_twitter_errors train synth, 1)
-def synth (tweet: String) : String {
-    (?hole:String)
-    }
+def synth (tweet: String) : String = (?hole:String);

--- a/examples/PSB2/annotations/multi_objective/vector_distance.ae
+++ b/examples/PSB2/annotations/multi_objective/vector_distance.ae
@@ -19,7 +19,7 @@ def List_size: (l:List) -> Int = uninterpreted;
 
 def List_new : {x:List | List_size x == 0} = native "[]" ;
 
-def List_append_float (l:List) (i: Float) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]"}
+def List_append_float (l:List) (i: Float) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
 def train: TrainData = extract_train_data (load_dataset "vector-distance" 200 200);
@@ -37,6 +37,4 @@ def calculate_vector_distance_errors : (train : TrainData) -> (f:(a: List) -> (b
             calculate_vector_distance_errors,
             train)
 @multi_minimize_float(calculate_vector_distance_errors train synth, 1)
-def synth  (vector1: List) (vector2: List) : Float {
-    (?hole:Float)
- }
+def synth  (vector1: List) (vector2: List) : Float = (?hole:Float);

--- a/examples/PSB2/annotations/single_objective/bouncing_balls.ae
+++ b/examples/PSB2/annotations/single_objective/bouncing_balls.ae
@@ -24,6 +24,4 @@ def  expected_values : List =  get_output_list ( unpack_train_data train);
             calculate_list_errors)
 @minimize_float(  mean_absolute_error ( get_bb_synth_values  input_list synth) ( expected_values))
 def synth (a:Float) (b:Float) (c:Int) : Float
-    {
-        (?hole:Float)
-    }
+    = (?hole:Float);

--- a/examples/PSB2/annotations/single_objective/dice_game.ae
+++ b/examples/PSB2/annotations/single_objective/dice_game.ae
@@ -23,6 +23,4 @@ def  expected_values : List =  get_output_list ( unpack_train_data  train);
             calculate_list_errors)
 @minimize_float(mean_absolute_error  (get_dg_synth_values input_list synth)(expected_values))
 def synth (n: Int) (m: Int) : Float
-    {
-        (?hole:Float)
-    }
+    = (?hole:Float);

--- a/examples/PSB2/annotations/single_objective/gcd.ae
+++ b/examples/PSB2/annotations/single_objective/gcd.ae
@@ -24,6 +24,4 @@ def  expected_values : List =  get_output_list ( unpack_train_data  train);
             get_gcd_synth_values,
             calculate_list_errors)
 @minimize_float(  mean_absolute_error ( get_gcd_synth_values  input_list synth) ( expected_values))
-def synth (n:Int) (z:Int) : Int {
-    (?hole:Int)
-}
+def synth (n:Int) (z:Int) : Int = (?hole:Int);

--- a/examples/PSB2/annotations/single_objective/snow_day.ae
+++ b/examples/PSB2/annotations/single_objective/snow_day.ae
@@ -34,6 +34,4 @@ def  expected_values : List =  get_output_list ( unpack_train_data  train);
 def synth (n :Int)
             (m :Float)
             (t :Float)
-            (p :Float) : Float {
-    (?hole:Float)
-}
+            (p :Float) : Float = (?hole:Float);

--- a/examples/PSB2/annotations/single_objective/square_digit.ae
+++ b/examples/PSB2/annotations/single_objective/square_digit.ae
@@ -24,4 +24,4 @@ def expected_values : List = get_output_list (unpack_train_data train);
             get_sd_synth_values,
             calculate_list_errors)
 @minimize_float(String_distance (join_string_list(get_sd_synth_values input_list synth)) (join_string_list(  expected_values)))
-def synth ( n : Int) : String {(?hole:String)}
+def synth ( n : Int) : String = (?hole:String);

--- a/examples/PSB2/annotations/twitter_annotations.ae
+++ b/examples/PSB2/annotations/twitter_annotations.ae
@@ -7,4 +7,4 @@ def  input_list : List =  get_input_list ( unpack_train_data  train);
 def  expected_values : List =  get_output_list ( unpack_train_data  train);
 
 @minimize_float(String_distance ( join_string_list( get_tt_synth_values  input_list synth)) ( join_string_list( expected_values)))
-def synth (tweet:String) : String {(?hole:String)}
+def synth (tweet:String) : String = (?hole:String);

--- a/examples/PSB2/bouncing_balls.ae
+++ b/examples/PSB2/bouncing_balls.ae
@@ -13,19 +13,13 @@ import "PSB2.ae";
 
 def bounciness_index_c (starting_height: {x:Float | 1.0 <= x && x <= 100.0} )
                      (bounce_height:{y:Float | 1.0 <= y && y <= 100.0} )
-                     : Float {
-   bounce_height / starting_height
-}
+                     : Float = bounce_height / starting_height;
 
-def calculate_distance_helper (bounciness_index: Float) (height: Float) (n: Int) (distance: Float) : Float {
-   if n == 0 then distance else calculate_distance_helper bounciness_index (bounciness_index * height) (n-1) (distance + height + (bounciness_index * height))
-}
+def calculate_distance_helper (bounciness_index: Float) (height: Float) (n: Int) (distance: Float) : Float = if n == 0 then distance else calculate_distance_helper bounciness_index (bounciness_index * height) (n-1) (distance + height + (bounciness_index * height));
 
 def bouncing_balls (starting_height: {x:Float | 1.0 <= x && x <= 100.0} )
                    (bounce_height : {y:Float | 1.0 <= y && y <= 100.0} )
-                   (bounces:{z:Int | 1 <= z && z <= 20}) : Float {
-   calculate_distance_helper (bounciness_index_c starting_height bounce_height) starting_height bounces 0.0
-}
+                   (bounces:{z:Int | 1 <= z && z <= 20}) : Float = calculate_distance_helper (bounciness_index_c starting_height bounce_height) starting_height bounces 0.0;
 
 
 #def synth  (a:{x:Float | 1.0 <= x && x <= 100.0} , b:{y:Float | 1.0 <= y && y <= 100.0} ,  c:{z:Int | 1 <= z && z <= 20}) : Float {
@@ -36,8 +30,6 @@ def train: TrainData = extract_train_data (load_dataset "bouncing-balls" 200 200
 def input_list : List = get_input_list (unpack_train_data train);
 def expected_values : List = get_output_list (unpack_train_data train);
 
-def synth (a:Float) (b:Float) (c:Int) : Float {
-   (?hole:Float)
-}
+def synth (a:Float) (b:Float) (c:Int) : Float = (?hole:Float);
 
 def fitness : Float = mean_absolute_error (get_bb_synth_values input_list synth) (expected_values);

--- a/examples/PSB2/dice_game.ae
+++ b/examples/PSB2/dice_game.ae
@@ -16,10 +16,9 @@ def mult (n:Int) (m:Int ) : Int = n * m;
 
 def peter_wins: ( n:Int ) -> ( m:Int ) -> Int = \n -> \m-> if m == 0 then 0 else (Math_max 0 (n - m)) + peter_wins n (m - 1);
 
-def dice_game ( n : {x:Int | 1 <= x && x <= 10000}) (m : {y:Int | 1 <= y && y <= 10000}) : Float {
-    Math_toFloat(peter_wins n  m ) / Math_toFloat(mult n m)  }
+def dice_game ( n : {x:Int | 1 <= x && x <= 10000}) (m : {y:Int | 1 <= y && y <= 10000}) : Float = Math_toFloat(peter_wins n  m ) / Math_toFloat(mult n m);
 
-def synth ( n : {a:Int | 1 <= a && a <= 10000}) (m : {b:Int | 1 <= b && b <= 10000}) : Float { (?hole:Float) }
+def synth ( n : {a:Int | 1 <= a && a <= 10000}) (m : {b:Int | 1 <= b && b <= 10000}) : Float = (?hole:Float);
 
 def fitness : Float =
     ds = load_dataset "dice-game" 200 200;

--- a/examples/PSB2/fizz_buzz.ae
+++ b/examples/PSB2/fizz_buzz.ae
@@ -21,27 +21,20 @@ def div5 ( n :{x:Int | 1 <= x && x <= 1000000}) : Bool = if ((n % 5) == 0) then 
 def div15 ( n :{x:Int | 1 <= x && x <= 1000000}) : Bool = if ((n % 15) == 0) then true else false;
 
 
-def FizzBuzz ( n :{x:Int | 1 <= x && x <= 1000000}) : String {
-
-    if div15 n then "FizzBuzz" else (if ((n % 3) == 0) then "Fizz" else (if ((n % 5) == 0)  then "Buzz" else native "str(n)"))
-
-}
+def FizzBuzz ( n :{x:Int | 1 <= x && x <= 1000000}) : String =
+    if div15 n then "FizzBuzz" else (if ((n % 3) == 0) then "Fizz" else (if ((n % 5) == 0)  then "Buzz" else native "str(n)"));
 
 #def synth_fizz ( n :{x:Int | 1 <= x && x <= 1000000}) : String {
-def synth_fizz ( n :Int ) : String {
-
-    (?hole:String)
-}
+def synth_fizz ( n :Int ) : String = (?hole:String);
 
 def train: TrainData = extract_train_data (load_dataset "fizz-buzz" 200 200);
 def input_list : List = get_input_list (unpack_train_data train);
 def expected_values : List = get_output_list (unpack_train_data train);
 
 
-def fitness(): Float {
+def fitness : Float =
     actual_values : List = get_fb_synth_values input_list synth_fizz;
     expected_values_str = join_string_list expected_values;
     actual_values_str = join_string_list actual_values;
     str_distance = String_distance expected_values_str actual_values_str;
-    str_distance
-}
+    str_distance;

--- a/examples/PSB2/solved/basement.ae
+++ b/examples/PSB2/solved/basement.ae
@@ -1,25 +1,19 @@
 type List;
 
 def List_size: (l:List) -> Int = uninterpreted;
-def List_len (l:List) : Int  { native "len(l)" }
+def List_len (l:List) : Int  = native "len(l)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
-def List_get (l:List) (i: Int) : Int { native "l[i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
+def List_get (l:List) (i: Int) : Int = native "l[i]";
 
-def fst_negative (l:List) (i:Int) (u:Int) : Int {
-    if (i >= (List_len l)) then
+def fst_negative (l:List) (i:Int) (u:Int) : Int = if (i >= (List_len l)) then
         i
      else if (u < 0) then
         i
      else
-        fst_negative l (i + 1) (u + (List_get l (i + 1)))
-     }
+        fst_negative l (i + 1) (u + (List_get l (i + 1)));
 
-def basement (nums: List) : Int {
-     fst_negative nums 0 (List_get nums 0)
-}
+def basement (nums: List) : Int = fst_negative nums 0 (List_get nums 0);
 
 
-def main (args:Int): Unit {
-    print (basement (List_append List_new (-100)) )
-}
+def main (args:Int): Unit = print (basement (List_append List_new (-100)) );

--- a/examples/PSB2/solved/bowling.ae
+++ b/examples/PSB2/solved/bowling.ae
@@ -1,36 +1,31 @@
 type List;
 
 
-def List_sum (l:List) : Int { native "sum(l)" }
+def List_sum (l:List) : Int = native "sum(l)";
 
 def List_map (f: (a: Int) -> Int)
              (xs: List) :
-              List {
-    native "list(map(f, xs))"
-}
+              List = native "list(map(f, xs))";
 
 
-def String_replace (s:String) (t:String) (rep:String) : String { native "s.replace(t, rep)" }
-def String_length (list:String) : Int { native "len(list)" }
-def String_get (l:String) (i:Int) : String { native "l[i]" }
-def String_to_int (s:String) : Int { native "int(s)" }
-def String_eq (s:String) (s2:String) : Bool { native "s == s2" }
+def String_replace (s:String) (t:String) (rep:String) : String = native "s.replace(t, rep)";
+def String_length (list:String) : Int = native "len(list)";
+def String_get (l:String) (i:Int) : String = native "l[i]";
+def String_to_int (s:String) : Int = native "int(s)";
+def String_eq (s:String) (s2:String) : Bool = native "s == s2";
 
-def List_range_step (start:Int) (end:Int) (step:Int) : List { native "list(range(start, end, step))" }
+def List_range_step (start:Int) (end:Int) (step:Int) : List = native "list(range(start, end, step))";
 
- def convert_bowling(score: String) : Int {
- if String_eq score "X" then
+ def convert_bowling(score: String) : Int = if String_eq score "X" then
     10
  else
     if String_eq score "/" then
         10
     else
-        String_to_int score
- }
+        String_to_int score;
 
 
-def create_mapper (scores:String) (i:Int) : Int {
-    current : String = String_get scores i;
+def create_mapper (scores:String) (i:Int) : Int = current : String = String_get scores i;
     next : String = String_get scores (i+1);
     if String_eq current "X" then
         next_frame1 : String = String_get scores (i+2);
@@ -48,26 +43,21 @@ def create_mapper (scores:String) (i:Int) : Int {
         next_next : String = String_get scores (i+2);
         10 + (convert_bowling next_next)
     else
-        String_to_int current + convert_bowling next
-}
+        String_to_int current + convert_bowling next;
 
 
-def bowling_score (scores: String) : Int {
-    scores_right_size = String_replace scores "X" "X_";
+def bowling_score (scores: String) : Int = scores_right_size = String_replace scores "X" "X_";
     scores_zero = String_replace scores_right_size "-" "0";
     r : List = List_range_step 0 20 2;
     mapper : (i:Int) -> Int = create_mapper scores_zero;
     components : List = List_map mapper r;
-    List_sum components
- }
+    List_sum components;
 
-def main (args:Int) : Unit {
-    example : String = "23232323232323232323"; # 50
+def main (args:Int) : Unit = example : String = "23232323232323232323"; # 50
     example : String = "2/232323232323232323"; # 57
     example : String = "X232323232323232323"; # 60
     example : String = "X2/2323232323232323"; # 20 + 12 + 40 = 72
     example : String = "--------------------"; # 0
     example : String = "XXXXXXXXXXXX"; # 300
     example : String = "2323232323232323232/1"; # 55
-    print (bowling_score example)
-}
+    print (bowling_score example);

--- a/examples/PSB2/solved/camel_case.ae
+++ b/examples/PSB2/solved/camel_case.ae
@@ -14,8 +14,7 @@ def String_get : (s:String) -> (i:Int) -> String = \s -> \i -> native "s[i]";
 def String_tail:(l:String) -> String = \xs -> native "xs[1:]";
 
 
-def camel_case (s:String) : String {
-    groups: List = String_split s " ";
+def camel_case (s:String) : String = groups: List = String_split s " ";
 
     camel_case_groups : List = (Map_string_list
         ((\group ->  (String_concat
@@ -29,10 +28,7 @@ def camel_case (s:String) : String {
         (Map_list_list ((\g -> (String_split g "-")):(s:String) -> List) groups)
     );
     result : String = String_join camel_case_groups " ";
-    result
-}
+    result;
 
 
-def main (args:Int) : Unit {
-    print(camel_case "two-words")
-}
+def main (args:Int) : Unit = print(camel_case "two-words");

--- a/examples/PSB2/solved/coin_sum.ae
+++ b/examples/PSB2/solved/coin_sum.ae
@@ -6,17 +6,13 @@ def List_size : (l:List) -> Int = uninterpreted;
 
 def List_new : {x:List | List_size x == 0} = native "[]" ;
 
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
-def coin_sum (cents: Int) : List {
-  quarters:Int = Math_floor_division cents 25;
+def coin_sum (cents: Int) : List = quarters:Int = Math_floor_division cents 25;
   dimes:Int = Math_floor_division (cents % 25) 10;
   nickels:Int = Math_floor_division ((cents % 25) % 10) 5;
   pennies:Int = ((cents % 25) % 10) % 5;
-  List_append (List_append (List_append ( List_append List_new pennies) nickels) dimes) quarters
- }
+  List_append (List_append (List_append ( List_append List_new pennies) nickels) dimes) quarters;
 
-def main (args:Int): Unit {
-  print (coin_sum 5)
-}
+def main (args:Int): Unit = print (coin_sum 5);

--- a/examples/PSB2/solved/cut_vector.ae
+++ b/examples/PSB2/solved/cut_vector.ae
@@ -26,8 +26,7 @@ def get_fst : (i:List) -> Int = \i -> native "i[0]";
 def get_snd : (i:List) -> Int = \i -> native "i[1]";
 def get_zip : (i:List) -> List = \i -> native "i[1]";
 
-def cut_vector ( ls : List ) : List {
-    if (List_length ls == 1) then
+def cut_vector ( ls : List ) : List = if (List_length ls == 1) then
         Tuple_list ls List_new
     else
     inits: List = Accumulate (List_remove_last ls);
@@ -41,12 +40,8 @@ def cut_vector ( ls : List ) : List {
     vec1: List = List_slice ls 0 (cut_position +1);
     vec2: List = List_slice ls (cut_position +1) (List_length ls);
 
-    Tuple_list vec1 vec2
-}
+    Tuple_list vec1 vec2;
 
-def main (args:Int) : Unit {
-    vec: List = List_append (List_append List_new 1) 2;
+def main (args:Int) : Unit = vec: List = List_append (List_append List_new 1) 2;
     #vec: List = Range 0 10 1;
-    print(cut_vector vec)
-
-}
+    print(cut_vector vec);

--- a/examples/PSB2/solved/dice_game.ae
+++ b/examples/PSB2/solved/dice_game.ae
@@ -4,18 +4,12 @@ def math : Unit = native_import "math";
 def Math_toFloat : (i:Int) -> Float = \i -> native "float(i)" ;
 def Math_max : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "max(i,j)" ;
 
-def peter_wins (n:Int) (m:Int) : Int {
-    if m == 0 then 0 else Math_max 0 (n - m) + peter_wins n (m - 1)
-}
+def peter_wins (n:Int) (m:Int) : Int = if m == 0 then 0 else Math_max 0 (n - m) + peter_wins n (m - 1);
 
-def dice_game (n:Int | 1 <= n && n <= 10000) (m:Int | 1 <= m && m <= 10000) : Float {
-     a : Float = Math_toFloat (peter_wins n m);
+def dice_game (n:Int | 1 <= n && n <= 10000) (m:Int | 1 <= m && m <= 10000) : Float = a : Float = Math_toFloat (peter_wins n m);
      b : Float = Math_toFloat (n * m);
      c : Float = a / b;
-     c
-}
+     c;
 
 
-def main (args:Int) : Unit {
-    print (dice_game 100 99)
-}
+def main (args:Int) : Unit = print (dice_game 100 99);

--- a/examples/PSB2/solved/find_pair.ae
+++ b/examples/PSB2/solved/find_pair.ae
@@ -13,20 +13,16 @@ def List_head : (l: List) -> List = \xs -> native "xs[0]";
 def List_size : (l:List) -> Int = uninterpreted;
 def List_length : (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
 #assuming that the list always has at least 2 elements that sum to the target
-def find_pair (numbers: List) (target: Int) : List {
-    pairs : List = combinations numbers 2;
+def find_pair (numbers: List) (target: Int) : List = pairs : List = combinations numbers 2;
     pred : (s:List) -> Bool = \pair -> List_sum pair == target;
     matching_pairs : List = List_filter pred pairs;
-    List_head matching_pairs
-}
+    List_head matching_pairs;
 
 
-def main (args:Int) : Unit {
-    l : List = List_append (List_append List_new 5) 7;
+def main (args:Int) : Unit = l : List = List_append (List_append List_new 5) 7;
     p : List = find_pair l 12;
-    print p
-}
+    print p;

--- a/examples/PSB2/solved/fizzbuzz.ae
+++ b/examples/PSB2/solved/fizzbuzz.ae
@@ -4,12 +4,8 @@ def div3 (n:Int) : Bool = if ((n % 3) == 0) then true else false;
 def div5 (n:Int) : Bool = if ((n % 5) == 0) then true else false;
 def div15 (n:Int) : Bool = if ((n % 15) == 0) then true else false;
 
-def toString (i:Int) : String { native "str(i)" }
+def toString (i:Int) : String = native "str(i)";
 
-def fizzbuzz (n:Int) : String {
-    if div15 n then "FizzBuzz" else (if ((n % 3) == 0) then "Fizz" else (if ((n % 5) == 0) then "Buzz" else toString n))
-}
+def fizzbuzz (n:Int) : String = if div15 n then "FizzBuzz" else (if ((n % 3) == 0) then "Fizz" else (if ((n % 5) == 0) then "Buzz" else toString n));
 
-def main (args:Int) : Unit {
-    print (fizzbuzz 15)
-}
+def main (args:Int) : Unit = print (fizzbuzz 15);

--- a/examples/PSB2/solved/fuel_cost.ae
+++ b/examples/PSB2/solved/fuel_cost.ae
@@ -3,21 +3,17 @@ type List;
 def List_size: (l:List) -> Int = uninterpreted;
 def List_length: (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
-def Math_sum (xs:List) : Int { native "sum(xs)" }
+def Math_sum (xs:List) : Int = native "sum(xs)";
 def Math_max (i:Int) (j:Int) : Int = if i > j then i else j;
-def Math_floor_division (i:Int) (j:Int) : Int { native "i // j" }
+def Math_floor_division (i:Int) (j:Int) : Int = native "i // j";
 
-def List_map_Int_Int (fun:(a: Int) -> Int)  (xs: List) : List { native "map(fun, xs)" }
+def List_map_Int_Int (fun:(a: Int) -> Int)  (xs: List) : List = native "map(fun, xs)";
 
-def fuel_cost  (xs: List) : Int {
-    mapper : (x: Int) -> Int = \x -> Math_max (Math_floor_division x 3 - 2) 0;
-    Math_sum (List_map_Int_Int mapper xs)
-}
+def fuel_cost  (xs: List) : Int = mapper : (x: Int) -> Int = \x -> Math_max (Math_floor_division x 3 - 2) 0;
+    Math_sum (List_map_Int_Int mapper xs);
 
-def main (args:Int) : Unit {
-    l = (List_append (List_append List_new 1) 9);
-    print (fuel_cost l)
-}
+def main (args:Int) : Unit = l = (List_append (List_append List_new 1) 9);
+    print (fuel_cost l);

--- a/examples/PSB2/solved/gcd.ae
+++ b/examples/PSB2/solved/gcd.ae
@@ -1,5 +1,3 @@
 def gcd (n:Int) (z:Int) : Int = if z == 0 then n else gcd z (n % z);
 
-def main (args:Int) : Unit {
-    print (gcd 15 5)
-}
+def main (args:Int) : Unit = print (gcd 15 5);

--- a/examples/PSB2/solved/indices_of_substring.ae
+++ b/examples/PSB2/solved/indices_of_substring.ae
@@ -10,17 +10,11 @@ def String_equal : (i:String) -> (j:String) -> Bool = \i -> \j -> native "i == j
 
 def String_slice : (i:String) -> (j:Int) -> (l:Int)-> String = \i -> \j -> \l -> native "i[j:l]" ;
 
-def indices_of_substring ( text :String) (target: String) : List {
-    start: Int = 0;
+def indices_of_substring ( text :String) (target: String) : List = start: Int = 0;
     end: Int = ((String_len text) - (String_len target)) + 1 ;
     step: Int = 1;
     indices : List = Range start end step;
     matching_indices : List = Filter ((\i -> String_equal (String_slice text i (i + (String_len target))) target):(s:Int) -> Bool)  indices;
-    matching_indices
+    matching_indices;
 
-}
-
-def main (args:Int) : Unit {
-    print(indices_of_substring "hello world" "lo" )
-
-}
+def main (args:Int) : Unit = print(indices_of_substring "hello world" "lo" );

--- a/examples/PSB2/solved/leaders.ae
+++ b/examples/PSB2/solved/leaders.ae
@@ -12,16 +12,11 @@ def Filter :  (f: (s:List) -> Bool) -> (l:List) -> List = \f -> \xs -> native "[
 def Zip : (xs:List) -> (ys:List) -> List = \xs -> \ys -> native "list(zip(xs, ys))";
 def Map : (f: (s:List) -> Int) -> (l:List) -> List = \f -> \xs -> native "list(map(f, xs))";
 
-def cut_vector ( vector : List ) : List {
-    reversed_vector: List = List_reversed vector;
+def cut_vector ( vector : List ) : List = reversed_vector: List = List_reversed vector;
     scanl_max: List = Scanl_max reversed_vector;
     leaders_reverse: List = Filter ((\x -> List_get x 0 == List_get x 1) : (s:List) -> Bool) (Zip reversed_vector scanl_max);
     leaders = List_reversed (Map (\x -> List_get x 0 : (s:List) -> Int) leaders_reverse);
-    leaders
+    leaders;
 
-}
-
-def main (args:Int) : Unit {
-    vec: List = List_append (List_append (List_append (List_append List_new 47) 87) 43) 44;
-    print(cut_vector vec)
-}
+def main (args:Int) : Unit = vec: List = List_append (List_append (List_append (List_append List_new 47) 87) 43) 44;
+    print(cut_vector vec);

--- a/examples/PSB2/solved/luhn.ae
+++ b/examples/PSB2/solved/luhn.ae
@@ -6,7 +6,7 @@ type Map;
 def List_size: (l:List) -> Int = uninterpreted;
 def List_length: (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
 
@@ -23,19 +23,13 @@ def Range_new : (a:Int) -> (b:Int) -> Range = \a -> \b -> native "range(a,b)";
 
 def even : (n:Int) -> Bool = \n -> n % 2 == 0;
 
-def map_digit (x:Int) (i:Int) : Int {
-    if (i % 2) == 0 then ( if (x * 2) > 9 then ((x * 2) - 9) else ( x * 2 ) : Int) else x
-}
+def map_digit (x:Int) (i:Int) : Int = if (i % 2) == 0 then ( if (x * 2) > 9 then ((x * 2) - 9) else ( x * 2 ) : Int) else x;
 
-def luhn (digits: List) : Int {
-    range : Range = Range_new 0 (List_length digits);
+def luhn (digits: List) : Int = range : Range = Range_new 0 (List_length digits);
     transformed_digits: List = List_map_List_Range map_digit digits range;
-    Math_sum transformed_digits
-}
+    Math_sum transformed_digits;
 
 def repeated_list: (n:Int) -> (x:Int) -> List = \n -> \x -> native "[x]*n";
 
-def main (args:Int) : Unit {
-    l : List = repeated_list 16 9;
-    print (luhn l)
-}
+def main (args:Int) : Unit = l : List = repeated_list 16 9;
+    print (luhn l);

--- a/examples/PSB2/solved/mastermind.ae
+++ b/examples/PSB2/solved/mastermind.ae
@@ -21,8 +21,7 @@ def Counter_intersection : (c1:Counter) -> (c2:Counter) -> Counter = \c1 -> \c2 
 def Counter_values : (c:Counter) -> List = \c -> native "list(c.values())";
 def Tuple : (a:Int) -> (b:Int) -> List = \a -> \b -> native "[a,b]";
 
-def mastermind ( code : String) (guess: String ) : List {
-    items_eq : (x:List) -> Int = \x -> if String_eq (List_get_fst x) (List_get_snd x) then 1 else 0;
+def mastermind ( code : String) (guess: String ) : List = items_eq : (x:List) -> Int = \x -> if String_eq (List_get_fst x) (List_get_snd x) then 1 else 0;
     black_map : List = Map_bool items_eq (String_Zip code guess);
     black_pegs : Int = List_sum black_map;
 
@@ -35,10 +34,7 @@ def mastermind ( code : String) (guess: String ) : List {
     white_pegs_f : (x:List) -> (y:List) -> Int = \c -> \g -> List_sum (Counter_values (Counter_intersection (Counter c) (Counter g)));
     white_pegs :Int = white_pegs_f code_unmatched guess_unmatched;
 
-    Tuple white_pegs black_pegs
-}
+    Tuple white_pegs black_pegs;
 
 
-def main (args:Int) : Unit {
-    print(mastermind "GGGB" "BGGG")
-}
+def main (args:Int) : Unit = print(mastermind "GGGB" "BGGG");

--- a/examples/PSB2/solved/middle_char.ae
+++ b/examples/PSB2/solved/middle_char.ae
@@ -11,8 +11,7 @@ def String_slice : (i:String) -> (j:Int) -> (l:Int)-> String = \i -> \j -> \l ->
 
 def equal_int : (a: Int) -> (b: Int) -> Bool = \x -> \y -> native "x == y";
 
-def middle_char  (s: String) : String {
-    str_len : Int = String_len s;
+def middle_char  (s: String) : String = str_len : Int = String_len s;
     a : Int = (str_len % 2);
     b : Bool = equal_int a 0;
     if (b) then
@@ -27,11 +26,8 @@ def middle_char  (s: String) : String {
         y: Float = (x / 2.0);
         mid_char_index: Int = (Math_floor y);
         m_char = String_slice s mid_char_index (mid_char_index+1);
-        m_char
-}
+        m_char;
 
 
 
-def main (args:Int) : Unit {
-    print (middle_char "ola")
-}
+def main (args:Int) : Unit = print (middle_char "ola");

--- a/examples/PSB2/solved/paired_digits.ae
+++ b/examples/PSB2/solved/paired_digits.ae
@@ -15,15 +15,11 @@ def filter :  (f: (s:String) -> Bool) -> (l:List) -> List = \f -> \xs -> native 
 def List_sum: (l:List) -> Int = \xs -> native "sum(xs)";
 def List_map_String_Int: (function:(a: String) -> Int) -> (l: List) -> List = \f -> \xs -> native "map(f, xs)";
 
-def paired_digits (nums: String) : Int {
-    pairs: List = String_to_List (String_zip (nums) (String_slice nums 1 (String_len nums)));
+def paired_digits (nums: String) : Int = pairs: List = String_to_List (String_zip (nums) (String_slice nums 1 (String_len nums)));
     pred : (x:String) -> Bool = \x -> (get_fst x) == (get_snd x);
     matching_pairs : List = filter pred pairs;
     mapper : (x: String) -> Int = \x -> String_to_Int (get_fst x);
     total_sum : Int = List_sum (List_map_String_Int mapper matching_pairs);
-    total_sum
- }
+    total_sum;
 
-def main (args:Int) : Unit {
-    print (paired_digits "99")
-}
+def main (args:Int) : Unit = print (paired_digits "99");

--- a/examples/PSB2/solved/shopping.ae
+++ b/examples/PSB2/solved/shopping.ae
@@ -4,7 +4,7 @@ type Map;
 def List_size: (l:List) -> Int = uninterpreted;
 def List_length: (l:List) -> Int = \list -> native "len(list)";
 def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]" }
+def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
 
@@ -18,15 +18,10 @@ def List_map_Int_Int_Int_List: (function: (a: Int) -> (b: Int) -> Int) ->
                                List =
     \f -> \xs -> \ys -> native "list(map(lambda x, y: f(x)(y), xs, ys))";
 
-def shopping  (prices: List) (discounts: List) : Int {
-    f: (x:Int) -> (y:Int) -> Int = \x -> \y -> x * (1 - y / 100);
+def shopping  (prices: List) (discounts: List) : Int = f: (x:Int) -> (y:Int) -> Int = \x -> \y -> x * (1 - y / 100);
     l: List = List_map_Int_Int_Int_List f prices discounts;
-    List_sum l
+    List_sum l;
 
- }
-
-def main (args:Int) : Unit {
-    l1: List = List_append (List_append List_new 50) 0;
+def main (args:Int) : Unit = l1: List = List_append (List_append List_new 50) 0;
     l2: List = List_append (List_append List_new 10) 0;
-    print (shopping l1 l2)
-}
+    print (shopping l1 l2);

--- a/examples/PSB2/solved/snow_day.ae
+++ b/examples/PSB2/solved/snow_day.ae
@@ -1,7 +1,6 @@
 def isZero : (n: Int) -> Bool = \n -> n == 0;
 
-def snow_day ( n: Int) ( m: Float) (t: Float) (p: Float) : Float {
-    if isZero n then
+def snow_day ( n: Int) ( m: Float) (t: Float) (p: Float) : Float = if isZero n then
         m
     else
         a: Float = m + t;
@@ -9,10 +8,6 @@ def snow_day ( n: Int) ( m: Float) (t: Float) (p: Float) : Float {
         c: Float = a - b;
         n1: Int = n - 1;
 
-        snow_day n1 c t p
+        snow_day n1 c t p;
 
-}
-
-def main(n: Int) : Unit{
-    print (snow_day 10 0.0 1.0 0.0)
-}
+def main(n: Int) : Unit= print (snow_day 10 0.0 1.0 0.0);

--- a/examples/PSB2/solved/solve_boolean.ae
+++ b/examples/PSB2/solved/solve_boolean.ae
@@ -13,8 +13,7 @@ def String_slice: (s:String) -> (start:Int) -> (end:Int) -> String = \s -> \star
 def String_length: (s:String) -> Int = \s -> native "len(s)";
 def List_get: (l:List) -> (i:Int) -> String = \xs -> \i -> native "xs[i]";
 
-def solve_boolean ( s : String ) : Bool {
-    if (String_equal s "t") then
+def solve_boolean ( s : String ) : Bool = if (String_equal s "t") then
         true
     else
         if (String_equal s "f") then
@@ -27,12 +26,8 @@ def solve_boolean ( s : String ) : Bool {
              else
                 operand1: String = String_slice s 0 (-2);
                 operand2: String = String_slice s (-1) (String_length s);
-                solve_boolean operand1 || solve_boolean operand2
-
-        }
+                solve_boolean operand1 || solve_boolean operand2;
 
 
 
-def main (args:Int) : Unit {
-    print (solve_boolean "f&f|t")
-}
+def main (args:Int) : Unit = print (solve_boolean "f&f|t");

--- a/examples/PSB2/solved/spin_words.ae
+++ b/examples/PSB2/solved/spin_words.ae
@@ -6,13 +6,9 @@ def map_String_String_List : (function:(a: String) -> String) -> (l: List) -> Li
 def String_split : (i:String) -> (j:String) -> List = \i -> \j -> native "i.split(j)" ;
 def String_reverse : (i:String) -> String = \i -> native "i[::-1]";
 
-def spin_words (phrase: String) : String {
-    words: List = String_split phrase " ";
+def spin_words (phrase: String) : String = words: List = String_split phrase " ";
     rev : (x:String) -> String = \x -> if String_len(x) >= 5 then String_reverse x else x;
     reversed_words : List = map_String_String_List rev words;
-    String_list_to_String reversed_words
- }
+    String_list_to_String reversed_words;
 
-def main (args:Int) : Unit {
-    print (spin_words "this is another test")
-}
+def main (args:Int) : Unit = print (spin_words "this is another test");

--- a/examples/PSB2/solved/square_digits.ae
+++ b/examples/PSB2/solved/square_digits.ae
@@ -5,8 +5,7 @@ def String_concat : (i:String) -> (j:String) -> String = \i -> \j -> native "i +
 def String_intToString : (i:Int) -> String = \i -> native "str(i)";
 
 
-def square_digits ( n : Int) : String {
-    if n == 0 then
+def square_digits ( n : Int) : String = if n == 0 then
         "0"
     else
         digit = n % 10;
@@ -15,9 +14,6 @@ def square_digits ( n : Int) : String {
         if floor == 0 then
             String_intToString(square)
         else
-            String_concat (square_digits(Math_floor_division n 10)) (String_intToString(square))
-}
+            String_concat (square_digits(Math_floor_division n 10)) (String_intToString(square));
 
-def main (n : Int) : Unit {
-    print (square_digits 44 )
-}
+def main (n : Int) : Unit = print (square_digits 44 );

--- a/examples/PSB2/solved/substitution_cipher.ae
+++ b/examples/PSB2/solved/substitution_cipher.ae
@@ -10,13 +10,9 @@ def Dict_get : (d: Dict) -> (k: String) -> (default: String) -> String = \d -> \
 
 def Map_String_String: (function: (a:String) -> String) -> (l: String) -> List = \f -> \xs -> native "map(f, xs)";
 
-def cipher (cipher_from: String) ( cypher_to: String) (msg: String) : String {
- cipher_dict: Dict = Dict_zip (Zip_String_String cipher_from cypher_to);
+def cipher (cipher_from: String) ( cypher_to: String) (msg: String) : String = cipher_dict: Dict = Dict_zip (Zip_String_String cipher_from cypher_to);
  mapper : (x:String) -> String = \x -> Dict_get cipher_dict x x;
  deciphered_chars: List = Map_String_String mapper msg;
- String_list_to_String deciphered_chars
- }
+ String_list_to_String deciphered_chars;
 
-def main (args:Int) : Unit {
-    print (cipher "e" "l" "eeeeeeeeeeee")
-}
+def main (args:Int) : Unit = print (cipher "e" "l" "eeeeeeeeeeee");

--- a/examples/PSB2/solved/twitter.ae
+++ b/examples/PSB2/solved/twitter.ae
@@ -4,8 +4,7 @@ def String_intToString : (i:Int) -> String = \i -> native "str(i)";
 def String_concat : (i:String) -> (j:String) -> String = \i -> \j -> native "i + j";
 
 
-def validate_tweet (tweet: String) : String {
-    tweet_length = String_len(tweet);
+def validate_tweet (tweet: String) : String = tweet_length = String_len(tweet);
     if tweet_length == 0 then
         "You didn’t type anything"
     else
@@ -13,10 +12,7 @@ def validate_tweet (tweet: String) : String {
             "Too many characters"
         else
             tweet_length_str = String_intToString(tweet_length);
-            String_concat (String_concat "Your tweet has " tweet_length_str)   " characters"
-    }
+            String_concat (String_concat "Your tweet has " tweet_length_str)   " characters";
 
-def  main (x: Int) : Unit {
-    tweet = validate_tweet "Hello, World!";
-    print tweet
-}
+def  main (x: Int) : Unit = tweet = validate_tweet "Hello, World!";
+    print tweet;

--- a/examples/PSB2/solved/vector_distance.ae
+++ b/examples/PSB2/solved/vector_distance.ae
@@ -17,21 +17,17 @@ def List_size: (l:List) -> Int = uninterpreted;
 
 def List_new : {x:List | List_size x == 0} = native "[]" ;
 
-def List_append_float (l:List) (i: Float) : {l2:List | List_size l2 == List_size l + 1} { native "l + [i]"}
+def List_append_float (l:List) (i: Float) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
 
 
 
 
 
-def vector_distance  (vector1: List) (vector2: List) : Float {
-    mapper : (x:Float) -> (y:Float) -> Float = \x -> \y ->  Math_pow_Float (x - y) 2.0;
+def vector_distance  (vector1: List) (vector2: List) : Float = mapper : (x:Float) -> (y:Float) -> Float = \x -> \y ->  Math_pow_Float (x - y) 2.0;
     squared_diffs: List = Map_Float_Float_Float_List_List mapper vector1 vector2;
     distance = Math_sqrt_Float (List_sum_Float squared_diffs);
-    distance
- }
+    distance;
 
-def main (args:Int) : Unit {
-    v1: List = List_append_float List_new 42.91283;
+def main (args:Int) : Unit = v1: List = List_append_float List_new 42.91283;
     v2: List = List_append_float List_new (-22.134);
-    print(vector_distance v1 v2)
-}
+    print(vector_distance v1 v2);

--- a/examples/PSB2/square_digit.ae
+++ b/examples/PSB2/square_digit.ae
@@ -18,19 +18,18 @@ import "PSB2.ae";
 #        result
 #}
 
-def square_digit_unsafe  ( n : Int) : String {
+def square_digit_unsafe  ( n : Int) : String =
     if n == 0 then
         ""
     else
         digit = n % 10;
         square = digit * digit;
         result = String_concat (square_digit_unsafe(Math_floor_division n 10)) (String_intToString(square));
-        result
-}
+        result;
 
-def synth_sd ( n : Int) : String {(?hole:String)}
+def synth_sd ( n : Int) : String = (?hole:String);
 
-def fitness(): Float {
+def fitness : Float =
     ds = load_dataset "square-digits" 200 200;
     train = extract_train_data ds;
     unpacked_data = unpack_train_data train;
@@ -40,5 +39,4 @@ def fitness(): Float {
     expected_values_str = join_string_list expected_values;
     actual_values_str = join_string_list actual_values;
     str_distance = String_distance expected_values_str actual_values_str;
-    str_distance
-}
+    str_distance;

--- a/examples/benchmarks/bench_function_clamp.ae
+++ b/examples/benchmarks/bench_function_clamp.ae
@@ -3,6 +3,4 @@
 # A constant like 50 is the simplest valid solution.
 
 @minimize_int(0)
-def clamp (x:Int) : {y:Int | y >= 0 && y <= 100} {
-    ?hole
-}
+def clamp (x:Int) : {y:Int | y >= 0 && y <= 100} = ?hole;

--- a/examples/benchmarks/bench_function_increment.ae
+++ b/examples/benchmarks/bench_function_increment.ae
@@ -2,11 +2,7 @@
 # The return type enforces j > i (any increment works), while the fitness
 # guides the search toward the identity shift f(x) = x + 1 via two examples.
 
-def abs (n:Int) : Int {
-    if n < 0 then - n else n
-}
+def abs (n:Int) : Int = if n < 0 then - n else n;
 
 @minimize_int(abs(fun 5 - 6) + abs(fun 10 - 11))
-def fun (i:Int) : {j:Int | j > i} {
-    ?hole
-}
+def fun (i:Int) : {j:Int | j > i} = ?hole;

--- a/examples/benchmarks/bench_function_negate.ae
+++ b/examples/benchmarks/bench_function_negate.ae
@@ -2,11 +2,7 @@
 # No type-level constraint on the output; fitness examples at x=3, 5, 10
 # drive the synthesizer to discover negation via optimization alone.
 
-def abs (n:Int) : Int {
-    if n < 0 then - n else n
-}
+def abs (n:Int) : Int = if n < 0 then - n else n;
 
 @minimize_int(abs(fun 5 + 5) + abs(fun 3 + 3) + abs(fun 10 + 10))
-def fun (x:Int) : Int {
-    ?hole
-}
+def fun (x:Int) : Int = ?hole;

--- a/examples/benchmarks/bench_int_divisible.ae
+++ b/examples/benchmarks/bench_int_divisible.ae
@@ -3,9 +3,7 @@
 # so it is encoded purely via fitness: |result % 100| is minimised to 0,
 # which is satisfied exactly by 100, 200, ..., 1000 (10 out of 1000 candidates).
 
-def abs (n:Int) : Int {
-    if n < 0 then 0 - n else n
-}
+def abs (n:Int) : Int = if n < 0 then 0 - n else n;
 
 @minimize_int(abs(result % 100))
 def result : {v:Int | v > 0 && v <= 1000} = ?hole;

--- a/examples/benchmarks/bench_maybe.ae
+++ b/examples/benchmarks/bench_maybe.ae
@@ -11,9 +11,7 @@ def Just (x:Int) : Maybe = native "x";
 def is_nothing (m:Maybe) : Bool = native "m is None";
 def from_just (m:Maybe) : Int = native "m";
 
-def abs (n:Int) : Int {
-    if n < 0 then 0 - n else n
-}
+def abs (n:Int) : Int = if n < 0 then 0 - n else n;
 
 @minimize_int(if is_nothing result then 100 else abs(from_just result - 42))
 def result : Maybe = ?hole;

--- a/examples/benchmarks/bench_peano.ae
+++ b/examples/benchmarks/bench_peano.ae
@@ -8,9 +8,7 @@ def Zero : Nat = native "0";
 def Succ (n:Nat) : Nat = native "n + 1";
 def nat_val (n:Nat) : Int = native "n";
 
-def abs (n:Int) : Int {
-    if n < 0 then 0 - n else n
-}
+def abs (n:Int) : Int = if n < 0 then 0 - n else n;
 
 @minimize_int(abs(nat_val result - 5))
 def result : Nat = ?hole;

--- a/examples/benchmarks/bench_tree.ae
+++ b/examples/benchmarks/bench_tree.ae
@@ -13,15 +13,11 @@ def tree_left (t:Tree) : Tree = native "t[0]";
 def tree_right (t:Tree) : Tree = native "t[2]";
 def tree_val (t:Tree) : Int = native "t[1]";
 
-def tree_sum (t:Tree) : Int {
-    if is_leaf t
+def tree_sum (t:Tree) : Int = if is_leaf t
     then 0
-    else tree_val t + tree_sum (tree_left t) + tree_sum (tree_right t)
-}
+    else tree_val t + tree_sum (tree_left t) + tree_sum (tree_right t);
 
-def abs (n:Int) : Int {
-    if n < 0 then 0 - n else n
-}
+def abs (n:Int) : Int = if n < 0 then 0 - n else n;
 
 @minimize_int(abs(tree_sum result - 10))
 def result : Tree = ?hole;

--- a/examples/bug.ae
+++ b/examples/bug.ae
@@ -1,5 +1,5 @@
     type List a;
     def List_size: (l:(List a)) -> Int = uninterpreted;
-    def List_length (l:(List a)) : {x:Int | x == List_size l} { native "len(l)" }
+    def List_length (l:(List a)) : {x:Int | x == List_size l} = native "len(l)";
     def List_new : {x:(List a) | (List_size x) == 0} = native "[]" ;
-    def List_empty (l: (List a)) : {x:Bool | x == ((List_size l) == 0)} { (List_length l) == 0 }
+    def List_empty (l: (List a)) : {x:Bool | x == ((List_size l) == 0)} = (List_length l) == 0;

--- a/examples/bugs/bug_77_shadow.ae
+++ b/examples/bugs/bug_77_shadow.ae
@@ -1,3 +1,3 @@
 type K;
 
-def fun (x:Int) (m:Int| m > x) : K { native "m * x" }
+def fun (x:Int) (m:Int| m > x) : K = native "m * x";

--- a/examples/bugs/nqueens_small.ae
+++ b/examples/bugs/nqueens_small.ae
@@ -2,14 +2,12 @@ type Board;
 
 def Board_size : (b:Board) -> Int = uninterpreted;
 
-def Board_is_empty (b:Board) : {t:Bool | t == (Board_size b == 0)  } { native "len(b) == 0" }
+def Board_is_empty (b:Board) : {t:Bool | t == (Board_size b == 0)  } = native "len(b) == 0";
 
-def Board_tail (b:Board | Board_size b > 0) : {b2:Board | Board_size b2 == (Board_size b - 1)} { native "b[1:]" }
+def Board_tail (b:Board | Board_size b > 0) : {b2:Board | Board_size b2 == (Board_size b - 1)} = native "b[1:]";
 
-def conflicts (b:Board | Board_size b >= 0) : Int {
-    if Board_is_empty b
+def conflicts (b:Board | Board_size b >= 0) : Int = if Board_is_empty b
     then 0
     else
         tl = Board_tail b;
-        conflicts tl
-}
+        conflicts tl;

--- a/examples/bugs/planet_orbit.ae
+++ b/examples/bugs/planet_orbit.ae
@@ -7,57 +7,43 @@
 import "Math.ae";
 
 def degrees_to_radians (angle: {deg: Float | 0.0 <= deg && deg <= 360.0 })
-                        : {rad: Float | 0.0 <= rad && rad <= 2.0 * Math_PI} {
-   let HALF_TURN: {deg: Float | deg == 180.0 } = 180.0 in
-   Math_PI * angle / HALF_TURN
-}
+                        : {rad: Float | 0.0 <= rad && rad <= 2.0 * Math_PI} = let HALF_TURN: {deg: Float | deg == 180.0 } = 180.0 in
+   Math_PI * angle / HALF_TURN;
 
 def cos_eccentric (tru_anomaly: {v: Float | 0.0 <= v && v <= 2.0 * Math_PI})
                   (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                  : {cos: Float | -1.0 <= cos && cos <= 1.0} {
-   let cos_num = eccentricity + (Math_cos tru_anomaly) in
+                  : {cos: Float | -1.0 <= cos && cos <= 1.0} = let cos_num = eccentricity + (Math_cos tru_anomaly) in
    let cos_denom = 1.0 + eccentricity * (Math_cos tru_anomaly) in
-   cos_num / cos_denom
-}
+   cos_num / cos_denom;
 
 def sin_eccentric (tru_anomaly: {v: Float | 0.0 <= v && v <= 2.0 * Math_PI})
                   (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                  : {sin: Float | -1.0 <= sin && sin <= 1.0} {
-   let sin_num = (Math_sqrtf (1.0 - eccentricity * eccentricity)) * (Math_sin tru_anomaly) in
+                  : {sin: Float | -1.0 <= sin && sin <= 1.0} = let sin_num = (Math_sqrtf (1.0 - eccentricity * eccentricity)) * (Math_sin tru_anomaly) in
    let sin_denom = 1.0 + eccentricity * (Math_cos tru_anomaly) in
-   sin_num / sin_denom
-}
+   sin_num / sin_denom;
 
 def tru_to_eccentric_anomaly (tru_anomaly: {v: Float | 0.0 <= v && v <= 360.0})
                               (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                              : {eccentric_anomaly: Float | 0.0 <= eccentric_anomaly && eccentric_anomaly <= 2.0 * Math_PI} {
-   let tru_anomaly_rad = degrees_to_radians tru_anomaly in
+                              : {eccentric_anomaly: Float | 0.0 <= eccentric_anomaly && eccentric_anomaly <= 2.0 * Math_PI} = let tru_anomaly_rad = degrees_to_radians tru_anomaly in
    let cos = cos_eccentric tru_anomaly_rad eccentricity in
    let sin = sin_eccentric tru_anomaly_rad eccentricity in
    let raw_angle_E = Math_atan2 sin cos in
    if raw_angle_E < 0.0 then
       raw_angle_E + (2.0 * Math_PI)
    else
-      raw_angle_E
-}
+      raw_angle_E;
 
 def tru_to_mean_anomaly (tru_anomaly: {v: Float | 0.0 <= v && v <= 360.0})
                         (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                        : {mean_anomaly: Float | 0.0 <= mean_anomaly && mean_anomaly <= 2.0 * Math_PI} {
-   let eccentric_anomaly = tru_to_eccentric_anomaly tru_anomaly eccentricity in
-   eccentric_anomaly - eccentricity * (Math_sin eccentric_anomaly)
-}
+                        : {mean_anomaly: Float | 0.0 <= mean_anomaly && mean_anomaly <= 2.0 * Math_PI} = let eccentric_anomaly = tru_to_eccentric_anomaly tru_anomaly eccentricity in
+   eccentric_anomaly - eccentricity * (Math_sin eccentric_anomaly);
 
 def min_elapsed_period_fraction (starting_tru_anomaly: {v1: Float | 0.0 <= v1 && v1 <= 360.0})
                                  (final_tru_anomaly: {v2: Float | 0.0 <= v2 && v2 <= 360.0})
                                  (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                                 : {fraction: Float | 0.0 <= fraction && fraction <= 1.0} {
-   let starting_mean_anomaly = tru_to_mean_anomaly starting_tru_anomaly eccentricity in
+                                 : {fraction: Float | 0.0 <= fraction && fraction <= 1.0} = let starting_mean_anomaly = tru_to_mean_anomaly starting_tru_anomaly eccentricity in
    let final_mean_anomaly = tru_to_mean_anomaly final_tru_anomaly eccentricity in
    let delta_fraction = (Math_absf (final_mean_anomaly - starting_mean_anomaly)) / (2.0 * Math_PI) in
-   Math_minf delta_fraction (1.0 - delta_fraction)
-}
+   Math_minf delta_fraction (1.0 - delta_fraction);
 
-def main (args:Int) : Unit {
-   print (min_elapsed_period_fraction 270.0 90.0 0.5)
-}
+def main (args:Int) : Unit = print (min_elapsed_period_fraction 270.0 90.0 0.5);

--- a/examples/demos/1_hello.ae
+++ b/examples/demos/1_hello.ae
@@ -2,18 +2,14 @@ import "Math.ae";
 
 def length : {n:Int | n == 10} = 10;
 
-def readIndex (i:Int | 0 <= i && i < length) : Unit {
-    # Dummy operation
-    print "okay"
-}
+def readIndex (i:Int | 0 <= i && i < length) : Unit = # Dummy operation
+    print "okay";
 
-def main (index:Int) : Unit {
-    pindex = Math_abs index;
+def main (index:Int) : Unit = pindex = Math_abs index;
     if pindex < length then
         readIndex pindex
     else
-        print "error"
-}
+        print "error";
 
 
 

--- a/examples/demos/2_image.ae
+++ b/examples/demos/2_image.ae
@@ -1,13 +1,11 @@
 import "Image.ae";
 
 
-def main (steps:Int) : Image {
-    white : Color = Color_mk 255 255 255;
+def main (steps:Int) : Image = white : Color = Color_mk 255 255 255;
     green : Color = Color_mk 0 255 0;
     image0 = Image_mk 64 64 white;
     image1 = Image_draw_rectangle image0 0 0 32 32 white;
     image2 = Image_draw_rectangle image1 0 32 32 32 green;
     image3 = Image_draw_rectangle image2 32 0 32 32 green;
     image4 = Image_draw_rectangle image3 32 32 32 32 white;
-    image4
-}
+    image4;

--- a/examples/demos/3_dataset.ae
+++ b/examples/demos/3_dataset.ae
@@ -1,11 +1,12 @@
 import "Learning.ae";
 
-def training_multinomial_nb (filename: String) : Model {
-    let df = Learning_load_dataset filename in
+def training_multinomial_nb (filename: String) : Model = let df = Learning_load_dataset filename in
     let balanced_df = Learning_smote_oversample df in
     let train_set = Learning_split_dataset_training balanced_df 0.7 in
     let test_set = Learning_split_dataset_testing balanced_df 0.7 in
-    Learning_train_multinomial_nb train_set
-}
+    Learning_train_multinomial_nb train_set;
+
+# https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf
+
 
 # https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf

--- a/examples/factorial.ae
+++ b/examples/factorial.ae
@@ -1,5 +1,3 @@
 def factorial (n:Int) : Int = if n == 0 then 1 else (n * factorial(n-1));
 
-def main (_:Int) : Unit {
-    print (factorial 3)
-}
+def main (_:Int) : Unit = print (factorial 3);

--- a/examples/ffi/custom_sort.ae
+++ b/examples/ffi/custom_sort.ae
@@ -2,19 +2,14 @@ type T;
 
 def propT : (t:T) -> Bool = uninterpreted;
 
-def mkT (i:Int) : {t:T | propT t} {
-    native "(0, i)"
-}
+def mkT (i:Int) : {t:T | propT t} = native "(0, i)";
 
-def getT (t:T | propT t) : Int {
-    native "t[1]"
-}
+def getT (t:T | propT t) : Int = native "t[1]";
 
 def failedT : T = native "0";
 
-def main (x:Int) : Int {
+def main (x:Int) : Int =
     a = mkT 42;
     _ = print (getT a);
     #_ = getT failedT;
-    0
-}
+    0;

--- a/examples/ffi/external.ae
+++ b/examples/ffi/external.ae
@@ -2,12 +2,10 @@ type Path;
 
 def pathlib : Unit = native_import "pathlib";
 def cwd : Path = native "pathlib.Path()";
-def append (p:Path) (e:String) : Path { native "p / e" }
-def mkPath (s:String) : Path { native "pathlib.Path(x)" }
+def append (p:Path) (e:String) : Path = native "p / e";
+def mkPath (s:String) : Path = native "pathlib.Path(x)";
 
 def example_ola : Path = append cwd "ola";
 
 
-def main (args:Int) : Unit {
-    print "hello"
-}
+def main (args:Int) : Unit = print "hello";

--- a/examples/ffi/native_test.ae
+++ b/examples/ffi/native_test.ae
@@ -5,7 +5,6 @@ def prop : (b:Int) -> Bool = uninterpreted;
 def f : {x:Int | x > 0} = native "3";
 def g : {x:Int | prop x } = native "5";
 
-def main (x:Int) : Int {
+def main (x:Int) : Int =
     _ = print (f + g);
-    0
-}
+    0;

--- a/examples/image/key.ae
+++ b/examples/image/key.ae
@@ -2,7 +2,7 @@ import "Image.ae";
 
 def target : Image = Image_open "examples/image/key_target.jpg";
 
-def key_example (steps:Int) : Image {
+def key_example (steps:Int) : Image =
     white : Color = Color_mk 255 255 255;
     key_color : Color = Color_mk 192 192 192;
     image0 = Image_mk 1024 768 white;
@@ -11,8 +11,7 @@ def key_example (steps:Int) : Image {
     image3 = Image_draw_rectangle image2 426 341 509 83 key_color;
     image4 = Image_draw_rectangle image3 836 424 100 68 key_color;
     image5 = Image_draw_rectangle image4 686 424 100 48 key_color;
-    image5
-}
+    image5;
 
 def k : Image = key_example 1;
 

--- a/examples/imports/import.ae
+++ b/examples/imports/import.ae
@@ -5,7 +5,6 @@ def pow : (b: {c:Int | ((c >= 1)  && (c <= 100))}) ->
            Int = Math_pow;
 
 
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     int_to_string : (x:Int) -> String = \x -> native "str(x)";
-    print (int_to_string (pow 3 4))
-}
+    print (int_to_string (pow 3 4));

--- a/examples/imports/import2.ae
+++ b/examples/imports/import2.ae
@@ -5,7 +5,6 @@ def pow : (b: {c:Int | ((c >= 1)  && (c <= 100))}) ->
           Int = Math_pow;
 
 
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     int_to_string : (x:Int) -> String = \x -> native "str(x)";
-    print (int_to_string (pow 3 4))
-}
+    print (int_to_string (pow 3 4));

--- a/examples/list/test_list_main.ae
+++ b/examples/list/test_list_main.ae
@@ -1,20 +1,19 @@
 import "List.ae";
 
-def consume : (l: {x:List | List_size x == 1}) -> Int = \n -> 0;
-def consume : (l:List | List_size l == 1) -> Int = \n -> 0;
+def consume : (l: {x:(List Int) | List_size x == 1}) -> Int = \n -> 0;
+def consume : (l:(List Int) | List_size l == 1) -> Int = \n -> 0;
 
 # def neg1 : Int = consume(List_new);
 
 # def neg2: Int = consume(List_append(List_append(List_new)(1))(1));
 
-def pos : Int = consume(List_append(List_new)(1));
+def pos : Int = consume (List_append (List_new[Int]) 1);
 
-def main (x:Int) : Unit {
-    empty = List_new;
+def main (x:Int) : Unit =
+    empty = List_new[Int];
     one = List_append empty 3;
     two = List_append one 2;
-    three : List = List_append two 1;
+    three : (List Int) = List_append two 1;
     plus : (x:Int) -> (y: Int) -> Int = (\x -> \y -> x + y);
     v : Int = (List_recursive three 0 plus);
-    print v
-}
+    print v;

--- a/examples/ml/balanced_dataset.ae
+++ b/examples/ml/balanced_dataset.ae
@@ -4,17 +4,15 @@
 import "Learning.ae";
 
 
-def generate_model_1 (filename: String) : Model {
+def generate_model_1 (filename: String) : Model =
     let df = Learning_load_dataset filename in
     let balanced_df = Learning_smote_oversample df in # Balance the dataset using SMOTE oversampling
     let train_set = Learning_split_dataset_training balanced_df 0.7 in
     let test_set = Learning_split_dataset_testing balanced_df 0.7 in
-    Learning_train_random_forest train_set # Train a random forest model on the training set
-}
+    Learning_train_random_forest train_set; # Train a random forest model on the training set
 
-def generate_model_2 (filename: String) : Model {
+def generate_model_2 (filename: String) : Model =
     let df = Learning_load_dataset filename in
     let train_set = Learning_split_dataset_training df 0.7 in
     let test_set = Learning_split_dataset_testing df 0.7 in
-    Learning_train_random_forest train_set # Train a random forest model on the training set
-}
+    Learning_train_random_forest train_set; # Train a random forest model on the training set

--- a/examples/pair.ae
+++ b/examples/pair.ae
@@ -4,7 +4,7 @@ def Pair_fst_logical : (p:Pair) -> Int = uninterpreted;
 
 def Pair_snd_logical : (p:Pair) -> Int = uninterpreted;
 
-def Pair_mk (x:Int) (y:{ y:Int | y > x}) : Pair { native "(x,y)" }
+def Pair_mk (x:Int) (y:{ y:Int | y > x}) : Pair = native "(x,y)";
 
 
 def assert : (b:{b:Bool | b}) -> Unit = native "()";
@@ -14,10 +14,8 @@ def assert : (b:{b:Bool | b}) -> Unit = native "()";
 # def Pair_snd (p:Pair) : { y:Int | y == Pair_snd_logical p } { native "p[1]" }
 
 
-def main (args:Int) : Unit {
-    a = 1;
+def main (args:Int) : Unit = a = 1;
     b = 3;
     #x = Pair_mk a b;
     #y = assert true;
-    print "hello"
-}
+    print "hello";

--- a/examples/pbt/pbt_int.ae
+++ b/examples/pbt/pbt_int.ae
@@ -2,16 +2,10 @@ import "PropTesting.ae";
 
 def negativeInt (x: Int) : Int = -x;
 
-def prop_int_plus_symmetric_is_zero (x: Int) : Bool {
-    (x + (negativeInt x)) == 0
-}
+def prop_int_plus_symmetric_is_zero (x: Int) : Bool = (x + (negativeInt x)) == 0;
 
 
-def int_property_testing (y: Int) : Float {
-    forAllInts prop_int_plus_symmetric_is_zero
-}
+def int_property_testing (y: Int) : Float = forAllInts prop_int_plus_symmetric_is_zero;
 
-def main (x:Int) : Unit {
-    x = int_property_testing(0);
-    print(x)
-}
+def main (x:Int) : Unit = x = int_property_testing(0);
+    print(x);

--- a/examples/pbt/pbt_reverse.ae
+++ b/examples/pbt/pbt_reverse.ae
@@ -1,20 +1,12 @@
 import "PropTesting.ae";
 
-def reverse (xs: (List Int)) : (List Int) {
-    List_reversed(xs)
-}
+def reverse (xs: (List Int)) : (List Int) = List_reversed(xs);
 
 
-def prop_reversed_lists_same_size (xs:(List Int)) : Bool {
-    (List_length xs) == (List_length (reverse xs))
-}
+def prop_reversed_lists_same_size (xs:(List Int)) : Bool = (List_length xs) == (List_length (reverse xs));
 
-def list_property_testing (y: Int) : Float {
-    forAllLists prop_reversed_lists_same_size
-}
+def list_property_testing (y: Int) : Float = forAllLists prop_reversed_lists_same_size;
 
 
-def main (x:Int) : Unit {
-    xs = list_property_testing(0);
-    print(xs)
-}
+def main (x:Int) : Unit = xs = list_property_testing(0);
+    print(xs);

--- a/examples/pbt/properties_synth.ae
+++ b/examples/pbt/properties_synth.ae
@@ -1,6 +1,4 @@
 import "PropTesting.ae";
 
 # @assert_properties(forAllInts(\x-> (synth_double(x) == (2 * x))) , forAllInts(\x-> ((synth_double(x) % 2) == 0) ) )
-def synth_double (x: Int) : Int {
-    (?hole:Int)
-}
+def synth_double (x: Int) : Int = (?hole:Int);

--- a/examples/pbt/property_synth.ae
+++ b/examples/pbt/property_synth.ae
@@ -3,6 +3,4 @@ import "PropTesting.ae";
 def negativeInt (x: Int) : Int = -x;
 
 # @assert_property( forAllInts(\x-> (x + synth_int(x)) == 0 ))
-def synth_int (x: Int) :Int {
-    (?hole:Int)
-}
+def synth_int (x: Int) :Int = (?hole:Int);

--- a/examples/syntax/ackermann_decreasing.ae
+++ b/examples/syntax/ackermann_decreasing.ae
@@ -4,6 +4,4 @@
 def ack (m:Int | m >= 0)(n:Int | n >= 0) : Int decreasing_by [m, n] =
   if m == 0 then n + 1 else (if n == 0 then ack (m - 1) 1 else ack m (n - 1));
 
-def main (_:Int) : Int {
-  ack 2 3
-}
+def main (_:Int) : Int = ack 2 3;

--- a/examples/syntax/factorial_decreasing.ae
+++ b/examples/syntax/factorial_decreasing.ae
@@ -4,6 +4,4 @@
 
 def fact (n:Int | n >= 0) : Int decreasing_by [n] = if n == 0 then 1 else n * fact (n - 1);
 
-def main (_:Int) : Int {
-  fact 5
-}
+def main (_:Int) : Int = fact 5;

--- a/examples/syntax/function_main.ae
+++ b/examples/syntax/function_main.ae
@@ -11,7 +11,6 @@ def ffff : (a:{n:Int | 1 <= n && n <= 10000}) -> (b:{ m:Int | 0 <= m }) -> Int =
 #def ffff : (a:{n:Int | 0 <= n}) -> (b:{ m:Int | 0 <= m }) -> Int = \x -> \y -> x + y;
 #def ffff : (a:Int) -> (b:Int) -> Int = \x -> \y -> x + y;
 
-def main (i:Int) : Unit {
+def main (i:Int) : Unit =
     w: Int = fff 1 ffff;
-    print (w)
-}
+    print (w);

--- a/examples/syntax/hello_world_main.ae
+++ b/examples/syntax/hello_world_main.ae
@@ -1,3 +1,1 @@
-def main (args:Int) : Unit {
-    print "Hello World"
-}
+def main (args:Int) : Unit = print "Hello World";

--- a/examples/syntax/id.ae
+++ b/examples/syntax/id.ae
@@ -1,7 +1,6 @@
 def id : (x : t<p>) -> t<p> = \x -> x;
 
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     x : Int | x > 0 = 3;
     y : Int | y > 0 = id x;
-    print y
-}
+    print y;

--- a/examples/syntax/implicit_id.ae
+++ b/examples/syntax/implicit_id.ae
@@ -1,7 +1,6 @@
 def id : forall t : B, forall <p : t -> Bool>,(x : t | p x) -> {v : t | p v} = Λ t : B => \x -> x;
 
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     x : Int | x > 0 = 3;
     y : Int | y > 0 = id[Int] x;
-    print (y)
-}
+    print (y);

--- a/examples/syntax/length.ae
+++ b/examples/syntax/length.ae
@@ -2,8 +2,6 @@ type List;
 
 def length : (l:List) -> Int = uninterpreted;
 
-def create(i:Int) : {l:List | length l == 0} { native "[]" }
+def create(i:Int) : {l:List | length l == 0} = native "[]";
 
-def main (args:Int) : Unit {
-    print "Hello World"
-}
+def main (args:Int) : Unit = print "Hello World";

--- a/examples/syntax/liquid_types_main.ae
+++ b/examples/syntax/liquid_types_main.ae
@@ -1,6 +1,4 @@
 def sqrt : (i: {x:Int | x > 0} ) -> Float = \i -> native "__import__('math').sqrt(i)";
 def sqrt : (i:Int | i > 0) -> Float = \i -> native "__import__('math').sqrt(i)";
 
-def main (i:Int) : Unit {
-    print (sqrt 25)
-}
+def main (i:Int) : Unit = print (sqrt 25);

--- a/examples/syntax/math_example_main.ae
+++ b/examples/syntax/math_example_main.ae
@@ -2,7 +2,6 @@ def abs (i:Int) : Int = if i > 0 then i else -i;
 
 def midpoint (a:Int) (b:Int) : Int = (a + b) / 2;
 
-def main (i:Int) : Unit {
+def main (i:Int) : Unit =
     x : Int = abs (-3) + midpoint 1 5;
-    print x
-}
+    print x;

--- a/examples/syntax/maxI.ae
+++ b/examples/syntax/maxI.ae
@@ -2,9 +2,8 @@ def maxI: (x : Int<p>) -> (y : Int<p>) -> Int<p> =
     \x -> \y -> if x < y then y else x;
 
 
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     x : Int | x > 0 = 3;
     y : Int | y > 0 = 5;
     z : Int | z > 0 = maxI x y;
-    print (z)
-}
+    print (z);

--- a/examples/syntax/mult.ae
+++ b/examples/syntax/mult.ae
@@ -4,11 +4,9 @@ def mult : (n:Int) -> (m:Int) -> Int = \x -> \y -> x * y  ;
 
 def mult2  (n:Int) (m:Int) : Int = n * m;
 
-def mult3  (n:Int) : (m:Int) -> {y:Int | true } { \m -> m * n }
+def mult3  (n:Int) : (m:Int) -> {y:Int | true } = \m -> m * n;
 
-def mult4  (n:Int) (m:Int) : {y:Int | true} { native "m * n" }
+def mult4  (n:Int) (m:Int) : {y:Int | true} = native "m * n";
 
 
-def main (args:Int) : Unit {
-    print "Hello World"
-}
+def main (args:Int) : Unit = print "Hello World";

--- a/examples/syntax/mylist.ae
+++ b/examples/syntax/mylist.ae
@@ -23,7 +23,6 @@ inductive IntList
 #}
 
 
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     #a : {x:(IntList) | len x > 0} = cons 3 empty;
-    print "Hello World"
-}
+    print "Hello World";

--- a/examples/syntax/planets.ae
+++ b/examples/syntax/planets.ae
@@ -1,5 +1,4 @@
 def test (angle: {deg:Float | 0.0 <= deg && deg < 360.0}) :
-         {r:Float | 0.0 <= r && r < 2.0} {
+         {r:Float | 0.0 <= r && r < 2.0} =
     half_turn = 180.0;
-    angle / half_turn
-}
+    angle / half_turn;

--- a/examples/syntax/pow.ae
+++ b/examples/syntax/pow.ae
@@ -1,9 +1,7 @@
 def math : Unit = native_import "math";
 def pow (x:Int | ((x >= 1)  && (x <= 100)))
         (y:Int | ((y >= 1)  && (y <= 100)))
-        : Int { native "math.pow(x, y)" }
+        : Int = native "math.pow(x, y)";
 
 
-def main (args:Int) : Unit {
-    print "Hello World"
-}
+def main (args:Int) : Unit = print "Hello World";

--- a/examples/syntax/precedence.ae
+++ b/examples/syntax/precedence.ae
@@ -1,9 +1,8 @@
 
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     x: Int =  12 - 1 * 5;
     y: Int = (12 - 1) * 5;
     _ = print "x=";
     _ = print x;
     _ = print "y=";
-    print y
-}
+    print y;

--- a/examples/syntax/typedecl.ae
+++ b/examples/syntax/typedecl.ae
@@ -2,6 +2,4 @@ type A;
 
 type B;
 
-def main (args:Int) : Unit {
-    print "Hello World"
-}
+def main (args:Int) : Unit = print "Hello World";

--- a/examples/syntax/uninterpreted.ae
+++ b/examples/syntax/uninterpreted.ae
@@ -3,10 +3,6 @@ def greater : (a:Int) -> Bool = uninterpreted;
 def f : (a:{k:Int| greater k }) -> {m:Int | m == 1} = \a -> 1;
 
 # cannot prove that 3 satisfies greater(y)??
-def g (y:Int | greater y) : {v:Int | v >= 1} {
-    f y
-}
+def g (y:Int | greater y) : {v:Int | v >= 1} = f y;
 
-def main (args:Int) : Unit {
-    print "Hello World"
-}
+def main (args:Int) : Unit = print "Hello World";

--- a/examples/synthesis/coin.ae
+++ b/examples/synthesis/coin.ae
@@ -23,9 +23,9 @@ def coinchange_mk
         (coins_1 c == c1) &&
         (coins_5 c == c5) &&
         (coins_10 c == c10)
-    } { native "[c1, c5, c10]" }
+    } = native "[c1, c5, c10]";
 
-def total_coins (c:CoinChange) : Int { native "c[0] + c[1] + c[2]" }
+def total_coins (c:CoinChange) : Int = native "c[0] + c[1] + c[2]";
 
 @minimize_int((total_coins coin_solution_hole))
 def coin_solution_hole : {c:CoinChange |

--- a/examples/synthesis/dummy.ae
+++ b/examples/synthesis/dummy.ae
@@ -1,4 +1,2 @@
 @minimize_int(-(fun 3 - fun 5))
-def fun (i:Int | i > 0) : {j:Int | j > i} {
-    ?todo
-}
+def fun (i:Int | i > 0) : {j:Int | j > i} = ?todo;

--- a/examples/synthesis/function_refined_synthesis_args.ae
+++ b/examples/synthesis/function_refined_synthesis_args.ae
@@ -1,10 +1,6 @@
 import Math_abs from "Math.ae";
 
-def test (j:{h:Int | h > 0 }): Int {
-    8
-}
+def test (j:{h:Int | h > 0 }): Int = 8;
 
 @minimize_int(Math_abs(64 - fun(8)))
-def fun (i:{x:Int | (x > 0 && x < 10) || (x > 20 && x < 30)}) : Int  {
-    (?hole: {g:Int | g > 0 } ) * i
-}
+def fun (i:{x:Int | (x > 0 && x < 10) || (x > 20 && x < 30)}) : Int  = (?hole: {g:Int | g > 0 } ) * i;

--- a/examples/synthesis/hole.ae
+++ b/examples/synthesis/hole.ae
@@ -1,4 +1,2 @@
 @minimize_int(test 7)
-def test(x:{k:Int | k > 0}) : {z:Int | z < 0} {
-    ?r
-}
+def test(x:{k:Int | k > 0}) : {z:Int | z < 0} = ?r;

--- a/examples/synthesis/hole_refined_synthesis.ae
+++ b/examples/synthesis/hole_refined_synthesis.ae
@@ -1,6 +1,4 @@
 import Math_abs from "Math.ae";
 
 @minimize_int(Math_abs(2024 - fun(253)))
-def fun (i:Int) : Int  {
-    (?hole: {x:Int | x > 0} ) * i
-}
+def fun (i:Int) : Int  = (?hole: {x:Int | x > 0} ) * i;

--- a/examples/synthesis/multiobjective.ae
+++ b/examples/synthesis/multiobjective.ae
@@ -6,12 +6,8 @@ def other_soft_constraint (n: Int) : Int = n + 4;
 
 @minimize_int(soft_constraint (fun 10))
 @minimize_int(other_soft_constraint (fun 21))
-def fun (i:Int | i >= 10) : {v:Int | v > 10 }  {
-    ?hole
-}
+def fun (i:Int | i >= 10) : {v:Int | v > 10 }  = ?hole;
 
 
 
-def main (args: Int) : Unit {
-    print (fun 42)
-}
+def main (args: Int) : Unit = print (fun 42);

--- a/examples/synthesis/nqueens.ae
+++ b/examples/synthesis/nqueens.ae
@@ -6,23 +6,22 @@ def N : {n:Int | n == 9} = 9;
 def C_mk
     (q1x:Int | 0 <= q1x && q1x < N )
     (q1y:Int | 0 <= q1y && q1y < N ) :
-    Coordinate { native "(x, y)" }
+    Coordinate = native "(x, y)";
 
-def C_x (s:Coordinate) : Int { native "s[0]" }
-def C_y (s:Coordinate) : Int { native "s[1]" }
+def C_x (s:Coordinate) : Int = native "s[0]";
+def C_y (s:Coordinate) : Int = native "s[1]";
 
 
 
 def Board_size : (b:Board) -> Int = uninterpreted;
 
-def Board_is_empty (b:Board) : {t:Bool | t == (Board_size b == 0)  } { native "len(b) == 0" }
+def Board_is_empty (b:Board) : {t:Bool | t == (Board_size b == 0)  } = native "len(b) == 0";
 
-def Board_head (b:Board | Board_size b > 0) : Coordinate { native "b[0]" }
+def Board_head (b:Board | Board_size b > 0) : Coordinate = native "b[0]";
 
-def Board_tail (b:Board | Board_size b > 0) : {b2:Board | Board_size b2 == (Board_size b - 1)} { native "b[1:]" }
+def Board_tail (b:Board | Board_size b > 0) : {b2:Board | Board_size b2 == (Board_size b - 1)} = native "b[1:]";
 
-def conflicts (t:Coordinate) (b:Board | Board_size b >= 0) : Int {
-    if Board_is_empty b
+def conflicts (t:Coordinate) (b:Board | Board_size b >= 0) : Int = if Board_is_empty b
     then 0
     else
         h : Coordinate = Board_head b;
@@ -35,8 +34,7 @@ def conflicts (t:Coordinate) (b:Board | Board_size b >= 0) : Int {
 
         component1 : {c:Int | 0 <= c && c <= 3} = row + col + diag;
         component2 : Int = conflicts t tl;
-        component1 + component2
-}
+        component1 + component2;
 
 
 
@@ -50,7 +48,7 @@ def create_solution
     (q7 : Coordinate)
     (q8 : Coordinate)
     (q9 : Coordinate) :
-   {b:Board | Board_size b == N} { native "[q1, q2, q3, q4, q5, q6, q7, q8, q9]" }
+   {b:Board | Board_size b == N} = native "[q1, q2, q3, q4, q5, q6, q7, q8, q9]";
 
 
 @minimize_int(1)

--- a/examples/synthesis/supermario.ae
+++ b/examples/synthesis/supermario.ae
@@ -16,15 +16,11 @@ def sizeB: (b: Boxes) -> Int = uninterpreted;
 def sizeE: (e: Enemies) -> Int = uninterpreted;
 
 # Level functions
-def new_level (cs: Chunks) (e: Enemies) : Level {
-    native "(sum(cs, []), sum(e, []))"
-}
+def new_level (cs: Chunks) (e: Enemies) : Level = native "(sum(cs, []), sum(e, []))";
 
 # Chunks functions
 def empty_chunks : Chunks = native "[]";
-def append_chunk (cs: Chunks) (c: Chunk) : Chunks {
-    native "cs + [c]"
-}
+def append_chunk (cs: Chunks) (c: Chunk) : Chunks = native "cs + [c]";
 
 # Chunk constructors
 def new_gap_chunk (x: Int | x >= 5 && x <= 95)
@@ -32,84 +28,62 @@ def new_gap_chunk (x: Int | x >= 5 && x <= 95)
                    (wg: Int | wg >= 2 && wg <= 5)
                    (wBefore: Int | wBefore >= 2 && wBefore <= 7)
                    (wAfter: Int | wAfter >= 2 && wAfter <= 7) :
-                   Chunk {
-    native "(' ', x, y, wg, wBefore, wAfter)"
-}
+                   Chunk = native "(' ', x, y, wg, wBefore, wAfter)";
 
 def new_platform_chunk (x: Int | x >= 5 && x <= 95)
                         (y: Int | y >= 3 && y <= 5)
                         (w: Int | w >= 3 && w <= 15) :
-                        Chunk {
-    native "('P', x, y, w)"
-}
+                        Chunk = native "('P', x, y, w)";
 
 def new_hill_chunk (x: Int | x >= 5 && x <= 95)
                     (y: Int | y >= 3 && y <= 5)
                     (w: Int | w >= 3 && w <= 15) :
-                    Chunk {
-    native "('H', x, y, w)"
-}
+                    Chunk = native "('H', x, y, w)";
 
 def new_canon_hill_chunk (x: Int | x >= 5 && x <= 95)
                          (y: Int | y >= 3 && y <= 5)
                          (h: Int | h >= 2 && h <= 3)
                          (wBefore: Int | wBefore >= 2 && wBefore <= 7)
                          (wAfter: Int | wAfter >= 2 && wAfter <= 7) :
-                         Chunk {
-    native "('C', x, y, h, wBefore, wAfter)"
-}
+                         Chunk = native "('C', x, y, h, wBefore, wAfter)";
 
 def new_tube_hill_chunk (x: Int | x >= 5 && x <= 95)
                         (y: Int | y >= 3 && y <= 5)
                         (h: Int | h >= 2 && h <= 3)
                         (wBefore: Int | wBefore >= 2 && wBefore <= 7)
                         (wAfter: Int | wAfter >= 2 && wAfter <= 7) :
-                        Chunk {
-    native "('T', x, y, h, wBefore, wAfter)"
-}
+                        Chunk = native "('T', x, y, h, wBefore, wAfter)";
 
 def new_coin_chunk (x: Int | x >= 5 && x <= 95)
                    (y: Int | y >= 3 && y <= 5)
                    (wc: Int | wc >= 3 && wc <= 15) :
-                   Chunk {
-    native "('c', x, y, wc)"
-}
+                   Chunk = native "('c', x, y, wc)";
 
 def new_canon_chunk (x: Int | x >= 5 && x <= 95)
                     (y: Int | y >= 3 && y <= 5)
                     (h: Int | h >= 2 && h <= 3)
                     (wBefore: Int | wBefore >= 2 && wBefore <= 7)
                     (wAfter: Int | wAfter >= 2 && wAfter <= 7) :
-                    Chunk {
-    native "('C', x, y, h, wBefore, wAfter)"
-}
+                    Chunk = native "('C', x, y, h, wBefore, wAfter)";
 
 def new_tube_chunk (x: Int | x >= 5 && x <= 95)
                    (y: Int | y >= 3 && y <= 5)
                    (h: Int | h >= 2 && h <= 3)
                    (wBefore: Int | wBefore >= 2 && wBefore <= 7)
                    (wAfter: Int | wAfter >= 2 && wAfter <= 7) :
-                   Chunk {
-    native "('T', x, y, h, wBefore, wAfter)"
-}
+                   Chunk = native "('T', x, y, h, wBefore, wAfter)";
 
 # Boxes functions
 def empty_boxes: {x: Boxes | sizeB x == 0} = native "[]";
-def append_box (l: Boxes) (i: Box) : {l2: Boxes | sizeB l2 == sizeB l + 1} {
-    native "l + [i]"
-}
+def append_box (l: Boxes) (i: Box) : {l2: Boxes | sizeB l2 == sizeB l + 1} = native "l + [i]";
 
 def new_box (box: BoxType)
             (x: Int | x >= 5 && x <= 95)
             (y: Int | y >= 3 && y <= 5) :
-            Box {
-    native "(box, x, y)"
-}
+            Box = native "(box, x, y)";
 
 def new_boxes (boxes: Boxes | (sizeB boxes) >= 2 && (sizeB boxes) <= 7) :
-              Chunk {
-    native "boxes"
-}
+              Chunk = native "boxes";
 
 def new_block_coin: BoxType = native "lambda x: 'c'";
 def new_block_power_up: BoxType = native "lambda x: 'p'";
@@ -118,21 +92,15 @@ def new_block_rock_empty: BoxType = native "lambda x: 'r'";
 
 # Enemies functions
 def empty_enemies: {x: Enemies | sizeE x == 0} = native "[]";
-def append_enemy (l: Enemies) (i: Enemy) : {l2: Enemies | sizeE l2 == sizeE l + 1} {
-    native "l + [i]"
-}
+def append_enemy (l: Enemies) (i: Enemy) : {l2: Enemies | sizeE l2 == sizeE l + 1} = native "l + [i]";
 
 def new_enemies (enemies: Enemies | (sizeE enemies) >= 2 && (sizeE enemies) <= 10) :
-                Enemies {
-    native "enemies"
-}
+                Enemies = native "enemies";
 
 # Mob functions
 def new_mob (m: MobType)
             (x: Int | x >= 5 && x <= 95) :
-            Mob {
-    native "[(m, x)]"
-}
+            Mob = native "[(m, x)]";
 
 def new_goompa: MobType = native "lambda x: 'G'";
 def new_koompa: MobType = native "lambda x: 'K'";
@@ -140,13 +108,9 @@ def new_koompa: MobType = native "lambda x: 'K'";
 # Fitness functions
 def numpy: Unit = native_import "numpy";
 
-def number_of_chunks (max_w: Int) (max_h: Int) (level: Level) : Float {
-    native "max_w * max_h - len(level[0])"
-}
+def number_of_chunks (max_w: Int) (max_h: Int) (level: Level) : Float = native "max_w * max_h - len(level[0])";
 
-def conflicts (max_w: Int) (max_h: Int) (level: Level) : Float {
-    native "sum(numpy.add.reduce([chunk.place_in(numpy.zeros((max_w, max_h))) or 0 for chunk in level[0]] + [enemy.place_in(numpy.zeros((max_w, max_h))) or 0 for enemy in level[1]]))"
-}
+def conflicts (max_w: Int) (max_h: Int) (level: Level) : Float = native "sum(numpy.add.reduce([chunk.place_in(numpy.zeros((max_w, max_h))) or 0 for chunk in level[0]] + [enemy.place_in(numpy.zeros((max_w, max_h))) or 0 for enemy in level[1]]))";
 
 @hide(numpy,
       number_of_chunks,

--- a/examples/synthesis/synthesis_proposal.ae
+++ b/examples/synthesis/synthesis_proposal.ae
@@ -1,2 +1,2 @@
 @minimize_int( if (fun 3) == 4 then 0 else 1)
-def fun (x:Int) : {y:Int | y > x} { ?hole }
+def fun (x:Int) : {y:Int | y > x} = ?hole;

--- a/scripts/examples_def_brace_to_eq.py
+++ b/scripts/examples_def_brace_to_eq.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Convert ``def f : T { e }`` to ``def f : T = e;`` in Aeon example files.
+
+Conservative about comments and strings; uses a small type parser so return-type
+refinements like ``{x:Int|...}`` are not mistaken for the function body ``{``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def _skip_string(src: str, i: int, n: int) -> int:
+    quote = src[i]
+    j = i + 1
+    while j < n:
+        ch = src[j]
+        if ch == "\\":
+            j += 2
+            continue
+        if ch == quote:
+            return j + 1
+        j += 1
+    return n
+
+
+def _skip_ws(src: str, i: int, n: int) -> int:
+    while i < n and src[i].isspace():
+        i += 1
+    return i
+
+
+def _parse_type(src: str, i: int, n: int) -> int:
+    i = _skip_ws(src, i, n)
+
+    def parse_atom(j: int) -> int:
+        j = _skip_ws(src, j, n)
+        if j >= n:
+            return j
+        if src.startswith("forall", j) and (j + 6 >= n or not (src[j + 6].isalnum() or src[j + 6] == "_")):
+            j += len("forall")
+            j = _skip_ws(src, j, n)
+            if j < n and src[j] == "<":
+                depth = 1
+                j += 1
+                while j < n and depth:
+                    ch = src[j]
+                    if ch == "#":
+                        while j < n and src[j] != "\n":
+                            j += 1
+                        continue
+                    if ch in "\"'":
+                        j = _skip_string(src, j, n)
+                        continue
+                    if j + 1 < n and ch == "-" and src[j + 1] == ">":
+                        j += 2
+                        continue
+                    if ch == "<":
+                        depth += 1
+                    elif ch == ">":
+                        depth -= 1
+                    j += 1
+            else:
+                while j < n and (src[j].isalnum() or src[j] == "_"):
+                    j += 1
+                j = _skip_ws(src, j, n)
+                if j < n and src[j] == ":":
+                    j += 1
+                    j = _skip_ws(src, j, n)
+                    if j < n and src[j] in "B*":
+                        j += 1
+            j = _skip_ws(src, j, n)
+            if j < n and src[j] == ",":
+                j += 1
+            j = _skip_ws(src, j, n)
+            return parse_type_prime(j)
+        if src[j] == "(":
+            depth = 1
+            j += 1
+            while j < n and depth:
+                ch = src[j]
+                if ch == "#":
+                    while j < n and src[j] != "\n":
+                        j += 1
+                    continue
+                if ch in "\"'":
+                    j = _skip_string(src, j, n)
+                    continue
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                j += 1
+            return j
+        if src[j] == "{":
+            depth = 1
+            j += 1
+            while j < n and depth:
+                ch = src[j]
+                if ch == "#":
+                    while j < n and src[j] != "\n":
+                        j += 1
+                    continue
+                if ch in "\"'":
+                    j = _skip_string(src, j, n)
+                    continue
+                if j + 1 < n and ch == "-" and src[j + 1] == ">":
+                    j += 2
+                    continue
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                j += 1
+            return j
+        while j < n and (src[j].isalnum() or src[j] in "_"):
+            j += 1
+        return j
+
+    def parse_type_prime(j: int) -> int:
+        j = parse_atom(j)
+        j = _skip_ws(src, j, n)
+        if j + 1 < n and src[j] == "-" and src[j + 1] == ">":
+            return parse_type_prime(j + 2)
+        return j
+
+    return parse_type_prime(i)
+
+
+def _skip_decreasing_by(src: str, i: int, n: int) -> int:
+    i = _skip_ws(src, i, n)
+    if not src.startswith("decreasing_by", i):
+        return i
+    j = i + len("decreasing_by")
+    j = _skip_ws(src, j, n)
+    if j >= n or src[j] != "[":
+        return j
+    depth = 1
+    j += 1
+    while j < n and depth:
+        ch = src[j]
+        if ch == "#":
+            while j < n and src[j] != "\n":
+                j += 1
+            continue
+        if ch in "\"'":
+            j = _skip_string(src, j, n)
+            continue
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+        j += 1
+    return j
+
+
+def _match_brace_body(src: str, body_open: int, n: int) -> int:
+    assert body_open < n and src[body_open] == "{"
+    t = body_open + 1
+    depth = 1
+    while t < n and depth:
+        ch = src[t]
+        if ch == "#":
+            while t < n and src[t] != "\n":
+                t += 1
+            continue
+        if ch in "\"'":
+            t = _skip_string(src, t, n)
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        t += 1
+    return t
+
+
+def convert_defs_brace_to_eq(src: str) -> tuple[str, bool]:
+    out: list[str] = []
+    i = 0
+    changed = False
+    n = len(src)
+
+    while i < n:
+        m_start = src.find("def ", i)
+        if m_start == -1:
+            out.append(src[i:])
+            break
+
+        line_start = src.rfind("\n", 0, m_start) + 1
+        ls = line_start
+        while ls < n and src[ls].isspace():
+            ls += 1
+        if ls < n and src[ls] == "#":
+            line_end = src.find("\n", m_start)
+            if line_end == -1:
+                line_end = n
+            else:
+                line_end += 1
+            out.append(src[i:line_end])
+            i = line_end
+            continue
+
+        if m_start > 0 and src[m_start - 1] not in "\n\r\t ":
+            out.append(src[i : m_start + 1])
+            i = m_start + 1
+            continue
+
+        out.append(src[i:m_start])
+        i = m_start
+        j = i + 4
+
+        while j < n and src[j].isspace():
+            j += 1
+        while j < n and (src[j].isalnum() or src[j] in "_"):
+            j += 1
+
+        while j < n:
+            while j < n and src[j].isspace():
+                j += 1
+            if j < n and src[j] == "(":
+                depth = 1
+                j += 1
+                while j < n and depth:
+                    c = src[j]
+                    if c == "#":
+                        while j < n and src[j] != "\n":
+                            j += 1
+                        continue
+                    if c in "\"'":
+                        j = _skip_string(src, j, n)
+                        continue
+                    if c == "(":
+                        depth += 1
+                    elif c == ")":
+                        depth -= 1
+                    j += 1
+                continue
+            break
+
+        j = _skip_ws(src, j, n)
+        if j >= n or src[j] != ":":
+            out.append(src[i:j])
+            i = j
+            continue
+
+        j += 1
+        type_end = _parse_type(src, j, n)
+        k = _skip_decreasing_by(src, type_end, n)
+        k = _skip_ws(src, k, n)
+        if k < n and src[k] == "=":
+            out.append(src[i:k])
+            t = k + 1
+            p2 = b2 = 0
+            while t < n:
+                ch = src[t]
+                if ch == "#":
+                    while t < n and src[t] != "\n":
+                        t += 1
+                    continue
+                if ch in "\"'":
+                    t = _skip_string(src, t, n)
+                    continue
+                if ch == "(":
+                    p2 += 1
+                elif ch == ")":
+                    p2 -= 1
+                elif ch == "{":
+                    b2 += 1
+                elif ch == "}":
+                    b2 -= 1
+                if ch == ";" and p2 == 0 and b2 == 0:
+                    t += 1
+                    break
+                t += 1
+            out.append(src[k:t])
+            i = t
+            continue
+
+        if k < n and src[k] == "{":
+            body_open = k
+            body_close_end = _match_brace_body(src, body_open, n)
+            body_close = body_close_end - 1
+            body = src[body_open + 1 : body_close]
+            prefix = src[i:body_open]
+            new_body = body.strip()
+            if not new_body.endswith(";"):
+                new_body += ";"
+            # Do not append ``src[body_close_end:]`` here: ``i`` will advance to
+            # ``body_close_end`` and the main loop will copy the tail exactly once.
+            out.append(prefix + "= " + new_body)
+            changed = True
+            i = body_close_end
+            continue
+
+        rel = re.search(r"\n\s*def\s+", src[m_start + 1 :])
+        if not rel:
+            out.append(src[m_start:])
+            break
+        split = m_start + 1 + rel.start()
+        out.append(src[m_start:split])
+        i = split
+
+    return "".join(out), changed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("roots", nargs="+", type=Path, help="Directories or files to rewrite")
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--no-verify", action="store_true")
+    args = ap.parse_args()
+
+    def verify(path: Path) -> bool:
+        if args.no_verify:
+            return True
+        try:
+            from aeon.sugar.bind import bind_program
+            from aeon.sugar.parser import parse_main_program
+
+            txt = path.read_text(encoding="utf-8")
+            prog = parse_main_program(txt, filename=str(path))
+            bind_program(prog, [])
+        except Exception:
+            return False
+        return True
+
+    paths: list[Path] = []
+    for root in args.roots:
+        if root.is_file():
+            paths.append(root)
+        else:
+            paths.extend(sorted(root.rglob("*.ae")))
+
+    failed: list[Path] = []
+    for path in paths:
+        src = path.read_text(encoding="utf-8")
+        new, changed = convert_defs_brace_to_eq(src)
+        if not changed:
+            if args.check:
+                print(f"{path}: unchanged")
+            continue
+        if args.check:
+            print(f"{path}: would_change")
+            continue
+        path.write_text(new, encoding="utf-8")
+        if not verify(path):
+            path.write_text(src, encoding="utf-8")
+            print(f"reverted (aeon failed): {path}", file=sys.stderr)
+            failed.append(path)
+        else:
+            print(f"updated: {path}")
+
+    if failed:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/intlist_len_match.ae
+++ b/tests/fixtures/intlist_len_match.ae
@@ -1,0 +1,10 @@
+inductive IntList
+| empty : IntList
+| cons (hd:Int) (tl:IntList) : IntList
+
+def len (l:IntList) : Int =
+    match l with
+    | empty => 0
+    | cons hd tl => 1 + (len tl);
+
+def main (args:Int) : Int = 0;

--- a/tests/intlist_match_typecheck_regression_test.py
+++ b/tests/intlist_match_typecheck_regression_test.py
@@ -33,5 +33,9 @@ def test_intlist_len_match_typechecker_raises_unhandled_abstraction() -> None:
     typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
     core_ast_anf = ensure_anf(core_ast)
 
-    with pytest.raises(ValueError, match="SYNTH_TYPE"):
+    # Depending on whether the ``SYNTH_TYPE`` log level is registered, the failure
+    # surfaces as a loguru ``ValueError`` or as the subsequent ``AssertionError``.
+    with pytest.raises((ValueError, AssertionError)) as excinfo:
         list(check_type_errors(typing_ctx, core_ast_anf, top))
+    msg = str(excinfo.value)
+    assert "SYNTH_TYPE" in msg or "Unhandled term" in msg

--- a/tests/intlist_match_typecheck_regression_test.py
+++ b/tests/intlist_match_typecheck_regression_test.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.frontend.anf_converter import ensure_anf
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import DesugaredProgram, desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_main_program
+from aeon.typechecking.typeinfer import check_type_errors
+
+
+def test_intlist_len_match_typechecker_raises_unhandled_abstraction() -> None:
+    """Guards ``tests/fixtures/intlist_len_match.ae`` until typechecking accepts the lowered match."""
+    path = Path(__file__).resolve().parent / "fixtures" / "intlist_len_match.ae"
+    src = path.read_text(encoding="utf-8")
+
+    prog = parse_main_program(src, filename=str(path))
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(progt, ctx, desugared.metadata)
+
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    core_ast_anf = ensure_anf(core_ast)
+
+    with pytest.raises(ValueError, match="SYNTH_TYPE"):
+        list(check_type_errors(typing_ctx, core_ast_anf, top))


### PR DESCRIPTION
## Summary
This pull request updates Aeon `.ae` examples to prefer the surface `def f : T = e;` form instead of `def f : T { e }`, including PSB2 (solved and annotations), synthesis, benchmarks, demos, and smaller snippets.

## Tooling
- `scripts/examples_def_brace_to_eq.py` automates the rewrite with a small type scanner (so return-type refinements are not mistaken for the function body) and optional parse/bind verification.

## Regression coverage
- `tests/fixtures/intlist_len_match.ae`: inductive `IntList` with a recursive `len` using `match`.
- `tests/intlist_match_typecheck_regression_test.py`: documents the current typechecker path that fails (loguru `SYNTH_TYPE` level) until match/rec typing is fixed. The fixture is kept out of `examples/syntax/` so `run_examples.sh` is unchanged.

## List example
- `examples/list/test_list_main.ae` now uses explicit `(List Int)` / `List_new[Int]` with the stdlib `List.ae`.

## Validation
- `bash run_examples.sh`
- `pytest tests/intlist_match_typecheck_regression_test.py`

Made with [Cursor](https://cursor.com)