### PR TITLE
docs: document new syntax (modules, match, parametric refinements, dot syntax)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,9 +27,8 @@ uvx --from aeonlang aeon [file.ae]
 ### Hello World
 
 ```
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     print "Hello World"
-}
 ```
 
 The documentation is available at [https://alcides.github.io/aeon](https://alcides.github.io/aeon).
@@ -42,9 +41,8 @@ In this example, you can see the refined type `{x:Int | x > 0}` that represents 
 ```
 def sqrt : (i: {x:Int | x > 0} ) -> Float = native "__import__('math').sqrt";
 
-def main (i:Int) : Unit {
+def main (i:Int) : Unit =
     print (sqrt (-25)) # This is a type-checking error!
-}
 ```
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,9 +25,8 @@ Aeon can be executed directly from PyPI using [uvx](https://github.com/astral-sh
 If your aeon file contains a function named `main`, it will be the entrypoint to the program.
 
 ```
-def main (args:Int) : Unit {
+def main (args:Int) : Unit =
     print "Hello World"
-}
 ```
 
 Main returns Unit, which is the singleton type. It can be used like void in C.
@@ -74,16 +73,24 @@ let a = 1.0 - 2.0;
 ## Functions
 
 ```
-def plus (x:Int) (y:Int) : Int {
-    x + y
-}
+def plus (x:Int) (y:Int) : Int = x + y;
 
-def plus : (x:Int) -> (y:Int) -> Int = \x -> \y -> x+y;
+def plus : (x:Int) -> (y:Int) -> Int = \x -> \y -> x + y;
 ```
 
-The above top-level definitions are equal to each-other. The first version defines a function that takes two arguments, and has them available directly in the body. The second version defines an object of type function from int, to a function from int to int (curried, like Haskell), and defines that object using nested lambda functions.
+The above top-level definitions are equal to each other. The first version defines a function that takes two arguments, and has them available directly in the body. The second version defines an object of type function from int, to a function from int to int (curried, like Haskell), and defines that object using nested lambda functions.
 
-`\x -> x + 1` is an annonymous lambda function, which can be annotated with the type `(x:Int) -> Int`.
+`\x -> x + 1` is an anonymous lambda function, which can be annotated with the type `(x:Int) -> Int`.
+
+### The `$` operator
+
+The `$` operator provides right-associative, low-precedence function application, similar to Haskell:
+
+```
+f $ g $ x    # equivalent to f (g x)
+```
+
+When used with parametrically refined functions, `$` preserves refinements through the application chain.
 
 ### Reflected functions and PLE
 
@@ -115,27 +122,50 @@ let x : Int = 1;
 let y : {z:Int | z > 0} = 2; # 0 would raise a type error!
 let w : {z:Int where z > 0} = 2; # equivalent to the above
 
-def plus (x:Int | x > 0) (y:Int | y > 0) : {z:Int | z > x && z > y} {
-    x + y
-}
+def plus (x:Int | x > 0) (y:Int | y > 0) : {z:Int | z > x && z > y} =
+    x + y;
 
 let k = 2; # inferred to be {k:Int | k == 2}
 let g = plus k x; # inferred to be {g:Int | g > 2 && g > 1}
 ```
 
-## Imports
+## Modules and Imports
 
-Currently, Aeon allows to include other files in the current file, similarly to C's include statement.
+Aeon has a Lean-style module system. Each `.ae` file is a module whose name matches the file name (without extension). There are three forms of import:
 
-```
-import "otherfile.ae";
-```
-
-You can also import a specific function from a file:
+### Qualified import
 
 ```
-import myFunction from "otherfile.ae";
+import Math
 ```
+
+After a qualified import, names from the module are accessed via dot syntax: `Math.pow 2 3`. The dot syntax is desugared internally to `Math_pow`.
+
+### Selective import
+
+```
+import Math (pow, abs)
+```
+
+This imports only the listed names, making them available unqualified.
+
+### Open import
+
+```
+open Math
+```
+
+This brings all names from the module into scope unqualified.
+
+### Module resolution
+
+Modules are resolved by searching (in order):
+
+1. The current directory
+2. The `libraries/` directory bundled with Aeon
+3. Directories listed in the `AEONPATH` environment variable
+
+Import results are cached by resolved path, and circular imports are detected and raise an error.
 
 ## Polymorphism
 
@@ -147,13 +177,106 @@ def id : forall t : B, (x : t) -> t = Λ t : B => \x -> x;
 
 The kind `B` represents base types, and `*` represents all types. Type abstraction is introduced with `Λ` (capital lambda) and `=>`.
 
-Aeon also supports refinement polymorphism, allowing a refinement predicate to be abstracted over:
+### Parametric Refinements
+
+Aeon supports refinement polymorphism, allowing a refinement predicate to be abstracted over. This is useful when a function preserves a refinement without needing to know what the refinement is.
+
+#### Implicit style (inferred)
+
+When a type variable appears with `<p>`, Aeon infers the refinement quantifier automatically:
 
 ```
-def id : forall t : B, forall <p : t -> Bool>, (x : t<p>) -> t<p> = Λ t : B => \x -> x;
+def id : (x : t<p>) -> t<p> = \x -> x
+
+def main (args:Int) : Unit =
+    x : Int | x > 0 = 3;
+    y : Int | y > 0 = id x;
+    print y;
 ```
 
-Here, `<p : t -> Bool>` abstracts over a predicate on type `t`, and `t<p>` applies that predicate as a refinement.
+Here `t` and `p` are both inferred. The refinement `x > 0` propagates through `id` because the type `t<p>` preserves whatever predicate `p` the argument satisfies.
+
+Another example — a `maxI` function that preserves the caller's refinement:
+
+```
+def maxI : (x : Int<p>) -> (y : Int<p>) -> Int<p> =
+    \x -> \y -> if x < y then y else x;
+
+def main (args:Int) : Unit =
+    x : Int | x > 0 = 3;
+    y : Int | y > 0 = 5;
+    z : Int | z > 0 = maxI x y;
+    print z;
+```
+
+#### Explicit style
+
+You can also write the refinement quantifier explicitly with `forall <p : T -> Bool>` and introduce it with `Λ`:
+
+```
+def id : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} =
+    Λ t : B => \x -> x;
+
+def main (args:Int) : Unit =
+    x : Int | x > 0 = 3;
+    y : Int | y > 0 = id[Int] x;
+    print y;
+```
+
+#### Refinement application
+
+When calling a function with an explicit refinement parameter, use `{predicate}` to apply the refinement:
+
+```
+id[Int]{\n -> n > 0} x
+```
+
+### Inductive types with parametric refinements
+
+Inductive types can also carry abstract refinement parameters:
+
+```
+inductive Box forall <p : Int -> Bool>
+| mk (x:Int) : Box
+```
+
+## Inductive Types and Pattern Matching
+
+Aeon supports user-defined inductive (algebraic) data types with Lean-style `match` expressions.
+
+### Defining inductive types
+
+```
+inductive IntList
+| empty : IntList
+| cons (hd:Int) (tl:IntList) : IntList
+```
+
+Each constructor is declared with `|`, followed by its name, arguments, and return type.
+
+### Pattern matching
+
+Use `match ... with` to destructure inductive values:
+
+```
+def len (l:IntList) : Int =
+    match l with
+    | empty => 0
+    | cons hd tl => 1 + (len tl);
+```
+
+Each branch binds the constructor's fields by position. The `match` expression is lowered internally to the inductive eliminator (e.g. `IntList_rec`), so all constructors must be covered.
+
+### Measures
+
+Inductive types can declare measure functions with `+`. These are used for refinements on the type itself:
+
+```
+inductive MList a
+| empty : {e:(MList a) | len e == 0}
+| cons (x:a) (y:(MList a)) : {z:(MList a) | len z == (len y + 1)}
++ len (m:(MList a)) : Int
+```
 
 <a name="FFI"></a>
 
@@ -218,9 +341,8 @@ There are a few libraries available, but unstable as they are under development:
 Aeon supports the automatic synthesis of incomplete code. Take the following example:
 
 ```
-def fun (i:Int | i > 0) : (j:Int | j > i) {
-    (?todo : Int)
-}
+def fun (i:Int | i > 0) : (j:Int | j > i) =
+    (?todo : Int);
 ```
 
 This function is incomplete: there is a hole in the program (`?todo`) name todo. If you run this program, the compiler will try to search for an expression to replace the hole with, that has the proper type.
@@ -231,9 +353,8 @@ Because liquid types are limited, you can define your target function using deco
 
 ```
 @minimize(fun 3.0 - 5.0)
-def fun (i:Int | i > 0) : Float {
-    (?todo : Float)
-}
+def fun (i:Int | i > 0) : Float =
+    (?todo : Float);
 ```
 
 - `@minimize(expr)` — minimize the given expression, also extracts training data when the expression matches `f(args) - expected`

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ Aeon is a programming that with a focus on Liquid Types. Liquid types allow deve
 
 ```
 let age : Int = 25;
-let age : (age:Int | age > 0) = 25;
-let age : (age:Int | age >= 18 && age < 130) = 25;
+let age : {age:Int | age > 0} = 25;
+let age : {age:Int | age >= 18 && age < 130} = 25;
 ```
 
 In Aeon, all three declarations are valid, and each more specific than the previous. Liquid Types restrict the domain of values and functions, support assertions in the source code, and can statically catch violations at compile time.
@@ -58,9 +58,16 @@ Aeon supports most operators that exist in mainstream languages.
 let price = 100;
 let total = price + (price * tax / 100);
 let eligible = (age >= 18) && (score > 50);
-let status = if eligible then 1 else 0;
-let best = Math_max score1 score2; # function application uses spaces
+let discount = if price > 50 then 10 else 0;
 true
+```
+
+Function application uses spaces (no parentheses around arguments):
+
+```
+open Math
+# ...
+let result = Math_max 10 20;
 ```
 
 Arithmetic operators work on both integers and floats:

--- a/docs/index.md
+++ b/docs/index.md
@@ -222,11 +222,11 @@ You can write the refinement quantifier explicitly with `forall <p : T -> Bool>`
 
 ```
 def wrap : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} =
-    Λ t : B => \x -> x;
+    Λ t : B => Λ <p : t -> Bool> => \x -> x;
 
 def main (args:Int) : Unit =
     score : Int | score > 0 = 42;
-    safe_score : Int | safe_score > 0 = wrap[Int] score;
+    safe_score : Int | safe_score > 0 = wrap[Int]{\n -> n > 0} score;
     print safe_score;
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,12 @@
 Aeon is a programming that with a focus on Liquid Types. Liquid types allow developers to be more specific and annotate their types with a predicate.
 
 ```
-let x : Int = 3;
-let x : (x:Int | x > 0) = 3;
-let x : (x:Int | x == 0) = 3;
+let age : Int = 25;
+let age : (age:Int | age > 0) = 25;
+let age : (age:Int | age >= 18 && age < 130) = 25;
 ```
 
-In aeon, all three declarations are valid, and each more specific than the previous. Liquid Types are able to restrict the domain of functions, support assertions in the source code and even statically detect violations of state machines.
+In Aeon, all three declarations are valid, and each more specific than the previous. Liquid Types restrict the domain of values and functions, support assertions in the source code, and can statically catch violations at compile time.
 
 There are other languages with Liquid Types, such as [LiquidHaskell](https://ucsd-progsys.github.io/liquidhaskell/), [LiquidJava](https://catarinagamboa.github.io/liquidjava.html), or Rust with [Flux](https://flux-rs.github.io/flux/). But while these languages add liquid types to an existing language, aeon is built with support from liquid types from the start.
 
@@ -55,27 +55,27 @@ Just like in Python, any line starting with # is a comment.
 Aeon supports most operators that exist in mainstream languages.
 
 ```
-let a = 1;
-let b = a + (b * (c / d));
-let c = (a == 1) || ((b >= 2) && (a > b));
-let d = if a == 1 then 2 else 2;
-let e = Math_max 2 5; # function application uses spaces.
+let price = 100;
+let total = price + (price * tax / 100);
+let eligible = (age >= 18) && (score > 50);
+let status = if eligible then 1 else 0;
+let best = Math_max score1 score2; # function application uses spaces
 true
 ```
 
 Arithmetic operators work on both integers and floats:
 
 ```
-let a = 1.0 + 2.0;
-let a = 1.0 - 2.0;
+let celsius = 36.6;
+let fahrenheit = celsius * 1.8 + 32.0;
 ```
 
 ## Functions
 
 ```
-def plus (x:Int) (y:Int) : Int = x + y;
+def add (x:Int) (y:Int) : Int = x + y;
 
-def plus : (x:Int) -> (y:Int) -> Int = \x -> \y -> x + y;
+def add : (x:Int) -> (y:Int) -> Int = \x -> \y -> x + y;
 ```
 
 The above top-level definitions are equal to each other. The first version defines a function that takes two arguments, and has them available directly in the body. The second version defines an object of type function from int, to a function from int to int (curried, like Haskell), and defines that object using nested lambda functions.
@@ -87,7 +87,7 @@ The above top-level definitions are equal to each other. The first version defin
 The `$` operator provides right-associative, low-precedence function application, similar to Haskell:
 
 ```
-f $ g $ x    # equivalent to f (g x)
+print $ int_to_string $ add 2 3    # equivalent to print (int_to_string (add 2 3))
 ```
 
 When used with parametrically refined functions, `$` preserves refinements through the application chain.
@@ -118,15 +118,23 @@ Before SMT solving, Aeon also simplifies generated verification constraints (boo
 Types in Aeon can be very expressive. In refined types, `where` can be used interchangeably with `|`:
 
 ```
-let x : Int = 1;
-let y : {z:Int | z > 0} = 2; # 0 would raise a type error!
-let w : {z:Int where z > 0} = 2; # equivalent to the above
+let count : Int = 5;
+let count : {n:Int | n > 0} = 5;            # 0 would raise a type error!
+let count : {n:Int where n > 0} = 5;        # equivalent to the above
 
-def plus (x:Int | x > 0) (y:Int | y > 0) : {z:Int | z > x && z > y} =
-    x + y;
+def divide (num:Int) (den:Int | den != 0) : Int =
+    native "num // den";
 
-let k = 2; # inferred to be {k:Int | k == 2}
-let g = plus k x; # inferred to be {g:Int | g > 2 && g > 1}
+def withdraw (balance:Int | balance >= 0) (amount:Int | amount > 0 && amount <= balance)
+    : {result:Int | result >= 0} =
+    balance - amount;
+```
+
+Aeon infers the most precise type it can for each binding:
+
+```
+let balance = 1000;                          # inferred: {balance:Int | balance == 1000}
+let remaining = withdraw balance 200;        # inferred: {remaining:Int | remaining >= 0}
 ```
 
 ## Modules and Imports
@@ -186,58 +194,50 @@ Aeon supports refinement polymorphism, allowing a refinement predicate to be abs
 When a type variable appears with `<p>`, Aeon infers the refinement quantifier automatically:
 
 ```
-def id : (x : t<p>) -> t<p> = \x -> x
-
-def main (args:Int) : Unit =
-    x : Int | x > 0 = 3;
-    y : Int | y > 0 = id x;
-    print y;
+def clamp : (x : Int<p>) -> (lo : Int<p>) -> (hi : Int<p>) -> Int<p> =
+    \x -> \lo -> \hi -> if x < lo then lo else if x > hi then hi else x;
 ```
 
-Here `t` and `p` are both inferred. The refinement `x > 0` propagates through `id` because the type `t<p>` preserves whatever predicate `p` the argument satisfies.
-
-Another example — a `maxI` function that preserves the caller's refinement:
+The predicate `p` is inferred. Whatever refinement the caller's arguments satisfy, the result is guaranteed to satisfy it too:
 
 ```
-def maxI : (x : Int<p>) -> (y : Int<p>) -> Int<p> =
-    \x -> \y -> if x < y then y else x;
-
 def main (args:Int) : Unit =
-    x : Int | x > 0 = 3;
-    y : Int | y > 0 = 5;
-    z : Int | z > 0 = maxI x y;
-    print z;
+    temp : Int | temp >= 0 = 50;
+    lo : Int | lo >= 0 = 10;
+    hi : Int | hi >= 0 = 100;
+    result : Int | result >= 0 = clamp temp lo hi;  # refinement preserved!
+    print result;
 ```
 
 #### Explicit style
 
-You can also write the refinement quantifier explicitly with `forall <p : T -> Bool>` and introduce it with `Λ`:
+You can write the refinement quantifier explicitly with `forall <p : T -> Bool>` and introduce it with `Λ`:
 
 ```
-def id : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} =
+def wrap : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} =
     Λ t : B => \x -> x;
 
 def main (args:Int) : Unit =
-    x : Int | x > 0 = 3;
-    y : Int | y > 0 = id[Int] x;
-    print y;
+    score : Int | score > 0 = 42;
+    safe_score : Int | safe_score > 0 = wrap[Int] score;
+    print safe_score;
 ```
 
 #### Refinement application
 
-When calling a function with an explicit refinement parameter, use `{predicate}` to apply the refinement:
+When calling a function with an explicit refinement parameter, use `{predicate}` to supply the refinement:
 
 ```
-id[Int]{\n -> n > 0} x
+wrap[Int]{\n -> n > 0} score
 ```
 
 ### Inductive types with parametric refinements
 
-Inductive types can also carry abstract refinement parameters:
+Inductive types can also carry abstract refinement parameters, allowing the same data structure to enforce different invariants depending on context:
 
 ```
-inductive Box forall <p : Int -> Bool>
-| mk (x:Int) : Box
+inductive Container forall <p : Int -> Bool>
+| mk (value:Int) : Container
 ```
 
 ## Inductive Types and Pattern Matching
@@ -289,16 +289,20 @@ native : forall a:*, String -> a
 native_import : forall a:*, String -> a
 ```
 
-You can use native to obtain anything you want:
+You can use `native` to evaluate any Python expression:
 
 ```
-let x : {x:Int | x > 0} = native "1+2";
-let x : List = native "[1,2,3]";
+let pi : Float = native "3.14159265";
+let primes : List = native "[2, 3, 5, 7, 11]";
 ```
 
-Using native allows you to convert any Python expression in a string to an Aeon object. Note that this is not type-checked statically, so you may write invalid code that will crash like `(native "2+2" : Float)`.
+Using `native` allows you to embed any Python expression as an Aeon value. Note that this is not type-checked statically, so an incorrect type annotation will crash at runtime.
 
-`let numpy = native_import "numpy";` allows developers to import Python modules directly.
+`native_import` allows importing Python modules directly:
+
+```
+let numpy = native_import "numpy";
+```
 
 ## Libraries
 
@@ -341,20 +345,20 @@ There are a few libraries available, but unstable as they are under development:
 Aeon supports the automatic synthesis of incomplete code. Take the following example:
 
 ```
-def fun (i:Int | i > 0) : (j:Int | j > i) =
-    (?todo : Int);
+def next_even (n:Int | n >= 0) : {r:Int | r > n && r % 2 == 0} =
+    (?hole : Int);
 ```
 
-This function is incomplete: there is a hole in the program (`?todo`) name todo. If you run this program, the compiler will try to search for an expression to replace the hole with, that has the proper type.
+This function is incomplete: there is a hole in the program (`?hole`). When you run this program with a synthesizer, Aeon will search for an expression to replace the hole with, that satisfies the refined return type.
 
 Because liquid types are limited, you can define your target function using decorators. The following decorators are available for guiding synthesis:
 
 ### Optimization decorators
 
 ```
-@minimize(fun 3.0 - 5.0)
-def fun (i:Int | i > 0) : Float =
-    (?todo : Float);
+@minimize(approx 3.0 - 5.0)
+def approx (x:Int | x > 0) : Float =
+    (?hole : Float);
 ```
 
 - `@minimize(expr)` — minimize the given expression, also extracts training data when the expression matches `f(args) - expected`


### PR DESCRIPTION
## Summary

- Document the **Lean-style module system**: `import`, `import ... (names)`, `open`, and qualified dot syntax (`Math.pow`)
- Document **pattern matching** on inductive types with `match ... with` and measures
- Document **parametric refinements**: implicit `t<p>` inference, explicit `forall <p : T -> Bool>`, refinement application `{pred}`, and inductive types with abstract refinement parameters
- Document the **`$` operator** for right-associative function application with refinement preservation
- Document **inductive types** with constructors, pattern matching, and measure functions
- Modernize all code examples from `{ body }` to `= body` syntax
- Replace abstract/meaningless examples (`x`, `a`, `fun`, `foo`) with motivating real-world ones (`age`, `withdraw`, `divide`, `clamp`, `celsius`, `next_even`, etc.)

## Test plan

- [ ] Verify documentation renders correctly on GitHub Pages
- [ ] Cross-check code examples against existing test fixtures (`intlist_len_match.ae`, `id.ae`, `maxI.ae`, `implicit_id.ae`, `import.ae`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)