### PR TITLE
Module-qualified names and inductive Color type

### DIFF
--- a/aeon/llvm/cpu/converter.py
+++ b/aeon/llvm/cpu/converter.py
@@ -141,7 +141,7 @@ class CPULLVMIRGenerator(LLVMIRGenerator, LLVMVisitor):
             return self.module.globals[str_name]
 
         base_name = var_name.name
-        if base_name == "PI":
+        if base_name == "PI" or base_name.endswith("_PI"):
             return ir.Constant(ir.DoubleType(), 3.141592653589793)
 
         builtin_map = {
@@ -157,6 +157,12 @@ class CPULLVMIRGenerator(LLVMIRGenerator, LLVMVisitor):
 
         name_parts = str_name.rsplit("_", 1)
         lookup_name = name_parts[0] if len(name_parts) > 1 and name_parts[1].isdigit() else str_name
+
+        # Strip module prefix (e.g. "Math_powf" -> "powf") for builtin lookup
+        if "_" in lookup_name and lookup_name not in builtin_map:
+            bare = lookup_name.split("_", 1)[1]
+            if bare in builtin_map:
+                lookup_name = bare
 
         actual_name = builtin_map.get(lookup_name, lookup_name)
 

--- a/aeon/llvm/cpu/converter.py
+++ b/aeon/llvm/cpu/converter.py
@@ -141,18 +141,18 @@ class CPULLVMIRGenerator(LLVMIRGenerator, LLVMVisitor):
             return self.module.globals[str_name]
 
         base_name = var_name.name
-        if base_name == "Math_PI":
+        if base_name == "PI":
             return ir.Constant(ir.DoubleType(), 3.141592653589793)
 
         builtin_map = {
-            "Math_pow": "pow",
-            "Math_powf": "pow",
-            "Math_sqrt": "sqrt",
-            "Math_sqrtf": "sqrt",
-            "Math_sin": "sin",
-            "Math_cos": "cos",
-            "Math_exp": "exp",
-            "Math_log": "log",
+            "pow": "pow",
+            "powf": "pow",
+            "sqrt": "sqrt",
+            "sqrtf": "sqrt",
+            "sin": "sin",
+            "cos": "cos",
+            "exp": "exp",
+            "log": "log",
         }
 
         name_parts = str_name.rsplit("_", 1)

--- a/aeon/llvm/cpu/executor.py
+++ b/aeon/llvm/cpu/executor.py
@@ -105,8 +105,8 @@ class CPULLVMExecutionEngine(LLVMExecutionEngine):
             return ctypes.c_void_p(None)
 
         return {
-            "Vector_get": vector_get,
-            "Vector_set": vector_set,
+            "get": vector_get,
+            "set": vector_set,
             "native": native_dummy,
         }
 

--- a/aeon/llvm/cpu/lowerer.py
+++ b/aeon/llvm/cpu/lowerer.py
@@ -184,9 +184,18 @@ class CPUFunctionCallValidationStep(ValidationStep):
 
     def _validate_var_call(self, name: Name, ctx: CPUValidationContext) -> None:
         str_name = sanitize_name(name)
-        is_builtin = name.name in BINARY_OPS or name.name in UNARY_OPS or name.name in BUILTIN_FUNCTION_TYPES
+        # Strip module prefix for builtin lookup (e.g. "Math_powf" -> "powf")
+        bare_name = name.name.split("_", 1)[1] if "_" in name.name else name.name
+        is_builtin = (
+            name.name in BINARY_OPS
+            or name.name in UNARY_OPS
+            or name.name in BUILTIN_FUNCTION_TYPES
+            or bare_name in BINARY_OPS
+            or bare_name in UNARY_OPS
+            or bare_name in BUILTIN_FUNCTION_TYPES
+        )
         is_allowed = name in ctx.allowed_func_calls or str_name in ctx.env_names
-        if not (is_builtin or is_allowed or name.name == "native" or name.name == "PI"):
+        if not (is_builtin or is_allowed or name.name == "native" or name.name == "PI" or bare_name == "PI"):
             if ctx.strict:
                 raise LLVMValidationError(f"Function {name.name} is not allowed in this LLVM context")
 
@@ -322,14 +331,18 @@ class CPULLVMLowerer(LLVMLowerer):
         target = self._get_target_name(val) if isinstance(val, LLVMVar) else ""
         if isinstance(val, LLVMCall):
             target = self._get_target_name(val.target)
+        # Strip module prefix for builtin lookup
+        bare_target = target.split("_", 1)[1] if "_" in target else target
         is_op = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and (
-            target in BINARY_OPS or target in UNARY_OPS
+            target in BINARY_OPS or target in UNARY_OPS or bare_target in BINARY_OPS or bare_target in UNARY_OPS
         )
-        is_vec = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and target in (
-            VECTOR_OPERATIONS | {"set", "get"}
+        is_vec = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and (
+            target in (VECTOR_OPERATIONS | {"set", "get"}) or bare_target in (VECTOR_OPERATIONS | {"set", "get"})
         )
         _MATH_BUILTINS = {"pow", "powf", "sqrt", "sqrtf", "sin", "cos", "exp", "log"}
-        is_math = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and target in _MATH_BUILTINS
+        is_math = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and (
+            target in _MATH_BUILTINS or bare_target in _MATH_BUILTINS
+        )
         if is_math and is_partial:
             return False
         return is_partial or is_op or is_vec or is_math
@@ -532,11 +545,14 @@ class CPULLVMLowerer(LLVMLowerer):
     def _lower_var(
         self, name: Name, expected: LLVMType | None, type_env: Dict[Name, LLVMType], env: Dict[Name, LLVMTerm]
     ) -> LLVMTerm:
-        if name.name in BINARY_OPS or name.name in UNARY_OPS:
-            return LLVMVar(self._get_operator_type(name.name, expected), name)
+        bare = name.name.split("_", 1)[1] if "_" in name.name else name.name
+        op_name = name.name if name.name in BINARY_OPS or name.name in UNARY_OPS else bare
+        if op_name in BINARY_OPS or op_name in UNARY_OPS:
+            return LLVMVar(self._get_operator_type(op_name, expected), name)
 
-        if name.name in BUILTIN_FUNCTION_TYPES:
-            ty = BUILTIN_FUNCTION_TYPES[name.name]
+        builtin_key = name.name if name.name in BUILTIN_FUNCTION_TYPES else bare
+        if builtin_key in BUILTIN_FUNCTION_TYPES:
+            ty = BUILTIN_FUNCTION_TYPES[builtin_key]
             if expected and isinstance(expected, LLVMFunctionType) and len(expected.arg_types) == len(ty.arg_types):
                 ty = expected
             elif expected and name.name == "new" and isinstance(expected, LLVMPointerType):
@@ -632,7 +648,13 @@ class CPULLVMLowerer(LLVMLowerer):
 
     def _get_lookup_name(self, target: LLVMTerm) -> str:
         name = self._get_target_name(target)
-        return name.rsplit("_", 1)[0] if name.rsplit("_", 1)[-1].isdigit() else name
+        lookup = name.rsplit("_", 1)[0] if name.rsplit("_", 1)[-1].isdigit() else name
+        # Strip module prefix (e.g. "Math_powf" -> "powf") for builtin lookup
+        if "_" in lookup and lookup not in BUILTIN_FUNCTION_TYPES and lookup not in VECTOR_OPERATIONS:
+            bare = lookup.split("_", 1)[1]
+            if bare in BUILTIN_FUNCTION_TYPES or bare in VECTOR_OPERATIONS:
+                lookup = bare
+        return lookup
 
     def _is_full_vector_op(self, op: str, total_args: int) -> bool:
         if op not in VECTOR_OPERATIONS:

--- a/aeon/llvm/cpu/lowerer.py
+++ b/aeon/llvm/cpu/lowerer.py
@@ -76,46 +76,44 @@ BUILTIN_FUNCTION_TYPES: Dict[str, LLVMFunctionType] = {
     "malloc": LLVMFunctionType([LLVMInt], _generic_ptr),
     "free": LLVMFunctionType([_generic_ptr], LLVMVoid),
     "printf": LLVMFunctionType([_generic_ptr], LLVMInt),
-    "Math_pow": LLVMFunctionType([LLVMInt, LLVMInt], LLVMInt),
-    "Math_powf": LLVMFunctionType([LLVMDouble, LLVMDouble], LLVMDouble),
-    "Math_sqrt": LLVMFunctionType([LLVMDouble], LLVMDouble),
-    "Math_sqrtf": LLVMFunctionType([LLVMDouble], LLVMDouble),
-    "Math_sin": LLVMFunctionType([LLVMDouble, LLVMDouble], LLVMDouble),
-    "Math_cos": LLVMFunctionType([LLVMDouble, LLVMDouble], LLVMDouble),
-    "Math_exp": LLVMFunctionType([LLVMDouble], LLVMDouble),
-    "Math_log": LLVMFunctionType([LLVMDouble], LLVMDouble),
-    "Vector_new": LLVMFunctionType([], _generic_ptr),
-    "Vector_append": LLVMFunctionType([_generic_ptr, LLVMInt], _generic_ptr),
-    "Vector_get": LLVMFunctionType([_generic_ptr, LLVMInt], LLVMInt),
-    "Vector_set": LLVMFunctionType([_generic_ptr, LLVMInt, LLVMInt], _generic_ptr),
-    "Vector_map": LLVMFunctionType([LLVMPointerType(_func_i_i), _generic_ptr, LLVMInt], _generic_ptr),
-    "Vector_reduce": LLVMFunctionType([LLVMPointerType(_func_ii_i), LLVMInt, _generic_ptr, LLVMInt], LLVMInt),
-    "Vector_imap": LLVMFunctionType([LLVMPointerType(_func_ii_i), _generic_ptr, LLVMInt], _generic_ptr),
-    "Vector_filter": LLVMFunctionType([LLVMPointerType(_func_i_b), _generic_ptr, LLVMInt], _generic_ptr),
-    "Vector_zipWith": LLVMFunctionType(
-        [LLVMPointerType(_func_ii_i), _generic_ptr, _generic_ptr, LLVMInt], _generic_ptr
-    ),
-    "Vector_count": LLVMFunctionType([LLVMPointerType(_func_i_b), _generic_ptr, LLVMInt], LLVMInt),
+    "pow": LLVMFunctionType([LLVMInt, LLVMInt], LLVMInt),
+    "powf": LLVMFunctionType([LLVMDouble, LLVMDouble], LLVMDouble),
+    "sqrt": LLVMFunctionType([LLVMDouble], LLVMDouble),
+    "sqrtf": LLVMFunctionType([LLVMDouble], LLVMDouble),
+    "sin": LLVMFunctionType([LLVMDouble, LLVMDouble], LLVMDouble),
+    "cos": LLVMFunctionType([LLVMDouble, LLVMDouble], LLVMDouble),
+    "exp": LLVMFunctionType([LLVMDouble], LLVMDouble),
+    "log": LLVMFunctionType([LLVMDouble], LLVMDouble),
+    "new": LLVMFunctionType([], _generic_ptr),
+    "append": LLVMFunctionType([_generic_ptr, LLVMInt], _generic_ptr),
+    "get": LLVMFunctionType([_generic_ptr, LLVMInt], LLVMInt),
+    "set": LLVMFunctionType([_generic_ptr, LLVMInt, LLVMInt], _generic_ptr),
+    "map": LLVMFunctionType([LLVMPointerType(_func_i_i), _generic_ptr, LLVMInt], _generic_ptr),
+    "reduce": LLVMFunctionType([LLVMPointerType(_func_ii_i), LLVMInt, _generic_ptr, LLVMInt], LLVMInt),
+    "imap": LLVMFunctionType([LLVMPointerType(_func_ii_i), _generic_ptr, LLVMInt], _generic_ptr),
+    "filter": LLVMFunctionType([LLVMPointerType(_func_i_b), _generic_ptr, LLVMInt], _generic_ptr),
+    "zipWith": LLVMFunctionType([LLVMPointerType(_func_ii_i), _generic_ptr, _generic_ptr, LLVMInt], _generic_ptr),
+    "count": LLVMFunctionType([LLVMPointerType(_func_i_b), _generic_ptr, LLVMInt], LLVMInt),
 }
 
 POLYMORPHIC_FUNCTIONS: set[str] = {
-    "Math_pow",
-    "Math_powf",
-    "Math_exp",
-    "Math_sqrt",
-    "Math_sqrtf",
-    "Math_sin",
-    "Math_cos",
-    "Math_log",
-    "Vector_get",
-    "Vector_set",
-    "Vector_new",
-    "Vector_map",
-    "Vector_reduce",
-    "Vector_imap",
-    "Vector_filter",
-    "Vector_zipWith",
-    "Vector_count",
+    "pow",
+    "powf",
+    "exp",
+    "sqrt",
+    "sqrtf",
+    "sin",
+    "cos",
+    "log",
+    "get",
+    "set",
+    "new",
+    "map",
+    "reduce",
+    "imap",
+    "filter",
+    "zipWith",
+    "count",
 }
 
 
@@ -188,7 +186,7 @@ class CPUFunctionCallValidationStep(ValidationStep):
         str_name = sanitize_name(name)
         is_builtin = name.name in BINARY_OPS or name.name in UNARY_OPS or name.name in BUILTIN_FUNCTION_TYPES
         is_allowed = name in ctx.allowed_func_calls or str_name in ctx.env_names
-        if not (is_builtin or is_allowed or name.name == "native" or name.name == "Math_PI"):
+        if not (is_builtin or is_allowed or name.name == "native" or name.name == "PI"):
             if ctx.strict:
                 raise LLVMValidationError(f"Function {name.name} is not allowed in this LLVM context")
 
@@ -328,11 +326,10 @@ class CPULLVMLowerer(LLVMLowerer):
             target in BINARY_OPS or target in UNARY_OPS
         )
         is_vec = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and target in (
-            VECTOR_OPERATIONS | {"Vector_set", "Vector_get"}
+            VECTOR_OPERATIONS | {"set", "get"}
         )
-        is_math = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and target.startswith(
-            "Math_"
-        )
+        _MATH_BUILTINS = {"pow", "powf", "sqrt", "sqrtf", "sin", "cos", "exp", "log"}
+        is_math = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and target in _MATH_BUILTINS
         if is_math and is_partial:
             return False
         return is_partial or is_op or is_vec or is_math
@@ -434,7 +431,7 @@ class CPULLVMLowerer(LLVMLowerer):
         def low_term(term, exp=None):
             return self._lower_term(term, exp, type_env, env, allowed, in_vector_op=True)
 
-        if op == "Vector_reduce":
+        if op == "reduce":
             kernel_term, init_term, vector_term, size_term = args
             low_vec, low_init, low_size = low_term(vector_term), low_term(init_term), low_term(size_term, LLVMInt)
             element_type = self._get_vector_base_type(low_vec.type)
@@ -449,7 +446,7 @@ class CPULLVMLowerer(LLVMLowerer):
             )
             return LLVMVectorReduce(low_init.type, kernel, low_init, vec_cast, low_size)
 
-        if op == "Vector_zipWith":
+        if op == "zipWith":
             kernel_term, v1_term, v2_term, size_term = args
             v1_low, v2_low, sz_low = low_term(v1_term), low_term(v2_term), low_term(size_term, LLVMInt)
             res_el = expected.element_type if expected and isinstance(expected, LLVMPointerType) else LLVMInt
@@ -469,7 +466,7 @@ class CPULLVMLowerer(LLVMLowerer):
         element_type = self._get_vector_base_type(v_low.type)
         vec_cast = self._cast_if_needed(v_low, LLVMPointerType(element_type))
 
-        if op in ("Vector_filter", "Vector_count"):
+        if op in ("filter", "count"):
             res_el = LLVMBool
         elif expected and isinstance(expected, LLVMPointerType):
             res_el = expected.element_type
@@ -477,21 +474,21 @@ class CPULLVMLowerer(LLVMLowerer):
             k_lowered = self._lower_as_standalone(kernel_term, None, type_env, env, allowed, True)
             res_el = k_lowered.type.return_type if isinstance(k_lowered.type, LLVMFunctionType) else LLVMInt
 
-        k_params = [LLVMInt, element_type] if op == "Vector_imap" else [element_type]
+        k_params = [LLVMInt, element_type] if op == "imap" else [element_type]
         kernel = self._lower_as_standalone(
             kernel_term, LLVMFunctionType(k_params, res_el), type_env, env, allowed, True
         )
 
-        if op == "Vector_filter":
+        if op == "filter":
             return LLVMVectorFilter(vec_cast.type, kernel, vec_cast, sz_low)
-        if op == "Vector_count":
+        if op == "count":
             return LLVMVectorCount(LLVMInt, kernel, vec_cast, sz_low)
 
         assert isinstance(kernel.type, LLVMFunctionType)
         res_vec_ty = LLVMPointerType(kernel.type.return_type)
         return (
             LLVMVectorMap(res_vec_ty, kernel, vec_cast, sz_low)
-            if op == "Vector_map"
+            if op == "map"
             else LLVMVectorIMap(res_vec_ty, kernel, vec_cast, sz_low)
         )
 
@@ -542,7 +539,7 @@ class CPULLVMLowerer(LLVMLowerer):
             ty = BUILTIN_FUNCTION_TYPES[name.name]
             if expected and isinstance(expected, LLVMFunctionType) and len(expected.arg_types) == len(ty.arg_types):
                 ty = expected
-            elif expected and name.name == "Vector_new" and isinstance(expected, LLVMPointerType):
+            elif expected and name.name == "new" and isinstance(expected, LLVMPointerType):
                 ty = LLVMFunctionType([], expected)
             return LLVMVar(ty, name)
 
@@ -620,10 +617,10 @@ class CPULLVMLowerer(LLVMLowerer):
                 all_args = [self._cast_if_needed(a, p) for a, p in zip(all_args, params)]
                 return LLVMCall(ret, target, all_args)
 
-            if name == "Vector_get" and len(all_args) == 2:
+            if name == "get" and len(all_args) == 2:
                 return self._lower_vector_get(all_args[0], all_args[1])
 
-            if name == "Vector_set" and len(all_args) == 3:
+            if name == "set" and len(all_args) == 3:
                 return self._lower_vector_set(all_args[0], all_args[1], all_args[2])
 
         return self._create_call_or_partial(target, all_args, params, ret)
@@ -640,7 +637,7 @@ class CPULLVMLowerer(LLVMLowerer):
     def _is_full_vector_op(self, op: str, total_args: int) -> bool:
         if op not in VECTOR_OPERATIONS:
             return False
-        threshold = 4 if op in ("Vector_reduce", "Vector_zipWith") else 3
+        threshold = 4 if op in ("reduce", "zipWith") else 3
         return total_args >= threshold
 
     def _lower_vector_get(self, vec: LLVMTerm, idx: LLVMTerm) -> LLVMLoad:

--- a/aeon/llvm/llvm_ast.py
+++ b/aeon/llvm/llvm_ast.py
@@ -137,12 +137,12 @@ LLVMVectorDouble = LLVMPointerType(LLVMDouble)
 
 VECTOR_OPERATIONS: frozenset[str] = frozenset(
     [
-        "Vector_map",
-        "Vector_reduce",
-        "Vector_imap",
-        "Vector_filter",
-        "Vector_zipWith",
-        "Vector_count",
+        "map",
+        "reduce",
+        "imap",
+        "filter",
+        "zipWith",
+        "count",
     ]
 )
 

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -794,6 +794,14 @@ def determine_main_function(p: Program, is_main_hole: bool = True) -> STerm:
         return SLiteral(1, st_int)
 
 
+def _is_native_import_def(d: Definition) -> bool:
+    """Check if a definition's body is a native_import call (side-effect import)."""
+    match d.body:
+        case SApplication(SVar(Name("native_import", _)), _):
+            return True
+    return False
+
+
 def _bare_name(module_name: str, def_name: str) -> str:
     """Strip module prefix from a definition name if present: Math_pow -> pow, or pow -> pow."""
     prefix = module_name + "_"
@@ -819,6 +827,8 @@ def handle_imports(
 
     for imp in imports[::-1]:
         import_p = _resolve_import(imp)
+        # Expand inductive declarations so constructors and eliminators become definitions.
+        import_p = expand_inductive_decls(import_p)
         import_p_definitions = import_p.definitions
         defs_recursive: list[Definition] = []
         type_decls_recursive: list[TypeDecl] = []
@@ -833,21 +843,43 @@ def handle_imports(
 
         module_name = imp.module_path.split(".")[-1]
 
-        # Build scope entries for this module's definitions
+        # Re-prefix definitions with module name to avoid name collisions in the let-chain.
+        # E.g. Color's "mk" becomes "Color_mk", Image's "mk" becomes "Image_mk".
+        prefixed_definitions: list[Definition] = []
         for d in import_p_definitions:
             bare = _bare_name(module_name, d.name.name)
-            # Always register for qualified access: Module.bare -> original name
-            qualified_scope[(module_name, bare)] = d.name
+            # Don't re-prefix native_import definitions — their name is used as a
+            # Python symbol during evaluation (e.g. `def math = native_import "math"`
+            # must keep name "math" so that `native "math.pi"` can resolve it).
+            if _is_native_import_def(d):
+                prefixed_definitions.append(d)
+                continue
+            # Build the internal name: module_name + "_" + bare
+            internal_name = Name(f"{module_name}_{bare}", d.name.id)
+            # Create a copy of the definition with the prefixed name
+            prefixed_d = Definition(
+                internal_name,
+                d.foralls,
+                d.args,
+                d.type,
+                d.body,
+                d.decorators,
+                d.rforalls,
+                d.decreasing_by,
+                d.loc,
+            )
+            prefixed_definitions.append(prefixed_d)
+
+            # Register for qualified access: Module.bare -> internal_name
+            qualified_scope[(module_name, bare)] = internal_name
 
             if imp.is_open:
-                # open Math: all names available unqualified
-                unqualified_scope[bare] = d.name
+                unqualified_scope[bare] = internal_name
             elif imp.selected_names:
-                # import Math (pow, abs): selected names available unqualified
                 if bare in imp.selected_names:
-                    unqualified_scope[bare] = d.name
+                    unqualified_scope[bare] = internal_name
 
-        defs = defs_recursive + import_p_definitions + defs
+        defs = defs_recursive + prefixed_definitions + defs
         type_decls = type_decls_recursive + import_p.type_decls + type_decls
     return defs, type_decls, qualified_scope, unqualified_scope
 

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -274,13 +274,42 @@ def resolve_qualified_names_in_sterm(
             return t
 
 
+def resolve_qualified_names_in_stype(
+    ty: SType, qualified_scope: QualifiedScope, unqualified_scope: UnqualifiedScope
+) -> SType:
+    """Resolve qualified names inside refinement predicates within types."""
+
+    def rec_ty(t: SType) -> SType:
+        return resolve_qualified_names_in_stype(t, qualified_scope, unqualified_scope)
+
+    def rec_term(t: STerm) -> STerm:
+        return resolve_qualified_names_in_sterm(t, qualified_scope, unqualified_scope)
+
+    match ty:
+        case SRefinedType(name, inner_ty, refinement, loc):
+            return SRefinedType(name, rec_ty(inner_ty), rec_term(refinement), loc=loc)
+        case SAbstractionType(var_name, var_type, body_type, loc):
+            return SAbstractionType(var_name, rec_ty(var_type), rec_ty(body_type), loc=loc)
+        case STypePolymorphism(name, kind, body, loc):
+            return STypePolymorphism(name, kind, rec_ty(body), loc=loc)
+        case SRefinementPolymorphism(name, sort, body, loc):
+            return SRefinementPolymorphism(name, rec_ty(sort), rec_ty(body), loc=loc)
+        case STypeConstructor(name, args, loc):
+            new_args = [rec_ty(a) for a in args]
+            return STypeConstructor(name, new_args, loc=loc)
+        case _:
+            return ty
+
+
 def resolve_qualified_names_in_definition(
     d: Definition, qualified_scope: QualifiedScope, unqualified_scope: UnqualifiedScope
 ) -> Definition:
     new_body = resolve_qualified_names_in_sterm(d.body, qualified_scope, unqualified_scope)
-    if new_body is d.body:
+    new_args = [(name, resolve_qualified_names_in_stype(ty, qualified_scope, unqualified_scope)) for name, ty in d.args]
+    new_type = resolve_qualified_names_in_stype(d.type, qualified_scope, unqualified_scope) if d.type else d.type
+    if new_body is d.body and new_args == d.args and new_type is d.type:
         return d
-    return Definition(d.name, d.foralls, d.args, d.type, new_body, d.decorators, d.rforalls, d.decreasing_by, d.loc)
+    return Definition(d.name, d.foralls, new_args, new_type, new_body, d.decorators, d.rforalls, d.decreasing_by, d.loc)
 
 
 def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType] | None = None) -> DesugaredProgram:
@@ -299,7 +328,7 @@ def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType]
     defs, type_decls = p.definitions, p.type_decls
     defs, type_decls, qualified_scope, unqualified_scope = handle_imports(p.imports, defs, type_decls)
 
-    # Resolve qualified names (Math.pow -> Math_pow) and unqualified bare names from open/selective imports
+    # Resolve qualified names (Math.pow -> pow) and unqualified bare names from open/selective imports
     defs = [resolve_qualified_names_in_definition(d, qualified_scope, unqualified_scope) for d in defs]
     prog = resolve_qualified_names_in_sterm(prog, qualified_scope, unqualified_scope)
 
@@ -766,7 +795,7 @@ def determine_main_function(p: Program, is_main_hole: bool = True) -> STerm:
 
 
 def _bare_name(module_name: str, def_name: str) -> str:
-    """Strip module prefix from a definition name: Math_pow -> pow."""
+    """Strip module prefix from a definition name if present: Math_pow -> pow, or pow -> pow."""
     prefix = module_name + "_"
     if def_name.startswith(prefix):
         return def_name[len(prefix) :]

--- a/examples/PSB2/dice_game.ae
+++ b/examples/PSB2/dice_game.ae
@@ -14,9 +14,9 @@ def constant_f1 : Float = 1.0
 
 def mult (n:Int) (m:Int ) : Int = n * m
 
-def peter_wins: ( n:Int ) -> ( m:Int ) -> Int = \n -> \m-> if m == 0 then 0 else (Math_max 0 (n - m)) + peter_wins n (m - 1);
+def peter_wins: ( n:Int ) -> ( m:Int ) -> Int = \n -> \m-> if m == 0 then 0 else (Math.max 0 (n - m)) + peter_wins n (m - 1);
 
-def dice_game ( n : {x:Int | 1 <= x && x <= 10000}) (m : {y:Int | 1 <= y && y <= 10000}) : Float = Math_toFloat(peter_wins n  m ) / Math_toFloat(mult n m);
+def dice_game ( n : {x:Int | 1 <= x && x <= 10000}) (m : {y:Int | 1 <= y && y <= 10000}) : Float = Math.toFloat(peter_wins n  m ) / Math.toFloat(mult n m);
 
 def synth ( n : {a:Int | 1 <= a && a <= 10000}) (m : {b:Int | 1 <= b && b <= 10000}) : Float = (?hole:Float);
 

--- a/examples/PSB2/square_digit.ae
+++ b/examples/PSB2/square_digit.ae
@@ -14,7 +14,7 @@ open PSB2
 #    else
 #        digit = n % 10
 #        square = digit * digit
-#        result = String_concat (square_digit(Math_floor_division n 10)) (String_intToString(square))
+#        result = String.concat (square_digit(Math.floor_division n 10)) (String.intToString(square))
 #        result
 #}
 
@@ -24,7 +24,7 @@ def square_digit_unsafe  ( n : Int) : String =
     else
         digit = n % 10;
         square = digit * digit;
-        result = String_concat (square_digit_unsafe(Math_floor_division n 10)) (String_intToString(square));
+        result = String.concat (square_digit_unsafe(Math.floor_division n 10)) (String.intToString(square));
         result;
 
 def synth_sd ( n : Int) : String = (?hole:String)

--- a/examples/bugs/planet_orbit.ae
+++ b/examples/bugs/planet_orbit.ae
@@ -7,43 +7,43 @@
 open Math
 
 def degrees_to_radians (angle: {deg: Float | 0.0 <= deg && deg <= 360.0 })
-                        : {rad: Float | 0.0 <= rad && rad <= 2.0 * Math_PI} = let HALF_TURN: {deg: Float | deg == 180.0 } = 180.0 in
-   Math_PI * angle / HALF_TURN;
+                        : {rad: Float | 0.0 <= rad && rad <= 2.0 * Math.PI} = let HALF_TURN: {deg: Float | deg == 180.0 } = 180.0 in
+   Math.PI * angle / HALF_TURN;
 
-def cos_eccentric (tru_anomaly: {v: Float | 0.0 <= v && v <= 2.0 * Math_PI})
+def cos_eccentric (tru_anomaly: {v: Float | 0.0 <= v && v <= 2.0 * Math.PI})
                   (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                  : {cos: Float | -1.0 <= cos && cos <= 1.0} = let cos_num = eccentricity + (Math_cos tru_anomaly) in
-   let cos_denom = 1.0 + eccentricity * (Math_cos tru_anomaly) in
+                  : {cos: Float | -1.0 <= cos && cos <= 1.0} = let cos_num = eccentricity + (Math.cos tru_anomaly) in
+   let cos_denom = 1.0 + eccentricity * (Math.cos tru_anomaly) in
    cos_num / cos_denom;
 
-def sin_eccentric (tru_anomaly: {v: Float | 0.0 <= v && v <= 2.0 * Math_PI})
+def sin_eccentric (tru_anomaly: {v: Float | 0.0 <= v && v <= 2.0 * Math.PI})
                   (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                  : {sin: Float | -1.0 <= sin && sin <= 1.0} = let sin_num = (Math_sqrtf (1.0 - eccentricity * eccentricity)) * (Math_sin tru_anomaly) in
-   let sin_denom = 1.0 + eccentricity * (Math_cos tru_anomaly) in
+                  : {sin: Float | -1.0 <= sin && sin <= 1.0} = let sin_num = (Math.sqrtf (1.0 - eccentricity * eccentricity)) * (Math.sin tru_anomaly) in
+   let sin_denom = 1.0 + eccentricity * (Math.cos tru_anomaly) in
    sin_num / sin_denom;
 
 def tru_to_eccentric_anomaly (tru_anomaly: {v: Float | 0.0 <= v && v <= 360.0})
                               (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                              : {eccentric_anomaly: Float | 0.0 <= eccentric_anomaly && eccentric_anomaly <= 2.0 * Math_PI} = let tru_anomaly_rad = degrees_to_radians tru_anomaly in
+                              : {eccentric_anomaly: Float | 0.0 <= eccentric_anomaly && eccentric_anomaly <= 2.0 * Math.PI} = let tru_anomaly_rad = degrees_to_radians tru_anomaly in
    let cos = cos_eccentric tru_anomaly_rad eccentricity in
    let sin = sin_eccentric tru_anomaly_rad eccentricity in
-   let raw_angle_E = Math_atan2 sin cos in
+   let raw_angle_E = Math.atan2 sin cos in
    if raw_angle_E < 0.0 then
-      raw_angle_E + (2.0 * Math_PI)
+      raw_angle_E + (2.0 * Math.PI)
    else
       raw_angle_E;
 
 def tru_to_mean_anomaly (tru_anomaly: {v: Float | 0.0 <= v && v <= 360.0})
                         (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
-                        : {mean_anomaly: Float | 0.0 <= mean_anomaly && mean_anomaly <= 2.0 * Math_PI} = let eccentric_anomaly = tru_to_eccentric_anomaly tru_anomaly eccentricity in
-   eccentric_anomaly - eccentricity * (Math_sin eccentric_anomaly);
+                        : {mean_anomaly: Float | 0.0 <= mean_anomaly && mean_anomaly <= 2.0 * Math.PI} = let eccentric_anomaly = tru_to_eccentric_anomaly tru_anomaly eccentricity in
+   eccentric_anomaly - eccentricity * (Math.sin eccentric_anomaly);
 
 def min_elapsed_period_fraction (starting_tru_anomaly: {v1: Float | 0.0 <= v1 && v1 <= 360.0})
                                  (final_tru_anomaly: {v2: Float | 0.0 <= v2 && v2 <= 360.0})
                                  (eccentricity: {e: Float | 0.0 <= e && e < 1.0})
                                  : {fraction: Float | 0.0 <= fraction && fraction <= 1.0} = let starting_mean_anomaly = tru_to_mean_anomaly starting_tru_anomaly eccentricity in
    let final_mean_anomaly = tru_to_mean_anomaly final_tru_anomaly eccentricity in
-   let delta_fraction = (Math_absf (final_mean_anomaly - starting_mean_anomaly)) / (2.0 * Math_PI) in
-   Math_minf delta_fraction (1.0 - delta_fraction);
+   let delta_fraction = (Math.absf (final_mean_anomaly - starting_mean_anomaly)) / (2.0 * Math.PI) in
+   Math.minf delta_fraction (1.0 - delta_fraction);
 
 def main (args:Int) : Unit = print (min_elapsed_period_fraction 270.0 90.0 0.5)

--- a/examples/demos/1_hello.ae
+++ b/examples/demos/1_hello.ae
@@ -5,7 +5,7 @@ def length : {n:Int | n == 10} = 10;
 def readIndex (i:Int | 0 <= i && i < length) : Unit = # Dummy operation
     print "okay";
 
-def main (index:Int) : Unit = pindex = Math_abs index;
+def main (index:Int) : Unit = pindex = Math.abs index;
     if pindex < length then
         readIndex pindex
     else
@@ -44,7 +44,7 @@ def main (index:Int) : Unit = pindex = Math_abs index;
 
 
 
-# pindex = Math_abs index
+# pindex = Math.abs index
     # if pindex < length then
     #     readIndex pindex
     # else

--- a/examples/demos/2_image.ae
+++ b/examples/demos/2_image.ae
@@ -3,9 +3,9 @@ open Image
 
 def main (steps:Int) : Image = white : Color = Color_mk 255 255 255;
     green : Color = Color_mk 0 255 0;
-    image0 = Image_mk 64 64 white;
-    image1 = Image_draw_rectangle image0 0 0 32 32 white;
-    image2 = Image_draw_rectangle image1 0 32 32 32 green;
-    image3 = Image_draw_rectangle image2 32 0 32 32 green;
-    image4 = Image_draw_rectangle image3 32 32 32 32 white;
+    image0 = Image.mk 64 64 white;
+    image1 = Image.draw_rectangle image0 0 0 32 32 white;
+    image2 = Image.draw_rectangle image1 0 32 32 32 green;
+    image3 = Image.draw_rectangle image2 32 0 32 32 green;
+    image4 = Image.draw_rectangle image3 32 32 32 32 white;
     image4;

--- a/examples/demos/2_image.ae
+++ b/examples/demos/2_image.ae
@@ -1,8 +1,9 @@
 open Image
+open Color
 
 
-def main (steps:Int) : Image = white : Color = Color_mk 255 255 255;
-    green : Color = Color_mk 0 255 0;
+def main (steps:Int) : Image = white : Color = Color.mk 255 255 255;
+    green : Color = Color.mk 0 255 0;
     image0 = Image.mk 64 64 white;
     image1 = Image.draw_rectangle image0 0 0 32 32 white;
     image2 = Image.draw_rectangle image1 0 32 32 32 green;

--- a/examples/demos/3_dataset.ae
+++ b/examples/demos/3_dataset.ae
@@ -1,10 +1,10 @@
 open Learning
 
-def training_multinomial_nb (filename: String) : Model = let df = Learning_load_dataset filename in
-    let balanced_df = Learning_smote_oversample df in
-    let train_set = Learning_split_dataset_training balanced_df 0.7 in
-    let test_set = Learning_split_dataset_testing balanced_df 0.7 in
-    Learning_train_multinomial_nb train_set;
+def training_multinomial_nb (filename: String) : Model = let df = Learning.load_dataset filename in
+    let balanced_df = Learning.smote_oversample df in
+    let train_set = Learning.split_dataset_training balanced_df 0.7 in
+    let test_set = Learning.split_dataset_testing balanced_df 0.7 in
+    Learning.train_multinomial_nb train_set;
 
 # https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf
 

--- a/examples/image/key.ae
+++ b/examples/image/key.ae
@@ -1,16 +1,16 @@
 open Image
 
-def target : Image = Image_open "examples/image/key_target.jpg"
+def target : Image = Image.open "examples/image/key_target.jpg"
 
 def key_example (steps:Int) : Image =
     white : Color = Color_mk 255 255 255;
     key_color : Color = Color_mk 192 192 192;
-    image0 = Image_mk 1024 768 white;
-    image1 = Image_draw_rectangle image0 170 256 256 256 key_color;
-    image2 = Image_draw_rectangle image1 255 341 85 83 white;
-    image3 = Image_draw_rectangle image2 426 341 509 83 key_color;
-    image4 = Image_draw_rectangle image3 836 424 100 68 key_color;
-    image5 = Image_draw_rectangle image4 686 424 100 48 key_color;
+    image0 = Image.mk 1024 768 white;
+    image1 = Image.draw_rectangle image0 170 256 256 256 key_color;
+    image2 = Image.draw_rectangle image1 255 341 85 83 white;
+    image3 = Image.draw_rectangle image2 426 341 509 83 key_color;
+    image4 = Image.draw_rectangle image3 836 424 100 68 key_color;
+    image5 = Image.draw_rectangle image4 686 424 100 48 key_color;
     image5;
 
 def k : Image = key_example 1
@@ -19,8 +19,8 @@ def mod : (x: Int) -> (y: Int) -> Int = \x -> \y -> (x % y)
 
 def synth : Image = ?hole
 
-def fitness : Float = Image_diff synth target
+def fitness : Float = Image.diff synth target
 
-# def keyshow : Unit = Image_show k
-# def keysave : Unit = Image_save k "examples/image/key.jpg"
+# def keyshow : Unit = Image.show k
+# def keysave : Unit = Image.save k "examples/image/key.jpg"
 # def main (x:Int) : Unit { keysave }

--- a/examples/image/key.ae
+++ b/examples/image/key.ae
@@ -1,10 +1,11 @@
 open Image
+open Color
 
 def target : Image = Image.open "examples/image/key_target.jpg"
 
 def key_example (steps:Int) : Image =
-    white : Color = Color_mk 255 255 255;
-    key_color : Color = Color_mk 192 192 192;
+    white : Color = Color.mk 255 255 255;
+    key_color : Color = Color.mk 192 192 192;
     image0 = Image.mk 1024 768 white;
     image1 = Image.draw_rectangle image0 170 256 256 256 key_color;
     image2 = Image.draw_rectangle image1 255 341 85 83 white;

--- a/examples/imports/import.ae
+++ b/examples/imports/import.ae
@@ -1,10 +1,10 @@
 open Math
 
-def pow : (b: {c:Int | ((c >= 1)  && (c <= 100))}) ->
+def my_pow : (b: {c:Int | ((c >= 1)  && (c <= 100))}) ->
           (e:{d:Int | ((d >= 1) && (d <= 100))}) ->
-           Int = Math_pow;
+           Int = Math.pow;
 
 
 def main (args:Int) : Unit =
     int_to_string : (x:Int) -> String = \x -> native "str(x)";
-    print (int_to_string (pow 3 4));
+    print (int_to_string (my_pow 3 4));

--- a/examples/imports/import2.ae
+++ b/examples/imports/import2.ae
@@ -1,10 +1,10 @@
 import Math (pow)
 
-def pow : (b: {c:Int | ((c >= 1)  && (c <= 100))}) ->
+def my_pow : (b: {c:Int | ((c >= 1)  && (c <= 100))}) ->
           (e:{d:Int | ((d >= 1) && (d <= 100))}) ->
-          Int = Math_pow;
+          Int = Math.pow;
 
 
 def main (args:Int) : Unit =
     int_to_string : (x:Int) -> String = \x -> native "str(x)";
-    print (int_to_string (pow 3 4));
+    print (int_to_string (my_pow 3 4));

--- a/examples/list/test_list_main.ae
+++ b/examples/list/test_list_main.ae
@@ -1,19 +1,19 @@
 open List
 
-def consume : (l: {x:(List Int) | List_size x == 1}) -> Int = \n -> 0;
-def consume : (l:(List Int) | List_size l == 1) -> Int = \n -> 0;
+def consume : (l: {x:(List Int) | List.size x == 1}) -> Int = \n -> 0;
+def consume : (l:(List Int) | List.size l == 1) -> Int = \n -> 0;
 
-# def neg1 : Int = consume(List_new)
+# def neg1 : Int = consume(List.new)
 
-# def neg2: Int = consume(List_append(List_append(List_new)(1))(1))
+# def neg2: Int = consume(List.append(List.append(List.new)(1))(1))
 
-def pos : Int = consume (List_append (List_new[Int]) 1)
+def pos : Int = consume (List.append (List.new[Int]) 1)
 
 def main (x:Int) : Unit =
-    empty = List_new[Int];
-    one = List_append empty 3;
-    two = List_append one 2;
-    three : (List Int) = List_append two 1;
+    empty = List.new[Int];
+    one = List.append empty 3;
+    two = List.append one 2;
+    three : (List Int) = List.append two 1;
     plus : (x:Int) -> (y: Int) -> Int = (\x -> \y -> x + y);
-    v : Int = (List_recursive three 0 plus);
+    v : Int = (List.recursive three 0 plus);
     print v;

--- a/examples/llvm/gpu/busy.ae
+++ b/examples/llvm/gpu/busy.ae
@@ -2,10 +2,10 @@ open Vector
 
 @gpu(target="cuda", debug=true)
 def multiply_by_ten (v:(Vector Int)) (size:Int) : (Vector Int) =
-    Vector_map[Int][Int] (\x:Int -> x * 10) v size;
+    Vector.map[Int][Int] (\x:Int -> x * 10) v size;
 
 def main (args:Int) : Unit =
     let size : Int = 1000000 in
     let v : (Vector Int) = native "[0] * size" in
     let res : (Vector Int) = multiply_by_ten v size in
-    print (Vector_get[Int] res 1);
+    print (Vector.get[Int] res 1);

--- a/examples/llvm/gpu/vector_map.ae
+++ b/examples/llvm/gpu/vector_map.ae
@@ -2,12 +2,12 @@ open Vector
 
 @gpu(target="cuda", block_size=256)
 def multiply_by_ten (v:(Vector Int)) (size:Int) : (Vector Int) =
-    Vector_map[Int][Int] (\x:Int -> x * 10) v size;
+    Vector.map[Int][Int] (\x:Int -> x * 10) v size;
 
 def main (args:Int) : Unit =
-    let v : (Vector Int) = Vector_new[Int] in
-    let v1 : (Vector Int) = Vector_append[Int] v 1 in
-    let v2 : (Vector Int) = Vector_append[Int] v1 2 in
-    let v3 : (Vector Int) = Vector_append[Int] v2 3 in
+    let v : (Vector Int) = Vector.new[Int] in
+    let v1 : (Vector Int) = Vector.append[Int] v 1 in
+    let v2 : (Vector Int) = Vector.append[Int] v1 2 in
+    let v3 : (Vector Int) = Vector.append[Int] v2 3 in
     let res : (Vector Int) = multiply_by_ten v3 3 in
-    print (Vector_get[Int] res 1);
+    print (Vector.get[Int] res 1);

--- a/examples/ml/balanced_dataset.ae
+++ b/examples/ml/balanced_dataset.ae
@@ -5,14 +5,14 @@ open Learning
 
 
 def generate_model_1 (filename: String) : Model =
-    let df = Learning_load_dataset filename in
-    let balanced_df = Learning_smote_oversample df in # Balance the dataset using SMOTE oversampling
-    let train_set = Learning_split_dataset_training balanced_df 0.7 in
-    let test_set = Learning_split_dataset_testing balanced_df 0.7 in
-    Learning_train_random_forest train_set; # Train a random forest model on the training set
+    let df = Learning.load_dataset filename in
+    let balanced_df = Learning.smote_oversample df in # Balance the dataset using SMOTE oversampling
+    let train_set = Learning.split_dataset_training balanced_df 0.7 in
+    let test_set = Learning.split_dataset_testing balanced_df 0.7 in
+    Learning.train_random_forest train_set; # Train a random forest model on the training set
 
 def generate_model_2 (filename: String) : Model =
-    let df = Learning_load_dataset filename in
-    let train_set = Learning_split_dataset_training df 0.7 in
-    let test_set = Learning_split_dataset_testing df 0.7 in
-    Learning_train_random_forest train_set; # Train a random forest model on the training set
+    let df = Learning.load_dataset filename in
+    let train_set = Learning.split_dataset_training df 0.7 in
+    let test_set = Learning.split_dataset_testing df 0.7 in
+    Learning.train_random_forest train_set; # Train a random forest model on the training set

--- a/examples/pbt/pbt_reverse.ae
+++ b/examples/pbt/pbt_reverse.ae
@@ -1,9 +1,10 @@
+open List
 open PropTesting
 
-def reverse (xs: (List Int)) : (List Int) = List_reversed(xs)
+def reverse (xs: (List Int)) : (List Int) = List.reversed(xs)
 
 
-def prop_reversed_lists_same_size (xs:(List Int)) : Bool = (List_length xs) == (List_length (reverse xs));
+def prop_reversed_lists_same_size (xs:(List Int)) : Bool = (List.length xs) == (List.length (reverse xs));
 
 def list_property_testing (y: Int) : Float = forAllLists prop_reversed_lists_same_size
 

--- a/examples/synthesis/function_refined_synthesis_args.ae
+++ b/examples/synthesis/function_refined_synthesis_args.ae
@@ -2,5 +2,5 @@ import Math (abs)
 
 def test (j:{h:Int | h > 0 }): Int = 8
 
-@minimize_int(Math_abs(64 - fun(8)))
+@minimize_int(Math.abs(64 - fun(8)))
 def fun (i:{x:Int | (x > 0 && x < 10) || (x > 20 && x < 30)}) : Int  = (?hole: {g:Int | g > 0 } ) * i

--- a/examples/synthesis/hole_refined_synthesis.ae
+++ b/examples/synthesis/hole_refined_synthesis.ae
@@ -1,4 +1,4 @@
 import Math (abs)
 
-@minimize_int(Math_abs(2024 - fun(253)))
+@minimize_int(Math.abs(2024 - fun(253)))
 def fun (i:Int) : Int  = (?hole: {x:Int | x > 0} ) * i

--- a/examples/synthesis/list_Empty.aef
+++ b/examples/synthesis/list_Empty.aef
@@ -1,7 +1,7 @@
 open List
 
-@minimize_int( if (List_empty List_new) then 0 else 1 )
-def is_empty (xs: (List a)) : { j:Bool | (j == ((List_size xs) == 0)) } {
-    let i : Int = List_length xs;
+@minimize_int( if (List.empty List.new) then 0 else 1 )
+def is_empty (xs: (List a)) : { j:Bool | (j == ((List.size xs) == 0)) } {
+    let i : Int = List.length xs;
     ?hole
 }

--- a/examples/synthesis/list_Insert.aef
+++ b/examples/synthesis/list_Insert.aef
@@ -1,5 +1,5 @@
 open List
 
-def insert_end (n: Int) (xs:(List Int)) : { j:(List Int)| ((List_size xs) + 1) == (List_size j) } {
+def insert_end (n: Int) (xs:(List Int)) : { j:(List Int)| ((List.size xs) + 1) == (List.size j) } {
     ?hole
 }

--- a/examples/synthesis/list_Replicate.aef
+++ b/examples/synthesis/list_Replicate.aef
@@ -1,7 +1,7 @@
 open List
 import Math (abs)
 
-@minimize_int(Math_abs((List_sum (replicate 3 3)) - 9))
-def replicate (n: {x:Int | x > 0} ) (elem: Int) : { j:(List Int) | n == (List_size j) } {
+@minimize_int(Math.abs((List.sum (replicate 3 3)) - 9))
+def replicate (n: {x:Int | x > 0} ) (elem: Int) : { j:(List Int) | n == (List.size j) } {
     ?hole
 }

--- a/libraries/Color.ae
+++ b/libraries/Color.ae
@@ -1,0 +1,2 @@
+inductive Color
+| mk (r:{v:Int | v >= 0 && v < 256}) (g:{v:Int | v >= 0 && v < 256}) (b:{v:Int | v >= 0 && v < 256}) : Color

--- a/libraries/Image.ae
+++ b/libraries/Image.ae
@@ -23,57 +23,57 @@ def Color_mk
 
 
 # Returns the height of the image in pixels.
-def Image_height : (im:Image) -> Int = uninterpreted
+def height : (im:Image) -> Int = uninterpreted
 
 # Returns the width of the image in pixels.
-def Image_width : (im:Image) -> Int = uninterpreted
+def width : (im:Image) -> Int = uninterpreted
 
 # Creates a new image of given width, height, and color.
-# width: image width (>0)
-# height: image height (>0)
+# w: image width (>0)
+# h: image height (>0)
 # color: fill color
 # returns: image with specified dimensions and color
-def Image_mk
-    (width:{p:Int | p > 0})
-    (height:{p:Int | p > 0})
+def mk
+    (w:{p:Int | p > 0})
+    (h:{p:Int | p > 0})
     (color:Color) :
-    {i : Image | (Image_width i == width) && (Image_height i == height) } =
-native "__import__('aeon.bindings.image').bindings.image.Image_mk(width, height, color)"
+    {i : Image | (width i == w) && (height i == h) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_mk(w, h, color)"
 
 # Displays the image.
 # image: image to display
-def Image_show (image:Image) : Unit = native "im.show()"
+def show (image:Image) : Unit = native "im.show()"
 
 # Saves the image to a file.
 # image: image to save
 # path: file path
-def Image_save (image:Image) (path:String) : Unit = native "im.save(path)"
+def save (image:Image) (path:String) : Unit = native "im.save(path)"
 
 # Opens an image from a file.
 # path: file path
 # returns: loaded image
-def Image_open (path:String) : Image = native "__import__('PIL.Image').Image.open(path)"
+def open (path:String) : Image = native "__import__('PIL.Image').Image.open(path)"
 
 # Computes the mean squared error (MSE) difference between two images.
 # img: first image
 # img2: second image
 # returns: MSE difference as float
-def Image_diff (img : Image) (img2 : Image) : Float = native "__import__('aeon.bindings.image').bindings.image.Image_diff_mse(img, img2)"
+def diff (img : Image) (img2 : Image) : Float = native "__import__('aeon.bindings.image').bindings.image.Image_diff_mse(img, img2)"
 
 # Draws a rectangle on the image.
 # im: input image
 # x: x-coordinate of top-left corner (>0 and < image width)
 # y: y-coordinate of top-left corner (>0 and < image height)
-# width: rectangle width (>0 and x+width < image width)
-# height: rectangle height (>0 and y+height < image height)
+# w: rectangle width (>0 and x+w < image width)
+# h: rectangle height (>0 and y+h < image height)
 # color: rectangle color
 # returns: new image with rectangle drawn
-def Image_draw_rectangle
+def draw_rectangle
     (im:Image)
-    (x:{p:Int | p >= 0 && p <= Image_width im })
-    (y:{p:Int | p >= 0 && p <= Image_height im})
-    (width:{p:Int | p > 0 && x + p <= Image_width im })
-    (height:{p:Int | p > 0 && y + p <= Image_height im })
+    (x:{p:Int | p >= 0 && p <= width im })
+    (y:{p:Int | p >= 0 && p <= height im})
+    (w:{p:Int | p > 0 && x + p <= width im })
+    (h:{p:Int | p > 0 && y + p <= height im })
     (color:Color) :
-    {rim:Image | (Image_width rim == Image_width im) && (Image_height rim == Image_height im) } =
-        native "__import__('aeon.bindings.image').bindings.image.Image_draw_rectangle(im, x, y, width, height, color)"
+    {rim:Image | (width rim == width im) && (height rim == height im) } =
+        native "__import__('aeon.bindings.image').bindings.image.Image_draw_rectangle(im, x, y, w, h, color)"

--- a/libraries/Image.ae
+++ b/libraries/Image.ae
@@ -1,26 +1,6 @@
-type Color
+open Color
+
 type Image
-
-# Returns the red component of a color (0-255).
-def Color_r: (c:Color) -> Int = uninterpreted
-
-# Returns the green component of a color (0-255).
-def Color_g: (c:Color) -> Int = uninterpreted
-
-# Returns the blue component of a color (0-255).
-def Color_b: (c:Color) -> Int = uninterpreted
-
-# Constructs a color from red, green, and blue components.
-# r: red (0-255)
-# g: green (0-255)
-# b: blue (0-255)
-# returns: color with specified RGB values
-def Color_mk
-    (r:{r:Int | r >= 0 && r < 256})
-    (g:{r:Int | r >= 0 && r < 256})
-    (b:{r:Int | r >= 0 && r < 256}) :
-    {c:Color | (Color_r c == r) && (Color_g c == g) && (Color_b c == b) } = native "(r, g, b)"
-
 
 # Returns the height of the image in pixels.
 def height : (im:Image) -> Int = uninterpreted
@@ -38,7 +18,7 @@ def mk
     (h:{p:Int | p > 0})
     (color:Color) :
     {i : Image | (width i == w) && (height i == h) } =
-native "__import__('aeon.bindings.image').bindings.image.Image_mk(w, h, color)"
+native "__import__('aeon.bindings.image').bindings.image.Image_mk(w, h, color[1:])"
 
 # Displays the image.
 # image: image to display
@@ -76,4 +56,4 @@ def draw_rectangle
     (h:{p:Int | p > 0 && y + p <= height im })
     (color:Color) :
     {rim:Image | (width rim == width im) && (height rim == height im) } =
-        native "__import__('aeon.bindings.image').bindings.image.Image_draw_rectangle(im, x, y, w, h, color)"
+        native "__import__('aeon.bindings.image').bindings.image.Image_draw_rectangle(im, x, y, w, h, color[1:])"

--- a/libraries/Learning.ae
+++ b/libraries/Learning.ae
@@ -6,63 +6,63 @@ def skl : Unit = native_import "sklearn"
 def imblearn : Unit = native_import "imblearn"
 
 # Returns true if the dataset is balanced.
-def Learning_is_balanced: (ds: Dataset) -> Bool = uninterpreted
+def is_balanced: (ds: Dataset) -> Bool = uninterpreted
 
 # Loads a dataset from a file.
-def Learning_load_dataset (filename: String) : Dataset = native "learning.load_dataset(filename)"
+def load_dataset (filename: String) : Dataset = native "learning.load_dataset(filename)"
 
 # Splits a dataset into two parts according to the given fraction.
-def Learning_split_dataset_training (original: Dataset) (fraction: {f: Float | 0.0 <= f && f <= 1.0}) :
-    {training:Dataset | Learning_is_balanced training == Learning_is_balanced original } =
+def split_dataset_training (original: Dataset) (fraction: {f: Float | 0.0 <= f && f <= 1.0}) :
+    {training:Dataset | is_balanced training == is_balanced original } =
     native "learning.split_dataset(original, fraction)[0]"
 
 
 # Splits a dataset into two parts according to the given fraction.
-def Learning_split_dataset_testing (original: Dataset) (fraction: {f: Float | 0.0 <= f && f <= 1.0}) :
-    {testing:Dataset | Learning_is_balanced testing == Learning_is_balanced original } =
+def split_dataset_testing (original: Dataset) (fraction: {f: Float | 0.0 <= f && f <= 1.0}) :
+    {testing:Dataset | is_balanced testing == is_balanced original } =
     native "learning.split_dataset(original, fraction)[1]"
 
 
 # Trains a random forest model on a balanced dataset.
-def Learning_train_random_forest (dataset: {training_dataset: Dataset | Learning_is_balanced training_dataset}) : Model =
+def train_random_forest (dataset: {training_dataset: Dataset | is_balanced training_dataset}) : Model =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_train_random_forest(training_dataset)"
 
 
 # Trains a random forest model on a balanced dataset.
-def Learning_train_multinomial_nb (dataset: {training_dataset: Dataset | Learning_is_balanced training_dataset}) : Model =
+def train_multinomial_nb (dataset: {training_dataset: Dataset | is_balanced training_dataset}) : Model =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_train_random_forest(training_dataset)"
  # TODO fix binding
 
 # Trains a random forest model on a balanced dataset.
-def Learning_train_complement_nb (dataset: {training_dataset: Dataset | Learning_is_balanced training_dataset == false}) : Model =
+def train_complement_nb (dataset: {training_dataset: Dataset | is_balanced training_dataset == false}) : Model =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_train_random_forest(training_dataset)"
  # TODO fix binding
 
 # Applies SMOTE oversampling to balance the dataset.
-def Learning_smote_oversample (ds: Dataset) : {ds2: Dataset | Learning_is_balanced ds2 } =
+def smote_oversample (ds: Dataset) : {ds2: Dataset | is_balanced ds2 } =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_smote_oversample(ds)"
 
 
 # Predicts labels for the given dataset using the trained model.
-def Learning_predict (model: Model) (ds: Dataset) : List =
+def predict (model: Model) (ds: Dataset) : List =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_predict(model, ds)"
 
 
 # Returns the accuracy score of the model on the given dataset.
-def Learning_score (model: Model) (ds: Dataset) : Float =
+def score (model: Model) (ds: Dataset) : Float =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_score(model, ds)"
 
 
 # Returns the confusion matrix for predictions on the dataset.
-def Learning_confusion_matrix (model: Model) (ds: Dataset) : List =
+def confusion_matrix (model: Model) (ds: Dataset) : List =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_confusion_matrix(model, ds)"
 
 
 # Applies standard scaling (zero mean, unit variance) to the dataset features.
-def Learning_standard_scale (ds: Dataset) : Dataset =
+def standard_scale (ds: Dataset) : Dataset =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_standard_scale(ds)"
 
 
 # Applies min-max scaling to the dataset features.
-def Learning_minmax_scale (ds: Dataset) : Dataset =
+def minmax_scale (ds: Dataset) : Dataset =
     native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_minmax_scale(ds)"

--- a/libraries/List.ae
+++ b/libraries/List.ae
@@ -3,74 +3,74 @@ type List a
 def functools : Unit = native_import "functools"
 
 # Returns the size (length) of the list.
-def List_size: (l:(List a)) -> Int = uninterpreted
+def size: (l:(List a)) -> Int = uninterpreted
 
 # Returns the length of the list.
 # l: list
 # returns: number of elements in the list
-def List_length (l:(List a)) : {x:Int | x == List_size l} = native "len(l)"
+def length (l:(List a)) : {x:Int | x == size l} = native "len(l)"
 
 # Creates a new empty list.
 # returns: an empty list
-def List_new : {x:(List a) | (List_size x) == 0} = native "[]" ;
+def new : {x:(List a) | (size x) == 0} = native "[]" ;
 
 # Appends an item to the end of the list.
 # l: list
 # i: item to append
 # returns: new list with item appended
-def List_append (l:(List a)) (i: a) : {l2:(List a) | List_size l2 == (List_size l) + 1} = native "l + [i]"
+def append (l:(List a)) (i: a) : {l2:(List a) | size l2 == (size l) + 1} = native "l + [i]"
 
 # Prepends an item to the start of the list.
 # l: list
 # i: item to prepend
 # returns: new list with item prepended
-def List_cons (l:(List a)) (i:a) : {l2:(List a) | List_size l2 == (List_size l) + 1} = native "[i] + l"
+def cons (l:(List a)) (i:a) : {l2:(List a) | size l2 == (size l) + 1} = native "[i] + l"
 
 # Applies a recursive reduction over the list.
 # l: list
 # cb: initial value
 # rec: recursive function
 # returns: result of reduction
-def List_recursive (l:(List a)) (cb:b) (rec:(v:a) -> (o:b) -> b) : b = native "functools.reduce(lambda seed, next: rec(next)(seed), l, cb)"
+def recursive (l:(List a)) (cb:b) (rec:(v:a) -> (o:b) -> b) : b = native "functools.reduce(lambda seed, next: rec(next)(seed), l, cb)"
 
 # Returns the sum of the list.
 # l: list of numbers
 # returns: sum of elements
-def List_sum (l:(List Int)) : Int = native "sum(l)"
+def sum (l:(List Int)) : Int = native "sum(l)"
 
 # Returns the first element of a non-empty list.
 # l: non-empty list
 # returns: first element
-def List_head (l: {x:(List a) | List_size x > 0 }) : a = native "l[0]"
+def head (l: {x:(List a) | size x > 0 }) : a = native "l[0]"
 
 # Maps a function over the list.
 # f: function to apply
 # l: list
 # returns: new list with function applied to each element
-def List_map (f: (v:a) -> b) (l:(List a)) : (List b) = native "list(map(f, l))"
+def map (f: (v:a) -> b) (l:(List a)) : (List b) = native "list(map(f, l))"
 
 # Returns a reversed copy of the list.
 # l: list
 # returns: reversed list
-def List_reversed (l: (List a)) : (List a) = native "l[::-1]"
+def reversed (l: (List a)) : (List a) = native "l[::-1]"
 
-def List_empty (l: (List a)) : {x:Bool | x == ((List_size l) == 0)} = (List_length l) == 0
+def empty (l: (List a)) : {x:Bool | x == ((size l) == 0)} = (length l) == 0
 
 
-# def List_tail:(l:{x:(List a) | List_size x > 0 }) -> {l2:(List a) | List_size l2 ==  (List_size l) - 1 }  = \xs -> native "xs[1:]"
+# def List_tail:(l:{x:(List a) | size x > 0 }) -> {l2:(List a) | size l2 ==  (size l) - 1 }  = \xs -> native "xs[1:]"
 
-# def List_last: (l:{x:(List a) | List_size x > 0 }) -> a = \xs -> native "xs[-1]"
+# def List_last: (l:{x:(List a) | size x > 0 }) -> a = \xs -> native "xs[-1]"
 
-# def List_get: (l:{x:(List a) | List_size x > 0 }) -> (i:{y:Int | (y >= 0) && y < List_size l}) -> a = \xs -> \i -> native "xs[i]"
+# def List_get: (l:{x:(List a) | size x > 0 }) -> (i:{y:Int | (y >= 0) && y < size l}) -> a = \xs -> \i -> native "xs[i]"
 
 # def List_elem: (l:(List a)) -> (i:a) -> Bool = \xs -> \x -> native "x in xs"
 
-# def List_remove: (l:{x:(List a) | List_size x > 0 }) -> (i:a) -> {y:(List a) | List_size y == (List_size l) - 1 } = \xs -> \x -> native "[elem for elem in xs if elem != x]"
+# def List_remove: (l:{x:(List a) | size x > 0 }) -> (i:a) -> {y:(List a) | size y == (size l) - 1 } = \xs -> \x -> native "[elem for elem in xs if elem != x]"
 
-# def List_extends: (l:(List a))->(l2:(List a))-> {x:(List a) | List_size x == (List_size l + List_size l2) } = \xs -> \ys -> native "xs + ys"
+# def List_extends: (l:(List a))->(l2:(List a))-> {x:(List a) | size x == (size l + size l2) } = \xs -> \ys -> native "xs + ys"
 
-# def List_sort: (l:(List a)) -> {x:(List a) | List_size x == List_size l } = \xs -> native "sorted(xs, key=lambda x: x)"
+# def List_sort: (l:(List a)) -> {x:(List a) | size x == size l } = \xs -> native "sorted(xs, key=lambda x: x)"
 
 # def List_count:(l:(List a)) -> (i:a) -> Int= \xs -> \x -> native "xs.count(x)"
 
-# def List_index:(l:(List a)) -> (i:a) -> {y:Int | (y >= 0) && y < List_size l}= \xs -> \x -> native "xs.index(x)"
+# def List_index:(l:(List a)) -> (i:a) -> {y:Int | (y >= 0) && y < size l}= \xs -> \x -> native "xs.index(x)"

--- a/libraries/Map.ae
+++ b/libraries/Map.ae
@@ -1,32 +1,32 @@
 type Map k v
 
 # Returns the size (number of entries) of the map.
-def Map_size: (m: (Map k v)) -> Int = uninterpreted
+def size: (m: (Map k v)) -> Int = uninterpreted
 
 # Creates a new empty map.
-def Map_new : {m: (Map k v) | Map_size m == 0} = native "{}";
+def new : {m: (Map k v) | size m == 0} = native "{}";
 
 # Sets the value for a key in the map.
 # m: map
 # k: key
 # v: value
 # returns: new map with key set to value
-def Map_set (m: (Map k v)) (key: k) (value: v) : (Map k v) = native "{**m, key: value}"
+def set (m: (Map k v)) (key: k) (value: v) : (Map k v) = native "{**m, key: value}"
 
 # Gets the value for a key in the map.
 # m: map
 # k: key
 # returns: value for key, or default if not found
-def Map_get (m: (Map k v)) (key: k) : v = native "m.get(key)"
+def get (m: (Map k v)) (key: k) : v = native "m.get(key)"
 
 # Checks if the map contains a key.
 # m: map
 # k: key
 # returns: true if key is in map
-def Map_has (m: (Map k v)) (key: k) : Bool = native "key in m"
+def has (m: (Map k v)) (key: k) : Bool = native "key in m"
 
 # Removes a key from the map.
 # m: map
 # k: key
 # returns: new map with key removed
-def Map_delete (m: (Map k v)) (key: k) : (Map k v) = native "{k_: v_ for k_, v_ in m.items() if k_ != key}"
+def delete (m: (Map k v)) (key: k) : (Map k v) = native "{k_: v_ for k_, v_ in m.items() if k_ != key}"

--- a/libraries/Math.ae
+++ b/libraries/Math.ae
@@ -1,70 +1,215 @@
 def math : Unit = native_import "math"
 
-# Returns the minimum of two integers.
-def Math_min (i: Int) (j: Int) : Int = native "min(i, j)"
-
-# Returns the maximum of two integers.
-def Math_max (i: Int) (j: Int) : Int = native "max(i, j)"
-
-# Returns the absolute value of an integer.
-def Math_abs (i:Int) : {v:Int | v >= 0} = native "abs(i)"
-
-# Returns the ceiling of a float as an integer.
-def Math_ceil (i:Float) : Int = native "math.ceil(i)"
-
-# Returns the floor of an integer as an integer.
-def Math_floor (i:Int) : Int = native "math.floor(i)"
-
-# Converts an integer to a float.
-def Math_toFloat (i:Int) : Float = native "float(i)"
-
-# Converts a float to an integer (truncates towards zero).
-def Math_toInt (i:Float) : Int = native "int(i)"
-
-# Returns the square root of an integer as a float.
-def Math_sqrt (i:Int) : Float = native "math.sqrt(i)"
-
-# Raises a float to the power of another float.
-def Math_powf (i:Float) (j:Float) : Float = native "i ** j";
-
-# Raises an integer to the power of another integer.
-def Math_pow (i:Int) (j:Int) : Int = native "i ** j"
-
-# Rounds a float to the nearest integer.
-def Math_round (i:Float) : Int = native "round(i)"
-
-# Performs integer division (floor division).
-def Math_floor_division (i:Int) (j: Int) : Int = native "i // j"
-
-# Returns the sine of a float (in radians).
-def Math_sin (i: Float) : Float = native "math.sin(i)"
-
-# Returns the cosine of a float (in radians).
-def Math_cos (i: Float) : Float = native "math.cos(i)"
-
-# Returns the arc tangent of sinVal/cosVal, in radians.
-def Math_atan2 (sinVal: Float) (cosVal: Float) : Float = native "math.atan2(sinVal, cosVal)"
+# ── Constants ──────────────────────────────────────────────────────────
 
 # The value of PI.
-def Math_PI : Float = native "math.pi"
+def PI : Float = native "math.pi"
+
+# The value of Euler's number e.
+def E : Float = native "math.e"
+
+# The value of tau (2 * PI).
+def TAU : Float = native "math.tau"
+
+# Positive infinity.
+def INF : Float = native "math.inf"
+
+# ── Conversions ────────────────────────────────────────────────────────
+
+# Converts an integer to a float.
+def toFloat (i:Int) : Float = native "float(i)"
+
+# Converts a float to an integer (truncates towards zero).
+def toInt (i:Float) : Int = native "int(i)"
+
+# ── Integer arithmetic ─────────────────────────────────────────────────
+
+# Returns the minimum of two integers.
+def min (i: Int) (j: Int) : Int = native "min(i, j)"
+
+# Returns the maximum of two integers.
+def max (i: Int) (j: Int) : Int = native "max(i, j)"
+
+# Returns the absolute value of an integer.
+def abs (i:Int) : {v:Int | v >= 0} = native "abs(i)"
+
+# Raises an integer to the power of a non-negative integer.
+def pow (i:Int) (j:{v:Int | v >= 0}) : Int = native "i ** j"
+
+# Performs integer division (floor division). Divisor must be nonzero.
+def floor_division (i:Int) (j:{v:Int | v != 0}) : Int = native "i // j"
+
+# Returns the greatest common divisor of two integers.
+def gcd (i:Int) (j:Int) : {v:Int | v >= 0} = native "math.gcd(i, j)"
+
+# Returns the least common multiple of two integers.
+def lcm (i:Int) (j:Int) : {v:Int | v >= 0} = native "math.lcm(i, j)"
+
+# Returns the factorial of a non-negative integer.
+def factorial (i:{v:Int | v >= 0}) : {v:Int | v >= 1} = native "math.factorial(i)"
+
+# Returns n choose k (binomial coefficient).
+def comb (n:{v:Int | v >= 0}) (k:{v:Int | v >= 0}) : {v:Int | v >= 0} = native "math.comb(n, k)"
+
+# Returns n permute k (number of permutations).
+def perm (n:{v:Int | v >= 0}) (k:{v:Int | v >= 0}) : {v:Int | v >= 0} = native "math.perm(n, k)"
+
+# ── Float arithmetic ──────────────────────────────────────────────────
 
 # Returns the minimum of two floats.
-def Math_minf (i: Float) (j: Float): Float = native "min(i, j)"
+def minf (i: Float) (j: Float): Float = native "min(i, j)"
 
-# Returns the square root of a float.
-def Math_sqrtf (i: Float) : Float = native "math.sqrt(i)"
+# Returns the maximum of two floats.
+def maxf (i: Float) (j: Float): Float = native "max(i, j)"
 
 # Returns the absolute value of a float.
-def Math_absf (i:Float) : Float = native "abs(i)"
+def absf (i:Float) : {v:Float | v >= 0.0} = native "abs(i)"
 
-# Returns the natural logarithm (base e) of a float.
-def Math_log (i: Float) : Float = native "math.log(i)"
+# Raises a float to the power of another float.
+def powf (i:Float) (j:Float) : Float = native "i ** j"
 
-# Returns the base-10 logarithm of a float.
-def Math_log10 (i: Float) : Float = native "math.log10(i)"
+# Returns the remainder of i / j (IEEE 754 style).
+def remainder (i:Float) (j:{v:Float | v != 0.0}) : Float = native "math.remainder(i, j)"
 
-# Returns the base-2 logarithm of a float.
-def Math_log2 (i: Float) : Float = native "math.log2(i)"
+# Returns the float modulo.
+def fmod (i:Float) (j:{v:Float | v != 0.0}) : Float = native "math.fmod(i, j)"
+
+# ── Rounding ──────────────────────────────────────────────────────────
+
+# Rounds a float to the nearest integer.
+def round (i:Float) : Int = native "round(i)"
+
+# Returns the ceiling of a float as an integer.
+def ceil (i:Float) : Int = native "math.ceil(i)"
+
+# Returns the floor of a float as an integer.
+def floor (i:Float) : Int = native "math.floor(i)"
+
+# Truncates a float to an integer (towards zero).
+def trunc (i:Float) : Int = native "math.trunc(i)"
+
+# ── Powers, roots, and exponentials ───────────────────────────────────
+
+# Returns the square root of a non-negative integer as a float.
+def sqrt (i:{v:Int | v >= 0}) : {v:Float | v >= 0.0} = native "math.sqrt(i)"
+
+# Returns the square root of a non-negative float.
+def sqrtf (i:{v:Float | v >= 0.0}) : {v:Float | v >= 0.0} = native "math.sqrt(i)"
+
+# Returns the integer square root of a non-negative integer.
+def isqrt (i:{v:Int | v >= 0}) : {v:Int | v >= 0} = native "math.isqrt(i)"
+
+# Returns the cube root of a float.
+def cbrt (i:Float) : Float = native "math.cbrt(i)"
 
 # Returns e raised to the power of the given float.
-def Math_exp (i: Float) : Float = native "math.exp(i)"
+def exp (i: Float) : {v:Float | v > 0.0} = native "math.exp(i)"
+
+# Returns e**x - 1, more precise for small x.
+def expm1 (i: Float) : Float = native "math.expm1(i)"
+
+# Returns 2 raised to the power of the given float.
+def exp2 (i: Float) : {v:Float | v > 0.0} = native "2.0 ** i"
+
+# ── Logarithms ────────────────────────────────────────────────────────
+
+# Returns the natural logarithm (base e) of a positive float.
+def log (i: {v:Float | v > 0.0}) : Float = native "math.log(i)"
+
+# Returns the base-10 logarithm of a positive float.
+def log10 (i: {v:Float | v > 0.0}) : Float = native "math.log10(i)"
+
+# Returns the base-2 logarithm of a positive float.
+def log2 (i: {v:Float | v > 0.0}) : Float = native "math.log2(i)"
+
+# Returns log(1 + x), more precise for small x.
+def log1p (i: {v:Float | v > -1.0}) : Float = native "math.log1p(i)"
+
+# ── Trigonometry ──────────────────────────────────────────────────────
+
+# Returns the sine of a float (in radians).
+def sin (i: Float) : Float = native "math.sin(i)"
+
+# Returns the cosine of a float (in radians).
+def cos (i: Float) : Float = native "math.cos(i)"
+
+# Returns the tangent of a float (in radians).
+def tan (i: Float) : Float = native "math.tan(i)"
+
+# Returns the arc sine of a float in [-1, 1].
+def asin (i: {v:Float | -1.0 <= v && v <= 1.0}) : Float = native "math.asin(i)"
+
+# Returns the arc cosine of a float in [-1, 1].
+def acos (i: {v:Float | -1.0 <= v && v <= 1.0}) : Float = native "math.acos(i)"
+
+# Returns the arc tangent of a float.
+def atan (i: Float) : Float = native "math.atan(i)"
+
+# Returns the arc tangent of sinVal/cosVal, in radians.
+def atan2 (sinVal: Float) (cosVal: Float) : Float = native "math.atan2(sinVal, cosVal)"
+
+# Converts degrees to radians.
+def radians (deg: Float) : Float = native "math.radians(deg)"
+
+# Converts radians to degrees.
+def degrees (rad: Float) : Float = native "math.degrees(rad)"
+
+# Returns the Euclidean distance between two 2D points.
+def hypot (x: Float) (y: Float) : {v:Float | v >= 0.0} = native "math.hypot(x, y)"
+
+# ── Hyperbolic functions ──────────────────────────────────────────────
+
+# Returns the hyperbolic sine.
+def sinh (i: Float) : Float = native "math.sinh(i)"
+
+# Returns the hyperbolic cosine. Result is always >= 1.
+def cosh (i: Float) : {v:Float | v >= 1.0} = native "math.cosh(i)"
+
+# Returns the hyperbolic tangent.
+def tanh (i: Float) : Float = native "math.tanh(i)"
+
+# Returns the inverse hyperbolic sine.
+def asinh (i: Float) : Float = native "math.asinh(i)"
+
+# Returns the inverse hyperbolic cosine. Input must be >= 1.
+def acosh (i: {v:Float | v >= 1.0}) : {v:Float | v >= 0.0} = native "math.acosh(i)"
+
+# Returns the inverse hyperbolic tangent. Input must be in (-1, 1).
+def atanh (i: {v:Float | -1.0 < v && v < 1.0}) : Float = native "math.atanh(i)"
+
+# ── Special functions ─────────────────────────────────────────────────
+
+# Returns the error function.
+def erf (i: Float) : Float = native "math.erf(i)"
+
+# Returns the complementary error function.
+def erfc (i: Float) : Float = native "math.erfc(i)"
+
+# Returns the natural log of the absolute value of the Gamma function.
+def lgamma (i: Float) : Float = native "math.lgamma(i)"
+
+# Returns the Gamma function. Input must be positive or non-integer.
+def gamma (i: {v:Float | v > 0.0}) : {v:Float | v > 0.0} = native "math.gamma(i)"
+
+# ── Classification ────────────────────────────────────────────────────
+
+# Returns true if the float is finite (not infinity or NaN).
+def isfinite (i: Float) : Bool = native "math.isfinite(i)"
+
+# Returns true if the float is infinity.
+def isinf (i: Float) : Bool = native "math.isinf(i)"
+
+# Returns true if the float is NaN.
+def isnan (i: Float) : Bool = native "math.isnan(i)"
+
+# Returns the sign of an integer: -1, 0, or 1.
+def sign (i: Int) : {v:Int | v >= (0 - 1) && v <= 1} = native "(0 < i) - (i < 0)"
+
+# Returns the sign of a float: -1, 0, or 1.
+def signf (i: Float) : {v:Int | v >= (0 - 1) && v <= 1} = native "(0.0 < i) - (i < 0.0)"
+
+# Clamps an integer to the range [lo, hi].
+def clamp (x: Int) (lo: Int) (hi: {v:Int | v >= lo}) : {v:Int | v >= lo && v <= hi} = native "max(lo, min(x, hi))"
+
+# Clamps a float to the range [lo, hi].
+def clampf (x: Float) (lo: Float) (hi: {v:Float | v >= lo}) : {v:Float | v >= lo && v <= hi} = native "max(lo, min(x, hi))"

--- a/libraries/Plot.ae
+++ b/libraries/Plot.ae
@@ -6,7 +6,7 @@ type List a; # Assuming this is how you define generic lists
 def plt : Unit = native_import "matplotlib.pyplot"
 
 # Creates a new, empty plot.
-def Plot_new : Plot = native "(plt.figure(), plt.gca())[0]"; # Returns the figure object; gca() ensures axes are created
+def new : Plot = native "(plt.figure(), plt.gca())[0]"; # Returns the figure object; gca() ensures axes are created
 
 # Adds a line plot to an existing plot object.
 # p_old: The existing plot object (Matplotlib Figure instance).
@@ -16,7 +16,7 @@ def Plot_new : Plot = native "(plt.figure(), plt.gca())[0]"; # Returns the figur
 # linestyle: String representing the line style (e.g., "-", "--", ":").
 # returns: The plot object, now with the added line.
 #          (Matplotlib's plot modifies in place; we return the same figure object).
-def Plot_add_line (p_old: Plot)
+def add_line (p_old: Plot)
                    (x_values: (List Float))
                    (y_values: (List Float))
                    (color: String)
@@ -31,7 +31,7 @@ def Plot_add_line (p_old: Plot)
 # color: String representing the color.
 # marker: String representing the marker style (e.g., "o", "x", "+").
 # returns: The plot object, now with the added scatter plot.
-def Plot_add_scatter (p_old: Plot)
+def add_scatter (p_old: Plot)
                       (x_values: (List Float))
                       (y_values: (List Float))
                       (color: String)
@@ -43,7 +43,7 @@ def Plot_add_scatter (p_old: Plot)
 # p_old: The existing plot object.
 # title_text: The string for the title.
 # returns: The plot object with the title set.
-def Plot_set_title (p_old: Plot) (title_text: String) : Plot =
+def set_title (p_old: Plot) (title_text: String) : Plot =
     native "(lambda fig, text: (fig.gca().set_title(text), fig)[1])(p_old, title_text)"
 
 
@@ -51,7 +51,7 @@ def Plot_set_title (p_old: Plot) (title_text: String) : Plot =
 # p_old: The existing plot object.
 # label_text: The string for the X-axis label.
 # returns: The plot object with the X-axis label set.
-def Plot_set_xlabel (p_old: Plot) (label_text: String) : Plot =
+def set_xlabel (p_old: Plot) (label_text: String) : Plot =
     native "(lambda fig, text: (fig.gca().set_xlabel(text), fig)[1])(p_old, label_text)"
 
 
@@ -59,18 +59,18 @@ def Plot_set_xlabel (p_old: Plot) (label_text: String) : Plot =
 # p_old: The existing plot object.
 # label_text: The string for the Y-axis label.
 # returns: The plot object with the Y-axis label set.
-def Plot_set_ylabel (p_old: Plot) (label_text: String) : Plot =
+def set_ylabel (p_old: Plot) (label_text: String) : Plot =
     native "(lambda fig, text: (fig.gca().set_ylabel(text), fig)[1])(p_old, label_text)"
 
 
 # Displays the plot.
 # p: The plot object to display.
-def Plot_show (p: Plot) : Unit =
+def show (p: Plot) : Unit =
     native "plt.show(p)" # Pass the specific figure to show, or just plt.show() for all active
 
 
 # Saves the plot to a file.
 # p: The plot object to save.
 # filename: The name of the file (e.g., "myplot.png").
-def Plot_save (p: Plot) (filename: String) : Unit =
+def save (p: Plot) (filename: String) : Unit =
     native "p.savefig(filename)"

--- a/libraries/PropTesting.ae
+++ b/libraries/PropTesting.ae
@@ -28,8 +28,8 @@ def ratio (a:Int) (b:Int) : Float = native "a/b"
 def forAllInts (fun:(a: Int) -> Bool) : Float =
     n = 1000;
     vs = repeat random n;
-    rds = List_map generateInt vs;
-    rs = List_map fun rds;
+    rds = List.map generateInt vs;
+    rs = List.map fun rds;
     positive = (countTrues rs);
     ratio positive n
 
@@ -37,8 +37,8 @@ def forAllInts (fun:(a: Int) -> Bool) : Float =
 def forAllFloats (fun:(a: Float) -> Bool) : Float =
     n = 1000;
     vs = repeat random n;
-    rds = List_map generateFloat vs;
-    rs = List_map fun rds;
+    rds = List.map generateFloat vs;
+    rs = List.map fun rds;
     positive = (countTrues rds);
     ratio positive n
 
@@ -46,7 +46,7 @@ def forAllFloats (fun:(a: Float) -> Bool) : Float =
 def forAllLists (fun:(a: List) -> Bool) : Float =
     n = 1000;
     vs = repeat random n;
-    rds = List_map generateList vs;
-    rs = List_map fun rds;
+    rds = List.map generateList vs;
+    rs = List.map fun rds;
     positive = (countTrues rds);
     ratio positive n

--- a/libraries/Random.ae
+++ b/libraries/Random.ae
@@ -3,22 +3,22 @@ open List
 def random : Unit = native_import "random"
 
 # Seeds the random number generator.
-def Random_seed (seed: Int) : Unit = native "random.seed(seed)"
+def seed (seed: Int) : Unit = native "random.seed(seed)"
 
 # Returns a random integer N such that a <= N <= b.
-def Random_randint (a: Int) (b: Int) : {r:Int | r >= a && r <= b} = native "random.randint(a, b)"
+def randint (a: Int) (b: Int) : {r:Int | r >= a && r <= b} = native "random.randint(a, b)"
 
 # Returns a random float in the range [0.0, 1.0).
-def Random_random : {r:Float | r >= 0.0 && r < 1.0} = native "random.random()";
+def random : {r:Float | r >= 0.0 && r < 1.0} = native "random.random()";
 
 # Returns a random float N such that a <= N < b.
-def Random_uniform (a: Float) (b: Float) : {r:Float | r >= a && r < b} = native "random.uniform(a, b)"
+def uniform (a: Float) (b: Float) : {r:Float | r >= a && r < b} = native "random.uniform(a, b)"
 
 # Returns a random element from a non-empty list.
-def Random_choice (xs: {l: (List a) | List_size l > 0}) : a = native "random.choice(xs)"
+def choice (xs: {l: (List a) | List.size l > 0}) : a = native "random.choice(xs)"
 
 # Shuffles a list in place.
-def Random_shuffle (xs: (List a)) : Unit = native "random.shuffle(xs)"
+def shuffle (xs: (List a)) : Unit = native "random.shuffle(xs)"
 
 # Returns a k length list of unique elements chosen from the population sequence.
-def Random_sample (k: Int) (xs: {l: (List a) | List_size l >= k}) : {l: (List a) | List_size l == k} = native "random.sample(xs, k)"
+def sample (k: Int) (xs: {l: (List a) | List.size l >= k}) : {l: (List a) | List.size l == k} = native "random.sample(xs, k)"

--- a/libraries/Set.ae
+++ b/libraries/Set.ae
@@ -1,51 +1,51 @@
 type Set a
 
 # Returns the size (number of elements) of the set.
-def Set_size: (s:(Set a)) -> Int = uninterpreted
+def size: (s:(Set a)) -> Int = uninterpreted
 
 # Returns whether the set contains an element.
-def Set_contains: (s:(Set a)) -> (x:a) -> Bool = uninterpreted
+def contains: (s:(Set a)) -> (x:a) -> Bool = uninterpreted
 
 # Creates a new empty set.
-def Set_new : {s:(Set a) | Set_size s == 0} = native "set()";
+def new : {s:(Set a) | size s == 0} = native "set()";
 
 # Adds an element to the set.
 # s: set
 # x: element to add
 # returns: new set with element added
-def Set_add: (s:(Set a)) -> (x:a) -> {s2:(Set a) | Set_size s2 >= Set_size s} = native "set.add(x)";
+def add: (s:(Set a)) -> (x:a) -> {s2:(Set a) | size s2 >= size s} = native "set.add(x)";
 
 # Checks if the set contains an element.
 # s: set
 # x: element to check
 # returns: true if element is in set
-def Set_has: (s:(Set a)) -> (x:a) -> Bool = native "x in s"
+def has: (s:(Set a)) -> (x:a) -> Bool = native "x in s"
 
 # Removes an element from the set.
 # s: set
 # x: element to remove
 # returns: new set with element removed
-def Set_remove: (s:(Set a)) -> (x: {el: a | Set_contains s el}) -> (Set a) = native "set.remove(x)"
+def remove: (s:(Set a)) -> (x: {el: a | contains s el}) -> (Set a) = native "set.remove(x)"
 
 # Returns the union of two sets.
 # s1: set
 # s2: set
 # returns: union of s1 and s2
-def Set_union: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 | s2"
+def union: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 | s2"
 
 # Returns the intersection of two sets.
 # s1: set
 # s2: set
 # returns: intersection of s1 and s2
-def Set_intersection: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 & s2"
+def intersection: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 & s2"
 
 # Returns the difference of two sets.
 # s1: set
 # s2: set
 # returns: elements in s1 but not in s2
-def Set_difference: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 - s2"
+def difference: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 - s2"
 
 # Returns the list of elements in the set.
 # s: set
 # returns: list of elements
-def Set_toList: (s:(Set a)) -> (List a) = native "list(s)"
+def toList: (s:(Set a)) -> (List a) = native "list(s)"

--- a/libraries/Statistics.ae
+++ b/libraries/Statistics.ae
@@ -3,93 +3,93 @@ open List
 # Returns the mean (average) of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: mean of the numbers
-def mean(xs: {x: (List Float) | List_size x > 0}): Float = native "__import__('numpy').mean(xs)"
+def mean(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').mean(xs)"
 
 # Returns the median (middle value) of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: median of the numbers
-def median(xs: {x: (List Float) | List_size x > 0}): Float = native "__import__('numpy').median(xs)"
+def median(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').median(xs)"
 
 # Returns the sample standard deviation of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: standard deviation
-def std(xs: {x: (List Float) | List_size x > 0}): Float = native "__import__('numpy').std(xs, ddof=1)"
+def std(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').std(xs, ddof=1)"
 
 # Returns the sample variance of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: variance
-def var(xs: {x: (List Float) | List_size x > 0}): Float = native "__import__('numpy').var(xs, ddof=1)"
+def var(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').var(xs, ddof=1)"
 
 # Returns the minimum value in a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: minimum value
-def min(xs: {x: (List Float) | List_size x > 0}): Float = native "min(xs)"
+def min(xs: {x: (List Float) | List.size x > 0}): Float = native "min(xs)"
 
 # Returns the maximum value in a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: maximum value
-def max(xs: {x: (List Float) | List_size x > 0}): Float = native "max(xs)"
+def max(xs: {x: (List Float) | List.size x > 0}): Float = native "max(xs)"
 
 # Returns the sum of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: sum of the numbers
-def sum(xs: {x: (List Float) | List_size x > 0}): Float = native "sum(xs)"
+def sum(xs: {x: (List Float) | List.size x > 0}): Float = native "sum(xs)"
 
 # Returns the quantile of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # q: quantile to compute (between 0 and 1, e.g., 0.25 for Q1, 0.5 for median, 0.75 for Q3)
 # returns: quantile value
-def quantile(xs: {x: (List Float) | List_size x > 0}) (q: Float): Float = native "__import__('numpy').quantile(xs, q)"
+def quantile(xs: {x: (List Float) | List.size x > 0}) (q: Float): Float = native "__import__('numpy').quantile(xs, q)"
 
 # Returns the product of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: product of the numbers
-def prod(xs: {x: (List Float) | List_size x > 0}): Float = native "__import__('numpy').prod(xs)"
+def prod(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').prod(xs)"
 
 # Returns the cumulative sum of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: list of cumulative sums
-def cumsum(xs: {x: (List Float) | List_size x > 0}): (List Float) = native "list(__import__('numpy').cumsum(xs))"
+def cumsum(xs: {x: (List Float) | List.size x > 0}): (List Float) = native "list(__import__('numpy').cumsum(xs))"
 
 # Returns the cumulative product of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: list of cumulative products
-def cumprod(xs: {x: (List Float) | List_size x > 0}): (List Float) = native "list(__import__('numpy').cumprod(xs))"
+def cumprod(xs: {x: (List Float) | List.size x > 0}): (List Float) = native "list(__import__('numpy').cumprod(xs))"
 
 # Returns the 1st (Q1), 2nd (median), and 3rd (Q3) quartiles of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: list [Q1, Q2, Q3]
-def quartiles(xs: {x: (List Float) | List_size x > 0}): (List Float) = native "list(__import__('numpy').quantile(xs, [0.25, 0.5, 0.75]))"
+def quartiles(xs: {x: (List Float) | List.size x > 0}): (List Float) = native "list(__import__('numpy').quantile(xs, [0.25, 0.5, 0.75]))"
 
 # Returns the unique values in a non-empty list.
 # xs: non-empty list of numbers
 # returns: list of unique values
-def unique(xs: {x: (List Float) | List_size x > 0}): (List Float) = native "list(__import__('numpy').unique(xs))"
+def unique(xs: {x: (List Float) | List.size x > 0}): (List Float) = native "list(__import__('numpy').unique(xs))"
 
 # Returns the index of the maximum value in a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: index of the maximum value
-def argmax(xs: {x: (List Float) | List_size x > 0}): Float = native "__import__('numpy').argmax(xs)"
+def argmax(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').argmax(xs)"
 
 # Returns the index of the minimum value in a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: index of the minimum value
-def argmin(xs: {x: (List Float) | List_size x > 0}): Float = native "__import__('numpy').argmin(xs)"
+def argmin(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').argmin(xs)"
 
 # Returns the percentile of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # p: percentile to compute (between 0 and 100)
 # returns: percentile value
-def percentile(xs: {x: (List Float) | List_size x > 0}) (p: Float): Float = native "__import__('numpy').percentile(xs, p)"
+def percentile(xs: {x: (List Float) | List.size x > 0}) (p: Float): Float = native "__import__('numpy').percentile(xs, p)"
 
 # Returns the correlation coefficient of two non-empty lists of equal length.
 # xs: non-empty list of numbers
 # ys: non-empty list of numbers, same length as xs
 # returns: correlation coefficient
-def corrcoef(xs: {x: (List Float) | List_size x > 0}) (ys: {y: (List Float) | List_size y == List_size xs}): Float = native "__import__('numpy').corrcoef(xs, ys)[0,1]"
+def corrcoef(xs: {x: (List Float) | List.size x > 0}) (ys: {y: (List Float) | List.size y == List.size xs}): Float = native "__import__('numpy').corrcoef(xs, ys)[0,1]"
 
 # Returns the covariance of two non-empty lists of equal length.
 # xs: non-empty list of numbers
 # ys: non-empty list of numbers, same length as xs
 # returns: covariance
-def cov(xs: {x: (List Float) | List_size x > 0}) (ys: {y: (List Float) | List_size y == List_size xs}): Float = native "__import__('numpy').cov(xs, ys, ddof=1)[0,1]"
+def cov(xs: {x: (List Float) | List.size x > 0}) (ys: {y: (List Float) | List.size y == List.size xs}): Float = native "__import__('numpy').cov(xs, ys, ddof=1)[0,1]"

--- a/libraries/String.ae
+++ b/libraries/String.ae
@@ -5,113 +5,113 @@ type String
 # Returns the length of the string.
 # i: input string
 # returns: number of characters in the string
-def String_len(i: String): Int = native "len(i)"
+def len(i: String): Int = native "len(i)"
 
 # Converts an integer to a string.
 # i: integer
 # returns: string representation of the integer
-def String_intToString(i: Int): String = native "str(i)"
+def intToString(i: Int): String = native "str(i)"
 
 # Checks if two strings are equal.
 # i: first string
 # j: second string
 # returns: true if strings are equal, false otherwise
-def String_equal: (i: String) -> (j: String) -> Bool = \i -> \j -> native "i == j";
+def equal: (i: String) -> (j: String) -> Bool = \i -> \j -> native "i == j";
 
 # Returns a substring (slice) of the string from index j to l (exclusive).
 # i: input string
 # j: start index (>= 0, < length of i)
 # l: end index (>= j, <= length of i)
 # returns: substring from j to l
-def String_slice: (i: String) -> (j: {x: Int | x >= 0 && x < String_len i}) -> (l: {y: Int | y >= j && y <= String_len i}) -> String =
+def slice: (i: String) -> (j: {x: Int | x >= 0 && x < len i}) -> (l: {y: Int | y >= j && y <= len i}) -> String =
     \i -> \j -> \l -> native "i[j:l]";
 
 # Converts the string to uppercase.
 # i: input string
 # returns: uppercase version of the string
-def String_upper: (i: String) -> String = \i -> native "i.upper()"
+def upper: (i: String) -> String = \i -> native "i.upper()"
 
 # Converts the string to lowercase.
 # i: input string
 # returns: lowercase version of the string
-def String_lower: (i: String) -> String = \i -> native "i.lower()"
+def lower: (i: String) -> String = \i -> native "i.lower()"
 
 # Replaces all occurrences of substring j with l in string i.
 # i: input string
 # j: substring to replace (non-empty)
 # l: replacement string
 # returns: new string with replacements
-def String_replace(i: String) (j: {s: String | String_len s > 0}) (l: String): String = native "i.replace(j, l)"
+def replace(i: String) (j: {s: String | len s > 0}) (l: String): String = native "i.replace(j, l)"
 
 # Splits the string by the given separator.
 # i: input string
 # j: separator string (non-empty)
 # returns: list of substrings
-def String_split(i: String) (j: {s: String | String_len s > 0}): (List String) = native "i.split(j)"
+def split(i: String) (j: {s: String | len s > 0}): (List String) = native "i.split(j)"
 
 # Concatenates two strings.
 # i: first string
 # j: second string
 # returns: concatenated string
-def String_concat(i: String) (j: String): String = native "i + j"
+def concat(i: String) (j: String): String = native "i + j"
 
 # Checks if the string starts with the given prefix.
 # i: input string
 # prefix: prefix string
 # returns: true if i starts with prefix
-def String_startsWith(i: String) (prefix: String): Bool = native "i.startswith(prefix)"
+def startsWith(i: String) (prefix: String): Bool = native "i.startswith(prefix)"
 
 # Checks if the string ends with the given suffix.
 # i: input string
 # suffix: suffix string
 # returns: true if i ends with suffix
-def String_endsWith(i: String) (suffix: String): Bool = native "i.endswith(suffix)"
+def endsWith(i: String) (suffix: String): Bool = native "i.endswith(suffix)"
 
 # Finds the first index of substring sub in i, or -1 if not found.
 # i: input string
 # sub: substring to find
 # returns: index of first occurrence or -1
-def String_indexOf(i: String) (sub: String): Int = native "i.find(sub)"
+def indexOf(i: String) (sub: String): Int = native "i.find(sub)"
 
 # Finds the last index of substring sub in i, or -1 if not found.
 # i: input string
 # sub: substring to find
 # returns: index of last occurrence or -1
-def String_lastIndexOf(i: String) (sub: String): Int = native "i.rfind(sub)"
+def lastIndexOf(i: String) (sub: String): Int = native "i.rfind(sub)"
 
 # Checks if the string contains the given substring.
 # i: input string
 # sub: substring to check
 # returns: true if sub is in i
-def String_contains(i: String) (sub: String): Bool = native "sub in i"
+def contains(i: String) (sub: String): Bool = native "sub in i"
 
 # Removes whitespace from both ends of the string.
 # i: input string
 # returns: trimmed string
-def String_trim(i: String): String = native "i.strip()"
+def trim(i: String): String = native "i.strip()"
 
 # Removes whitespace from the left end of the string.
 # i: input string
 # returns: left-trimmed string
-def String_trimLeft(i: String): String = native "i.lstrip()"
+def trimLeft(i: String): String = native "i.lstrip()"
 
 # Removes whitespace from the right end of the string.
 # i: input string
 # returns: right-trimmed string
-def String_trimRight(i: String): String = native "i.rstrip()"
+def trimRight(i: String): String = native "i.rstrip()"
 
 # Repeats the string n times.
 # i: input string
 # n: number of repetitions (>= 0)
 # returns: repeated string
-def String_repeat(i: String) (n: {x: Int | x >= 0}): String = native "i * n"
+def repeat(i: String) (n: {x: Int | x >= 0}): String = native "i * n"
 
 # Returns true if the string is empty.
 # i: input string
 # returns: true if i is empty
-def String_isEmpty(i: String): Bool = native "i == ''"
+def isEmpty(i: String): Bool = native "i == ''"
 
 # Splits the string into a list of characters.
 # i: input string
 # returns: list of single-character strings
-def String_toCharList(i: String): (List String) = native "list(i)"
+def toCharList(i: String): (List String) = native "list(i)"

--- a/libraries/Table.ae
+++ b/libraries/Table.ae
@@ -9,21 +9,21 @@ type Row
 # Reads a CSV file and returns a Table.
 # path: path to the CSV file
 # returns: table loaded from the CSV file
-def Table_from_csv(path: String): Table =
+def from_csv(path: String): Table =
     native "__import__('pandas').read_csv(path).to_dict('records')"
 
 
 # Writes a Table to a CSV file.
 # table: the table to write
 # path: path to the output CSV file
-def Table_to_csv(table: Table) (path: String): Unit =
+def to_csv(table: Table) (path: String): Unit =
     native "__import__('pandas').DataFrame(table).to_csv(path, index=False)"
 
 
 # Returns the list of column names in the table.
 # table: the table to inspect
 # returns: list of column names
-def Table_columns(table: Table): (List String) =
+def columns(table: Table): (List String) =
     native "list(table[0].keys()) if len(table) > 0 else []"
 
 
@@ -31,7 +31,7 @@ def Table_columns(table: Table): (List String) =
 # table: the table to select from
 # columns: columns to select
 # returns: new table with only the selected columns
-def Table_select(table: Table) (columns: (List String)): Table =
+def select(table: Table) (columns: (List String)): Table =
     native "[{col: row[col] for col in columns} for row in table]"
 
 
@@ -39,7 +39,7 @@ def Table_select(table: Table) (columns: (List String)): Table =
 # table: the table to filter
 # predicate: function to decide if a row is kept
 # returns: filtered table
-def Table_filter(table: Table) (predicate: (row: Row) -> Bool): Table =
+def filter(table: Table) (predicate: (row: Row) -> Bool): Table =
     native "[row for row in table if predicate(row)]"
 
 
@@ -48,7 +48,7 @@ def Table_filter(table: Table) (predicate: (row: Row) -> Bool): Table =
 # column: column to modify
 # f: function to apply to each value in the column
 # returns: table with updated column values
-def Table_map_column(table: Table) (column: String) (f: (a: t) -> b): Table =
+def map_column(table: Table) (column: String) (f: (a: t) -> b): Table =
     native "[dict(row, **{column: f(row[column])}) for row in table]"
 
 
@@ -57,7 +57,7 @@ def Table_map_column(table: Table) (column: String) (f: (a: t) -> b): Table =
 # column: column to summarize
 # f: summary function (e.g., sum, mean)
 # returns: result of the summary function
-def Table_summary(table: Table) (column: String) (f: (a: (List Int)) -> b): b =
+def summary(table: Table) (column: String) (f: (a: (List Int)) -> b): b =
     native "f([row[column] for row in table])"
 
 
@@ -66,7 +66,7 @@ def Table_summary(table: Table) (column: String) (f: (a: (List Int)) -> b): b =
 # table: the table to group
 # column: column to group by
 # returns: list of tables, each corresponding to a group
-def Table_group_by(table: Table) (column: String): (List Table) =
+def group_by(table: Table) (column: String): (List Table) =
     native "__import__('aeon.aeon.bindings.table').aeon.aeon.bindings.table.group_by(table, column)"
 
 
@@ -79,7 +79,7 @@ def Table_group_by(table: Table) (column: String): (List Table) =
 # columns: column whose unique values become new columns
 # values: column to fill values from
 # returns: reshaped table (list of dicts)
-def Table_pivot(table: Table) (index: String) (columns: String) (values: String): Table =
+def pivot(table: Table) (index: String) (columns: String) (values: String): Table =
     native "__import__('aeon.aeon.bindings.table').aeon.aeon.bindings.table.pivot(table, index, columns, values)"
 
 
@@ -92,5 +92,5 @@ def Table_pivot(table: Table) (index: String) (columns: String) (values: String)
 # var_name: name for the new variable column
 # value_name: name for the new value column
 # returns: reshaped table (list of dicts)
-def Table_melt(table: Table) (id_vars: (List String)) (value_vars: (List String)) (var_name: String) (value_name: String): Table =
+def melt(table: Table) (id_vars: (List String)) (value_vars: (List String)) (var_name: String) (value_name: String): Table =
     native "__import__('aeon.aeon.bindings.table').aeon.aeon.bindings.table.melt(table, id_vars, value_vars, var_name, value_name)"

--- a/libraries/Tuple.ae
+++ b/libraries/Tuple.ae
@@ -3,28 +3,28 @@ open List
 type Tuple
 
 # Creates a new tuple from two values.
-def Tuple_new(x: a) (y: b): Tuple = native "(x, y)"
+def new(x: a) (y: b): Tuple = native "(x, y)"
 
 # Returns the first element of the tuple.
-def Tuple_fst(t: Tuple): a = native "t[0]"
+def fst(t: Tuple): a = native "t[0]"
 
 # Returns the second element of the tuple.
-def Tuple_snd(t: Tuple): b = native "t[1]"
+def snd(t: Tuple): b = native "t[1]"
 
 # Swaps the elements of the tuple.
-def Tuple_swap(t: Tuple): Tuple = native "(t[1], t[0])"
+def swap(t: Tuple): Tuple = native "(t[1], t[0])"
 
 # Maps a function over the first element of the tuple.
-def Tuple_map_fst(f: (a: t) -> c) (t: Tuple): Tuple = native "(f(t[0]), t[1])"
+def map_fst(f: (a: t) -> c) (t: Tuple): Tuple = native "(f(t[0]), t[1])"
 
 # Maps a function over the second element of the tuple.
-def Tuple_map_snd(f: (b: t) -> c) (t: Tuple): Tuple = native "(t[0], f(t[1]))"
+def map_snd(f: (b: t) -> c) (t: Tuple): Tuple = native "(t[0], f(t[1]))"
 
 # Converts a tuple to a list.
-def Tuple_to_list(t: Tuple): (List a) = native "list(t)"
+def to_list(t: Tuple): (List a) = native "list(t)"
 
 # Checks if two tuples are equal.
-def Tuple_eq(t1: Tuple) (t2: Tuple): Bool = native "t1 == t2"
+def eq(t1: Tuple) (t2: Tuple): Bool = native "t1 == t2"
 
 # Returns the length of the tuple.
-def Tuple_length(t: Tuple): Int = native "len(t)"
+def length(t: Tuple): Int = native "len(t)"

--- a/libraries/Vector.ae
+++ b/libraries/Vector.ae
@@ -1,27 +1,27 @@
 type Vector a;
 
-def Vector_new : forall a:B, (Vector a) = native "[]";
+def new : forall a:B, (Vector a) = native "[]";
 
-def Vector_append : forall a:B, (v:(Vector a)) -> (x:a) -> (Vector a) = \v -> \x -> native "v + [x]";
+def append : forall a:B, (v:(Vector a)) -> (x:a) -> (Vector a) = \v -> \x -> native "v + [x]";
 
-def Vector_get : forall a:B, (v:(Vector a)) -> (i:Int) -> a = \v -> \i -> native "v[i]";
+def get : forall a:B, (v:(Vector a)) -> (i:Int) -> a = \v -> \i -> native "v[i]";
 
-def Vector_set : forall a:B, (v:(Vector a)) -> (i:Int) -> (x:a) -> (Vector a) = \v -> \i -> \x -> native "v[:i] + [x] + v[i+1:]";
+def set : forall a:B, (v:(Vector a)) -> (i:Int) -> (x:a) -> (Vector a) = \v -> \i -> \x -> native "v[:i] + [x] + v[i+1:]";
 
-def Vector_map : forall a:B, forall b:B, (f:(x:a) -> b) -> (v:(Vector a)) -> (size:Int) -> (Vector b) = \f -> \v -> \size ->
+def map : forall a:B, forall b:B, (f:(x:a) -> b) -> (v:(Vector a)) -> (size:Int) -> (Vector b) = \f -> \v -> \size ->
     native "[f(x) for x in v]";
 
-def Vector_reduce : forall a:B, forall b:B, (f:(acc:a) -> (curr:b) -> a) -> (initial:a) -> (v:(Vector b)) -> (size:Int) -> a = \f -> \initial -> \v -> \size ->
+def reduce : forall a:B, forall b:B, (f:(acc:a) -> (curr:b) -> a) -> (initial:a) -> (v:(Vector b)) -> (size:Int) -> a = \f -> \initial -> \v -> \size ->
     native "__import__('functools').reduce(lambda acc, curr: f(acc)(curr), v, initial)";
 
-def Vector_imap : forall a:B, forall b:B, (f:(i:Int) -> (x:a) -> b) -> (v:(Vector a)) -> (size:Int) -> (Vector b) = \f -> \v -> \size ->
+def imap : forall a:B, forall b:B, (f:(i:Int) -> (x:a) -> b) -> (v:(Vector a)) -> (size:Int) -> (Vector b) = \f -> \v -> \size ->
     native "[f(i)(x) for i, x in enumerate(v)]";
 
-def Vector_filter : forall a:B, (f:(x:a) -> Bool) -> (v:(Vector a)) -> (size:Int) -> (Vector a) = \f -> \v -> \size ->
+def filter : forall a:B, (f:(x:a) -> Bool) -> (v:(Vector a)) -> (size:Int) -> (Vector a) = \f -> \v -> \size ->
     native "list(filter(f, v))";
 
-def Vector_zipWith : forall a:B, forall b:B, forall c:B, (f:(x:a) -> (y:b) -> c) -> (v1:(Vector a)) -> (v2:(Vector b)) -> (size:Int) -> (Vector c) = \f -> \v1 -> \v2 -> \size ->
+def zipWith : forall a:B, forall b:B, forall c:B, (f:(x:a) -> (y:b) -> c) -> (v1:(Vector a)) -> (v2:(Vector b)) -> (size:Int) -> (Vector c) = \f -> \v1 -> \v2 -> \size ->
     native "[f(x)(y) for x, y in zip(v1, v2)]";
 
-def Vector_count : forall a:B, (f:(x:a) -> Bool) -> (v:(Vector a)) -> (size:Int) -> Int = \f -> \v -> \size ->
+def count : forall a:B, (f:(x:a) -> Bool) -> (v:(Vector a)) -> (size:Int) -> Int = \f -> \v -> \size ->
     native "len(list(filter(f, v)))";

--- a/tests/llvm_e2e_test.py
+++ b/tests/llvm_e2e_test.py
@@ -74,7 +74,7 @@ def test_e2e_llvm_matrix_sum():
     def add(acc:Int) (curr:Int) : Int = acc + curr;
 
     @llvm
-    def sum_matrix(m:(Vector Int)) (s:Int) : Int = Vector_reduce[Int][Int] add 0 m s;
+    def sum_matrix(m:(Vector Int)) (s:Int) : Int = Vector.reduce[Int][Int] add 0 m s;
 
     def main (i:Int) : Int = sum_matrix (native "[1, 2, 3, 4]") 4;
     """
@@ -91,12 +91,12 @@ def test_e2e_llvm_matrix_filter():
 
     @llvm
     def filter_even(m:(Vector Int)) (s:Int) : (Vector Int) =
-        Vector_filter[Int] (\x:Int -> x % 2 == 0) m s;
+        Vector.filter[Int] (\x:Int -> x % 2 == 0) m s;
 
     def main (i:Int) : Int =
         let m : (Vector Int) = native "[1, 2, 3, 4, 5, 6]" in
         let filtered : (Vector Int) = filter_even m 6 in
-        Vector_get[Int] filtered 0;
+        Vector.get[Int] filtered 0;
     """
     res = compile_and_run(source)
     assert res == 2
@@ -111,13 +111,13 @@ def test_e2e_llvm_matrix_zip_with():
 
     @llvm
     def vec_add(v1:(Vector Int)) (v2:(Vector Int)) (s:Int) : (Vector Int) =
-        Vector_zipWith[Int][Int][Int] (\x:Int -> \y:Int -> x + y) v1 v2 s;
+        Vector.zipWith[Int][Int][Int] (\x:Int -> \y:Int -> x + y) v1 v2 s;
 
     def main (i:Int) : Int =
         let v1 : (Vector Int) = native "[1, 2, 3]" in
         let v2 : (Vector Int) = native "[10, 20, 30]" in
         let v3 : (Vector Int) = vec_add v1 v2 3 in
-        Vector_get[Int] v3 1;
+        Vector.get[Int] v3 1;
     """
     res = compile_and_run(source)
     assert res == 22
@@ -132,7 +132,7 @@ def test_e2e_llvm_matrix_count():
 
     @llvm
     def count_gt_10(v:(Vector Int)) (s:Int) : Int =
-        Vector_count[Int] (\x:Int -> x > 10) v s;
+        Vector.count[Int] (\x:Int -> x > 10) v s;
 
     def main (i:Int) : Int =
         let v : (Vector Int) = native "[5, 15, 8, 25, 3]" in
@@ -151,12 +151,12 @@ def test_e2e_llvm_matrix_map():
 
     @llvm
     def vec_inc(v:(Vector Int)) (s:Int) : (Vector Int) =
-        Vector_map[Int][Int] (\x:Int -> x + 1) v s;
+        Vector.map[Int][Int] (\x:Int -> x + 1) v s;
 
     def main (i:Int) : Int =
         let v : (Vector Int) = native "[1, 2, 3, 4, 5]" in
         let v2 : (Vector Int) = vec_inc v 5 in
-        Vector_get[Int] v2 2;
+        Vector.get[Int] v2 2;
     """
     res = compile_and_run(source)
     assert res == 4
@@ -167,7 +167,7 @@ def test_e2e_llvm_math_integration():
     open Math
 
     @llvm
-    def compute_circle_area(radius:Float) : Float = Math_PI * Math_powf radius 2.0;
+    def compute_circle_area(radius:Float) : Float = Math.PI * Math.powf radius 2.0;
 
     def main (i:Int) : Float = compute_circle_area 5.0;
     """

--- a/tests/llvm_gpu_test.py
+++ b/tests/llvm_gpu_test.py
@@ -15,14 +15,14 @@ def test_gpu_fallback():
 
         @gpu(target="cuda", debug=false, cache=false, block_size=32, thread_count=1024)
         def multiply_by_two (v:(Vector Int)) (size:Int) : (Vector Int) =
-            Vector_map[Int][Int] (\\x:Int -> x * 2) v size;
+            Vector.map[Int][Int] (\\x:Int -> x * 2) v size;
 
         def main (args:Int) : Int =
-            let v : (Vector Int) = Vector_new[Int] in
-            let v2 : (Vector Int) = Vector_append[Int] v 10 in
-            let v3 : (Vector Int) = Vector_append[Int] v2 20 in
+            let v : (Vector Int) = Vector.new[Int] in
+            let v2 : (Vector Int) = Vector.append[Int] v 10 in
+            let v3 : (Vector Int) = Vector.append[Int] v2 20 in
             let res : (Vector Int) = multiply_by_two v3 2 in
-            Vector_get[Int] res 0;
+            Vector.get[Int] res 0;
     """
     config = AeonConfig(synthesizer="none", synthesis_ui=SynthesisUI(), synthesis_budget=0)
     driver = AeonDriver(config)

--- a/tests/llvm_lowerer_test.py
+++ b/tests/llvm_lowerer_test.py
@@ -53,8 +53,8 @@ def test_lower_abstraction_full():
 
 def test_lower_vector_get():
     lowerer = CPULLVMLowerer()
-    # Vector_get vec 0
-    app = Application(Application(Var(Name("Vector_get")), Var(Name("vec"))), Literal(0, t_int))
+    # get vec 0
+    app = Application(Application(Var(Name("get")), Var(Name("vec"))), Literal(0, t_int))
     from aeon.llvm.llvm_ast import LLVMPointerType
 
     type_env = {Name("vec"): LLVMPointerType(LLVMInt)}
@@ -64,9 +64,9 @@ def test_lower_vector_get():
 
 def test_lower_vector_map():
     lowerer = CPULLVMLowerer()
-    # Vector_map (\x -> x + 1) vec sz
+    # map (\x -> x + 1) vec sz
     kernel = Abstraction(Name("x"), Application(Application(Var(Name("+")), Var(Name("x"))), Literal(1, t_int)))
-    app = Application(Application(Application(Var(Name("Vector_map")), kernel), Var(Name("vec"))), Var(Name("sz")))
+    app = Application(Application(Application(Var(Name("map")), kernel), Var(Name("vec"))), Var(Name("sz")))
     from aeon.llvm.llvm_ast import LLVMPointerType
 
     type_env = {Name("vec"): LLVMPointerType(LLVMInt), Name("sz"): LLVMInt}
@@ -77,17 +77,17 @@ def test_lower_vector_map():
 
 def test_lower_math_pow():
     lowerer = CPULLVMLowerer()
-    # Math_pow is (Int, Int) -> Int; mixed float literal is cast to Int.
-    app = Application(Application(Var(Name("Math_pow")), Literal(2, t_int)), Literal(3, t_int))
+    # pow is (Int, Int) -> Int; mixed float literal is cast to Int.
+    app = Application(Application(Var(Name("pow")), Literal(2, t_int)), Literal(3, t_int))
     llvm_pow = lowerer.lower(app)
     from aeon.llvm.llvm_ast import LLVMInt
 
     assert llvm_pow.type == LLVMInt
 
-    # Float exponentiation uses Math_powf : (Double, Double) -> Double
+    # Float exponentiation uses powf : (Double, Double) -> Double
     from aeon.core.types import t_float
     from aeon.llvm.llvm_ast import LLVMDouble
 
-    appf = Application(Application(Var(Name("Math_powf")), Literal(2.0, t_float)), Literal(3.0, t_float))
+    appf = Application(Application(Var(Name("powf")), Literal(2.0, t_float)), Literal(3.0, t_float))
     llvm_powf = lowerer.lower(appf)
     assert llvm_powf.type == LLVMDouble


### PR DESCRIPTION
## Summary

Implements Lean-style qualified name access (`Module.name`) for library definitions and extracts Color into its own inductive module.

### Key changes

- **Strip module prefixes from library definitions**: All libraries (Math, List, Image, etc.) now define functions with bare names (e.g. `pow` instead of `Math_pow`). Users access them via qualified syntax (`Math.pow`) or unqualified after `open Math`.

- **Inductive Color module** (`libraries/Color.ae`): Color is now an inductive type with refined RGB arguments (`0 ≤ v < 256`), replacing the opaque `type Color` + manual constructor/accessors that lived in Image.ae.

- **Import name collision fix**: When multiple imported modules define functions with the same bare name (e.g. `Color.mk` and `Image.mk`), `handle_imports` re-prefixes them with the module name to avoid shadowing in the let-chain. `native_import` definitions are excluded from re-prefixing since their names serve as Python symbol bindings.

- **LLVM backend**: Updated lowerer and converter to handle module-prefixed names (e.g. `Math_powf` → `powf`) when looking up builtin function types, math intrinsics, and polymorphic functions.

### How qualified names work

```
open Image    -- all Image names available unqualified
open Color    -- all Color names available unqualified

-- Qualified access always works:
def img = Image.mk 64 64 (Color.mk 255 255 255)

-- After open, unqualified also works:
def img = mk 64 64 (mk 255 255 255)  -- ambiguous! re-prefix resolves it
```

Internally, `handle_imports` re-prefixes imported definitions (`Color.mk` → `Color_mk`, `Image.mk` → `Image_mk`) so names are unique in the flattened let-chain. Qualified references (`Module.name`) and unqualified references (from `open`) both resolve to these internal prefixed names during desugaring.

## Test plan

- [x] Full test suite passes (407 tests)
- [x] All examples pass (`run_examples.sh`)
- [x] LLVM e2e tests pass (including `test_e2e_llvm_math_integration`)
- [x] Image examples work with new `Color.mk` qualified syntax
- [x] Import examples work correctly
- [x] Pre-commit hooks pass (mypy, ruff, ruff-format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)