### PR TITLE
Add SMT Set support for refinement types

### DIFF
--- a/aeon/core/liquid_ops.py
+++ b/aeon/core/liquid_ops.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from aeon.core.liquid import LiquidApp
 from aeon.core.liquid import LiquidLiteralBool
 from aeon.core.liquid import LiquidTerm
-from aeon.core.types import TypeConstructor, TypeVar, t_bool, t_int
+from aeon.core.types import TypeConstructor, TypeVar, t_bool, t_int, t_set
 from aeon.utils.name import Name
 
 
@@ -27,6 +27,13 @@ liquid_prelude: dict[Name, list[TypeConstructor | TypeVar]] = {
     Name("/", 0): [tv("a"), tv("a"), tv("a")],
     Name("%", 0): [t_int, t_int, t_int],
     Name("!", 0): [t_bool, t_bool],
+    # SMT Set operations
+    Name("Set_sng", 0): [t_int, t_set],
+    Name("Set_cup", 0): [t_set, t_set, t_set],
+    Name("Set_cap", 0): [t_set, t_set, t_set],
+    Name("Set_dif", 0): [t_set, t_set, t_set],
+    Name("Set_mem", 0): [t_int, t_set, t_bool],
+    Name("Set_sub", 0): [t_set, t_set, t_bool],
 }
 
 ops = [x for x in liquid_prelude]

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -173,10 +173,11 @@ t_bool = TypeConstructor(Name("Bool", 0), [])
 t_int = TypeConstructor(Name("Int", 0), [])
 t_float = TypeConstructor(Name("Float", 0), [])
 t_string = TypeConstructor(Name("String", 0), [])
+t_set = TypeConstructor(Name("Set", 0), [])
 t_tensor = TypeConstructor(Name("Tensor", 0), [])
 t_gpu_config = TypeConstructor(Name("GpuConfig", 0), [])
 
-builtin_core_types = [t_unit, t_bool, t_int, t_float, t_string, t_tensor, t_gpu_config]
+builtin_core_types = [t_unit, t_bool, t_int, t_float, t_string, t_set, t_tensor, t_gpu_config]
 
 top = Top()
 

--- a/aeon/prelude/prelude.py
+++ b/aeon/prelude/prelude.py
@@ -30,6 +30,7 @@ native_types: list[Name] = [
     Name("Int", 0),
     Name("Float", 0),
     Name("String", 0),
+    Name("Set", 0),
     Name("Tensor", 0),
     Name("GpuConfig", 0),
 ]
@@ -110,6 +111,14 @@ prelude = [
     ("&&", "(x:Bool) -> (y:Bool) -> Bool", lambda x: lambda y: x and y),
     ("||", "(x:Bool) -> (y:Bool) -> Bool", lambda x: lambda y: x or y),
     ("!", "(x:Bool) -> Bool", lambda x: not x),
+    # SMT Set operations (logical only, used in refinements)
+    ("Set_empty", "Set", set()),
+    ("Set_sng", "(x:Int) -> Set", lambda x: {x}),
+    ("Set_cup", "(a:Set) -> (b:Set) -> Set", lambda a: lambda b: a | b),
+    ("Set_cap", "(a:Set) -> (b:Set) -> Set", lambda a: lambda b: a & b),
+    ("Set_dif", "(a:Set) -> (b:Set) -> Set", lambda a: lambda b: a - b),
+    ("Set_mem", "(x:Int) -> (s:Set) -> Bool", lambda x: lambda s: x in s),
+    ("Set_sub", "(a:Set) -> (b:Set) -> Bool", lambda a: lambda b: a <= b),
     (
         "$",
         "forall a:B, forall b:B, forall <p:a -> Bool>, forall <q:b -> Bool>, (f:(x:a<p>) -> b<q>) -> (x:a<p>) -> b<q>",

--- a/aeon/sugar/ast_helpers.py
+++ b/aeon/sugar/ast_helpers.py
@@ -15,6 +15,7 @@ st_bool = STypeConstructor(Name("Bool", 0))
 st_int = STypeConstructor(Name("Int", 0))
 st_float = STypeConstructor(Name("Float", 0))
 st_string = STypeConstructor(Name("String", 0))
+st_set = STypeConstructor(Name("Set", 0))
 st_tensor = STypeConstructor(Name("Tensor", 0))
 st_gpu_config = STypeConstructor(Name("GpuConfig", 0))
 

--- a/aeon/sugar/stypes.py
+++ b/aeon/sugar/stypes.py
@@ -87,7 +87,7 @@ class STypeConstructor(SType):
         return hash(self.name) + sum(hash(c) for c in self.args)
 
 
-builtin_types = ["Top", "Bool", "Int", "Float", "String", "Unit", "Tensor", "GpuConfig"]
+builtin_types = ["Top", "Bool", "Int", "Float", "String", "Unit", "Set", "Tensor", "GpuConfig"]
 
 
 def get_type_vars(ty: SType) -> set[STypeVar]:

--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -232,7 +232,7 @@ def type_infer_liquid(
                             raise LiquidTypeCheckException(f"Function {fun_name} only applies to Floats or Ints.")
                     elif fun_name in ["==", "!="] and not isinstance(first_argument, TypeVar):
                         # TODO: Add type equality
-                        if not is_base_type_in(first_argument, ["Unit", "Bool", "Float", "Int", "String"]):
+                        if not is_base_type_in(first_argument, ["Unit", "Bool", "Float", "Int", "String", "Set"]):
                             raise LiquidTypeCheckException(f"Function {fun_name} only applies to built-in types.")
                     elif fun_name in ["+", "-", "*", "/"] and not isinstance(first_argument, TypeVar):
                         if not is_base_type_in(first_argument, ["Float", "Int"]):

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -43,6 +43,7 @@ from aeon.core.types import TypeVar
 from aeon.core.types import t_bool
 from aeon.core.types import t_float
 from aeon.core.types import t_int
+from aeon.core.types import t_set
 from aeon.core.types import top
 from aeon.core.types import type_free_term_vars
 from aeon.facade.api import (
@@ -241,6 +242,19 @@ def prim_op(t: Name) -> Type:
         case "!":
             name = Name("fresh", fresh_counter.fresh())
             return AbstractionType(name, t_bool, t_bool)
+        case "-->":
+            return make_binary_app_type(t, t_bool, t_bool)
+        case "Set_sng":
+            name = Name("fresh", fresh_counter.fresh())
+            return AbstractionType(name, t_int, t_set)
+        case "Set_cup" | "Set_cap" | "Set_dif":
+            return make_binary_app_type(t, t_set, t_set)
+        case "Set_mem":
+            xname = Name("x", fresh_counter.fresh())
+            sname = Name("s", fresh_counter.fresh())
+            return AbstractionType(xname, t_int, AbstractionType(sname, t_set, t_bool))
+        case "Set_sub":
+            return make_binary_app_type(t, t_set, t_bool)
         case _:
             assert False, f"Unknown selfication of {t}"
 

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -26,6 +26,7 @@ from z3.z3 import String
 from z3.z3 import StringSort
 from z3.z3 import SortRef
 from z3.z3types import Z3Exception
+from z3 import EmptySet, SetAdd, SetUnion, SetIntersect, SetDifference, IsMember, IsSubset, SetSort
 
 from aeon.core.liquid import LiquidApp
 from aeon.core.types import LiquidHornApplication, TypeConstructor
@@ -40,7 +41,7 @@ from aeon.core.substitutions import substitution_in_liquid
 from aeon.core.types import AbstractionType, RefinedType, RefinementPolymorphism, Top, TypePolymorphism
 from aeon.core.types import Type
 from aeon.core.types import TypeVar
-from aeon.core.types import t_bool, t_int, t_float, t_string, t_unit
+from aeon.core.types import t_bool, t_int, t_float, t_set, t_string, t_unit
 from aeon.verification.sub import lower_constraint_type
 from aeon.verification.vcs import Conjunction
 from aeon.verification.vcs import Constraint
@@ -76,11 +77,20 @@ smt_function_types: dict[str, list[Type]] = {
     "smtMultFloat": [t_float, t_float, t_float],
     "smtDivFloat": [t_float, t_float, t_float],
     "smtImplies": [t_bool, t_bool, t_bool],
+    # SMT Set operations
+    "smtSetSng": [t_int, t_set],
+    "smtSetCup": [t_set, t_set, t_set],
+    "smtSetCap": [t_set, t_set, t_set],
+    "smtSetDif": [t_set, t_set, t_set],
+    "smtSetMem": [t_int, t_set, t_bool],
+    "smtSetSub": [t_set, t_set, t_bool],
+    "smtEqSet": [t_set, t_set, t_bool],
+    "smtNeqSet": [t_set, t_set, t_bool],
 }
 
 smt_function_translation: dict[str, list[str]] = {
-    "==": ["smtEqBool", "smtEqInt", "smtEqFloat", "smtEqString"],
-    "!=": ["smtNeqBool", "smtNeqInt", "smtNeqFloat", "smtNeqString"],
+    "==": ["smtEqBool", "smtEqInt", "smtEqFloat", "smtEqString", "smtEqSet"],
+    "!=": ["smtNeqBool", "smtNeqInt", "smtNeqFloat", "smtNeqString", "smtNeqSet"],
     "!": ["smtNot"],
     "<": ["smtLeqInt", "smtLeqFloat"],
     "<=": ["smtLtInt", "smtLtFloat"],
@@ -92,6 +102,12 @@ smt_function_translation: dict[str, list[str]] = {
     "/": ["smtDivInt", "smtDivFloat"],
     "%": ["smtModInt"],
     "-->": ["smtImplies"],
+    "Set_sng": ["smtSetSng"],
+    "Set_cup": ["smtSetCup"],
+    "Set_cap": ["smtSetCap"],
+    "Set_dif": ["smtSetDif"],
+    "Set_mem": ["smtSetMem"],
+    "Set_sub": ["smtSetSub"],
 }
 
 base_functions: dict[str, Any] = {
@@ -110,6 +126,14 @@ base_functions: dict[str, Any] = {
     "/": lambda x, y: x / y,
     "%": lambda x, y: x % y,
     "-->": lambda x, y: Implies(x, y),
+    # SMT Set operations
+    "Set_empty": EmptySet(IntSort()),
+    "Set_sng": lambda x: SetAdd(EmptySet(IntSort()), x),
+    "Set_cup": lambda a, b: SetUnion(a, b),
+    "Set_cap": lambda a, b: SetIntersect(a, b),
+    "Set_dif": lambda a, b: SetDifference(a, b),
+    "Set_mem": lambda x, s: IsMember(x, s),
+    "Set_sub": lambda a, b: IsSubset(a, b),
 }
 
 
@@ -494,6 +518,8 @@ def get_sort(base: Type) -> SortRef:
             return Float64()
         case TypeConstructor(Name("String", _)):
             return StringSort()
+        case TypeConstructor(Name("Set", _)):
+            return SetSort(IntSort())
         case TypeConstructor(name, _):
             return IntSort()
             # This will be reenable once we have typeclasses
@@ -574,6 +600,8 @@ def make_variable(name: str, base: TypeConstructor | AbstractionType | Top) -> A
             # return FP(name, fpsort)
         case TypeConstructor(Name("String", _)):
             return String(name)
+        case TypeConstructor(Name("Set", _)):
+            return Const(name, SetSort(IntSort()))
         case TypeConstructor(_, _):
             return Int(name)
             # TODO: we always use int, in the case of a typevar.
@@ -602,7 +630,12 @@ def translate_liq(t: LiquidTerm, variables: dict[str, Any]):
         case LiquidLiteralString(s):
             return s
         case LiquidVar(name):
-            return variables[str(name)]
+            sname = str(name)
+            if sname in variables:
+                return variables[sname]
+            if sname in base_functions:
+                return base_functions[sname]
+            raise KeyError(f"Variable {sname} not found in SMT context")
         case LiquidHornApplication(name, args):
             assert False, "LiquidHornApplication should not get to SMT solver!"
         case LiquidApp(fun_name, args):

--- a/examples/sets/verified_list.ae
+++ b/examples/sets/verified_list.ae
@@ -1,0 +1,44 @@
+# SMT Set example: verified list operations with element tracking.
+#
+# Set is a built-in type with operations available in refinements:
+#   Set_empty           : Set             (empty set)
+#   Set_sng x           : Set             (singleton {x})
+#   Set_cup a b         : Set             (union)
+#   Set_cap a b         : Set             (intersection)
+#   Set_dif a b         : Set             (difference)
+#   Set_mem x s         : Bool            (membership)
+#   Set_sub a b         : Bool            (subset)
+
+type IntList
+
+# Uninterpreted measure: maps a list to its element set
+def elts : (l:IntList) -> Set = uninterpreted
+
+# Empty list has no elements
+def empty : {l:IntList | elts l == Set_empty} = native "[]"
+
+# Cons adds exactly one element
+def cons (x:Int) (xs:IntList) : {l:IntList | elts l == Set_cup (Set_sng x) (elts xs)} =
+    native "[x] + xs"
+
+# Append is union of elements
+def append (xs:IntList) (ys:IntList) : {l:IntList | elts l == Set_cup (elts xs) (elts ys)} =
+    native "xs + ys"
+
+# Sort preserves elements (permutation property)
+def sort (xs:IntList) : {l:IntList | elts l == elts xs} = native "sorted(xs)"
+
+# Filter returns a subset
+def myfilter (xs:IntList) : {l:IntList | Set_sub (elts l) (elts xs)} =
+    native "[x for x in xs if x > 0]"
+
+# Membership check is faithful
+def contains (x:Int) (xs:IntList) : {b:Bool | b == Set_mem x (elts xs)} =
+    native "x in xs"
+
+def main (_:Int) : Unit =
+    a = cons 3 (cons 1 (cons 2 empty));
+    b = sort a;
+    c = append a b;
+    d = myfilter c;
+    print(contains 3 d)

--- a/tests/smt_sets_test.py
+++ b/tests/smt_sets_test.py
@@ -1,0 +1,218 @@
+"""Tests for SMT Set support in refinement types."""
+
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidVar
+from aeon.core.types import t_int, t_set
+from aeon.sugar.ast_helpers import st_top
+from aeon.verification.smt import smt_valid
+from aeon.verification.vcs import Implication, LiquidConstraint
+from tests.driver import check_compile
+from aeon.utils.name import Name
+
+
+# ---------------------------------------------------------------------------
+# SMT-level set constraint tests
+# ---------------------------------------------------------------------------
+
+
+def _imp(name: str, base, pred, seq):
+    return Implication(Name(name), base, pred, seq)
+
+
+def test_set_empty_is_subset_of_any():
+    """Set_sub(Set_empty, s) is always true."""
+    s = Name("s")
+    c = _imp(
+        "s",
+        t_set,
+        LiquidLiteralBool(True),
+        LiquidConstraint(LiquidApp(Name("Set_sub", 0), [LiquidVar(Name("Set_empty", 0)), LiquidVar(s)])),
+    )
+    assert smt_valid(c)
+
+
+def test_set_member_after_singleton():
+    """Set_mem(x, Set_sng(x)) is always true."""
+    x = Name("x")
+    c = _imp(
+        "x",
+        t_int,
+        LiquidLiteralBool(True),
+        LiquidConstraint(LiquidApp(Name("Set_mem", 0), [LiquidVar(x), LiquidApp(Name("Set_sng", 0), [LiquidVar(x)])])),
+    )
+    assert smt_valid(c)
+
+
+def test_set_union_contains_both():
+    """Set_mem(x, Set_cup(Set_sng(x), s)) is always true."""
+    x = Name("x")
+    s = Name("s")
+    sng_x = LiquidApp(Name("Set_sng", 0), [LiquidVar(x)])
+    union = LiquidApp(Name("Set_cup", 0), [sng_x, LiquidVar(s)])
+    mem = LiquidApp(Name("Set_mem", 0), [LiquidVar(x), union])
+    c = _imp(
+        "x",
+        t_int,
+        LiquidLiteralBool(True),
+        _imp("s", t_set, LiquidLiteralBool(True), LiquidConstraint(mem)),
+    )
+    assert smt_valid(c)
+
+
+def test_set_difference_removes_element():
+    """Set_mem(x, Set_dif(Set_sng(x), Set_sng(x))) is always false."""
+    x = Name("x")
+    sng_x = LiquidApp(Name("Set_sng", 0), [LiquidVar(x)])
+    diff = LiquidApp(Name("Set_dif", 0), [sng_x, sng_x])
+    mem = LiquidApp(Name("Set_mem", 0), [LiquidVar(x), diff])
+    not_mem = LiquidApp(Name("!", 0), [mem])
+    c = _imp("x", t_int, LiquidLiteralBool(True), LiquidConstraint(not_mem))
+    assert smt_valid(c)
+
+
+def test_set_intersection_subset():
+    """Set_sub(Set_cap(a, b), a) is always true."""
+    a = Name("a")
+    b = Name("b")
+    cap = LiquidApp(Name("Set_cap", 0), [LiquidVar(a), LiquidVar(b)])
+    sub = LiquidApp(Name("Set_sub", 0), [cap, LiquidVar(a)])
+    c = _imp(
+        "a",
+        t_set,
+        LiquidLiteralBool(True),
+        _imp("b", t_set, LiquidLiteralBool(True), LiquidConstraint(sub)),
+    )
+    assert smt_valid(c)
+
+
+def test_set_equality_union_commutative():
+    """Set_cup(a, b) == Set_cup(b, a)."""
+    a = Name("a")
+    b = Name("b")
+    cup_ab = LiquidApp(Name("Set_cup", 0), [LiquidVar(a), LiquidVar(b)])
+    cup_ba = LiquidApp(Name("Set_cup", 0), [LiquidVar(b), LiquidVar(a)])
+    eq = LiquidApp(Name("==", 0), [cup_ab, cup_ba])
+    c = _imp(
+        "a",
+        t_set,
+        LiquidLiteralBool(True),
+        _imp("b", t_set, LiquidLiteralBool(True), LiquidConstraint(eq)),
+    )
+    assert smt_valid(c)
+
+
+def test_set_invalid_constraint_rejected():
+    """Set_sub(a, Set_empty) should NOT be valid for all a."""
+    a = Name("a")
+    sub = LiquidApp(Name("Set_sub", 0), [LiquidVar(a), LiquidVar(Name("Set_empty", 0))])
+    c = _imp("a", t_set, LiquidLiteralBool(True), LiquidConstraint(sub))
+    assert not smt_valid(c)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end Aeon program tests with sets
+# ---------------------------------------------------------------------------
+
+
+def test_set_empty_list():
+    """Verify a list with an uninterpreted 'elts' measure and Set_empty."""
+    code = """
+type IntList
+
+def elts : (l:IntList) -> Set = uninterpreted
+
+def empty : {l:IntList | elts l == Set_empty} = native "[]"
+
+def main (_:Int) : Unit = print(empty)
+"""
+    assert check_compile(code, st_top)
+
+
+def test_set_cons_union():
+    """Verify cons adds an element to the set."""
+    code = """
+type IntList
+
+def elts : (l:IntList) -> Set = uninterpreted
+
+def empty : {l:IntList | elts l == Set_empty} = native "[]"
+
+def cons (x:Int) (xs:IntList) : {l:IntList | elts l == Set_cup (Set_sng x) (elts xs)} =
+    native "[x] + xs"
+
+def main (_:Int) : Unit =
+    a = cons 1 empty;
+    print(a)
+"""
+    assert check_compile(code, st_top)
+
+
+def test_set_append_is_union():
+    """Verify append is the union of elements."""
+    code = """
+type IntList
+
+def elts : (l:IntList) -> Set = uninterpreted
+
+def empty : {l:IntList | elts l == Set_empty} = native "[]"
+
+def cons (x:Int) (xs:IntList) : {l:IntList | elts l == Set_cup (Set_sng x) (elts xs)} =
+    native "[x] + xs"
+
+def append (xs:IntList) (ys:IntList) : {l:IntList | elts l == Set_cup (elts xs) (elts ys)} =
+    native "xs + ys"
+
+def main (_:Int) : Unit =
+    a = cons 1 empty;
+    b = cons 2 empty;
+    c = append a b;
+    print(c)
+"""
+    assert check_compile(code, st_top)
+
+
+def test_set_sort_is_permutation():
+    """Sort preserves elements (permutation property)."""
+    code = """
+type IntList
+
+def elts : (l:IntList) -> Set = uninterpreted
+
+def sort (xs:IntList) : {l:IntList | elts l == elts xs} = native "sorted(xs)"
+
+def main (_:Int) : Unit =
+    print(0)
+"""
+    assert check_compile(code, st_top)
+
+
+def test_set_contains_faithful():
+    """Membership check is faithful to the logical set."""
+    code = """
+type IntList
+
+def elts : (l:IntList) -> Set = uninterpreted
+
+def contains (x:Int) (xs:IntList) : {b:Bool | b == Set_mem x (elts xs)} =
+    native "x in xs"
+
+def main (_:Int) : Unit =
+    print(0)
+"""
+    assert check_compile(code, st_top)
+
+
+def test_set_filter_subset():
+    """Filter returns a subset."""
+    code = """
+type IntList
+
+def elts : (l:IntList) -> Set = uninterpreted
+
+def myfilter (xs:IntList) : {l:IntList | Set_sub (elts l) (elts xs)} =
+    native "[x for x in xs if x > 0]"
+
+def main (_:Int) : Unit = print(0)
+"""
+    assert check_compile(code, st_top)


### PR DESCRIPTION
## Summary
- Adds a built-in `Set` type with 7 Z3-backed set operations for use in refinement types
- Follows LiquidHaskell's design: sets are logical/ghost values for specifying properties about data structure contents (permutation, subset, membership, disjointness)
- Maps directly to Z3's native set theory (`Array(Int, Bool)`) — fully decidable

### Operations
| Operation | Type | Description |
|---|---|---|
| `Set_empty` | `Set` | Empty set constant |
| `Set_sng x` | `Int -> Set` | Singleton set |
| `Set_cup a b` | `Set -> Set -> Set` | Union |
| `Set_cap a b` | `Set -> Set -> Set` | Intersection |
| `Set_dif a b` | `Set -> Set -> Set` | Difference |
| `Set_mem x s` | `Int -> Set -> Bool` | Membership |
| `Set_sub a b` | `Set -> Set -> Bool` | Subset |

### Example usage
```aeon
type IntList
def elts : (l:IntList) -> Set = uninterpreted
def empty : {l:IntList | elts l == Set_empty} = native "[]"
def cons (x:Int) (xs:IntList) : {l:IntList | elts l == Set_cup (Set_sng x) (elts xs)} = native "[x] + xs"
def sort (xs:IntList) : {l:IntList | elts l == elts xs} = native "sorted(xs)"
```

### Files changed
- `core/types.py`: add `t_set` type constructor
- `sugar/stypes.py`, `ast_helpers.py`: register `Set` as builtin type
- `prelude/prelude.py`: register `Set` type and operations with runtime implementations
- `core/liquid_ops.py`: add set ops to liquid prelude (for horn clause solver)
- `verification/smt.py`: Z3 `SetSort` translation, `base_functions` for set ops, SMT function type/translation mappings
- `typechecking/typeinfer.py`: selfification for set operators
- `typechecking/liquid.py`: allow `==`/`!=` on `Set` type

## Test plan
- [x] 13 new tests: 7 SMT-level constraint tests + 6 end-to-end Aeon program tests
- [x] Full suite: 352 passed, 9 skipped
- [x] Example program `examples/sets/verified_list.ae` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)