### PR TITLE
feat(synthesis): inst tactic (type instantiation)

### DIFF
--- a/aeon/synthesis/tactics/holes.py
+++ b/aeon/synthesis/tactics/holes.py
@@ -4,12 +4,44 @@ from dataclasses import dataclass
 
 from aeon.core.liquid import LiquidTerm
 from aeon.core.substitutions import substitution, substitution_in_type
-from aeon.core.terms import Abstraction, Annotation, Application, Hole, If, Literal, Term, Var
-from aeon.core.types import AbstractionType, RefinedType, Type, refined_to_unrefined_type, t_bool
+from aeon.core.terms import Abstraction, Annotation, Application, Hole, If, Literal, Term, TypeApplication, Var
+from aeon.core.types import AbstractionType, RefinedType, Type, TypePolymorphism, refined_to_unrefined_type, t_bool
 from aeon.synthesis.identification import get_holes
 from aeon.typechecking.context import TypingContext
 from aeon.typechecking.typeinfer import synth
 from aeon.utils.name import Name
+
+
+def replace_focal_hole(term: Term, hole_name: Name, replacement: Term) -> Term:
+    """Replace the focal ``Hole`` (or its sole ``Annotation`` wrapper) by ``replacement``."""
+    match term:
+        case Hole(name=n) if n == hole_name:
+            return replacement
+        case Annotation(expr=Hole(name=n), type=_, loc=aloc) if n == hole_name:
+            return replacement
+        case Annotation(expr=e, type=ty, loc=aloc):
+            return Annotation(replace_focal_hole(e, hole_name, replacement), ty, loc=aloc)
+        case Application(fun, arg, loc):
+            return Application(
+                replace_focal_hole(fun, hole_name, replacement),
+                replace_focal_hole(arg, hole_name, replacement),
+                loc=loc,
+            )
+        case Abstraction(v, body, loc):
+            return Abstraction(v, replace_focal_hole(body, hole_name, replacement), loc=loc)
+        case If(cond, then, otherwise, loc):
+            return If(
+                replace_focal_hole(cond, hole_name, replacement),
+                replace_focal_hole(then, hole_name, replacement),
+                replace_focal_hole(otherwise, hole_name, replacement),
+                loc=loc,
+            )
+        case TypeApplication(body, ty, loc):
+            return TypeApplication(replace_focal_hole(body, hole_name, replacement), ty, loc=loc)
+        case Var(_) | Literal(_, _) | Hole(_):
+            return term
+        case _:
+            raise AssertionError(f"tactics: unsupported term shape in replace_focal_hole: {term}")
 
 
 def replace_hole_expected_annotation(term: Term, hole_name: Name, new_ty: Type) -> Term:
@@ -36,6 +68,8 @@ def replace_hole_expected_annotation(term: Term, hole_name: Name, new_ty: Type) 
                 replace_hole_expected_annotation(otherwise, hole_name, new_ty),
                 loc=loc,
             )
+        case TypeApplication(body, ty, loc):
+            return TypeApplication(replace_hole_expected_annotation(body, hole_name, new_ty), ty, loc=loc)
         case Var(_) | Literal(_, _) | Hole(_):
             return term
         case _:
@@ -108,6 +142,13 @@ def collect_hole_judgments(
                 | collect_hole_judgments(ctx, then, expected, refined_types)
                 | collect_hole_judgments(ctx, otherwise, expected, refined_types)
             )
+        case TypeApplication(body=body, type=_):
+            _, ty_body = synth(ctx, body)
+            match ty_body:
+                case TypePolymorphism(_, _, _):
+                    return collect_hole_judgments(ctx, body, ty_body, refined_types)
+                case _:
+                    return collect_hole_judgments(ctx, body, expected, refined_types)
         case Var(_) | Literal(_, _):
             return {}
         case _:

--- a/aeon/synthesis/tactics/inst.py
+++ b/aeon/synthesis/tactics/inst.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from aeon.core.instantiation import type_substitution
+from aeon.core.terms import Annotation, Hole, Term, TypeApplication
+from aeon.core.types import TypePolymorphism
+from aeon.synthesis.modules.tdsyn.helpers import _collect_concrete_types
+from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_focal_hole
+from aeon.synthesis.tactics.state import TacticState
+from aeon.typechecking.typeinfer import is_compatible
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name, fresh_counter
+
+_loc = SynthesizedLocation("tactics")
+
+
+def tactic_inst(state: TacticState, hole_name: Name) -> TacticState | None:
+    """``inst``: instantiate a ``forall`` goal with a concrete type from context (or built-ins).
+
+    Replaces ``?h : forall a:k. B`` with ``(?i : forall a:k. B)[τ]``, where ``τ`` is the first
+    well-kinded candidate from ``_collect_concrete_types``. If the hole's expected type is the
+    synthesizer root goal, ``state.goal`` is updated to ``B[a := τ]``.
+    """
+    holes = collect_hole_judgments(state.ctx, state.term, state.goal, refined_types=True)
+    if hole_name not in holes:
+        return None
+    goal_ty, hole_ctx = holes[hole_name]
+
+    match goal_ty:
+        case TypePolymorphism(pname, kind, pbody):
+            pass
+        case _:
+            return None
+
+    for tau in _collect_concrete_types(hole_ctx):
+        try:
+            tau_kind = hole_ctx.kind_of(tau)
+        except (AssertionError, Exception):
+            continue
+        if not is_compatible(tau_kind, kind):
+            continue
+        inst_ty = type_substitution(pbody, pname, tau)
+        hn = Name("_ti", fresh_counter.fresh())
+        inner: Term = Annotation(Hole(hn, loc=_loc), goal_ty, loc=_loc)
+        wrapped = TypeApplication(inner, tau, loc=_loc)
+        new_term = replace_focal_hole(state.term, hole_name, wrapped)
+        new_goal = inst_ty if goal_ty == state.goal else state.goal
+        return TacticState(state.ctx, new_term, new_goal)
+
+    return None

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -12,6 +12,7 @@ from aeon.synthesis.tactics.assumption import tactic_assumption
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
 from aeon.synthesis.tactics.by_cases import tactic_by_cases
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
+from aeon.synthesis.tactics.inst import tactic_inst
 from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.holes import collect_hole_judgments
 from aeon.synthesis.tactics.state import TacticState
@@ -24,7 +25,7 @@ _loc = SynthesizedLocation("tactics")
 
 
 class TacticRandomSynthesizer(Synthesizer):
-    """Random tactic search: ``apply?``, ``assumption``, ``constructor``, ``choose_literal``, ``by_cases``, ``split``."""
+    """Random tactic search: ``apply?``, ``assumption``, ``constructor``, ``inst``, ``choose_literal``, ``by_cases``, ``split``."""
 
     def __init__(self, seed: int = 0):
         self.seed = seed
@@ -51,6 +52,7 @@ class TacticRandomSynthesizer(Synthesizer):
             tactic_apply_question,
             tactic_assumption,
             tactic_constructor,
+            tactic_inst,
             tactic_choose_literal,
             tactic_by_cases,
             tactic_split,

--- a/tests/tactic_synth_test.py
+++ b/tests/tactic_synth_test.py
@@ -8,6 +8,7 @@ from aeon.synthesis.identification import get_holes
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.tactics.builtin import tactic_apply_question, tactic_constructor
 from aeon.synthesis.tactics.assumption import tactic_assumption
+from aeon.synthesis.tactics.inst import tactic_inst
 from aeon.synthesis.tactics.by_cases import tactic_by_cases
 from aeon.synthesis.tactics.split import tactic_split
 from aeon.synthesis.tactics.choose_literal import tactic_choose_literal
@@ -31,6 +32,29 @@ def test_fits_int_refines_to_int():
     ctx = TypingContext()
     subt = parse_type(r"{k:Int | k > 0}")
     assert fits(ctx, subt, t_int)
+
+
+def test_inst_specializes_forall_base_kind():
+    poly = parse_type("forall a:B, a")
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    term = Annotation(Hole(h), poly, loc=_loc)
+    st = TacticState(ctx, term, poly)
+    out = tactic_inst(st, h)
+    assert out is not None
+    assert out.goal == t_int
+    hs = get_holes(out.term)
+    assert len(hs) == 1
+    mp = collect_hole_judgments(out.ctx, out.term, out.goal, refined_types=True)
+    assert len(mp) == 1
+
+
+def test_inst_noop_on_non_polymorphic_goal():
+    ctx = _prelude_ctx()
+    h = Name("h", 0)
+    term = Annotation(Hole(h), t_int, loc=_loc)
+    st = TacticState(ctx, term, t_int)
+    assert tactic_inst(st, h) is None
 
 
 def test_assumption_succeeds_when_types_are_bidirectionally_subtyping():


### PR DESCRIPTION
## Summary

Stacked on **`feat/tactics-assumption`** (#187).

Adds **`inst`** (`tactic_inst`): when a hole expects **`TypePolymorphism`**, pick the first **well-kinded** concrete type from `_collect_concrete_types` (built-ins + context bases) and replace the hole with

```
(?fresh : forall a:k. B)[τ]
```

If that polymorphic type **is** the synthesizer root `state.goal`, `state.goal` is updated to **`B[a := τ]`** so the remaining search targets the monomorphized type.

## Supporting changes
- `collect_hole_judgments` handles `TypeApplication` (body typed with `synth`, holes under polymorphic head).
- `replace_focal_hole` replaces a focal hole or its annotation wrapper without duplicating an outer annotation (used by `inst`).
- `replace_hole_expected_annotation` recurses through `TypeApplication`.

## Tests
- `forall a:B, a` → first candidate `Int`, new goal `Int`, one inner hole
- non-polymorphic goal → `None`

## Stack
Base: `feat/tactics-assumption`

Made with [Cursor](https://cursor.com)