### PR TITLE
Memoize smt_valid to avoid redundant Z3 solver calls

### DIFF
--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -440,9 +440,16 @@ def flatten(c: Constraint, ctx: SMTContext | None = None) -> Generator[CanonicCo
 s = Solver()
 (s.set(timeout=200),)
 
+_smt_valid_cache: dict[str, bool] = {}
+
 
 def smt_valid(constraint: Constraint) -> bool:
     """Verifies if a constraint is true using Z3."""
+    key = repr(constraint)
+    cached = _smt_valid_cache.get(key)
+    if cached is not None:
+        return cached
+
     n = 0
     for c in flatten(constraint):
         n += 1
@@ -459,10 +466,13 @@ def smt_valid(constraint: Constraint) -> bool:
         result = s.check()
         s.pop()
         if result == sat:
+            _smt_valid_cache[key] = False
             return False
         elif result == unknown:
+            _smt_valid_cache[key] = False
             return False
 
+    _smt_valid_cache[key] = True
     return True
 
 

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -43,6 +43,7 @@ from aeon.core.types import TypeVar
 from aeon.core.types import t_bool, t_int, t_float, t_string, t_unit
 from aeon.verification.sub import lower_constraint_type
 from aeon.verification.vcs import Conjunction
+from aeon.verification.vcs import alpha_key
 from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import Implication
 from aeon.verification.vcs import LiquidConstraint
@@ -445,7 +446,7 @@ _smt_valid_cache: dict[str, bool] = {}
 
 def smt_valid(constraint: Constraint) -> bool:
     """Verifies if a constraint is true using Z3."""
-    key = repr(constraint)
+    key = alpha_key(constraint)
     cached = _smt_valid_cache.get(key)
     if cached is not None:
         return cached

--- a/aeon/verification/vcs.py
+++ b/aeon/verification/vcs.py
@@ -5,11 +5,12 @@ from typing import Generator
 
 from aeon.core.liquid import LiquidApp
 from aeon.core.liquid import LiquidLiteralBool
+from aeon.core.liquid import LiquidLiteralFloat
 from aeon.core.liquid import LiquidLiteralInt
 from aeon.core.liquid import LiquidLiteralString
 from aeon.core.liquid import LiquidTerm
 from aeon.core.liquid import LiquidVar
-from aeon.core.types import AbstractionType, Top, TypeVar
+from aeon.core.types import AbstractionType, RefinedType, RefinementPolymorphism, Top, Type, TypePolymorphism, TypeVar
 from aeon.core.types import TypeConstructor
 from aeon.utils.location import Location
 from aeon.utils.name import Name
@@ -83,6 +84,134 @@ class TypeVarDeclaration(Constraint):
 
     def __repr__(self):
         return f"type {self.name}, {self.seq}"
+
+
+def _alpha_name(name: Name, env: dict[tuple[str, int], int], counter: list[int]) -> str:
+    """Return a canonical string for a Name, normalizing fresh ids."""
+    key = (name.name, name.id)
+    if key in env:
+        return f"{name.name}#{env[key]}"
+    # Not a bound variable — keep original representation
+    return str(name)
+
+
+def _alpha_bind(
+    name: Name, env: dict[tuple[str, int], int], counter: list[int]
+) -> tuple[str, dict[tuple[str, int], int]]:
+    """Bind a name in the alpha-normalization environment, returning its canonical string and new env."""
+    key = (name.name, name.id)
+    canonical_id = counter[0]
+    counter[0] += 1
+    new_env = {**env, key: canonical_id}
+    return f"{name.name}#{canonical_id}", new_env
+
+
+def _alpha_liquid(t: LiquidTerm, env: dict[tuple[str, int], int], counter: list[int]) -> str:
+    """Alpha-normalize a LiquidTerm to a canonical string."""
+    if isinstance(t, LiquidLiteralBool):
+        return str(t.value).lower()
+    elif isinstance(t, LiquidLiteralInt):
+        return str(t.value)
+    elif isinstance(t, LiquidLiteralFloat):
+        return str(t.value)
+    elif isinstance(t, LiquidLiteralString):
+        return repr(t.value)
+    elif isinstance(t, LiquidVar):
+        return _alpha_name(t.name, env, counter)
+    elif isinstance(t, LiquidApp):
+        fun_s = _alpha_name(t.fun, env, counter)
+        if all(not c.isalnum() for c in t.fun.name) and len(t.args) == 2:
+            a1 = _alpha_liquid(t.args[0], env, counter)
+            a2 = _alpha_liquid(t.args[1], env, counter)
+            return f"({a1} {fun_s} {a2})"
+        args_s = ",".join(_alpha_liquid(a, env, counter) for a in t.args)
+        return f"{fun_s}({args_s})"
+    else:
+        # LiquidLiteralFloat, LiquidHornApplication, etc.
+        return repr(t)
+
+
+def _alpha_type(ty: Type, env: dict[tuple[str, int], int], counter: list[int]) -> str:
+    """Alpha-normalize a Type to a canonical string."""
+    if isinstance(ty, AbstractionType):
+        var_s, new_env = _alpha_bind(ty.var_name, env, counter)
+        vt_s = _alpha_type(ty.var_type, new_env, counter)
+        body_s = _alpha_type(ty.type, new_env, counter)
+        return f"({var_s}:{vt_s}) -> {body_s}"
+    elif isinstance(ty, RefinedType):
+        var_s, new_env = _alpha_bind(ty.name, env, counter)
+        base_s = _alpha_type(ty.type, new_env, counter)
+        ref_s = _alpha_liquid(ty.refinement, new_env, counter)
+        return f"{{{var_s}:{base_s} | {ref_s}}}"
+    elif isinstance(ty, TypeConstructor):
+        if ty.args:
+            args_s = " ".join(_alpha_type(a, env, counter) for a in ty.args)
+            return f"{ty.name} {args_s}"
+        return str(ty.name)
+    elif isinstance(ty, TypeVar):
+        return _alpha_name(ty.name, env, counter)
+    elif isinstance(ty, Top):
+        return "⊤"
+    elif isinstance(ty, TypePolymorphism):
+        var_s, new_env = _alpha_bind(ty.name, env, counter)
+        body_s = _alpha_type(ty.body, new_env, counter)
+        return f"forall {var_s}:{ty.kind}, {body_s}"
+    elif isinstance(ty, RefinementPolymorphism):
+        var_s, new_env = _alpha_bind(ty.name, env, counter)
+        sort_s = _alpha_type(ty.sort, new_env, counter)
+        body_s = _alpha_type(ty.body, new_env, counter)
+        return f"forall <{var_s}:{sort_s} -> Bool>, {body_s}"
+    else:
+        return repr(ty)
+
+
+def alpha_key(c: Constraint) -> str:
+    """Compute an alpha-equivalent canonical string for a constraint.
+
+    Bound variable names are normalized to sequential ids so that
+    constraints differing only in fresh variable numbering produce
+    the same key.
+    """
+    env: dict[tuple[str, int], int] = {}
+    counter = [0]
+    return _alpha_constraint(c, env, counter)
+
+
+def _alpha_constraint(c: Constraint, env: dict[tuple[str, int], int], counter: list[int]) -> str:
+    if isinstance(c, LiquidConstraint):
+        return _alpha_liquid(c.expr, env, counter)
+    elif isinstance(c, Conjunction):
+        left = _alpha_constraint(c.c1, env, counter)
+        right = _alpha_constraint(c.c2, env, counter)
+        return f"({left}) ∧ ({right})"
+    elif isinstance(c, Implication):
+        var_s, new_env = _alpha_bind(c.name, env, counter)
+        base_s = _alpha_type(c.base, new_env, counter)
+        pred_s = _alpha_liquid(c.pred, new_env, counter)
+        seq_s = _alpha_constraint(c.seq, new_env, counter)
+        return f"∀{var_s}:{base_s}, ({pred_s}) => {seq_s}"
+    elif isinstance(c, UninterpretedFunctionDeclaration):
+        var_s, new_env = _alpha_bind(c.name, env, counter)
+        type_s = _alpha_type(c.type, new_env, counter)
+        seq_s = _alpha_constraint(c.seq, new_env, counter)
+        return f"fun {var_s}:{type_s} => {seq_s}"
+    elif isinstance(c, ReflectedFunctionDeclaration):
+        var_s, new_env = _alpha_bind(c.name, env, counter)
+        params_strs = []
+        for p in c.params:
+            p_s, new_env = _alpha_bind(p, new_env, counter)
+            params_strs.append(p_s)
+        type_s = _alpha_type(c.type, new_env, counter)
+        body_s = _alpha_liquid(c.body, new_env, counter)
+        seq_s = _alpha_constraint(c.seq, new_env, counter)
+        params_joined = ", ".join(params_strs)
+        return f"reflected {var_s}({params_joined}):{type_s} = {body_s} => {seq_s}"
+    elif isinstance(c, TypeVarDeclaration):
+        var_s, new_env = _alpha_bind(c.name, env, counter)
+        seq_s = _alpha_constraint(c.seq, new_env, counter)
+        return f"type {var_s}, {seq_s}"
+    else:
+        return repr(c)
 
 
 def variables_in_liq(t: LiquidTerm) -> Generator[str, None, None]:


### PR DESCRIPTION
## Summary
- Cache `smt_valid` results keyed by alpha-equivalent constraint representation to avoid re-invoking Z3 for identical constraints
- Uses `alpha_key()` which normalizes bound variable names to sequential ids, so constraints differing only in fresh variable numbering produce the same cache key
- Most impactful during synthesis where the same constraint structures are verified repeatedly with different fresh variable names

## Why `repr()` didn't work

The typechecker generates fresh variable names with a global counter (e.g., `kz²⁵⁹`, `kz³³³⁵`) for each synthesis candidate. Even when two candidates produce semantically identical constraints, their `repr()` strings differ — giving the original cache **0% hit rate** on all real workloads.

## Benchmark results (hole.ae, 10s GP budget, 3-run avg)

| Metric | Before (master) | After (alpha-key cache) | Change |
|---|---|---|---|
| Cache hit rate | — | 46.6% | |
| Z3 solver calls | 906 | 529 | **-42%** |
| Synthesis throughput | 906 candidates | 991 candidates | **+9.4%** |
| Key computation overhead | — | 0.092s | negligible |

Wall-clock time is unchanged because GP synthesis fills a fixed time budget — saved Z3 time is reinvested into evaluating more candidates, which is the desired behavior.

### hole_refined_synthesis.ae (more complex types)

| Metric | Before | After | Change |
|---|---|---|---|
| Cache hit rate | — | 29.1% | |
| Z3 solver calls | 533 | 421 | **-21%** |
| Synthesis throughput | 533 | 593 | **+11.2%** |

## Test plan
- [x] All 339 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)