### PR TITLE
Add @minimize_cputime, @minimize_cpu_time, and @minimize_energy synthesis objectives

### DIFF
--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -29,6 +29,8 @@ from aeon.synthesis.decorators import (
     maximize_float,
     maximize_int,
     minimize,
+    minimize_cputime,
+    minimize_energy,
     minimize_float,
     minimize_int,
     multi_minimize_float,
@@ -53,6 +55,8 @@ sugar_decorators_environment: dict[str, DecoratorType] = {
     "csv_file": csv_file,
     "minimize": minimize,
     "maximize": maximize,
+    "minimize_cputime": minimize_cputime,
+    "minimize_energy": minimize_energy,
 }
 
 # Backwards-compatible name (sugar-phase registry only).

--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -56,6 +56,8 @@ sugar_decorators_environment: dict[str, DecoratorType] = {
     "minimize": minimize,
     "maximize": maximize,
     "minimize_cputime": minimize_cputime,
+    # Spelled-out alias (same implementation as minimize_cputime).
+    "minimize_cpu_time": minimize_cputime,
     "minimize_energy": minimize_energy,
 }
 

--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -440,7 +440,8 @@ def minimize_cputime(
 ) -> tuple[Definition, list[Definition], Metadata]:
     """Adds CPU time of the given expression as a synthesis objective.
 
-    Usage: @minimize_cputime(fun 42)
+    Usage: ``@minimize_cputime(fun 42)`` — equivalent registry name:
+    ``@minimize_cpu_time(fun 42)``.
 
     The expression is typically a call to the decorated function. During
     synthesis, the synthesizer evaluates the candidate program against this

--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 from aeon.decorators.api import Metadata, metadata_update
 from aeon.sugar.program import Decorator, Definition, SApplication, STerm, SVar
 from aeon.sugar.stypes import STypeConstructor
-from aeon.sugar.ast_helpers import st_int, st_float
+from aeon.sugar.ast_helpers import st_int, st_float, st_top
 from aeon.utils.name import Name, fresh_counter
 
 from aeon.sugar.program import SLiteral
@@ -20,10 +20,23 @@ class Goal(NamedTuple):
     minimize: bool
     length: int
     function: Name
+    # Discriminator for how the synthesizer should compute the fitness value
+    # for this goal. ``"expression"`` (the default) evaluates the internal
+    # fitness function and returns its numeric result. ``"cputime"`` measures
+    # the CPU time consumed evaluating it. ``"energy"`` measures the energy
+    # consumed evaluating it (via RAPL when available, otherwise a CPU-time
+    # proxy). See ``aeon/synthesis/entrypoint.py``.
+    kind: str = "expression"
 
 
 def make_optimizer(
-    args: list[STerm], fun: Definition, metadata: Metadata, typ: STypeConstructor, minimize: bool, length: int = 1
+    args: list[STerm],
+    fun: Definition,
+    metadata: Metadata,
+    typ: STypeConstructor,
+    minimize: bool,
+    length: int = 1,
+    kind: str = "expression",
 ) -> tuple[Definition, list[Definition], Metadata]:
     """This decorator expects a single argument (the body of the definition).
 
@@ -41,7 +54,7 @@ def make_optimizer(
         type=typ,
         body=args[0],
     )
-    goal = Goal(minimize, length, function_name)
+    goal = Goal(minimize, length, function_name, kind)
 
     metadata = metadata_update(
         metadata,
@@ -418,3 +431,45 @@ def maximize(
     # Convert maximize(expr) to minimize(0 - expr)
     negated = _binop("-", SLiteral(0.0, st_float), decorator.macro_args[0])
     return make_optimizer([negated], fun, metadata, st_float, minimize=True)
+
+
+def minimize_cputime(
+    decorator: Decorator,
+    fun: Definition,
+    metadata: Metadata,
+) -> tuple[Definition, list[Definition], Metadata]:
+    """Adds CPU time of the given expression as a synthesis objective.
+
+    Usage: @minimize_cputime(fun 42)
+
+    The expression is typically a call to the decorated function. During
+    synthesis, the synthesizer evaluates the candidate program against this
+    expression and the CPU time consumed (in seconds) is contributed as a
+    fitness value to be minimized. Composes with other objectives. The value
+    produced by the expression itself is ignored, so its type is unconstrained.
+    """
+    assert len(decorator.macro_args) == 1, "minimize_cputime decorator expects a single argument"
+    return make_optimizer(decorator.macro_args, fun, metadata, st_top, minimize=True, kind="cputime")
+
+
+def minimize_energy(
+    decorator: Decorator,
+    fun: Definition,
+    metadata: Metadata,
+) -> tuple[Definition, list[Definition], Metadata]:
+    """Adds energy consumption of the given expression as a synthesis objective.
+
+    Usage: @minimize_energy(fun 42)
+
+    The expression is typically a call to the decorated function. During
+    synthesis, the synthesizer evaluates the candidate program against this
+    expression and the energy consumed (in joules) is contributed as a fitness
+    value to be minimized. When the optional ``pyRAPL`` package is installed
+    and the platform provides Intel RAPL counters, real hardware readings are
+    used; otherwise a CPU-time proxy is used (energy = cpu_time * default_power)
+    so the search signal is still meaningful. Composes with other objectives.
+    The value produced by the expression itself is ignored, so its type is
+    unconstrained.
+    """
+    assert len(decorator.macro_args) == 1, "minimize_energy decorator expects a single argument"
+    return make_optimizer(decorator.macro_args, fun, metadata, st_top, minimize=True, kind="energy")

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import sys
 import time
 from typing import Any, Optional
@@ -69,7 +70,7 @@ def _measure_energy(thunk: Callable[[], Any]) -> float:
     falls back to ``cpu_time * _DEFAULT_PROXY_POWER_W``.
     """
     try:
-        import pyRAPL  # type: ignore[import-not-found]
+        pyRAPL = importlib.import_module("pyRAPL")
 
         pyRAPL.setup()
         meter = pyRAPL.Measurement("aeon_synth")

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -49,6 +49,57 @@ def make_validator(ctx: TypingContext, replace: Callable[[Term], Term]) -> Calla
 Evaluators: TypeAlias = list[Callable[[Term], float]]
 
 
+def _measure_cputime(thunk: Callable[[], Any]) -> float:
+    """Run ``thunk`` and return the CPU time it consumed, in seconds."""
+    start = time.process_time()
+    thunk()
+    return time.process_time() - start
+
+
+# Fallback power estimate (in watts) used to convert CPU time to a joules-like
+# proxy when no hardware energy counter is available. The exact value matters
+# less than monotonicity: faster candidates score better.
+_DEFAULT_PROXY_POWER_W = 15.0
+
+
+def _measure_energy(thunk: Callable[[], Any]) -> float:
+    """Run ``thunk`` and return the energy it consumed, in joules.
+
+    Uses Intel RAPL via ``pyRAPL`` when importable and supported; otherwise
+    falls back to ``cpu_time * _DEFAULT_PROXY_POWER_W``.
+    """
+    try:
+        import pyRAPL  # type: ignore[import-not-found]
+
+        pyRAPL.setup()
+        meter = pyRAPL.Measurement("aeon_synth")
+        meter.begin()
+        thunk()
+        meter.end()
+        # pyRAPL reports per-package energy in microjoules.
+        pkg = meter.result.pkg if meter.result and meter.result.pkg else [0.0]
+        return float(sum(pkg)) / 1e6
+    except Exception:
+        return _measure_cputime(thunk) * _DEFAULT_PROXY_POWER_W
+
+
+def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float]:
+    """Build a fitness function for a single goal, dispatching on ``goal.kind``."""
+
+    def fitness(v: Term) -> float:
+        program_for_fitness = substitution(v, Var(goal.function), Name("main", 0))
+        try:
+            if goal.kind == "cputime":
+                return _measure_cputime(lambda: eval(program_for_fitness, ectx))
+            if goal.kind == "energy":
+                return _measure_energy(lambda: eval(program_for_fitness, ectx))
+            return eval(program_for_fitness, ectx)
+        except Exception:
+            return sys.maxsize
+
+    return fitness
+
+
 def make_evaluators(ectx: EvaluationContext, fun_name: Name, metadata: Metadata) -> Evaluators:
     """Returns a list of functions that take the original program and return each fitness value"""
 
@@ -56,16 +107,7 @@ def make_evaluators(ectx: EvaluationContext, fun_name: Name, metadata: Metadata)
     fitnesses: list[Callable[[Term], float]] = []
     for goal in goals:
         assert goal.length == 1, "Currently, we only support 1 fitness value per function"
-
-        def fitness(v: Term) -> float:
-            program_for_fitness = substitution(v, Var(goal.function), Name("main", 0))
-            try:
-                result = eval(program_for_fitness, ectx)
-            except Exception:
-                result = sys.maxsize
-            return result
-
-        fitnesses.append(fitness)
+        fitnesses.append(_make_fitness(goal, ectx))
     return fitnesses
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -376,6 +376,16 @@ def approx (x:Int | x > 0) : Float =
 - `@maximize_float(expr)` — maximize a float expression
 - `@multi_minimize_float(expr)` — multi-objective float minimization
 
+### Resource-use objectives
+
+These add extra minimization objectives alongside numeric ones (for example `@minimize_int`). The synthesizer measures how expensive it is to **evaluate** the given expression for each candidate; the expression’s *value* is ignored, so its static type is unconstrained.
+
+- `@minimize_cputime(expr)` — fitness is CPU time in seconds for evaluating `expr` (`time.process_time()` around the evaluation).
+- `@minimize_cpu_time(expr)` — same as `@minimize_cputime` (alternate spelling).
+- `@minimize_energy(expr)` — fitness is energy in joules for evaluating `expr`. Uses Intel RAPL via the optional `pyRAPL` package when available; otherwise a CPU-time proxy (`cpu_time ×` a fixed watt estimate) so cheaper candidates still score better.
+
+See `examples/synthesis/cputime_energy.ae` for a program that combines correctness and resource objectives.
+
 ### Data-driven decorators
 
 - `@csv_data("1.0,2.0,3.0\n4.0,5.0,12.0")` — provide inline CSV training data (last column is expected output)

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -14,7 +14,7 @@ The `--budget` flag sets the time limit in seconds (default: 60).
 
 ### `gp` — Genetic Programming *(default)*
 
-Evolves a population of candidate programs using genetic programming, implemented via [GeneticEngine](https://github.com/alcides/GeneticEngine). Candidate programs are represented as syntax trees drawn from a grammar derived from the typing context. Selection, crossover, and mutation operators drive the search towards better fitness scores as defined by the synthesis decorators (`@minimize`, `@maximize`, etc.).
+Evolves a population of candidate programs using genetic programming, implemented via [GeneticEngine](https://github.com/alcides/GeneticEngine). Candidate programs are represented as syntax trees drawn from a grammar derived from the typing context. Selection, crossover, and mutation operators drive the search towards better fitness scores as defined by the synthesis decorators (`@minimize`, `@maximize`, `@minimize_cputime` / `@minimize_cpu_time`, `@minimize_energy`, etc.).
 
 Best suited for problems with a rich fitness landscape and sufficient budget.
 

--- a/examples/synthesis/cputime_energy.ae
+++ b/examples/synthesis/cputime_energy.ae
@@ -1,0 +1,23 @@
+# Optimize a synthesized function for value-correctness AND for resource use.
+#
+# @minimize_int drives correctness: we want fun(10) close to 100.
+# @minimize_cputime drives the synthesizer toward candidates that are cheap
+#                   to evaluate (CPU time, in seconds).
+# @minimize_energy  drives the synthesizer toward candidates that consume
+#                   little energy (joules; uses Intel RAPL when available,
+#                   otherwise a CPU-time-based proxy).
+#
+# All three goals are minimized simultaneously by the multi-objective
+# synthesizer.
+
+def target : Int = 100
+
+def err (v: Int) : Int = (target - v) * (target - v)
+
+@minimize_int(err (fun 10))
+@minimize_cputime(fun 10)
+@minimize_energy(fun 10)
+def fun (i:Int) : Int = i * (?hole: Int)
+
+
+def main (args: Int) : Unit = print (fun 10)

--- a/tests/optimization_decorators_test.py
+++ b/tests/optimization_decorators_test.py
@@ -59,6 +59,18 @@ def test_minimize_cputime_registers_goal():
     assert goals[0].kind == "cputime"
 
 
+def test_minimize_cpu_time_alias_registers_goal():
+    source = """
+        @minimize_cpu_time(synth 7)
+        def synth (i:Int) : Int = i * (?hole: Int)
+    """
+    _, _, _, metadata = check_and_return_core(source)
+    goals = _find_goals(metadata)
+    assert len(goals) == 1
+    assert goals[0].minimize is True
+    assert goals[0].kind == "cputime"
+
+
 def test_minimize_energy_registers_goal():
     source = """
         @minimize_energy(synth 7)
@@ -134,9 +146,7 @@ def test_cputime_synthesis_smoke():
     """
     core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
     incomplete = incomplete_functions_and_holes(ctx, core_ast_anf)
-    mapping = synthesize_holes(
-        ctx, ectx, core_ast_anf, incomplete, metadata, synthesizer=GESynthesizer(), budget=0.25
-    )
+    mapping = synthesize_holes(ctx, ectx, core_ast_anf, incomplete, metadata, synthesizer=GESynthesizer(), budget=0.25)
     assert len(mapping) == 1
 
 

--- a/tests/optimization_decorators_test.py
+++ b/tests/optimization_decorators_test.py
@@ -1,7 +1,19 @@
-from aeon.synthesis.identification import iterate_top_level
-from aeon.sugar.ast_helpers import st_top
+from unittest import mock
 
-from tests.driver import check_compile, extract_core
+from aeon.synthesis.entrypoint import (
+    _DEFAULT_PROXY_POWER_W,
+    _measure_cputime,
+    _measure_energy,
+    make_evaluators,
+    synthesize_holes,
+)
+from aeon.synthesis.decorators import Goal
+from aeon.synthesis.grammar.ge_synthesis import GESynthesizer, create_problem
+from aeon.synthesis.identification import incomplete_functions_and_holes, iterate_top_level
+from aeon.sugar.ast_helpers import st_top
+from aeon.utils.name import Name
+
+from tests.driver import check_and_return_core, check_compile, extract_core
 
 
 def test_hole_minimize_int():
@@ -26,3 +38,108 @@ def test_eq() -> None:
 """
 
     check_compile(aeon_code, st_top)
+
+
+def _find_goals(metadata):
+    for v in metadata.values():
+        if isinstance(v, dict) and "goals" in v:
+            return v["goals"]
+    return []
+
+
+def test_minimize_cputime_registers_goal():
+    source = """
+        @minimize_cputime(synth 7)
+        def synth (i:Int) : Int = i * (?hole: Int)
+    """
+    _, _, _, metadata = check_and_return_core(source)
+    goals = _find_goals(metadata)
+    assert len(goals) == 1
+    assert goals[0].minimize is True
+    assert goals[0].kind == "cputime"
+
+
+def test_minimize_energy_registers_goal():
+    source = """
+        @minimize_energy(synth 7)
+        def synth (i:Int) : Int = i * (?hole: Int)
+    """
+    _, _, _, metadata = check_and_return_core(source)
+    goals = _find_goals(metadata)
+    assert len(goals) == 1
+    assert goals[0].minimize is True
+    assert goals[0].kind == "energy"
+
+
+def test_cputime_and_other_objective_compose():
+    source = """def year : Int = 2023;
+        @minimize_int( year - (synth 7) )
+        @minimize_cputime(synth 7)
+        def synth (i:Int) : Int = i * (?hole: Int)
+    """
+    _, _, _, metadata = check_and_return_core(source)
+    goals = _find_goals(metadata)
+    assert len(goals) == 2
+    kinds = sorted(g.kind for g in goals)
+    assert kinds == ["cputime", "expression"]
+
+
+def test_cputime_and_energy_make_two_evaluators_and_minimize_problem():
+    source = """
+        @minimize_cputime(synth 7)
+        @minimize_energy(synth 7)
+        def synth (i:Int) : Int = i * (?hole: Int)
+    """
+    core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
+    # Use the metadata's actual Name key (the unbound one used during desugaring)
+    # to look up goals; the Name from incomplete_functions_and_holes carries a
+    # post-binding id that doesn't match.
+    fun_name = next(k for k, v in metadata.items() if isinstance(v, dict) and "goals" in v)
+    evaluators = make_evaluators(ectx, fun_name, metadata)
+    assert len(evaluators) == 2
+    problem = create_problem(
+        validate=lambda _t: True,
+        evaluate=lambda _t: [0.0, 0.0],
+        fun_name=fun_name,
+        metadata=metadata,
+    )
+    assert problem.minimize == [True, True]
+
+
+def test_measure_cputime_is_nonnegative():
+    cheap = _measure_cputime(lambda: None)
+    busy = _measure_cputime(lambda: sum(range(200_000)))
+    assert cheap >= 0.0
+    assert busy >= 0.0
+
+
+def test_measure_energy_falls_back_to_proxy_without_pyrapl():
+    # Force the pyRAPL import to fail and verify we hit the CPU-time proxy.
+    with mock.patch.dict("sys.modules", {"pyRAPL": None}):
+
+        def work():
+            sum(range(50_000))
+
+        joules = _measure_energy(work)
+
+    assert joules >= 0.0
+    assert joules < _DEFAULT_PROXY_POWER_W * 10.0
+
+
+def test_cputime_synthesis_smoke():
+    """Synthesis with a CPU-time objective completes and returns a hole filling."""
+    source = """
+        @minimize_cputime(synth 7)
+        def synth (i:Int) : Int = i * (?hole: Int)
+    """
+    core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
+    incomplete = incomplete_functions_and_holes(ctx, core_ast_anf)
+    mapping = synthesize_holes(
+        ctx, ectx, core_ast_anf, incomplete, metadata, synthesizer=GESynthesizer(), budget=0.25
+    )
+    assert len(mapping) == 1
+
+
+def test_goal_default_kind_is_expression():
+    g = Goal(minimize=True, length=1, function=Name("x", 0))
+    assert g.kind == "expression"


### PR DESCRIPTION
## Summary

Introduces sugar-phase decorators for **CPU time** and **energy** as synthesis fitness objectives, composable with existing goals (e.g. `@minimize_int`). The synthesizer measures the cost of **evaluating** the given expression; the expression’s return value is not used as the numeric fitness (see docs).

## Changes

- **`@minimize_cputime(expr)`**: fitness = CPU seconds (`time.process_time()`) for evaluating `expr`.
- **`@minimize_cpu_time(expr)`**: alias for `@minimize_cputime`.
- **`@minimize_energy(expr)`**: fitness = joules via Intel RAPL / optional `pyRAPL` when available; otherwise a CPU-time proxy so faster candidates still rank better.
- **`Goal.kind`** in metadata so `make_evaluators` dispatches measurement vs plain expression evaluation.
- **Example**: `examples/synthesis/cputime_energy.ae`.
- **Docs**: `docs/index.md` (resource-use section), `docs/synthesizers.md` (GP blurb).
- **Tests**: registration, composition, measurement helpers, GP smoke; `importlib.import_module` for optional `pyRAPL` (mypy-clean).

Closes #214, #215 (per original commit message).

Made with [Cursor](https://cursor.com)