### PR TITLE
feat: Image library (PIL-like), key synthesis benchmark, synthesis terminal UI

### DIFF
--- a/aeon/bindings/image.py
+++ b/aeon/bindings/image.py
@@ -1,13 +1,37 @@
 from __future__ import annotations
 
 import math
+from typing import Any
 
 import numpy as np
 from PIL import Image
+from PIL import ImageFilter
+from PIL import ImageOps
 from PIL.ImageDraw import Draw
 from skimage.metrics import mean_squared_error as mse
 
 from aeon.bindings.binding_utils import curried
+
+
+def _lanczos_resample() -> Any:
+    resampling = getattr(Image, "Resampling", None)
+    if resampling is not None:
+        return resampling.LANCZOS
+    return Image.LANCZOS
+
+
+def _transpose_flip_lr() -> Any:
+    transpose = getattr(Image, "Transpose", None)
+    if transpose is not None:
+        return transpose.FLIP_LEFT_RIGHT
+    return Image.FLIP_LEFT_RIGHT
+
+
+def _transpose_flip_tb() -> Any:
+    transpose = getattr(Image, "Transpose", None)
+    if transpose is not None:
+        return transpose.FLIP_TOP_BOTTOM
+    return Image.FLIP_TOP_BOTTOM
 
 
 @curried
@@ -16,11 +40,95 @@ def Image_mk(w, h, c):
 
 
 @curried
+def Image_open(path):
+    """Open an image and normalize to RGB so Color / pixel helpers stay consistent."""
+    im = Image.open(path)
+    if im.mode != "RGB":
+        im = im.convert("RGB")
+    return im
+
+
+@curried
 def Image_draw_rectangle(im, x, y, w, h, c):
     im2 = im.copy()
     d = Draw(im2)
     d.rectangle((x, y, x + w, y + h), c)
     return im2
+
+
+@curried
+def Image_copy(im):
+    return im.copy()
+
+
+@curried
+def Image_crop(im, x, y, w, h):
+    return im.crop((x, y, x + w, y + h))
+
+
+@curried
+def Image_resize(im, w, h):
+    return im.resize((w, h), _lanczos_resample())
+
+
+@curried
+def Image_fit_inside(im, max_w, max_h):
+    """Resize preserving aspect ratio to fit within max_w × max_h (PIL thumbnail semantics)."""
+    im2 = im.copy()
+    im2.thumbnail((max_w, max_h), _lanczos_resample())
+    return im2
+
+
+@curried
+def Image_rotate(im, angle):
+    return im.rotate(float(angle), expand=False)
+
+
+@curried
+def Image_flip_horizontal(im):
+    return im.transpose(_transpose_flip_lr())
+
+
+@curried
+def Image_flip_vertical(im):
+    return im.transpose(_transpose_flip_tb())
+
+
+@curried
+def Image_get_pixel(im, x, y):
+    r, g, b = im.getpixel((x, y))
+    return ("Color_mk", r, g, b)
+
+
+@curried
+def Image_put_pixel(im, x, y, color):
+    im2 = im.copy()
+    im2.putpixel((x, y), tuple(color[1:]))
+    return im2
+
+
+@curried
+def Image_paste(dest, src, x, y):
+    out = dest.copy()
+    src2 = src if src.mode == out.mode else src.convert(out.mode)
+    out.paste(src2, (int(x), int(y)))
+    return out
+
+
+@curried
+def Image_grayscale_rgb(im):
+    """Luminance convert then back to RGB so downstream Color / drawing stays RGB-sized."""
+    return im.convert("L").convert("RGB")
+
+
+@curried
+def Image_invert(im):
+    return ImageOps.invert(im)
+
+
+@curried
+def Image_blur(im, radius):
+    return im.filter(ImageFilter.GaussianBlur(radius=float(radius)))
 
 
 @curried
@@ -34,3 +142,61 @@ def Image_diff_mse(im1, im2):
     im1 = np.array(im1)
     im2 = np.array(im2)
     return mse(im1, im2)
+
+
+_HUGE = 1e30
+
+
+@curried
+def Image_fitness_bw_mse(candidate, reference):
+    """MSE on luminance (single channel), lowest when grey tones align."""
+    if candidate.size != reference.size:
+        return _HUGE
+    a = np.asarray(candidate.convert("L"), dtype=np.float64)
+    b = np.asarray(reference.convert("L"), dtype=np.float64)
+    return float(np.mean((a - b) ** 2))
+
+
+@curried
+def Image_fitness_half_size_mse(candidate, reference):
+    """MSE on luminance after resizing both images to half width and height (floor)."""
+    if candidate.size != reference.size:
+        return _HUGE
+    w, h = candidate.size
+    w2, h2 = max(1, w // 2), max(1, h // 2)
+    a = np.asarray(candidate.resize((w2, h2)).convert("L"), dtype=np.float64)
+    b = np.asarray(reference.resize((w2, h2)).convert("L"), dtype=np.float64)
+    return float(np.mean((a - b) ** 2))
+
+
+@curried
+def Image_fitness_row_mismatch(candidate, reference):
+    """Number of horizontal scanlines that differ from the reference anywhere on that row."""
+    if candidate.size != reference.size:
+        return _HUGE
+    a = np.asarray(candidate.convert("RGB"))
+    b = np.asarray(reference.convert("RGB"))
+    bad_rows = np.any(a != b, axis=(1, 2))
+    return float(np.sum(bad_rows))
+
+
+@curried
+def Image_fitness_col_mismatch(candidate, reference):
+    """Number of vertical columns that differ from the reference anywhere on that column."""
+    if candidate.size != reference.size:
+        return _HUGE
+    a = np.asarray(candidate.convert("RGB"))
+    b = np.asarray(reference.convert("RGB"))
+    bad_cols = np.any(a != b, axis=(0, 2))
+    return float(np.sum(bad_cols))
+
+
+@curried
+def Image_fitness_pixel_mismatch(candidate, reference):
+    """Number of pixels whose RGB triple differs from the reference."""
+    if candidate.size != reference.size:
+        return _HUGE
+    a = np.asarray(candidate.convert("RGB"))
+    b = np.asarray(reference.convert("RGB"))
+    diff_px = np.any(a != b, axis=2)
+    return float(np.sum(diff_px))

--- a/aeon/synthesis/uis/terminal.py
+++ b/aeon/synthesis/uis/terminal.py
@@ -1,11 +1,44 @@
+import numbers
 from typing import Any
+
 from aeon.backend.evaluator import EvaluationContext
-from aeon.core.terms import Term
 from aeon.core.terms import Hole
+from aeon.core.terms import Term
 from aeon.core.types import Type
-from aeon.utils.name import Name
+from aeon.sugar.lifting import lift
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+from aeon.utils.pprint import pretty_print_sterm
+
+# When fitness is a 5-vector from Image multi-objective examples (see libraries/Image.ae fitness_*).
+_MULTIOBJ_LABELS = ("bw_mse", "half_mse", "rows_bad", "cols_bad", "pixels_bad")
+
+
+def _format_quality(quality: Any) -> str:
+    """Pretty-print fitness from geneticengine (`Fitness`) or raw numeric lists."""
+    components: list[float] | None = None
+    valid = True
+    if hasattr(quality, "fitness_components"):
+        components = list(quality.fitness_components)
+        valid = bool(getattr(quality, "valid", True))
+    elif isinstance(quality, list):
+        components = [float(x) for x in quality]
+
+    if components is not None and len(components) == len(_MULTIOBJ_LABELS):
+        parts = [f"{lb}={v:.6g}" for lb, v in zip(_MULTIOBJ_LABELS, components)]
+        suffix = "" if valid else " | INVALID (type/liquid check failed before numeric fitness)"
+        return "[" + ", ".join(parts) + "]" + suffix
+    if components is not None:
+        return repr(components) + ("" if valid else " | INVALID")
+    return repr(quality)
+
+
+def _pretty_program(solution: Term) -> str:
+    try:
+        return pretty_print_sterm(lift(solution))
+    except Exception:
+        return str(solution)
 
 
 class TerminalUI(SynthesisUI):
@@ -25,6 +58,16 @@ class TerminalUI(SynthesisUI):
         self.budget = budget
         self.best_solution = Hole(Name("sorry", -1))
         self.best_quality = None
+        print(
+            f"# Synthesis target: ?{target_name} :: {target_type} | "
+            f"budget={budget}s | each line is one evaluated candidate (pareto memory updates on `best`).",
+            flush=True,
+        )
+        if isinstance(budget, numbers.Real) and float(budget) >= 15:
+            print(
+                "# Five-objective Image runs label fitness as " + ", ".join(_MULTIOBJ_LABELS) + " (all minimized).",
+                flush=True,
+            )
 
     def register(
         self,
@@ -37,11 +80,15 @@ class TerminalUI(SynthesisUI):
             self.best_solution = solution
             self.best_quality = quality
 
+        cur_pp = _pretty_program(solution)
+        q_cur = _format_quality(quality)
+        star = "*" if is_best else " "
         print(
-            f"Target: {self.target_name} ({elapsed_time:.1f} / {self.budget:.1f}s) "
-            + f"| Best: {self.best_solution} ({self.best_quality}) "
-            + f"| Current: {solution} ({quality})",
+            f"{star} t={elapsed_time:6.1f}s/{self.budget}s | fitness {q_cur}",
+            flush=True,
         )
+        print(cur_pp, flush=True)
+        print("---", flush=True)
 
     def end(self, solution: Term, quality: Any):
         pass

--- a/examples/image/key.ae
+++ b/examples/image/key.ae
@@ -1,27 +1,47 @@
+# Grey key synthesis benchmark against examples/image/key_target.jpg (1024×768).
+#
+# The synthesizer fills `synth_key` so it matches the raster in key_target.jpg.
+# The hole type is inferred from the refined return type: an Image of exactly `target_w`×`target_h` (1024×768).
+# Fitness terms still punish size mismatch for synthesizers that ignore liquid constraints.
+#
+# Programmatic refinements still apply wherever geometry is explicit: `reference_key` below uses `Image.mk` and
+# `draw_rectangle` so every rectangle argument stays inside the canvas (see libraries/Image.ae).
+#
+# Five independent objectives are minimized together (Pareto-style in the GP backend): luminance MSE,
+# half-resolution luminance MSE, mismatched scanlines, mismatched columns, and mismatched pixels.
+#
+# Recommended run (GP fits structured Image programs better than type-directed enumeration):
+#   uv run python -m aeon examples/image/key.ae -s gp --budget 120
+#
 open Image
 open Color
 
 def target : Image = Image.open "examples/image/key_target.jpg"
 
-def key_example (steps:Int) : Image =
-    white : Color = Color.mk 255 255 255;
-    key_color : Color = Color.mk 192 192 192;
-    image0 = Image.mk 1024 768 white;
-    image1 = Image.draw_rectangle image0 170 256 256 256 key_color;
+# Exact raster size for key_target.jpg (used so refinements prove rectangle bounds against the canvas).
+def target_w : { v : Int | v == 1024 } = 1024
+
+def target_h : { v : Int | v == 768 } = 768
+
+def white : Color = Color.mk 255 255 255
+
+def key_grey : Color = Color.mk 192 192 192
+
+@minimize_float(fitness_bw_mse synth_key target)
+@minimize_float(fitness_half_size_mse synth_key target)
+@minimize_float(fitness_row_mismatch synth_key target)
+@minimize_float(fitness_col_mismatch synth_key target)
+@minimize_float(fitness_pixel_mismatch synth_key target)
+def synth_key : { img : Image | (width img == target_w) && (height img == target_h) } = ?hole
+
+# Human-readable reference for the shape (matches the historical hand-written key program).
+def reference_key : Image =
+    image0 = Image.mk target_w target_h white;
+    image1 = Image.draw_rectangle image0 170 256 256 256 key_grey;
     image2 = Image.draw_rectangle image1 255 341 85 83 white;
-    image3 = Image.draw_rectangle image2 426 341 509 83 key_color;
-    image4 = Image.draw_rectangle image3 836 424 100 68 key_color;
-    image5 = Image.draw_rectangle image4 686 424 100 48 key_color;
+    image3 = Image.draw_rectangle image2 426 341 509 83 key_grey;
+    image4 = Image.draw_rectangle image3 836 424 100 68 key_grey;
+    image5 = Image.draw_rectangle image4 686 424 100 48 key_grey;
     image5;
 
-def k : Image = key_example 1
-
-def mod : (x: Int) -> (y: Int) -> Int = \x -> \y -> (x % y)
-
-def synth : Image = ?hole
-
-def fitness : Float = Image.diff synth target
-
-# def keyshow : Unit = Image.show k
-# def keysave : Unit = Image.save k "examples/image/key.jpg"
-# def main (x:Int) : Unit { keysave }
+# def dump_reference : Unit = Image.save reference_key "examples/image/key.jpg"

--- a/examples/image/pil_style.ae
+++ b/examples/image/pil_style.ae
@@ -1,0 +1,17 @@
+# PIL-style pipeline: build, paste, crop, resize, and save.
+open Image
+open Color
+
+def white : Color = Color.mk 255 255 255
+def accent : Color = Color.mk 220 90 50
+
+def demo : Image =
+    base = Image.mk 400 300 white;
+    stamp = Image.mk 80 60 accent;
+    layered = Image.paste base stamp 40 30;
+    region = Image.crop layered 20 20 200 120;
+    thumb = Image.resize region 100 60;
+    thumb;
+
+# Writing to disk is side-effecting; keep as a named unit if you add a main later.
+# def _save : Unit = Image.save demo "examples/image/pil_style_out.png"

--- a/examples/image/pixels.ae
+++ b/examples/image/pixels.ae
@@ -1,0 +1,22 @@
+# Pixel-level read / write and simple transforms.
+open Image
+open Color
+
+def white : Color = Color.mk 255 255 255
+def black : Color = Color.mk 0 0 0
+
+def line_scan : Color =
+    canvas = Image.mk 32 1 white;
+    c0 = Image.get_pixel canvas 0 0;
+    dotted = Image.put_pixel canvas 16 0 black;
+    c1 = Image.get_pixel dotted 16 0;
+    # A tiny pipeline: read default white, then read after painting black
+    c1;
+
+def negated : Image =
+    small = Image.mk 64 64 white;
+    Image.invert small;
+
+def softened : Image =
+    small = Image.mk 64 64 white;
+    Image.blur small 2.0;

--- a/libraries/Image.ae
+++ b/libraries/Image.ae
@@ -20,25 +20,146 @@ def mk
     {i : Image | (width i == w) && (height i == h) } =
 native "__import__('aeon.bindings.image').bindings.image.Image_mk(w, h, color[1:])"
 
+# Returns an independent copy (PIL Image.copy).
+def copy (im:Image) :
+    { c:Image | (width c == width im) && (height c == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_copy(im)"
+
+# Crops a rectangular region [x, x+w) × [y, y+h) into a new image of size w×h.
+def crop
+    (im:Image)
+    (x:{p:Int | p >= 0 && p <= width im })
+    (y:{p:Int | p >= 0 && p <= height im})
+    (w:{p:Int | p > 0 && x + p <= width im })
+    (h:{p:Int | p > 0 && y + p <= height im }) :
+    { r:Image | (width r == w) && (height r == h) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_crop(im, x, y, w, h)"
+
+# Resamples to an exact width and height (PIL Image.resize with high-quality filter).
+def resize
+    (im:Image)
+    (w:{p:Int | p > 0})
+    (h:{p:Int | p > 0}) :
+    { r:Image | (width r == w) && (height r == h) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_resize(im, w, h)"
+
+# Shrinks the image in-place on a copy so it fits inside max_w×max_h while preserving aspect ratio (PIL thumbnail).
+def fit_inside
+    (im:Image)
+    (max_w:{p:Int | p > 0})
+    (max_h:{p:Int | p > 0}) :
+    Image =
+native "__import__('aeon.bindings.image').bindings.image.Image_fit_inside(im, max_w, max_h)"
+
+# Rotates counter-clockwise by angle degrees; output size matches input (expand=False, PIL default behavior).
+def rotate
+    (im:Image)
+    (angle:Float) :
+    { r:Image | (width r == width im) && (height r == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_rotate(im, angle)"
+
+# Horizontal mirror (PIL FLIP_LEFT_RIGHT).
+def flip_horizontal
+    (im:Image) :
+    { r:Image | (width r == width im) && (height r == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_flip_horizontal(im)"
+
+# Vertical mirror (PIL FLIP_TOP_BOTTOM).
+def flip_vertical
+    (im:Image) :
+    { r:Image | (width r == width im) && (height r == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_flip_vertical(im)"
+
+# Samples the RGB pixel at (x, y) as a Color (always RGB mode after open/mk).
+def get_pixel
+    (im:Image)
+    (x:{p:Int | p >= 0 && p < width im })
+    (y:{p:Int | p >= 0 && p < height im }) :
+    Color =
+native "__import__('aeon.bindings.image').bindings.image.Image_get_pixel(im, x, y)"
+
+# Functional single-pixel draw: returns a new image with one pixel replaced (PIL putpixel on a copy).
+def put_pixel
+    (im:Image)
+    (x:{p:Int | p >= 0 && p < width im })
+    (y:{p:Int | p >= 0 && p < height im })
+    (color:Color) :
+    { r:Image | (width r == width im) && (height r == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_put_pixel(im, x, y, color)"
+
+# Pastes `src` onto `dest` with top-left at (x, y); both images stay RGB-aligned in the binding layer.
+def paste
+    (dest:Image)
+    (src:Image)
+    (x:{p:Int | p >= 0 && p + width src <= width dest })
+    (y:{p:Int | p >= 0 && p + height src <= height dest }) :
+    { r:Image | (width r == width dest) && (height r == height dest) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_paste(dest, src, x, y)"
+
+# Converts to grayscale luminance then back to RGB so Color-based pipelines keep one channel width.
+def grayscale
+    (im:Image) :
+    { g:Image | (width g == width im) && (height g == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_grayscale_rgb(im)"
+
+# Per-channel photographic invert (ImageOps.invert).
+def invert
+    (im:Image) :
+    { r:Image | (width r == width im) && (height r == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_invert(im)"
+
+# Gaussian blur; radius is the PIL GaussianBlur radius (in pixels, ≥ 0).
+def blur
+    (im:Image)
+    (radius:Float) :
+    { r:Image | (width r == width im) && (height r == height im) } =
+native "__import__('aeon.bindings.image').bindings.image.Image_blur(im, radius)"
+
 # Displays the image.
 # image: image to display
-def show (image:Image) : Unit = native "im.show()"
+def show (image:Image) : Unit = native "image.show()"
 
 # Saves the image to a file.
 # image: image to save
 # path: file path
-def save (image:Image) (path:String) : Unit = native "im.save(path)"
+def save (image:Image) (path:String) : Unit = native "image.save(path)"
 
-# Opens an image from a file.
+# Opens an image from a file (normalized to RGB for predictable Color / pixel operations).
 # path: file path
 # returns: loaded image
-def open (path:String) : Image = native "__import__('PIL.Image').Image.open(path)"
+def open (path:String) : Image = native "__import__('aeon.bindings.image').bindings.image.Image_open(path)"
 
 # Computes the mean squared error (MSE) difference between two images.
 # img: first image
 # img2: second image
 # returns: MSE difference as float
 def diff (img : Image) (img2 : Image) : Float = native "__import__('aeon.bindings.image').bindings.image.Image_diff_mse(img, img2)"
+
+# ── Multi-objective synthesis metrics (candidate first, reference/target second). All are minimized.
+# Mean squared error on luminance (true grayscale), robust for grey-key matching.
+
+def fitness_bw_mse (candidate : Image) (reference : Image) : Float =
+native "__import__('aeon.bindings.image').bindings.image.Image_fitness_bw_mse(candidate, reference)"
+
+# Same as above after halving both sides (floor half width/height), still luminance MSE.
+
+def fitness_half_size_mse (candidate : Image) (reference : Image) : Float =
+native "__import__('aeon.bindings.image').bindings.image.Image_fitness_half_size_mse(candidate, reference)"
+
+# Count of rows that are not byte-identical to the reference row (RGB).
+
+def fitness_row_mismatch (candidate : Image) (reference : Image) : Float =
+native "__import__('aeon.bindings.image').bindings.image.Image_fitness_row_mismatch(candidate, reference)"
+
+# Count of columns that are not byte-identical to the reference column (RGB).
+
+def fitness_col_mismatch (candidate : Image) (reference : Image) : Float =
+native "__import__('aeon.bindings.image').bindings.image.Image_fitness_col_mismatch(candidate, reference)"
+
+# Count of pixels where any RGB channel differs.
+
+def fitness_pixel_mismatch (candidate : Image) (reference : Image) : Float =
+native "__import__('aeon.bindings.image').bindings.image.Image_fitness_pixel_mismatch(candidate, reference)"
 
 # Draws a rectangle on the image.
 # im: input image


### PR DESCRIPTION
## Summary

- **`libraries/Image.ae`**: Broader PIL-shaped API with refinements—copy, crop, resize, `fit_inside`, rotate, horizontal/vertical flip, get/put pixel, paste, grayscale (via luminance→RGB), invert, blur; bugfixes for `show` (correct receiver name) and `open` (normalize to RGB via binding).
- **`aeon/bindings/image.py`**: Pillow-backed implementations with Pillow 9/10 compatibility helpers for resampling and transpose.
- **`examples/image/key.ae`**: Multi-objective synthesis benchmark targeting `key_target.jpg`: five `@minimize_float` objectives via new `fitness_*` helpers (grayscale MSE, half-resolution MSE, row/column mismatch counts, pixel mismatch); refined canvas width/height constants; optional `reference_key` construction.
- **`examples/image/pil_style.ae`** / **`pixels.ae`**: Small runnable examples.
- **`aeon/synthesis/uis/terminal.py`**: During GP (and other GE algorithms), each evaluated candidate is printed with pretty-printed surface syntax and labeled multi-objective fitness when geneticengine reports a 5-vector `Fitness`.

## Testing

- `uv run python -m aeon --format examples/image/key.ae`
- `uv run python -m aeon --no-main examples/image/pil_style.ae` / `pixels.ae`
- Pre-commit hooks (ruff, mypy, etc.) on commit.

## Notes

- Synthesis hole type for `synth_key` is inferred from the refined return type; fitness penalties still apply when dimensions disagree with the target.

Made with [Cursor](https://cursor.com)