### PR TITLE
Add support for destructive function arguments

### DIFF
--- a/aeon/core/bind.py
+++ b/aeon/core/bind.py
@@ -125,7 +125,9 @@ def bind_type(ty: Type, subs: RenamingSubstitions) -> Type:
         case AbstractionType(aname, atype, rtype, loc):
             nname, nsubs = check_name(aname, subs)
 
-            return AbstractionType(nname, bind_type(atype, subs), bind_type(rtype, nsubs), loc=loc)
+            return AbstractionType(
+                nname, bind_type(atype, subs), bind_type(rtype, nsubs), loc=loc, destructive=ty.destructive
+            )
         case RefinedType(name, ty, ref, loc):
             nty = bind_type(ty, subs)
             nname, nsubs = check_name(name, subs)

--- a/aeon/core/instantiation.py
+++ b/aeon/core/instantiation.py
@@ -35,7 +35,7 @@ def type_substitution(t: Type, alpha: Name, beta: Type) -> Type:
                 case city:
                     return RefinedType(name, city, ref, loc=loc)
         case AbstractionType(aname, aty, rty, loc):
-            return AbstractionType(aname, rec(aty), rec(rty), loc=loc)
+            return AbstractionType(aname, rec(aty), rec(rty), loc=loc, destructive=t.destructive)
         case TypePolymorphism(name, kind, body, loc):
             if name == alpha:
                 return t
@@ -79,7 +79,7 @@ def type_variable_instantiation(t: Type, alpha: Name, beta: Type) -> Type:
         case RefinedType(name, inner, ref, loc):
             return RefinedType(name, rec(inner), ref, loc)
         case AbstractionType(vn, vt, rt, loc):
-            return AbstractionType(vn, rec(vt), rec(rt), loc)
+            return AbstractionType(vn, rec(vt), rec(rt), loc, destructive=t.destructive)
         case TypePolymorphism(name, kind, body, loc):
             return TypePolymorphism(name, kind, rec(body), loc)
         case RefinementPolymorphism(name, sort, body, loc):

--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -48,7 +48,7 @@ def substitute_vartype(t: Type, rep: Type, name: Name) -> Type:
             assert not isinstance(ty, RefinedType)
             return RefinedType(rname, rec(ty), ref, loc=loc)
         case AbstractionType(a, aty, rty, loc):
-            return AbstractionType(a, rec(aty), rec(rty), loc=loc)
+            return AbstractionType(a, rec(aty), rec(rty), loc=loc, destructive=t.destructive)
         case TypePolymorphism(pname, kind, body, loc):
             if name == pname:
                 return t
@@ -164,6 +164,7 @@ def instantiate_refinement_in_type(
                 instantiate_refinement_in_type(atype, pred_name, refinement),
                 instantiate_refinement_in_type(rtype, pred_name, refinement),
                 loc=loc,
+                destructive=t.destructive,
             )
         # b{ν:p}[ρ := φ] = b[ρ := φ]{ν:p[ρ := φ]} per tutorial fig 8.6
         case RefinedType(vname, ity, ref, loc):
@@ -242,7 +243,7 @@ def instantiate_refinement_with_horn_in_type(
         case TypeConstructor(name, args, loc):
             return TypeConstructor(name, [rec(a) for a in args], loc=loc)
         case AbstractionType(aname, atype, rtype, loc):
-            return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
+            return AbstractionType(aname, rec(atype), rec(rtype), loc=loc, destructive=t.destructive)
         case RefinedType(vname, ity, ref, loc):
             nity = rec(ity)
             assert isinstance(nity, TypeConstructor) or isinstance(nity, TypeVar)
@@ -306,7 +307,7 @@ def substitution_liquid_in_type(t: Type, rep: LiquidTerm, name: Name) -> Type:
             if aname == name:
                 return t
             else:
-                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
+                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc, destructive=t.destructive)
         case RefinedType(vname, ity, ref, loc):
             if name == vname:
                 return t
@@ -378,7 +379,7 @@ def substitution_in_type(t: Type, rep: Term, name: Name) -> Type:
             if aname == name:
                 return t
             else:
-                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
+                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc, destructive=t.destructive)
         case RefinedType(vname, ity, ref, loc):
             if name == vname:
                 return t

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -82,9 +82,11 @@ class AbstractionType(Type):
     var_type: Type
     type: Type
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    destructive: bool = False
 
     def __repr__(self):
-        return f"({self.var_name}:{self.var_type}) -> {self.type}"
+        bang = "!" if self.destructive else ""
+        return f"({bang}{self.var_name}:{self.var_type}) -> {self.type}"
 
     def __eq__(self, other):
         return (
@@ -92,10 +94,11 @@ class AbstractionType(Type):
             and self.var_name == other.var_name
             and self.var_type == other.var_type
             and self.type == other.type
+            and self.destructive == other.destructive
         )
 
     def __hash__(self) -> int:
-        return hash(self.var_name) + hash(self.var_type) + hash(self.type)
+        return hash(self.var_name) + hash(self.var_type) + hash(self.type) + hash(self.destructive)
 
 
 @dataclass

--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -117,6 +117,7 @@ def collect_core_decorator_queue(
                         rforalls,
                         decreasing_by,
                         loc,
+                        destructive_args=d.destructive_args,
                     )
                 )
             case _:

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -211,6 +211,7 @@ def remove_unions_and_intersections(ctx: ElaborationTypingContext, ty: SType) ->
                 var_type=remove_unions_and_intersections(ctx, vtype),
                 type=remove_unions_and_intersections(ctx, rtype),
                 loc=loc,
+                destructive=ty.destructive,
             )
         case STypePolymorphism(name, kind, body, loc):
             return STypePolymorphism(
@@ -444,7 +445,9 @@ def replace_unification_variables(
             case STypeVar(_):
                 return ty
             case SAbstractionType(name, vty, rty, loc=loc):
-                return SAbstractionType(name, go(ctx, vty, not polarity), go(ctx, rty, polarity), loc=loc)
+                return SAbstractionType(
+                    name, go(ctx, vty, not polarity), go(ctx, rty, polarity), loc=loc, destructive=ty.destructive
+                )
             case SRefinedType(name, ity, ref, loc=loc):
                 nt = go(ctx, ity, polarity)
                 return SRefinedType(name, nt, ref, loc=loc)

--- a/aeon/elaboration/instantiation.py
+++ b/aeon/elaboration/instantiation.py
@@ -30,7 +30,7 @@ def type_substitution(ty: SType, alpha: Name, beta: SType) -> SType:
         case SRefinedType(name, ity, ref, loc):
             return normalize(SRefinedType(name, rec(ity), ref, loc=loc))
         case SAbstractionType(name, vty, rty, loc):
-            return SAbstractionType(name, rec(vty), rec(rty), loc=loc)
+            return SAbstractionType(name, rec(vty), rec(rty), loc=loc, destructive=ty.destructive)
         case STypePolymorphism(name, kind, body, loc):
             # TODO: Double-check alpha_renaming in substitution
             if name == alpha:

--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -141,6 +141,21 @@ class CoreVariableNotInContext(CoreTypeCheckingError):
 
 
 @dataclass
+class CoreDestroyedVariableUseError(CoreTypeCheckingError):
+    """Raised when a variable previously consumed by a destructive function
+    argument is used again."""
+
+    ctx: TypingContext
+    term: Term
+
+    def __str__(self) -> str:
+        return f"Variable {self.term} has been consumed by a destructive function argument and is no longer available."
+
+    def position(self) -> Location:
+        return self.term.loc
+
+
+@dataclass
 class CoreInvalidApplicationError(CoreTypeCheckingError):
     term: Term
     type: Type

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -54,6 +54,8 @@ args :                          -> empty_list
 
 arg : "(" ID ":" type ")"                       -> arg
     | "(" ID ":" type _PIPE expression ")"      -> refined_arg
+    | "(" "!" ID ":" type ")"                       -> destructive_arg
+    | "(" "!" ID ":" type _PIPE expression ")"      -> destructive_refined_arg
 
 
 type : "{" ID ":" type _PIPE expression "}"                -> refined_t // TODO delete later

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -212,7 +212,16 @@ def _bind_definition(
         ndargs = {name: bind_sterm(da, nsubs) for name, da in dec.named_args.items()}
         decorators.append(Decorator(dec.name, dargs, ndargs))
     return Definition(
-        name, foralls, args, ntype, body, decorators, rforalls, decreasing_by=decreasing, loc=df.loc
+        name,
+        foralls,
+        args,
+        ntype,
+        body,
+        decorators,
+        rforalls,
+        decreasing_by=decreasing,
+        loc=df.loc,
+        destructive_args=df.destructive_args,
     ), nsubs
 
 

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -224,6 +224,7 @@ def lower_by_blocks_in_definitions(
                         rforalls,
                         decreasing_by,
                         loc,
+                        destructive_args=d.destructive_args,
                     )
                 )
             case _:
@@ -342,7 +343,18 @@ def resolve_qualified_names_in_definition(
     )
     if new_body is d.body and new_args == d.args and new_type is d.type:
         return d
-    return Definition(d.name, d.foralls, new_args, new_type, new_body, d.decorators, d.rforalls, d.decreasing_by, d.loc)
+    return Definition(
+        d.name,
+        d.foralls,
+        new_args,
+        new_type,
+        new_body,
+        d.decorators,
+        d.rforalls,
+        d.decreasing_by,
+        d.loc,
+        destructive_args=d.destructive_args,
+    )
 
 
 def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType] | None = None) -> DesugaredProgram:
@@ -772,6 +784,7 @@ def introduce_forall_in_types(defs: list[Definition], type_decls: list[TypeDecl]
                         rforalls,
                         decreasing_by,
                         loc,
+                        destructive_args=d.destructive_args,
                     )
                 )
     return ndefs
@@ -856,6 +869,7 @@ def introduce_rforall_in_types(defs: list[Definition]) -> list[Definition]:
                         final_rforalls,
                         decreasing_by,
                         loc,
+                        destructive_args=d.destructive_args,
                     )
                 )
     return ndefs
@@ -945,6 +959,7 @@ def handle_imports(
                 d.rforalls,
                 d.decreasing_by,
                 d.loc,
+                destructive_args=d.destructive_args,
             )
             prefixed_definitions.append(prefixed_d)
 
@@ -1031,8 +1046,10 @@ def type_of_definition(d: Definition) -> SType:
     match d:
         case Definition(_, foralls, args, rtype, _, _, rforalls, _, loc):
             ntype = rtype
-            for name, atype in reversed(args):
-                ntype = SAbstractionType(name, atype, ntype, loc)
+            n_args = len(args)
+            for i, (name, atype) in enumerate(reversed(args)):
+                destructive = d.is_destructive(n_args - 1 - i)
+                ntype = SAbstractionType(name, atype, ntype, loc, destructive=destructive)
             for name, sort in reversed(rforalls):
                 ntype = SRefinementPolymorphism(name, sort, ntype, loc)
             for name, kind in reversed(foralls):
@@ -1048,8 +1065,10 @@ def convert_definition_to_srec(prog: STerm, d: Definition) -> STerm:
         case Definition(dname, foralls, args, rtype, body, _, rforalls, decreasing_by, loc):
             ntype = rtype
             nbody = body
-            for name, atype in reversed(args):
-                ntype = SAbstractionType(name, atype, ntype, loc=loc)
+            n_args = len(args)
+            for i, (name, atype) in enumerate(reversed(args)):
+                destructive = d.is_destructive(n_args - 1 - i)
+                ntype = SAbstractionType(name, atype, ntype, loc=loc, destructive=destructive)
                 nbody = SAbstraction(name, nbody, loc=loc)
             for name, sort in reversed(rforalls):
                 ntype = SRefinementPolymorphism(name, sort, ntype, loc=loc)

--- a/aeon/sugar/lifting.py
+++ b/aeon/sugar/lifting.py
@@ -91,7 +91,7 @@ def lift_type(ty: Type) -> SType:
         case TypeConstructor(name, args, loc):
             return STypeConstructor(name, [lift_type(arg) for arg in args], loc=loc)
         case AbstractionType(name, atype, rtype, loc):
-            return SAbstractionType(name, lift_type(atype), lift_type(rtype), loc=loc)
+            return SAbstractionType(name, lift_type(atype), lift_type(rtype), loc=loc, destructive=ty.destructive)
         case RefinedType(name, typ, ref, loc):
             from aeon.core.types import LiquidHornApplication
 

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -201,6 +201,7 @@ def type_to_core(ty: SType, available_vars: list[tuple[Name, TypeConstructor | T
         case STypeVar(name, loc):
             return TypeVar(name, loc=loc)
         case SAbstractionType(name, vty, rty, loc):
+            destructive = getattr(ty, "destructive", False)
             nname = Name(name.name, fresh_counter.fresh())
             at = type_to_core(vty, available_vars)
             if isinstance(at, TypeConstructor) or isinstance(at, TypeVar) or isinstance(at, RefinedType):
@@ -208,7 +209,7 @@ def type_to_core(ty: SType, available_vars: list[tuple[Name, TypeConstructor | T
                 nrty = substitution_sterm_in_stype(rty, SVar(nname), name)
             else:
                 nrty = rty
-            return AbstractionType(nname, at, type_to_core(nrty, available_vars), loc=loc)
+            return AbstractionType(nname, at, type_to_core(nrty, available_vars), loc=loc, destructive=destructive)
         case STypePolymorphism(name, kind, rty, loc):
             return TypePolymorphism(name, kind, type_to_core(rty, available_vars), loc=loc)
         case SRefinementPolymorphism(name, sort, body, loc):

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -58,6 +58,21 @@ def ensure_list(a):
         return [a]
 
 
+def _split_destructive(fn_args):
+    """Split parser argument 3-tuples ``(name, type, destructive)`` back into the legacy
+    ``(name, type)`` pair list plus a parallel tuple of destructive booleans."""
+    plain_args: list = []
+    destructive_flags: list[bool] = []
+    for a in fn_args:
+        if isinstance(a, tuple) and len(a) == 3:
+            plain_args.append((a[0], a[1]))
+            destructive_flags.append(bool(a[2]))
+        else:
+            plain_args.append(a)
+            destructive_flags.append(False)
+    return plain_args, tuple(destructive_flags)
+
+
 class AnnotatedStr(str):
     loc: Location
 
@@ -384,7 +399,16 @@ class TreeToSugar(Transformer):
 
     @v_args(meta=True)
     def def_ind_cons(self, meta, args):
-        return Definition(Name(args[0]), [], args[1], args[2], SLiteral(None, st_unit), loc=self._loc(meta))
+        plain_args, destructive_flags = _split_destructive(args[1])
+        return Definition(
+            Name(args[0]),
+            [],
+            plain_args,
+            args[2],
+            SLiteral(None, st_unit),
+            loc=self._loc(meta),
+            destructive_args=destructive_flags,
+        )
 
     def decreasing_by_none(self, args):
         return []
@@ -400,27 +424,31 @@ class TreeToSugar(Transformer):
     def def_fun(self, meta, args):
         if len(args) == 5:
             name, fn_args, rtype, decr, body = args
+            plain_args, destructive_flags = _split_destructive(fn_args)
             return Definition(
                 Name(name),
                 [],
-                fn_args,
+                plain_args,
                 rtype,
                 body,
                 decreasing_by=ensure_list(decr),
                 loc=self._loc(meta),
+                destructive_args=destructive_flags,
             )
         if len(args) == 6:
             decorators, name, fn_args, rtype, decr, body = args
+            plain_args, destructive_flags = _split_destructive(fn_args)
             return Definition(
                 Name(name),
                 [],
-                fn_args,
+                plain_args,
                 rtype,
                 body,
                 decorators,
                 [],
                 decreasing_by=ensure_list(decr),
                 loc=self._loc(meta),
+                destructive_args=destructive_flags,
             )
         raise AssertionError(f"def_fun: unexpected args {args!r}")
 
@@ -463,10 +491,16 @@ class TreeToSugar(Transformer):
         return args
 
     def arg(self, args):
-        return (Name(args[0]), args[1])
+        return (Name(args[0]), args[1], False)
 
     def refined_arg(self, args):
-        return Name(args[0]), SRefinedType(Name(args[0]), args[1], args[2])
+        return Name(args[0]), SRefinedType(Name(args[0]), args[1], args[2]), False
+
+    def destructive_arg(self, args):
+        return (Name(args[0]), args[1], True)
+
+    def destructive_refined_arg(self, args):
+        return Name(args[0]), SRefinedType(Name(args[0]), args[1], args[2]), True
 
     def abstraction_refined_t(self, args):
         type = SRefinedType(Name(args[0]), args[1], args[2])

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -400,15 +400,21 @@ class Definition(Node):
     rforalls: list[tuple[Name, SType]] = field(default_factory=list)
     decreasing_by: list[STerm] = field(default_factory=list)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    destructive_args: tuple[bool, ...] = field(default_factory=tuple)
 
     def __post_init__(self):
         assert isinstance(self.type, SType)
+
+    def is_destructive(self, i: int) -> bool:
+        if i < len(self.destructive_args):
+            return bool(self.destructive_args[i])
+        return False
 
     def __str__(self):
         if not self.args:
             return f"def {self.name} : {self.type} = {self.body};"
         else:
-            args = ", ".join([f"{n}:{t}" for (n, t) in self.args])
+            args = ", ".join([f"{'!' if self.is_destructive(i) else ''}{n}:{t}" for i, (n, t) in enumerate(self.args)])
             foralls = " ".join([f"∀{n}:{k}" for (n, k) in self.foralls])
             rforalls = " ".join([f"∀<{n}:{s} -> Bool>" for (n, s) in self.rforalls])
             sep = " " if (foralls or rforalls) else ""

--- a/aeon/sugar/stypes.py
+++ b/aeon/sugar/stypes.py
@@ -46,9 +46,11 @@ class SAbstractionType(SType):
     var_type: SType
     type: SType
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    destructive: bool = False
 
     def __str__(self):
-        return f"({self.var_name} : {self.var_type}) -> {self.type}"
+        bang = "!" if self.destructive else ""
+        return f"({bang}{self.var_name} : {self.var_type}) -> {self.type}"
 
 
 @dataclass(unsafe_hash=True)

--- a/aeon/sugar/substitutions.py
+++ b/aeon/sugar/substitutions.py
@@ -61,7 +61,9 @@ def substitute_svartype_in_stype(ty: SType, beta: SType, alpha: Name):
         case SRefinedType(name, ty, ref):
             return SRefinedType(name, rec(ty), ref)
         case SAbstractionType(var_name, var_type, return_type):
-            return SAbstractionType(var_name, rec(var_type), rec(return_type))
+            return SAbstractionType(
+                var_name, rec(var_type), rec(return_type), destructive=getattr(ty, "destructive", False)
+            )
         case STypePolymorphism(tname, kind, body):
             if tname == alpha:
                 return ty
@@ -85,7 +87,9 @@ def substitution_sterm_in_stype(ty: SType, beta: STerm, alpha: Name) -> SType:
         case SRefinedType(name, ty, ref):
             return SRefinedType(name, rec(ty), substitution_sterm_in_sterm(ref, beta, alpha))
         case SAbstractionType(var_name, var_type, return_type):
-            return SAbstractionType(var_name, rec(var_type), rec(return_type))
+            return SAbstractionType(
+                var_name, rec(var_type), rec(return_type), destructive=getattr(ty, "destructive", False)
+            )
         case STypePolymorphism(tname, kind, body):
             return STypePolymorphism(tname, kind, rec(body))
         case SRefinementPolymorphism(name, sort, body):
@@ -182,7 +186,9 @@ def substitute_refinement_param_in_stype(ty: SType, old: Name, new: Name) -> STy
         case SRefinedType(name, ity, ref):
             return SRefinedType(name, rec(ity), substitution_sterm_in_sterm(ref, SVar(new), old))
         case SAbstractionType(var_name, var_type, return_type):
-            return SAbstractionType(var_name, rec(var_type), rec(return_type))
+            return SAbstractionType(
+                var_name, rec(var_type), rec(return_type), destructive=getattr(ty, "destructive", False)
+            )
         case STypePolymorphism(tname, kind, body):
             return STypePolymorphism(tname, kind, rec(body))
         case SRefinementPolymorphism(rname, sort, body):

--- a/aeon/typechecking/context.py
+++ b/aeon/typechecking/context.py
@@ -83,6 +83,10 @@ class TypeConstructorBinder(TypingContextEntry):
 @dataclass
 class TypingContext:
     entries: MutableSequence[TypingContextEntry] = field(default_factory=list)
+    # Names that have been "consumed" by a destructive function argument.
+    # Shared by reference across derived contexts so destructive use in a Let's
+    # value is visible while typing the Let's body.
+    destroyed: set[Name] = field(default_factory=set)
 
     def __post_init__(self):
         for bt in builtin_core_types[::-1]:
@@ -96,11 +100,17 @@ class TypingContext:
 
     def with_var(self, name: Name, type: Type) -> TypingContext:
         nentries = [e for e in self.entries] + [VariableBinder(name, type)]
-        return TypingContext(nentries)
+        return TypingContext(nentries, self.destroyed)
 
     def with_typevar(self, name: Name, kind: Kind) -> TypingContext:
         nentries = [e for e in self.entries] + [TypeBinder(name, kind)]
-        return TypingContext(nentries)
+        return TypingContext(nentries, self.destroyed)
+
+    def mark_destroyed(self, name: Name) -> None:
+        self.destroyed.add(name)
+
+    def is_destroyed(self, name: Name) -> bool:
+        return name in self.destroyed
 
     def type_of(self, name: Name) -> Type | None:
         for e in self.entries:

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -48,6 +48,7 @@ from aeon.core.types import top
 from aeon.core.types import type_free_term_vars
 from aeon.facade.api import (
     AeonError,
+    CoreDestroyedVariableUseError,
     CoreInvalidApplicationError,
     CoreSubtypingError,
     CoreTypeApplicationRequiresBareTypesError,
@@ -320,6 +321,8 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
         case Var(name):
             if name in ops:
                 return (ctrue, prim_op(name))
+            if ctx.is_destroyed(name):
+                raise CoreDestroyedVariableUseError(ctx, t)
             ty = ctx.type_of(name)
             if not ty:
                 raise CoreVariableNotInContext(ctx, t)
@@ -355,6 +358,8 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                     cp = check(ctx, arg, atype)
                     t_subs = substitution_in_type(rtype, arg, aname)
                     c0 = Conjunction(c, cp)
+                    if ty.destructive and isinstance(arg, Var):
+                        ctx.mark_destroyed(arg.name)
                     return (c0, t_subs)
                 case _:
                     raise CoreInvalidApplicationError(t, ty)
@@ -476,6 +481,9 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
             if not check_type(ctx, cond, t_bool):
                 raise CoreTypingRelation(ctx, cond, t_bool)
             c0 = check(ctx, cond, t_bool)
+            # Snapshot destroyed before each branch so destructions don't leak
+            # between branches; after If, union both branches' destructions.
+            base_destroyed = set(ctx.destroyed)
             name_pos = Name("branch_pos", fresh_counter.fresh())
             c1 = implication_constraint(
                 y,
@@ -483,6 +491,9 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
                 check(ctx, then, ty),
                 then.loc,
             )
+            then_destroyed = set(ctx.destroyed)
+            ctx.destroyed.clear()
+            ctx.destroyed.update(base_destroyed)
             name_neg = Name("branch_neg", fresh_counter.fresh())
             c2 = implication_constraint(
                 y,
@@ -490,6 +501,7 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
                 check(ctx, otherwise, ty),
                 otherwise.loc,
             )
+            ctx.destroyed.update(then_destroyed)
             return Conjunction(c0, Conjunction(c1, c2))
         case TypeAbstraction(name, kind, body), TypePolymorphism(var_name, var_kind, var_body):
             if var_kind == BaseKind() and kind != var_kind:

--- a/aeon/verification/horn.py
+++ b/aeon/verification/horn.py
@@ -76,7 +76,7 @@ def fresh(context: TypingContext, ty: Type) -> Type:
         case AbstractionType(name, aty, rty):
             sp = fresh(context, aty)
             tp = fresh(context.with_var(name, aty), rty)
-            return AbstractionType(name, sp, tp)
+            return AbstractionType(name, sp, tp, destructive=ty.destructive)
         case TypePolymorphism(name, kind, body):
             return TypePolymorphism(name, kind, fresh(context, body))
         case RefinementPolymorphism(name, sort, body):

--- a/examples/syntax/destructive_args.ae
+++ b/examples/syntax/destructive_args.ae
@@ -1,0 +1,13 @@
+# Destructive argument example.
+#
+# Marking a parameter with a leading `!` declares it destructive.
+# After the function is called, the variable passed in that position
+# is no longer available in the surrounding scope.
+
+def consume (!x: Int | x > 0) : Int = x;
+
+def main (args:Int) : Unit =
+    let a : Int | a > 0 = 5 in
+    let result = consume a in
+    # `a` is no longer available here; only `result` is.
+    print result;

--- a/tests/destructive_args_test.py
+++ b/tests/destructive_args_test.py
@@ -1,0 +1,195 @@
+"""Tests for destructive function arguments.
+
+A parameter prefixed with ``!`` (e.g. ``def f (!x: Int)``) marks the parameter
+as destructive: passing a variable in that position consumes it, so the
+variable becomes unavailable in the surrounding scope.
+"""
+
+from __future__ import annotations
+
+from aeon.core.bind import bind_ids
+from aeon.core.types import top, AbstractionType
+from aeon.core.terms import Rec
+from aeon.elaboration import elaborate
+from aeon.facade.api import CoreDestroyedVariableUseError
+from aeon.frontend.anf_converter import ensure_anf
+from aeon.sugar.desugar import desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_program
+from aeon.sugar.stypes import SAbstractionType
+from aeon.typechecking.typeinfer import check_type_errors
+
+
+def _typecheck(source: str):
+    prog = parse_program(source)
+    desugared = desugar(prog)
+    sterm = elaborate(desugared.elabcontext, desugared.program)
+    core_ast = lower_to_core(sterm)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    core_ast_anf = ensure_anf(core_ast)
+    return list(check_type_errors(typing_ctx, core_ast_anf, top))
+
+
+def _find_rec(t, name: str):
+    if isinstance(t, Rec):
+        if t.var_name.name == name:
+            return t
+        return _find_rec(t.var_value, name) or _find_rec(t.body, name)
+    return None
+
+
+def test_parser_records_destructive_flag():
+    prog = parse_program("def f (!x: Int) : Int = x;")
+    f = next(d for d in prog.definitions if d.name.name == "f")
+    assert f.destructive_args == (True,)
+
+
+def test_parser_records_non_destructive_flag():
+    prog = parse_program("def f (x: Int) : Int = x;")
+    f = next(d for d in prog.definitions if d.name.name == "f")
+    assert f.destructive_args == (False,)
+
+
+def test_parser_records_mixed_destructive_flags():
+    prog = parse_program("def f (!x: Int) (y: Int) (!z: Int) : Int = x;")
+    f = next(d for d in prog.definitions if d.name.name == "f")
+    assert f.destructive_args == (True, False, True)
+
+
+def test_destructive_flag_reaches_sugar_abstraction_type():
+    """The destructive flag should be propagated to ``SAbstractionType.destructive``
+    when a definition is converted into the program ``SRec`` chain."""
+    from aeon.sugar.program import SRec
+
+    prog = parse_program("def f (!x: Int) : Int = x;")
+    desugared = desugar(prog)
+    # Walk the program SRec chain looking for the binding for f.
+    cur = desugared.program
+    found = None
+    while isinstance(cur, SRec):
+        if cur.var_name.name == "f":
+            found = cur
+            break
+        cur = cur.body
+    assert found is not None
+    ty = found.var_type
+    assert isinstance(ty, SAbstractionType)
+    assert ty.destructive is True
+
+
+def test_destructive_flag_reaches_core_abstraction_type():
+    prog = parse_program("def f (!x: Int) : Int = x;")
+    desugared = desugar(prog)
+    sterm = elaborate(desugared.elabcontext, desugared.program)
+    core_ast = lower_to_core(sterm)
+    f_rec = _find_rec(core_ast, "f")
+    assert f_rec is not None
+    assert isinstance(f_rec.var_type, AbstractionType)
+    assert f_rec.var_type.destructive is True
+
+
+def test_use_after_destruction_in_let_body_errors():
+    """Using a variable consumed by a destructive arg should be a type error."""
+    source = """
+def f (!x: Int | x > 0) : Int = x;
+
+def main (_:Int) : Int =
+    let a : Int | a > 0 = 5 in
+    let y = f a in
+    a + 1;
+"""
+    errors = _typecheck(source)
+    destroyed_errors = [e for e in errors if isinstance(e, CoreDestroyedVariableUseError)]
+    assert destroyed_errors, f"Expected CoreDestroyedVariableUseError, got: {errors}"
+
+
+def test_no_use_after_destruction_is_ok():
+    """If we never reference the variable again, the program type-checks."""
+    source = """
+def f (!x: Int | x > 0) : Int = x;
+
+def main (_:Int) : Int =
+    let a : Int | a > 0 = 5 in
+    let y = f a in
+    y + 1;
+"""
+    errors = _typecheck(source)
+    assert not errors, f"Expected no errors, got: {errors}"
+
+
+def test_non_destructive_does_not_consume():
+    """A non-destructive parameter leaves the argument variable available."""
+    source = """
+def g (x: Int | x > 0) : Int = x;
+
+def main (_:Int) : Int =
+    let a : Int | a > 0 = 5 in
+    let y = g a in
+    a + 1;
+"""
+    errors = _typecheck(source)
+    assert not errors, f"Expected no errors, got: {errors}"
+
+
+def test_destruction_inside_branch_does_not_leak_to_other_branch():
+    """Destruction inside one If branch must not affect the sibling branch."""
+    source = """
+def f (!x: Int | x > 0) : Int = x;
+
+def main (_:Int) : Int =
+    let a : Int | a > 0 = 5 in
+    let b : Int | b > 0 = 10 in
+    if a == b then
+        let y = f a in y
+    else
+        b;
+"""
+    errors = _typecheck(source)
+    assert not errors, f"Expected no errors, got: {errors}"
+
+
+def test_two_destructive_args_consume_both_variables():
+    """When a function has two destructive parameters, both arguments are consumed."""
+    source = """
+def f (!x: Int | x > 0) (!y: Int | y > 0) : Int = x + y;
+
+def main (_:Int) : Int =
+    let a : Int | a > 0 = 5 in
+    let b : Int | b > 0 = 7 in
+    let r = f a b in
+    a + 1;
+"""
+    errors = _typecheck(source)
+    destroyed_errors = [e for e in errors if isinstance(e, CoreDestroyedVariableUseError)]
+    assert destroyed_errors, f"Expected CoreDestroyedVariableUseError, got: {errors}"
+
+
+def test_mixed_destructive_only_consumes_marked_param():
+    """Only the destructive position consumes its argument."""
+    source = """
+def f (!x: Int | x > 0) (y: Int | y > 0) : Int = x + y;
+
+def main (_:Int) : Int =
+    let a : Int | a > 0 = 5 in
+    let b : Int | b > 0 = 7 in
+    let r = f a b in
+    b + 1;
+"""
+    errors = _typecheck(source)
+    assert not errors, f"Expected no errors (only `a` consumed), got: {errors}"
+
+
+def test_use_of_consumed_arg_in_mixed_signature_errors():
+    source = """
+def f (!x: Int | x > 0) (y: Int | y > 0) : Int = x + y;
+
+def main (_:Int) : Int =
+    let a : Int | a > 0 = 5 in
+    let b : Int | b > 0 = 7 in
+    let r = f a b in
+    a + 1;
+"""
+    errors = _typecheck(source)
+    destroyed_errors = [e for e in errors if isinstance(e, CoreDestroyedVariableUseError)]
+    assert destroyed_errors, f"Expected CoreDestroyedVariableUseError, got: {errors}"


### PR DESCRIPTION
## Summary

Adds support for destructive function arguments. A parameter prefixed with `!` (e.g. `def f (!x: Int | x > 0)`) declares that calling the function consumes the variable passed in that position; referencing that variable afterwards in the surrounding scope is a type error.

```aeon
def f (!x: Int | x > 0) : Int = x;

def main (_:Int) : Int =
    let a : Int | a > 0 = 5 in
    let y = f a in
    a + 1;   # error: a was consumed by f
```

## Changes

- **Grammar** (`aeon/sugar/aeon_sugar.lark`): new `destructive_arg` and `destructive_refined_arg` rules accepting a `!` before the binder name.
- **Sugar AST**:
  - `Definition` gains a parallel `destructive_args: tuple[bool, ...]` field, kept alongside `args` so existing iteration sites are unaffected.
  - `SAbstractionType` and core `AbstractionType` gain a `destructive: bool = False` field, threaded through `convert_definition_to_srec`, `type_of_definition`, `lower_to_core`, `lift_type`, substitutions, instantiation, binding, and `fresh`.
- **Type checker**:
  - `TypingContext` carries a shared mutable `destroyed: set[Name]`, propagated by reference from `with_var` / `with_typevar` so consumption in a `Let` value is visible while typing the body.
  - `synth(Application)` adds `arg.name` to `destroyed` when the function's parameter is marked destructive and `arg` is a `Var`.
  - `synth(Var)` raises `CoreDestroyedVariableUseError` when the name has been destroyed.
  - `If` snapshots `destroyed` between branches and unions destructions on exit so destruction in one branch does not leak into the other.
- **New error type**: `CoreDestroyedVariableUseError` in `aeon/facade/api.py`.
- **Example**: `examples/syntax/destructive_args.ae`.
- **Tests**: `tests/destructive_args_test.py` covers parser flags, propagation through sugar/core types, the failing case from the issue, the non-destructive baseline, mixed signatures, multi-argument destruction, and branch isolation.

## Test plan

- [x] `uv run pytest tests/destructive_args_test.py -v` (12 new tests pass)
- [x] `uv run pytest` (all 427 pre-existing + new tests pass, no regressions)
- [x] `uvx pre-commit run` on changed files (mypy, ruff, ruff-format pass)
- [x] `uv run python -m aeon --no-main examples/syntax/destructive_args.ae` runs and prints `5`

https://claude.ai/code/session_014Yvu5rQaY8SAGbsW7c36dU

---
_Generated by [Claude Code](https://claude.ai/code/session_014Yvu5rQaY8SAGbsW7c36dU)_