### PR TITLE
Fix double argparse parse; use match in CLI and type helpers

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -104,8 +104,6 @@ def _parse_common_arguments(parser: ArgumentParser):
         help="Uses a pretty print version of the code to reformat it",
     )
 
-    return parser.parse_args()
-
 
 def select_synthesis_ui() -> SynthesisUI:
     return TerminalUI()
@@ -124,10 +122,13 @@ def main() -> None:
 
     logger = setup_logger()
     logfile_name = None
-    if hasattr(args, "filename"):
-        logfile_name = args.filename
-    elif hasattr(args, "language_server_mode"):
-        logfile_name = "lsp"
+    match getattr(args, "filename", None), getattr(args, "language_server_mode", None):
+        case (str() as fn, _):
+            logfile_name = fn
+        case (_, True):
+            logfile_name = "lsp"
+        case _:
+            logfile_name = None
     export_log(args.log, args.logfile, logfile_name)
 
     if args.debug:
@@ -152,25 +153,27 @@ def main() -> None:
 
     errors = driver.parse(args.filename)
 
-    if errors:
-        for err in errors:
-            handle_error(err)
-    elif args.format:
-        driver.pretty_print(args.filename, args.fix)
-
-    elif driver.has_synth():
-        try:
-            term = driver.synth()
-        except SynthesisNotSuccessful:
-            print(f"Cannot find a suitable expression within {args.budget} seconds.", file=sys.stderr)
-            sys.exit(2)
-        print("Synthesized:")
-        print("#str")
-        print(str(term))
-        print("#pprint")
-        print(pretty_print_sterm(term))
-    else:
-        driver.run()
+    match errors:
+        case [*_]:
+            for err in errors:
+                handle_error(err)
+        case []:
+            match (args.format, driver.has_synth()):
+                case (True, _):
+                    driver.pretty_print(args.filename, args.fix)
+                case (False, True):
+                    try:
+                        term = driver.synth()
+                    except SynthesisNotSuccessful:
+                        print(f"Cannot find a suitable expression within {args.budget} seconds.", file=sys.stderr)
+                        sys.exit(2)
+                    print("Synthesized:")
+                    print("#str")
+                    print(str(term))
+                    print("#pprint")
+                    print(pretty_print_sterm(term))
+                case (False, False):
+                    driver.run()
 
 
 if __name__ == "__main__":

--- a/aeon/core/instantiation.py
+++ b/aeon/core/instantiation.py
@@ -55,34 +55,34 @@ def type_variable_instantiation(t: Type, alpha: Name, beta: Type) -> Type:
     def rec(x):
         return type_variable_instantiation(x, alpha, beta)
 
-    if isinstance(t, TypeConstructor):
-        return t
-    elif isinstance(t, TypeVar) and t.name == alpha:
-        return beta
-    elif isinstance(t, TypeVar) and t.name != alpha:
-        return t
-    elif (
-        isinstance(t, RefinedType)
-        and isinstance(t.type, TypeVar)
-        and t.type.name == alpha
-        and isinstance(beta, RefinedType)
-    ):
-        return RefinedType(
-            t.name,
-            beta.type,
-            mk_liquid_and(
-                t.refinement,
-                substitution_in_liquid(beta.refinement, LiquidVar(t.name), beta.name),
-            ),
-            t.loc,
-        )
-    elif isinstance(t, RefinedType):
-        return RefinedType(t.name, rec(t.type), t.refinement, t.loc)
-    elif isinstance(t, AbstractionType):
-        return AbstractionType(t.var_name, rec(t.var_type), rec(t.type), t.loc)
-    elif isinstance(t, TypePolymorphism):
-        return TypePolymorphism(t.name, t.kind, rec(t.body), t.loc)
-    elif isinstance(t, RefinementPolymorphism):
-        return RefinementPolymorphism(t.name, rec(t.sort), rec(t.body), t.loc)
-    else:
-        assert False
+    match t:
+        case TypeConstructor():
+            return t
+        case TypeVar(name) if name == alpha:
+            return beta
+        case TypeVar():
+            return t
+        case RefinedType(tname, TypeVar(name=tvn), tref, tloc) if tvn == alpha:
+            match beta:
+                case RefinedType(bname, btype, bref, _):
+                    return RefinedType(
+                        tname,
+                        btype,
+                        mk_liquid_and(
+                            tref,
+                            substitution_in_liquid(bref, LiquidVar(tname), bname),
+                        ),
+                        tloc,
+                    )
+                case _:
+                    return RefinedType(tname, rec(t.type), tref, tloc)
+        case RefinedType(name, inner, ref, loc):
+            return RefinedType(name, rec(inner), ref, loc)
+        case AbstractionType(vn, vt, rt, loc):
+            return AbstractionType(vn, rec(vt), rec(rt), loc)
+        case TypePolymorphism(name, kind, body, loc):
+            return TypePolymorphism(name, kind, rec(body), loc)
+        case RefinementPolymorphism(name, sort, body, loc):
+            return RefinementPolymorphism(name, rec(sort), rec(body), loc)
+        case _:
+            assert False

--- a/aeon/core/pprint.py
+++ b/aeon/core/pprint.py
@@ -63,25 +63,23 @@ aeon_prelude_ops_to_text = {
 
 
 def pretty_print(t: Type) -> str:
-    if isinstance(t, TypeConstructor):
-        return str(t)
-    elif isinstance(t, TypeVar):
-        return str(t)
-    elif isinstance(t, AbstractionType):
-        at = pretty_print(t.var_type)
-        rt = pretty_print(t.type)
-        if t.var_name in type_free_term_vars(t.var_type):
-            return f"""(
-                {t.var_name}:{at}) -> {rt}"""
-        else:
-            return f"""{at} -> {rt}"""
-    elif isinstance(t, RefinedType):
-        it = pretty_print(t.type)
-        if t.refinement == LiquidLiteralBool(True):
-            return it
-        else:
-            return f"{{{t.name}:{it} | {t.refinement}}}"
-    raise ValueError(f"Unknown type {t}")
+    match t:
+        case TypeConstructor() | TypeVar():
+            return str(t)
+        case AbstractionType(var_name=vn, var_type=vt, type=rt):
+            at = pretty_print(vt)
+            rts = pretty_print(rt)
+            if vn in type_free_term_vars(vt):
+                return f"""(
+                {vn}:{at}) -> {rts}"""
+            return f"""{at} -> {rts}"""
+        case RefinedType(name=n, type=ity, refinement=ref):
+            it = pretty_print(ity)
+            if ref == LiquidLiteralBool(True):
+                return it
+            return f"{{{n}:{it} | {ref}}}"
+        case _:
+            raise ValueError(f"Unknown type {t}")
 
 
 def pretty_print_term(term: Term):


### PR DESCRIPTION
## Summary

- **Bug fix:** `_parse_common_arguments` called `parser.parse_args()` even though `parse_arguments()` already parses, which parsed `sys.argv` twice and made the helper misleading. Parsing now happens only in `parse_arguments()`.
- **Refactors:** Use `match` for logfile name selection and main dispatch in `aeon/__main__.py`, for `pretty_print` in `aeon/core/pprint.py`, and for `type_variable_instantiation` in `aeon/core/instantiation.py` (consistent with `type_substitution` above it).

## Testing

`uv run pytest tests/` (full suite) passed locally.

Made with [Cursor](https://cursor.com)