### PR TITLE
feat(synthesis): by_cases tactic (If split on Bool hypothesis)

### DIFF
--- a/aeon/synthesis/tactics/by_cases.py
+++ b/aeon/synthesis/tactics/by_cases.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from aeon.core.liquid_ops import ops
+from aeon.core.terms import Annotation, Hole, If, Term, Var
+from aeon.core.types import Type, t_bool
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole
+from aeon.synthesis.tactics.state import TacticState
+from aeon.synthesis.tactics.subtyping import fits
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name, fresh_counter
+
+_loc = SynthesizedLocation("tactics")
+
+
+def tactic_by_cases(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``by_cases``: split on the first Boolean hypothesis ``b`` with ``bty <: Bool``.
+
+    Replaces the goal hole with ``if b then ?_then else ?_else``, reusing the same
+    goal type in both branches (Liquid ``If`` typing discharges branch VCs).
+    """
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty: Type
+    goal_ty, hole_ctx = holes[hole_name]
+
+    for b, bty in hole_ctx.concrete_vars():
+        if b in ops:
+            continue
+        if not fits(hole_ctx, bty, t_bool):
+            continue
+        hthen = Name("_then", fresh_counter.fresh())
+        helse = Name("_else", fresh_counter.fresh())
+        br_then: Term = Annotation(Hole(hthen), goal_ty, loc=_loc)
+        br_else: Term = Annotation(Hole(helse), goal_ty, loc=_loc)
+        ite = If(Var(b, _loc), br_then, br_else, loc=_loc)
+        return TacticState(state.ctx, replace_hole(state.term, hole_name, ite), state.goal)
+
+    return None

--- a/aeon/synthesis/tactics/holes.py
+++ b/aeon/synthesis/tactics/holes.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass
 
 from aeon.core.liquid import LiquidTerm
 from aeon.core.substitutions import substitution, substitution_in_type
-from aeon.core.terms import Abstraction, Annotation, Application, Hole, Literal, Term, Var
-from aeon.core.types import AbstractionType, RefinedType, Type, refined_to_unrefined_type
+from aeon.core.terms import Abstraction, Annotation, Application, Hole, If, Literal, Term, Var
+from aeon.core.types import AbstractionType, RefinedType, Type, refined_to_unrefined_type, t_bool
 from aeon.synthesis.identification import get_holes
 from aeon.typechecking.context import TypingContext
 from aeon.typechecking.typeinfer import synth
@@ -72,6 +72,12 @@ def collect_hole_judgments(
                     return collect_hole_judgments(ctx, fun, expected, refined_types) | collect_hole_judgments(
                         ctx, arg, expected, refined_types
                     )
+        case If(cond=cond, then=then, otherwise=otherwise):
+            return (
+                collect_hole_judgments(ctx, cond, t_bool, refined_types)
+                | collect_hole_judgments(ctx, then, expected, refined_types)
+                | collect_hole_judgments(ctx, otherwise, expected, refined_types)
+            )
         case Var(_) | Literal(_, _):
             return {}
         case _:

--- a/aeon/synthesis/tactics/holes.py
+++ b/aeon/synthesis/tactics/holes.py
@@ -12,6 +12,36 @@ from aeon.typechecking.typeinfer import synth
 from aeon.utils.name import Name
 
 
+def replace_hole_expected_annotation(term: Term, hole_name: Name, new_ty: Type) -> Term:
+    """Rewrite the focused hole to use ``new_ty`` in its nearest ``Annotation`` (or add one)."""
+    match term:
+        case Hole(name=n) if n == hole_name:
+            return Annotation(Hole(n, term.loc), new_ty, loc=term.loc)
+        case Annotation(expr=Hole(name=n, loc=hloc), type=_, loc=aloc) if n == hole_name:
+            return Annotation(Hole(n, hloc), new_ty, loc=aloc)
+        case Annotation(expr=e, type=ty, loc=aloc):
+            return Annotation(replace_hole_expected_annotation(e, hole_name, new_ty), ty, loc=aloc)
+        case Application(fun, arg, loc):
+            return Application(
+                replace_hole_expected_annotation(fun, hole_name, new_ty),
+                replace_hole_expected_annotation(arg, hole_name, new_ty),
+                loc=loc,
+            )
+        case Abstraction(v, body, loc):
+            return Abstraction(v, replace_hole_expected_annotation(body, hole_name, new_ty), loc=loc)
+        case If(cond, then, otherwise, loc):
+            return If(
+                replace_hole_expected_annotation(cond, hole_name, new_ty),
+                replace_hole_expected_annotation(then, hole_name, new_ty),
+                replace_hole_expected_annotation(otherwise, hole_name, new_ty),
+                loc=loc,
+            )
+        case Var(_) | Literal(_, _) | Hole(_):
+            return term
+        case _:
+            raise AssertionError(f"tactics: unsupported term shape in replace_hole_expected_annotation: {term}")
+
+
 def _norm_ty(ty: Type, refined_types: bool) -> Type:
     return ty if refined_types else refined_to_unrefined_type(ty)
 

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -9,6 +9,7 @@ from aeon.core.types import Type
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.by_cases import tactic_by_cases
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
 from aeon.synthesis.tactics.holes import collect_hole_judgments
 from aeon.synthesis.tactics.state import TacticState
@@ -21,7 +22,7 @@ _loc = SynthesizedLocation("tactics")
 
 
 class TacticRandomSynthesizer(Synthesizer):
-    """Random tactic search using ``apply?``, ``constructor``, and ``choose_literal``."""
+    """Random tactic search using ``apply?``, ``constructor``, ``choose_literal``, and ``by_cases``."""
 
     def __init__(self, seed: int = 0):
         self.seed = seed
@@ -44,7 +45,7 @@ class TacticRandomSynthesizer(Synthesizer):
         root = Name("_root", fresh_counter.fresh())
         term = Hole(root, loc=_loc)
         state = TacticState(ctx, term, type)
-        tactics = [tactic_apply_question, tactic_constructor, tactic_choose_literal]
+        tactics = [tactic_apply_question, tactic_constructor, tactic_choose_literal, tactic_by_cases]
 
         start = time.time()
         ui.register(None, None, 0.0, True)

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -11,6 +11,7 @@ from aeon.synthesis.api import Synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
 from aeon.synthesis.tactics.by_cases import tactic_by_cases
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
+from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.holes import collect_hole_judgments
 from aeon.synthesis.tactics.state import TacticState
 from aeon.synthesis.uis.api import SynthesisUI
@@ -22,7 +23,7 @@ _loc = SynthesizedLocation("tactics")
 
 
 class TacticRandomSynthesizer(Synthesizer):
-    """Random tactic search using ``apply?``, ``constructor``, ``choose_literal``, and ``by_cases``."""
+    """Random tactic search using ``apply?``, ``constructor``, ``choose_literal``, ``by_cases``, and ``split``."""
 
     def __init__(self, seed: int = 0):
         self.seed = seed
@@ -45,7 +46,13 @@ class TacticRandomSynthesizer(Synthesizer):
         root = Name("_root", fresh_counter.fresh())
         term = Hole(root, loc=_loc)
         state = TacticState(ctx, term, type)
-        tactics = [tactic_apply_question, tactic_constructor, tactic_choose_literal, tactic_by_cases]
+        tactics = [
+            tactic_apply_question,
+            tactic_constructor,
+            tactic_choose_literal,
+            tactic_by_cases,
+            tactic_split,
+        ]
 
         start = time.time()
         ui.register(None, None, 0.0, True)

--- a/aeon/synthesis/tactics/split.py
+++ b/aeon/synthesis/tactics/split.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidApp
+from aeon.core.types import RefinedType, Type
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole_expected_annotation
+from aeon.synthesis.tactics.state import TacticState
+from aeon.utils.name import Name
+
+_and = Name("&&", 0)
+
+
+def tactic_split(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``split``: peel a top-level liquid conjunction in the hole's refinement.
+
+    If the hole expects ``{x:T | P && Q}``, rewrite the annotation to ``{x:T | P}``.
+    The synthesizer's root ``goal`` type is unchanged, so final ``validate`` still
+    requires the full conjunction once the term is complete.
+    """
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty: Type
+    goal_ty, _hole_ctx = holes[hole_name]
+
+    match goal_ty:
+        case RefinedType(n, base, LiquidApp(fun, [p, _]), loc=rloc) if fun == _and:
+            new_ty = RefinedType(n, base, p, loc=rloc)
+            new_term = replace_hole_expected_annotation(state.term, hole_name, new_ty)
+            return TacticState(state.ctx, new_term, state.goal)
+        case _:
+            return None

--- a/tests/tactic_synth_test.py
+++ b/tests/tactic_synth_test.py
@@ -1,12 +1,13 @@
 from aeon.core.parser import parse_type
-from aeon.core.terms import Annotation, Hole, Literal, Term, Var
-from aeon.core.types import t_int
+from aeon.core.terms import Annotation, Hole, If, Literal, Term, Var
+from aeon.core.types import t_bool, t_int
 from aeon.elaboration.context import build_typing_context
 from aeon.prelude.prelude import typing_vars
 from aeon.sugar.lowering import lower_to_core_context
 from aeon.synthesis.identification import get_holes
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
+from aeon.synthesis.tactics.by_cases import tactic_by_cases
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
 from aeon.synthesis.tactics.holes import collect_hole_judgments, list_hole_infos
 from aeon.synthesis.tactics.random_synth import TacticRandomSynthesizer
@@ -117,6 +118,34 @@ def test_choose_literal_refined_int_satisfies_predicate():
     assert isinstance(e.value, int)
     assert e.value > 2
     assert check_type(ctx, out.term, gty)
+
+
+def test_by_cases_splits_on_bool_hypothesis():
+    b = Name("b", 0)
+    ctx = _prelude_ctx().with_var(b, t_bool)
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    out = tactic_by_cases(st, h)
+    assert out is not None
+    assert len(get_holes(out.term)) == 2
+
+
+def test_collect_hole_judgments_if_branches_share_goal():
+    b = Name("b", 0)
+    ctx = _prelude_ctx().with_var(b, t_bool)
+    ht = Name("t", 0)
+    he = Name("e", 0)
+    term = If(
+        Var(b, _loc),
+        Annotation(Hole(ht), t_int, loc=_loc),
+        Annotation(Hole(he), t_int, loc=_loc),
+        loc=_loc,
+    )
+    mp = collect_hole_judgments(ctx, term, t_int, refined_types=True)
+    assert set(mp.keys()) == {ht, he}
+    for _n, (ety, _c) in mp.items():
+        assert ety == t_int
 
 
 def test_choose_literal_unsat_refinement_returns_none():

--- a/tests/tactic_synth_test.py
+++ b/tests/tactic_synth_test.py
@@ -8,6 +8,7 @@ from aeon.synthesis.identification import get_holes
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
 from aeon.synthesis.tactics.by_cases import tactic_by_cases
+from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
 from aeon.synthesis.tactics.holes import collect_hole_judgments, list_hole_infos
 from aeon.synthesis.tactics.random_synth import TacticRandomSynthesizer
@@ -118,6 +119,28 @@ def test_choose_literal_refined_int_satisfies_predicate():
     assert isinstance(e.value, int)
     assert e.value > 2
     assert check_type(ctx, out.term, gty)
+
+
+def test_split_peels_conjunction_refinement():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    full_ty = parse_type(r"{z:Int | z > 0 && z < 10}")
+    term = Annotation(Hole(h), full_ty, loc=_loc)
+    st = TacticState(ctx, term, full_ty)
+    out = tactic_split(st, h)
+    assert out is not None
+    assert out.goal == full_ty
+    mp = collect_hole_judgments(out.ctx, out.term, full_ty, refined_types=True)
+    inner_ty, _ = mp[h]
+    assert "&&" not in str(inner_ty)
+
+
+def test_split_noop_without_conjunction():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    assert tactic_split(st, h) is None
 
 
 def test_by_cases_splits_on_bool_hypothesis():


### PR DESCRIPTION
## Summary

Stacked on **`feat/tactics-random-synthesizer`** (PR #184: `choose_literal` + earlier tactics).

Adds **`by_cases`**: pick the first context variable `b` with **`bty <: Bool`** and replace the focused hole with

```
if b then ?_then else ?_else
```

using the **same goal type** in both branches (Liquid-style `If` typing).

## Changes
- `aeon/synthesis/tactics/by_cases.py` — `tactic_by_cases`
- `collect_hole_judgments` now recurses through `If` (condition checked at `Bool`)
- `TacticRandomSynthesizer` includes `by_cases` in the random pool
- Tests for split + hole typing on `If`

## Merge note
After #184 lands on `master`, retarget this PR to `master` (or merge the stack in order).

Made with [Cursor](https://cursor.com)