### PR TITLE
feat(synthesis): choose_literal tactic for TacticRandomSynthesizer

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -78,8 +78,8 @@ def _parse_common_arguments(parser: ArgumentParser):
         default="tdsyn_enumerative",
         help=(
             "Select a synthesizer: tdsyn_enumerative (default, type-directed BFS), tdsyn (same as tdsyn_enumerative), "
-            "tdsyn_random (type-directed random walk), gp, synquid, random_search, enumerative (grammar enumeration), "
-            "hc, 1p1, smt, decision_tree, llm"
+            "tdsyn_random (type-directed random walk), tactics (random tactic search), gp, synquid, "
+            "random_search, enumerative (grammar enumeration), hc, 1p1, smt, decision_tree, llm"
         ),
     )
 

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -39,6 +39,7 @@ from aeon.facade.driver import AeonDriver
 SYNTHESIZERS = [
     "tdsyn_enumerative",
     "tdsyn",
+    "tactics",
     "gp",
     "enumerative",
     "random_search",

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -5,6 +5,7 @@ from aeon.synthesis.modules.llm import LLMSynthesizer
 from aeon.synthesis.modules.decision_tree import DecisionTreeSynthesizer
 from aeon.synthesis.modules.smt_synthesizer import SMTSynthesizer
 from aeon.synthesis.modules.tdsyn.synthesizer import TDSynSynthesizer
+from aeon.synthesis.tactics import TacticRandomSynthesizer
 
 
 def make_synthesizer(module: str) -> Synthesizer:
@@ -31,5 +32,7 @@ def make_synthesizer(module: str) -> Synthesizer:
             return TDSynSynthesizer(mode="enumerative")
         case "tdsyn_random":
             return TDSynSynthesizer(mode="random")
+        case "tactics":
+            return TacticRandomSynthesizer()
         case _:
             assert False, f"Not supported synthesizer with name {module}"

--- a/aeon/synthesis/tactics/__init__.py
+++ b/aeon/synthesis/tactics/__init__.py
@@ -1,0 +1,3 @@
+from aeon.synthesis.tactics.random_synth import TacticRandomSynthesizer
+
+__all__ = ["TacticRandomSynthesizer"]

--- a/aeon/synthesis/tactics/builtin.py
+++ b/aeon/synthesis/tactics/builtin.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from aeon.core.liquid_ops import ops
+from aeon.core.substitutions import substitution_in_type
+from aeon.core.terms import Abstraction, Annotation, Application, Hole, Term, Var
+from aeon.core.types import AbstractionType, Type
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole
+from aeon.synthesis.tactics.state import TacticState
+from aeon.synthesis.tactics.subtyping import fits
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name, fresh_counter
+
+_loc = SynthesizedLocation("tactics")
+
+
+def _split_arrow_spine(ty: Type) -> tuple[list[Type], Type]:
+    params: list[Type] = []
+    t = ty
+    while isinstance(t, AbstractionType):
+        params.append(t.var_type)
+        t = t.type
+    return params, t
+
+
+def tactic_apply_question(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``apply?``: use the first hypothesis ``x`` (in context order) with ``ctx_ty(x) <: goal``."""
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty, hole_ctx = holes[hole_name]
+    for x, xty in hole_ctx.concrete_vars():
+        if x in ops:
+            continue
+        if fits(hole_ctx, xty, goal_ty):
+            return TacticState(state.ctx, replace_hole(state.term, hole_name, Var(x, _loc)), state.goal)
+    return None
+
+
+def tactic_constructor(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``constructor``: intro for arrows, else first ``f : … -> goal`` spine with fresh argument holes."""
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty, hole_ctx = holes[hole_name]
+
+    match goal_ty:
+        case AbstractionType(var_name, _, ret_type):
+            vn = Name(var_name.name + "_i", fresh_counter.fresh())
+            body_ty = substitution_in_type(ret_type, Var(vn), var_name)
+            hn = Name("_h", fresh_counter.fresh())
+            body = Annotation(Hole(hn), body_ty, loc=_loc)
+            lam = Abstraction(vn, body, loc=_loc)
+            return TacticState(state.ctx, replace_hole(state.term, hole_name, lam), state.goal)
+
+    for f, fty in hole_ctx.concrete_vars():
+        if f in ops:
+            continue
+        params, ret = _split_arrow_spine(fty)
+        if not params:
+            continue
+        if not fits(hole_ctx, ret, goal_ty):
+            continue
+        app: Term = Var(f, _loc)
+        for pt in params:
+            hn = Name("_h", fresh_counter.fresh())
+            app = Application(app, Annotation(Hole(hn), pt, loc=_loc), loc=_loc)
+        return TacticState(state.ctx, replace_hole(state.term, hole_name, app), state.goal)
+
+    return None

--- a/aeon/synthesis/tactics/by_cases.py
+++ b/aeon/synthesis/tactics/by_cases.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from aeon.core.liquid_ops import ops
+from aeon.core.terms import Annotation, Hole, If, Term, Var
+from aeon.core.types import Type, t_bool
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole
+from aeon.synthesis.tactics.state import TacticState
+from aeon.synthesis.tactics.subtyping import fits
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name, fresh_counter
+
+_loc = SynthesizedLocation("tactics")
+
+
+def tactic_by_cases(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``by_cases``: split on the first Boolean hypothesis ``b`` with ``bty <: Bool``.
+
+    Replaces the goal hole with ``if b then ?_then else ?_else``, reusing the same
+    goal type in both branches (Liquid ``If`` typing discharges branch VCs).
+    """
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty: Type
+    goal_ty, hole_ctx = holes[hole_name]
+
+    for b, bty in hole_ctx.concrete_vars():
+        if b in ops:
+            continue
+        if not fits(hole_ctx, bty, t_bool):
+            continue
+        hthen = Name("_then", fresh_counter.fresh())
+        helse = Name("_else", fresh_counter.fresh())
+        br_then: Term = Annotation(Hole(hthen), goal_ty, loc=_loc)
+        br_else: Term = Annotation(Hole(helse), goal_ty, loc=_loc)
+        ite = If(Var(b, _loc), br_then, br_else, loc=_loc)
+        return TacticState(state.ctx, replace_hole(state.term, hole_name, ite), state.goal)
+
+    return None

--- a/aeon/synthesis/tactics/choose_literal.py
+++ b/aeon/synthesis/tactics/choose_literal.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidLiteralBool
+from aeon.core.terms import Literal, Term
+from aeon.core.types import RefinedType, Type, TypeConstructor, t_bool, t_float, t_int
+from aeon.synthesis.modules.tdsyn.helpers import base_type_of
+from aeon.synthesis.modules.tdsyn.smt_solve import solve_literals
+from aeon.synthesis.modules.tdsyn.worklist import TypedHole
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole
+from aeon.synthesis.tactics.state import TacticState
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name
+
+_loc = SynthesizedLocation("tactics")
+
+_LEAF_BASE_NAMES = frozenset({"Int", "Bool", "Float"})
+
+
+def _refinement_is_non_trivial(ty: Type) -> bool:
+    match ty:
+        case RefinedType(_, _, ref):
+            return ref != LiquidLiteralBool(True)
+        case _:
+            return False
+
+
+def _default_literal(base: TypeConstructor) -> Term | None:
+    match base.name.name:
+        case "Int":
+            return Literal(0, t_int, _loc)
+        case "Bool":
+            return Literal(True, t_bool, _loc)
+        case "Float":
+            return Literal(0.0, t_float, _loc)
+        case _:
+            return None
+
+
+def tactic_choose_literal(state: TacticState, hole_name: Name) -> TacticState | None:
+    """Fill a leaf hole with a Z3 model of its (refined) type, if possible.
+
+    Uses the same encoding as TDSyn's ``solve_literals`` (context refinements +
+    hole refinement). If Z3 finds no model and the goal carries a non-trivial
+    refinement, the tactic fails. If there is no non-trivial refinement and Z3
+    yields no constraints, falls back to a simple default (0 / true / 0.0).
+    """
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty, hole_ctx = holes[hole_name]
+
+    base = base_type_of(goal_ty)
+    if base is None or base.name.name not in _LEAF_BASE_NAMES:
+        return None
+
+    th = TypedHole(hole_name, goal_ty, hole_ctx, [])
+    solutions = solve_literals([th], max_models=1)
+    lit: Term | None = None
+    if solutions and hole_name in solutions[0]:
+        lit = solutions[0][hole_name]
+
+    if lit is None:
+        if _refinement_is_non_trivial(goal_ty):
+            return None
+        lit = _default_literal(base)
+        if lit is None:
+            return None
+
+    return TacticState(state.ctx, replace_hole(state.term, hole_name, lit), state.goal)

--- a/aeon/synthesis/tactics/holes.py
+++ b/aeon/synthesis/tactics/holes.py
@@ -4,12 +4,42 @@ from dataclasses import dataclass
 
 from aeon.core.liquid import LiquidTerm
 from aeon.core.substitutions import substitution, substitution_in_type
-from aeon.core.terms import Abstraction, Annotation, Application, Hole, Literal, Term, Var
-from aeon.core.types import AbstractionType, RefinedType, Type, refined_to_unrefined_type
+from aeon.core.terms import Abstraction, Annotation, Application, Hole, If, Literal, Term, Var
+from aeon.core.types import AbstractionType, RefinedType, Type, refined_to_unrefined_type, t_bool
 from aeon.synthesis.identification import get_holes
 from aeon.typechecking.context import TypingContext
 from aeon.typechecking.typeinfer import synth
 from aeon.utils.name import Name
+
+
+def replace_hole_expected_annotation(term: Term, hole_name: Name, new_ty: Type) -> Term:
+    """Rewrite the focused hole to use ``new_ty`` in its nearest ``Annotation`` (or add one)."""
+    match term:
+        case Hole(name=n) if n == hole_name:
+            return Annotation(Hole(n, term.loc), new_ty, loc=term.loc)
+        case Annotation(expr=Hole(name=n, loc=hloc), type=_, loc=aloc) if n == hole_name:
+            return Annotation(Hole(n, hloc), new_ty, loc=aloc)
+        case Annotation(expr=e, type=ty, loc=aloc):
+            return Annotation(replace_hole_expected_annotation(e, hole_name, new_ty), ty, loc=aloc)
+        case Application(fun, arg, loc):
+            return Application(
+                replace_hole_expected_annotation(fun, hole_name, new_ty),
+                replace_hole_expected_annotation(arg, hole_name, new_ty),
+                loc=loc,
+            )
+        case Abstraction(v, body, loc):
+            return Abstraction(v, replace_hole_expected_annotation(body, hole_name, new_ty), loc=loc)
+        case If(cond, then, otherwise, loc):
+            return If(
+                replace_hole_expected_annotation(cond, hole_name, new_ty),
+                replace_hole_expected_annotation(then, hole_name, new_ty),
+                replace_hole_expected_annotation(otherwise, hole_name, new_ty),
+                loc=loc,
+            )
+        case Var(_) | Literal(_, _) | Hole(_):
+            return term
+        case _:
+            raise AssertionError(f"tactics: unsupported term shape in replace_hole_expected_annotation: {term}")
 
 
 def _norm_ty(ty: Type, refined_types: bool) -> Type:
@@ -72,6 +102,12 @@ def collect_hole_judgments(
                     return collect_hole_judgments(ctx, fun, expected, refined_types) | collect_hole_judgments(
                         ctx, arg, expected, refined_types
                     )
+        case If(cond=cond, then=then, otherwise=otherwise):
+            return (
+                collect_hole_judgments(ctx, cond, t_bool, refined_types)
+                | collect_hole_judgments(ctx, then, expected, refined_types)
+                | collect_hole_judgments(ctx, otherwise, expected, refined_types)
+            )
         case Var(_) | Literal(_, _):
             return {}
         case _:

--- a/aeon/synthesis/tactics/holes.py
+++ b/aeon/synthesis/tactics/holes.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aeon.core.liquid import LiquidTerm
+from aeon.core.substitutions import substitution, substitution_in_type
+from aeon.core.terms import Abstraction, Annotation, Application, Hole, Literal, Term, Var
+from aeon.core.types import AbstractionType, RefinedType, Type, refined_to_unrefined_type
+from aeon.synthesis.identification import get_holes
+from aeon.typechecking.context import TypingContext
+from aeon.typechecking.typeinfer import synth
+from aeon.utils.name import Name
+
+
+def _norm_ty(ty: Type, refined_types: bool) -> Type:
+    return ty if refined_types else refined_to_unrefined_type(ty)
+
+
+@dataclass(frozen=True)
+class HoleInfo:
+    name: Name
+    ctx: TypingContext
+    expected: Type
+    refinement_name: Name | None = None
+    refinement_predicate: LiquidTerm | None = None
+
+
+def hole_constraint_fields(ty: Type) -> tuple[Name | None, LiquidTerm | None]:
+    """Surfaces refinement subject/predicate when ``ty`` is a ``RefinedType``."""
+    match ty:
+        case RefinedType(name, _, ref):
+            return name, ref
+        case _:
+            return None, None
+
+
+def collect_hole_judgments(
+    ctx: TypingContext,
+    term: Term,
+    expected: Type,
+    refined_types: bool = True,
+) -> dict[Name, tuple[Type, TypingContext]]:
+    """Map each hole name to ``(expected_type, typing_context)`` at its occurrence."""
+    match term:
+        case Annotation(expr=Hole(name=n), type=hty):
+            hty = _norm_ty(hty, refined_types)
+            return {n: (hty, ctx)}
+        case Hole(name=n):
+            return {n: (_norm_ty(expected, refined_types), ctx)}
+        case Annotation(expr=expr, type=ty):
+            ty = _norm_ty(ty, refined_types)
+            return collect_hole_judgments(ctx, expr, ty, refined_types)
+        case Abstraction(var_name=v, body=body):
+            match expected:
+                case AbstractionType(vn, vt, rt):
+                    body_expected = substitution_in_type(rt, Var(v), vn)
+                    return collect_hole_judgments(ctx.with_var(v, vt), body, body_expected, refined_types)
+                case _:
+                    raise AssertionError(f"Abstraction typed with non-arrow type {expected}")
+        case Application(fun=fun, arg=arg):
+            if get_holes(fun):
+                return collect_hole_judgments(ctx, fun, expected, refined_types) | collect_hole_judgments(
+                    ctx, arg, expected, refined_types
+                )
+            _, ty_fun = synth(ctx, fun)
+            match ty_fun:
+                case AbstractionType(_, atype, _):
+                    hs_fun = collect_hole_judgments(ctx, fun, ty_fun, refined_types)
+                    hs_arg = collect_hole_judgments(ctx, arg, atype, refined_types)
+                    return hs_fun | hs_arg
+                case _:
+                    return collect_hole_judgments(ctx, fun, expected, refined_types) | collect_hole_judgments(
+                        ctx, arg, expected, refined_types
+                    )
+        case Var(_) | Literal(_, _):
+            return {}
+        case _:
+            raise AssertionError(f"tactics: unsupported term shape in collect_hole_judgments: {term}")
+
+
+def list_hole_infos(
+    ctx: TypingContext,
+    term: Term,
+    root_expected: Type,
+    refined_types: bool = True,
+) -> list[HoleInfo]:
+    raw = collect_hole_judgments(ctx, term, root_expected, refined_types)
+    out: list[HoleInfo] = []
+    for name, (ety, hctx) in raw.items():
+        rn, rp = hole_constraint_fields(ety)
+        out.append(HoleInfo(name=name, ctx=hctx, expected=ety, refinement_name=rn, refinement_predicate=rp))
+    return out
+
+
+def replace_hole(term: Term, hole_name: Name, replacement: Term) -> Term:
+    return substitution(term, replacement, hole_name)

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -9,6 +9,7 @@ from aeon.core.types import Type
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
 from aeon.synthesis.tactics.holes import collect_hole_judgments
 from aeon.synthesis.tactics.state import TacticState
 from aeon.synthesis.uis.api import SynthesisUI
@@ -20,7 +21,7 @@ _loc = SynthesizedLocation("tactics")
 
 
 class TacticRandomSynthesizer(Synthesizer):
-    """Random tactic search using ``apply?`` and ``constructor`` with subtyping (``fits``)."""
+    """Random tactic search using ``apply?``, ``constructor``, and ``choose_literal``."""
 
     def __init__(self, seed: int = 0):
         self.seed = seed
@@ -43,7 +44,7 @@ class TacticRandomSynthesizer(Synthesizer):
         root = Name("_root", fresh_counter.fresh())
         term = Hole(root, loc=_loc)
         state = TacticState(ctx, term, type)
-        tactics = [tactic_apply_question, tactic_constructor]
+        tactics = [tactic_apply_question, tactic_constructor, tactic_choose_literal]
 
         start = time.time()
         ui.register(None, None, 0.0, True)

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import random
+import time
+from typing import Callable
+
+from aeon.core.terms import Hole, Term
+from aeon.core.types import Type
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import Synthesizer
+from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.holes import collect_hole_judgments
+from aeon.synthesis.tactics.state import TacticState
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name, fresh_counter
+
+_loc = SynthesizedLocation("tactics")
+
+
+class TacticRandomSynthesizer(Synthesizer):
+    """Random tactic search using ``apply?`` and ``constructor`` with subtyping (``fits``)."""
+
+    def __init__(self, seed: int = 0):
+        self.seed = seed
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+    ) -> Term | None:
+        assert isinstance(ctx, TypingContext)
+        assert isinstance(type, Type)
+
+        rng = random.Random(self.seed)
+        root = Name("_root", fresh_counter.fresh())
+        term = Hole(root, loc=_loc)
+        state = TacticState(ctx, term, type)
+        tactics = [tactic_apply_question, tactic_constructor]
+
+        start = time.time()
+        ui.register(None, None, 0.0, True)
+
+        deadline = start + float(budget)
+        while time.time() < deadline:
+            holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+            if not holes:
+                if validate(state.term):
+                    elapsed = time.time() - start
+                    try:
+                        score = evaluate(state.term)
+                        ui.register(state.term, score, elapsed, True)
+                    except Exception:
+                        ui.register(state.term, "Invalid", elapsed, False)
+                    return state.term
+                ui.register(state.term, "Invalid", time.time() - start, False)
+                return None
+
+            focal = rng.choice(list(holes.keys()))
+            tact = rng.choice(tactics)
+            nxt = tact(state, focal)
+            if nxt is not None:
+                state = nxt
+
+        ui.register(state.term, None, time.time() - start, False)
+        return None

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -9,7 +9,9 @@ from aeon.core.types import Type
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.by_cases import tactic_by_cases
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
+from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.holes import collect_hole_judgments
 from aeon.synthesis.tactics.state import TacticState
 from aeon.synthesis.uis.api import SynthesisUI
@@ -21,7 +23,7 @@ _loc = SynthesizedLocation("tactics")
 
 
 class TacticRandomSynthesizer(Synthesizer):
-    """Random tactic search using ``apply?``, ``constructor``, and ``choose_literal``."""
+    """Random tactic search using ``apply?``, ``constructor``, ``choose_literal``, ``by_cases``, and ``split``."""
 
     def __init__(self, seed: int = 0):
         self.seed = seed
@@ -44,7 +46,13 @@ class TacticRandomSynthesizer(Synthesizer):
         root = Name("_root", fresh_counter.fresh())
         term = Hole(root, loc=_loc)
         state = TacticState(ctx, term, type)
-        tactics = [tactic_apply_question, tactic_constructor, tactic_choose_literal]
+        tactics = [
+            tactic_apply_question,
+            tactic_constructor,
+            tactic_choose_literal,
+            tactic_by_cases,
+            tactic_split,
+        ]
 
         start = time.time()
         ui.register(None, None, 0.0, True)

--- a/aeon/synthesis/tactics/split.py
+++ b/aeon/synthesis/tactics/split.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidApp
+from aeon.core.types import RefinedType, Type
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole_expected_annotation
+from aeon.synthesis.tactics.state import TacticState
+from aeon.utils.name import Name
+
+_and = Name("&&", 0)
+
+
+def tactic_split(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``split``: peel a top-level liquid conjunction in the hole's refinement.
+
+    If the hole expects ``{x:T | P && Q}``, rewrite the annotation to ``{x:T | P}``.
+    The synthesizer's root ``goal`` type is unchanged, so final ``validate`` still
+    requires the full conjunction once the term is complete.
+    """
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty: Type
+    goal_ty, _hole_ctx = holes[hole_name]
+
+    match goal_ty:
+        case RefinedType(n, base, LiquidApp(fun, [p, _]), loc=rloc) if fun == _and:
+            new_ty = RefinedType(n, base, p, loc=rloc)
+            new_term = replace_hole_expected_annotation(state.term, hole_name, new_ty)
+            return TacticState(state.ctx, new_term, state.goal)
+        case _:
+            return None

--- a/aeon/synthesis/tactics/state.py
+++ b/aeon/synthesis/tactics/state.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aeon.core.terms import Term
+from aeon.core.types import Type
+from aeon.typechecking.context import TypingContext
+
+
+@dataclass
+class TacticState:
+    """Typing context for the synthesis goal plus the current partial core term."""
+
+    ctx: TypingContext
+    term: Term
+    goal: Type

--- a/aeon/synthesis/tactics/subtyping.py
+++ b/aeon/synthesis/tactics/subtyping.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidLiteralBool
+from aeon.core.types import Type
+from aeon.typechecking.context import TypingContext
+from aeon.typechecking.entailment import entailment
+from aeon.typechecking.well_formed import wellformed
+from aeon.verification.sub import sub
+from aeon.verification.vcs import LiquidConstraint
+
+_cfalse = LiquidConstraint(LiquidLiteralBool(False))
+
+
+def fits(ctx: TypingContext, actual: Type, goal: Type) -> bool:
+    """True iff the typechecker relation ``actual <: goal`` holds (via ``sub`` + entailment)."""
+    try:
+        if not wellformed(ctx, actual) or not wellformed(ctx, goal):
+            return False
+    except Exception:
+        # Narrow contexts (e.g. unit tests) may omit liquid operator binders required by
+        # ``wellformed``; still attempt ``sub`` + entailment, which matches ``check``'s VC path.
+        pass
+    c = sub(ctx, actual, goal, None)
+    if c == _cfalse:
+        return False
+    try:
+        return bool(entailment(ctx, c))
+    except Exception:
+        return False

--- a/tests/tactic_synth_test.py
+++ b/tests/tactic_synth_test.py
@@ -1,0 +1,121 @@
+from aeon.core.parser import parse_type
+from aeon.core.terms import Annotation, Hole, Term, Var
+from aeon.core.types import t_int
+from aeon.synthesis.identification import get_holes
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.holes import collect_hole_judgments, list_hole_infos
+from aeon.synthesis.tactics.random_synth import TacticRandomSynthesizer
+from aeon.synthesis.tactics.state import TacticState
+from aeon.synthesis.tactics.subtyping import fits
+from aeon.typechecking.context import TypingContext, VariableBinder
+from aeon.typechecking.typeinfer import check_type
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name
+
+_loc = SynthesizedLocation("test")
+
+
+def test_fits_int_refines_to_int():
+    ctx = TypingContext()
+    subt = parse_type(r"{k:Int | k > 0}")
+    assert fits(ctx, subt, t_int)
+
+
+def test_apply_question_uses_subtyping():
+    y = Name("y", 0)
+    yty = parse_type(r"{v:Int | v > 0}")
+    ctx = TypingContext([VariableBinder(y, yty)])
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    out = tactic_apply_question(st, h)
+    assert out is not None
+    assert not get_holes(out.term)
+    assert check_type(ctx, out.term, t_int)
+    assert _strip_trivial_ascription(out.term) == Var(y, _loc)
+
+
+def _strip_trivial_ascription(t: Term) -> Term:
+    match t:
+        case Annotation(expr=e, type=_):
+            return e
+        case _:
+            return t
+
+
+def test_constructor_builds_application_spine():
+    f = Name("f", 0)
+    fty = parse_type("(x:Int) -> Int")
+    ctx = TypingContext([VariableBinder(f, fty)])
+    r = Name("r", 0)
+    term = Annotation(Hole(r), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    out = tactic_constructor(st, r)
+    assert out is not None
+    hs = get_holes(out.term)
+    assert len(hs) == 1
+
+
+def test_constructor_arrow_intro():
+    ctx = TypingContext()
+    h = Name("h", 0)
+    goal = parse_type("(a:Int) -> Int")
+    term = Annotation(Hole(h), goal, loc=_loc)
+    st = TacticState(ctx, term, goal)
+    out = tactic_constructor(st, h)
+    assert out is not None
+    assert len(get_holes(out.term)) == 1
+
+
+def test_collect_hole_judgments_finds_arg_hole_type():
+    f = Name("f", 0)
+    fty = parse_type("(x:Int) -> Int")
+    ctx = TypingContext([VariableBinder(f, fty)])
+    r = Name("r", 0)
+    term = Annotation(Hole(r), t_int, loc=_loc)
+    out = tactic_constructor(TacticState(ctx, term, t_int), r)
+    assert out is not None
+    mp = collect_hole_judgments(out.ctx, out.term, t_int, refined_types=True)
+    assert len(mp) == 1
+    arg_ty, _ = next(iter(mp.values()))
+    assert arg_ty == t_int
+
+
+def test_list_hole_infos_includes_refinement_metadata():
+    ctx = TypingContext()
+    h = Name("h", 0)
+    gty = parse_type(r"{z:Int | z > 1}")
+    term = Annotation(Hole(h), gty, loc=_loc)
+    infos = list_hole_infos(ctx, term, gty, refined_types=True)
+    assert len(infos) == 1
+    assert infos[0].refinement_predicate is not None
+
+
+def test_tactic_random_synthesizer_smoke():
+    x = Name("x", 0)
+    ctx = TypingContext([VariableBinder(x, t_int)])
+    syn = TacticRandomSynthesizer(seed=42)
+
+    def validate(t) -> bool:
+        return check_type(ctx, t, t_int)
+
+    def evaluate(t):
+        return [0.0]
+
+    got = syn.synthesize(
+        ctx=ctx,
+        type=t_int,
+        validate=validate,
+        evaluate=evaluate,
+        fun_name=Name("main", 0),
+        metadata={},
+        budget=2.0,
+    )
+    assert got is not None
+    assert check_type(ctx, got, t_int)
+
+
+def test_make_synthesizer_tactics():
+    s = make_synthesizer("tactics")
+    assert isinstance(s, TacticRandomSynthesizer)

--- a/tests/tactic_synth_test.py
+++ b/tests/tactic_synth_test.py
@@ -1,9 +1,13 @@
 from aeon.core.parser import parse_type
-from aeon.core.terms import Annotation, Hole, Term, Var
+from aeon.core.terms import Annotation, Hole, Literal, Term, Var
 from aeon.core.types import t_int
+from aeon.elaboration.context import build_typing_context
+from aeon.prelude.prelude import typing_vars
+from aeon.sugar.lowering import lower_to_core_context
 from aeon.synthesis.identification import get_holes
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
 from aeon.synthesis.tactics.holes import collect_hole_judgments, list_hole_infos
 from aeon.synthesis.tactics.random_synth import TacticRandomSynthesizer
 from aeon.synthesis.tactics.state import TacticState
@@ -14,6 +18,10 @@ from aeon.utils.location import SynthesizedLocation
 from aeon.utils.name import Name
 
 _loc = SynthesizedLocation("test")
+
+
+def _prelude_ctx() -> TypingContext:
+    return lower_to_core_context(build_typing_context(typing_vars))
 
 
 def test_fits_int_refines_to_int():
@@ -80,6 +88,44 @@ def test_collect_hole_judgments_finds_arg_hole_type():
     assert len(mp) == 1
     arg_ty, _ = next(iter(mp.values()))
     assert arg_ty == t_int
+
+
+def test_choose_literal_plain_int_defaults():
+    ctx = TypingContext()
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    out = tactic_choose_literal(st, h)
+    assert out is not None
+    assert not get_holes(out.term)
+    e = _strip_trivial_ascription(out.term)
+    assert isinstance(e, Literal)
+    assert e.value == 0
+    assert check_type(ctx, out.term, t_int)
+
+
+def test_choose_literal_refined_int_satisfies_predicate():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    gty = parse_type(r"{z:Int | z > 2}")
+    term = Annotation(Hole(h), gty, loc=_loc)
+    st = TacticState(ctx, term, gty)
+    out = tactic_choose_literal(st, h)
+    assert out is not None
+    e = _strip_trivial_ascription(out.term)
+    assert isinstance(e, Literal)
+    assert isinstance(e.value, int)
+    assert e.value > 2
+    assert check_type(ctx, out.term, gty)
+
+
+def test_choose_literal_unsat_refinement_returns_none():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    gty = parse_type(r"{z:Int | z > 0 && z < 0}")
+    term = Annotation(Hole(h), gty, loc=_loc)
+    st = TacticState(ctx, term, gty)
+    assert tactic_choose_literal(st, h) is None
 
 
 def test_list_hole_infos_includes_refinement_metadata():

--- a/tests/tactic_synth_test.py
+++ b/tests/tactic_synth_test.py
@@ -1,12 +1,14 @@
 from aeon.core.parser import parse_type
-from aeon.core.terms import Annotation, Hole, Literal, Term, Var
-from aeon.core.types import t_int
+from aeon.core.terms import Annotation, Hole, If, Literal, Term, Var
+from aeon.core.types import t_bool, t_int
 from aeon.elaboration.context import build_typing_context
 from aeon.prelude.prelude import typing_vars
 from aeon.sugar.lowering import lower_to_core_context
 from aeon.synthesis.identification import get_holes
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.by_cases import tactic_by_cases
+from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
 from aeon.synthesis.tactics.holes import collect_hole_judgments, list_hole_infos
 from aeon.synthesis.tactics.random_synth import TacticRandomSynthesizer
@@ -117,6 +119,56 @@ def test_choose_literal_refined_int_satisfies_predicate():
     assert isinstance(e.value, int)
     assert e.value > 2
     assert check_type(ctx, out.term, gty)
+
+
+def test_split_peels_conjunction_refinement():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    full_ty = parse_type(r"{z:Int | z > 0 && z < 10}")
+    term = Annotation(Hole(h), full_ty, loc=_loc)
+    st = TacticState(ctx, term, full_ty)
+    out = tactic_split(st, h)
+    assert out is not None
+    assert out.goal == full_ty
+    mp = collect_hole_judgments(out.ctx, out.term, full_ty, refined_types=True)
+    inner_ty, _ = mp[h]
+    assert "&&" not in str(inner_ty)
+
+
+def test_split_noop_without_conjunction():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    assert tactic_split(st, h) is None
+
+
+def test_by_cases_splits_on_bool_hypothesis():
+    b = Name("b", 0)
+    ctx = _prelude_ctx().with_var(b, t_bool)
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    out = tactic_by_cases(st, h)
+    assert out is not None
+    assert len(get_holes(out.term)) == 2
+
+
+def test_collect_hole_judgments_if_branches_share_goal():
+    b = Name("b", 0)
+    ctx = _prelude_ctx().with_var(b, t_bool)
+    ht = Name("t", 0)
+    he = Name("e", 0)
+    term = If(
+        Var(b, _loc),
+        Annotation(Hole(ht), t_int, loc=_loc),
+        Annotation(Hole(he), t_int, loc=_loc),
+        loc=_loc,
+    )
+    mp = collect_hole_judgments(ctx, term, t_int, refined_types=True)
+    assert set(mp.keys()) == {ht, he}
+    for _n, (ety, _c) in mp.items():
+        assert ety == t_int
 
 
 def test_choose_literal_unsat_refinement_returns_none():


### PR DESCRIPTION
## Summary

Stacks on merged PR #182: adds **`choose_literal`** so the random tactic synthesizer can close leaf **Int / Bool / Float** holes using the same Z3 path as TDSyn (`solve_literals`), with safe defaults only when the goal has no non-trivial refinement.

## Changes
- New `aeon/synthesis/tactics/choose_literal.py`
- `TacticRandomSynthesizer` now picks among `apply?`, `constructor`, and `choose_literal`
- Tests for default Int, refined Int (with prelude ctx), and unsat refinement

## Base
`master`

Made with [Cursor](https://cursor.com)