### PR TITLE
Add selfification for reflected function unfolding (fixes #208)

### DIFF
--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -96,6 +96,14 @@ def _strip_type_level_wrappers(t: Term) -> Term:
     return t
 
 
+def _has_horn(t: LiquidTerm) -> bool:
+    if isinstance(t, LiquidHornApplication):
+        return True
+    if isinstance(t, LiquidApp):
+        return any(_has_horn(a) for a in t.args)
+    return False
+
+
 def _reflected_impl_for(
     name: Name,
     ty: Type,
@@ -103,12 +111,6 @@ def _reflected_impl_for(
     *,
     has_termination_metric: bool = False,
 ) -> tuple[tuple[Name, ...], LiquidTerm] | None:
-    def has_horn(t: LiquidTerm) -> bool:
-        if isinstance(t, LiquidHornApplication):
-            return True
-        if isinstance(t, LiquidApp):
-            return any(has_horn(a) for a in t.args)
-        return False
 
     if not isinstance(ty, AbstractionType):
         if not isinstance(ty, (TypePolymorphism, RefinementPolymorphism)):
@@ -139,7 +141,7 @@ def _reflected_impl_for(
     liq = liquefy(current)
     if liq is None:
         return None
-    if has_horn(liq):
+    if _has_horn(liq):
         return None
     for src, dst in zip(impl_params, ty_params):
         if src != dst:
@@ -355,6 +357,24 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                     cp = check(ctx, arg, atype)
                     t_subs = substitution_in_type(rtype, arg, aname)
                     c0 = Conjunction(c, cp)
+                    # Selfify: when the return type is a bare base type and the
+                    # function is a user-defined name (not an ANF temp or operator),
+                    # refine the result with v == f(arg) so PLE can unfold reflected functions.
+                    if (
+                        isinstance(t_subs, TypeConstructor)
+                        and t_subs in (t_int, t_bool)
+                        and isinstance(fun, Var)
+                        and fun.name not in ops
+                        and not fun.name.name.startswith("anf")
+                    ):
+                        liq_app = liquefy(t)
+                        if liq_app is not None and isinstance(liq_app, LiquidApp) and not _has_horn(liq_app):
+                            vname = Name("v", fresh_counter.fresh())
+                            t_subs = RefinedType(
+                                vname,
+                                t_subs,
+                                LiquidApp(Name("==", 0), [LiquidVar(vname), liq_app]),
+                            )
                     return (c0, t_subs)
                 case _:
                     raise CoreInvalidApplicationError(t, ty)


### PR DESCRIPTION
## Summary

- Selfifies function application results in the `synth` function of `typeinfer.py`: when a user-defined function returns a bare `Int` or `Bool`, the result type is refined with `v == f(arg)` so PLE can unfold reflected function definitions during SMT verification.
- Extracts `_has_horn` as a module-level helper (was previously nested inside `_reflected_impl_for`).
- Restricted to `Int`/`Bool` return types to avoid a Z3 sort mismatch — Float variables use `z3.Real` but function sorts use `Float64()`.

## Example that now works

```aeon
def inc (x:Int) : Int = x + 1;
def witness (x:Int) : {v:Int | v > x} = inc x;
```

Previously `witness` failed verification because the solver couldn't unfold `inc x` to `x + 1`. Now selfification adds `v == inc(x)` to the result type, enabling PLE to prove `v > x`.

## Test plan

- [x] All 407 existing tests pass
- [x] Reflected `inc`/`witness` example verifies successfully
- [x] `csv_decorators_test.py` (Float functions) still passes — no selfification applied to Float returns
- [ ] Manual review: verify selfification doesn't fire for operators, ANF temps, or Horn-containing applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)