### PR TITLE
feat(synthesis): split tactic for conjunction refinements

### DIFF
--- a/aeon/synthesis/tactics/holes.py
+++ b/aeon/synthesis/tactics/holes.py
@@ -12,6 +12,36 @@ from aeon.typechecking.typeinfer import synth
 from aeon.utils.name import Name
 
 
+def replace_hole_expected_annotation(term: Term, hole_name: Name, new_ty: Type) -> Term:
+    """Rewrite the focused hole to use ``new_ty`` in its nearest ``Annotation`` (or add one)."""
+    match term:
+        case Hole(name=n) if n == hole_name:
+            return Annotation(Hole(n, term.loc), new_ty, loc=term.loc)
+        case Annotation(expr=Hole(name=n, loc=hloc), type=_, loc=aloc) if n == hole_name:
+            return Annotation(Hole(n, hloc), new_ty, loc=aloc)
+        case Annotation(expr=e, type=ty, loc=aloc):
+            return Annotation(replace_hole_expected_annotation(e, hole_name, new_ty), ty, loc=aloc)
+        case Application(fun, arg, loc):
+            return Application(
+                replace_hole_expected_annotation(fun, hole_name, new_ty),
+                replace_hole_expected_annotation(arg, hole_name, new_ty),
+                loc=loc,
+            )
+        case Abstraction(v, body, loc):
+            return Abstraction(v, replace_hole_expected_annotation(body, hole_name, new_ty), loc=loc)
+        case If(cond, then, otherwise, loc):
+            return If(
+                replace_hole_expected_annotation(cond, hole_name, new_ty),
+                replace_hole_expected_annotation(then, hole_name, new_ty),
+                replace_hole_expected_annotation(otherwise, hole_name, new_ty),
+                loc=loc,
+            )
+        case Var(_) | Literal(_, _) | Hole(_):
+            return term
+        case _:
+            raise AssertionError(f"tactics: unsupported term shape in replace_hole_expected_annotation: {term}")
+
+
 def _norm_ty(ty: Type, refined_types: bool) -> Type:
     return ty if refined_types else refined_to_unrefined_type(ty)
 

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -11,6 +11,7 @@ from aeon.synthesis.api import Synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
 from aeon.synthesis.tactics.by_cases import tactic_by_cases
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
+from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.holes import collect_hole_judgments
 from aeon.synthesis.tactics.state import TacticState
 from aeon.synthesis.uis.api import SynthesisUI
@@ -22,7 +23,7 @@ _loc = SynthesizedLocation("tactics")
 
 
 class TacticRandomSynthesizer(Synthesizer):
-    """Random tactic search using ``apply?``, ``constructor``, ``choose_literal``, and ``by_cases``."""
+    """Random tactic search using ``apply?``, ``constructor``, ``choose_literal``, ``by_cases``, and ``split``."""
 
     def __init__(self, seed: int = 0):
         self.seed = seed
@@ -45,7 +46,13 @@ class TacticRandomSynthesizer(Synthesizer):
         root = Name("_root", fresh_counter.fresh())
         term = Hole(root, loc=_loc)
         state = TacticState(ctx, term, type)
-        tactics = [tactic_apply_question, tactic_constructor, tactic_choose_literal, tactic_by_cases]
+        tactics = [
+            tactic_apply_question,
+            tactic_constructor,
+            tactic_choose_literal,
+            tactic_by_cases,
+            tactic_split,
+        ]
 
         start = time.time()
         ui.register(None, None, 0.0, True)

--- a/aeon/synthesis/tactics/split.py
+++ b/aeon/synthesis/tactics/split.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidApp
+from aeon.core.types import RefinedType, Type
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole_expected_annotation
+from aeon.synthesis.tactics.state import TacticState
+from aeon.utils.name import Name
+
+_and = Name("&&", 0)
+
+
+def tactic_split(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``split``: peel a top-level liquid conjunction in the hole's refinement.
+
+    If the hole expects ``{x:T | P && Q}``, rewrite the annotation to ``{x:T | P}``.
+    The synthesizer's root ``goal`` type is unchanged, so final ``validate`` still
+    requires the full conjunction once the term is complete.
+    """
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty: Type
+    goal_ty, _hole_ctx = holes[hole_name]
+
+    match goal_ty:
+        case RefinedType(n, base, LiquidApp(fun, [p, _]), loc=rloc) if fun == _and:
+            new_ty = RefinedType(n, base, p, loc=rloc)
+            new_term = replace_hole_expected_annotation(state.term, hole_name, new_ty)
+            return TacticState(state.ctx, new_term, state.goal)
+        case _:
+            return None

--- a/tests/tactic_synth_test.py
+++ b/tests/tactic_synth_test.py
@@ -8,6 +8,7 @@ from aeon.synthesis.identification import get_holes
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
 from aeon.synthesis.tactics.by_cases import tactic_by_cases
+from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
 from aeon.synthesis.tactics.holes import collect_hole_judgments, list_hole_infos
 from aeon.synthesis.tactics.random_synth import TacticRandomSynthesizer
@@ -118,6 +119,28 @@ def test_choose_literal_refined_int_satisfies_predicate():
     assert isinstance(e.value, int)
     assert e.value > 2
     assert check_type(ctx, out.term, gty)
+
+
+def test_split_peels_conjunction_refinement():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    full_ty = parse_type(r"{z:Int | z > 0 && z < 10}")
+    term = Annotation(Hole(h), full_ty, loc=_loc)
+    st = TacticState(ctx, term, full_ty)
+    out = tactic_split(st, h)
+    assert out is not None
+    assert out.goal == full_ty
+    mp = collect_hole_judgments(out.ctx, out.term, full_ty, refined_types=True)
+    inner_ty, _ = mp[h]
+    assert "&&" not in str(inner_ty)
+
+
+def test_split_noop_without_conjunction():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    assert tactic_split(st, h) is None
 
 
 def test_by_cases_splits_on_bool_hypothesis():


### PR DESCRIPTION
## Summary

Third stacked PR after **`feat/tactics-by-cases`** (#185): adds **`split`** for liquid conjunctions.

When a hole expects `{x:T | P && Q}`, **`tactic_split`** rewrites the hole’s **annotation** to `{x:T | P}` (left conjunct). **`TacticState.goal`** is unchanged, so final `validate` / subtyping still requires the **full** `P && Q` once the term is complete—this only guides intermediate search (e.g. simpler VCs for `choose_literal`).

## Changes
- `aeon/synthesis/tactics/split.py` — `tactic_split`
- `replace_hole_expected_annotation` in `holes.py`
- `TacticRandomSynthesizer` includes `split`
- Tests: peel `z > 0 && z < 10`, noop on bare `Int`

## Stack
Base: `feat/tactics-by-cases` → merge after #185 (and #184) as appropriate.

Made with [Cursor](https://cursor.com)