### PR TITLE
Add Sys, Args, Json, Path libraries + string-literal type inference fix

### DIFF
--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -9,6 +9,7 @@ from aeon.core.types import LiquidHornApplication, RefinementPolymorphism, StarK
 from aeon.core.liquid import LiquidLiteralBool
 from aeon.core.liquid import LiquidLiteralFloat
 from aeon.core.liquid import LiquidLiteralInt
+from aeon.core.liquid import LiquidLiteralString
 from aeon.core.liquid import LiquidVar
 from aeon.core.liquid_ops import ops
 from aeon.core.substitutions import (
@@ -44,6 +45,7 @@ from aeon.core.types import TypeVar
 from aeon.core.types import t_bool
 from aeon.core.types import t_float
 from aeon.core.types import t_int
+from aeon.core.types import t_string
 from aeon.core.types import t_set
 from aeon.core.types import top
 from aeon.core.types import type_free_term_vars
@@ -204,6 +206,15 @@ def prim_litfloat(t: float) -> RefinedType:
     )
 
 
+def prim_litstring(t: str) -> RefinedType:
+    vname = Name("v", fresh_counter.fresh())
+    return RefinedType(
+        vname,
+        t_string,
+        LiquidApp(Name("==", 0), [LiquidVar(vname), LiquidLiteralString(t)]),
+    )
+
+
 def make_binary_app_type(t: Name, ity: TypeConstructor | TypeVar, oty: TypeConstructor | TypeVar) -> Type:
     """Creates the type of a binary operator"""
     xname = Name("x", fresh_counter.fresh())
@@ -315,9 +326,9 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
         case Literal(vf, TypeConstructor(Name("Float", _))):
             assert isinstance(vf, float)
             return (ctrue, prim_litfloat(vf))
-        case Literal(_, TypeConstructor(Name("String", _))):
-            # TODO: String support
-            return (ctrue, t.type)
+        case Literal(vs, TypeConstructor(Name("String", _))):
+            assert isinstance(vs, str)
+            return (ctrue, prim_litstring(vs))
         case Var(name):
             if name in ops:
                 return (ctrue, prim_op(name))

--- a/examples/imports/args_example.ae
+++ b/examples/imports/args_example.ae
@@ -1,0 +1,18 @@
+open Args
+open List
+
+# Build a parser with a flag and an option-with-default. We use parseList
+# with an explicit empty argv so the example runs cleanly under
+# `aeon args_example.ae` (which doesn't forward CLI args).
+
+def parser : Parser =
+    p0 : Parser = Args.newParser "Demo CLI";
+    p1 : Parser = Args.addOption p0 "greeting" "Hello" "what to say";
+    Args.addFlag p1 "uppercase" "shout instead of say"
+
+def emptyArgs : (List String) = native "[]"
+
+def main (_:Int) : Unit =
+    a : ParsedArgs = Args.parseList parser emptyArgs;
+    g : String = Args.getString a "greeting";
+    print g

--- a/examples/imports/json_example.ae
+++ b/examples/imports/json_example.ae
@@ -1,0 +1,15 @@
+open Json
+
+# Round-trip: build an object via mk + setKey, stringify, parse, query.
+
+def built : Json =
+    o0 : Json = Json.mkObject;
+    o1 : Json = Json.setKey o0 "name" (Json.mkString "Aeon");
+    Json.setKey o1 "version" (Json.mkInt 4)
+
+# stringify is refined non-empty, so it can be passed directly to parse.
+def decoded : Json = Json.parse (Json.stringify built)
+
+def name : String = Json.asString (Json.get decoded "name")
+
+def main (_:Int) : Unit = print name

--- a/examples/imports/path_example.ae
+++ b/examples/imports/path_example.ae
@@ -1,0 +1,15 @@
+open Path
+
+# Build a path to a file inside the current working directory and
+# query it. Pure operations only — no filesystem mutations so the
+# example is reproducible.
+
+def projectFile : Path = Path.join (Path.cwd unit) "pyproject.toml"
+
+def fileName : String = Path.name projectFile
+
+def fileSuffix : String = Path.suffix projectFile
+
+def main (_:Int) : Unit =
+    _ : Unit = print fileName;
+    print fileSuffix

--- a/examples/imports/sys_example.ae
+++ b/examples/imports/sys_example.ae
@@ -1,0 +1,11 @@
+open Sys
+open List
+
+# argv is statically known to be non-empty, so List.head is well-typed.
+def progName : String = List.head Sys.argv
+
+def show : Unit =
+    _ : Unit = print Sys.platform;
+    print progName
+
+def main (_:Int) : Unit = show

--- a/libraries/Args.ae
+++ b/libraries/Args.ae
@@ -1,0 +1,76 @@
+open List
+
+type Parser
+type ParsedArgs
+
+def argparse : Unit = native_import "argparse"
+
+# ── Parser construction ────────────────────────────────────────────────
+
+# Creates a new argument parser with a description shown in --help output.
+def newParser (description: String) : Parser =
+    native "argparse.ArgumentParser(description=description)"
+
+# Adds a required positional string argument.
+def addArg (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument(name, help=help), p)[1]"
+
+# Adds a required positional integer argument.
+def addIntArg (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument(name, type=int, help=help), p)[1]"
+
+# Adds a required positional float argument.
+def addFloatArg (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument(name, type=float, help=help), p)[1]"
+
+# Adds an optional boolean flag (e.g. --verbose). Defaults to false.
+def addFlag (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument('--' + name, action='store_true', help=help), p)[1]"
+
+# Adds an optional string option, e.g. --output FILE.
+def addOption (p: Parser) (name: {s:String | s != ""}) (default: String) (help: String) : Parser =
+    native "(p.add_argument('--' + name, default=default, help=help), p)[1]"
+
+# Adds an optional integer option.
+def addIntOption (p: Parser) (name: {s:String | s != ""}) (default: Int) (help: String) : Parser =
+    native "(p.add_argument('--' + name, type=int, default=default, help=help), p)[1]"
+
+# Adds an optional float option.
+def addFloatOption (p: Parser) (name: {s:String | s != ""}) (default: Float) (help: String) : Parser =
+    native "(p.add_argument('--' + name, type=float, default=default, help=help), p)[1]"
+
+# Adds an optional argument restricted to a non-empty list of choices.
+def addChoice (p: Parser) (name: {s:String | s != ""}) (options: {l: (List String) | List.size l > 0}) (default: String) (help: String) : Parser =
+    native "(p.add_argument('--' + name, default=default, choices=options, help=help), p)[1]"
+
+# ── Parsing ────────────────────────────────────────────────────────────
+
+# Parses sys.argv[1:] using the configured parser. argparse will call
+# sys.exit on parse error or when --help is passed.
+def parse (p: Parser) : ParsedArgs =
+    native "p.parse_args()"
+
+# Parses an explicit list of strings. Useful for tests and embedding.
+def parseList (p: Parser) (xs: (List String)) : ParsedArgs =
+    native "p.parse_args(xs)"
+
+# ── Reading parsed values ──────────────────────────────────────────────
+# argparse converts dashes in option names to underscores when accessing
+# attributes (e.g. --output-file becomes output_file). Look up names in
+# their underscored form.
+
+# Reads a string value by name.
+def getString (a: ParsedArgs) (name: {s:String | s != ""}) : String =
+    native "getattr(a, name)"
+
+# Reads an integer value by name.
+def getInt (a: ParsedArgs) (name: {s:String | s != ""}) : Int =
+    native "getattr(a, name)"
+
+# Reads a float value by name.
+def getFloat (a: ParsedArgs) (name: {s:String | s != ""}) : Float =
+    native "getattr(a, name)"
+
+# Reads a boolean flag value by name.
+def getBool (a: ParsedArgs) (name: {s:String | s != ""}) : Bool =
+    native "getattr(a, name)"

--- a/libraries/Json.ae
+++ b/libraries/Json.ae
@@ -1,0 +1,91 @@
+open List
+
+type Json
+
+def json : Unit = native_import "json"
+
+# ── Parsing / serialization ────────────────────────────────────────────
+
+# Parses a JSON string. Raises at runtime on malformed input.
+# s: non-empty JSON source
+def parse (s: {x:String | x != ""}) : Json = native "json.loads(s)"
+
+# Parses a JSON file at path.
+# path: non-empty file path
+def parseFile (path: {p:String | p != ""}) : Json =
+    native "json.load(open(path))"
+
+# Serializes a Json value to its string form. The result is always
+# non-empty (json.dumps(None) yields "null").
+def stringify (j: Json) : {s:String | s != ""} = native "json.dumps(j)"
+
+# Pretty-prints a Json value with 2-space indentation. Always non-empty.
+def stringifyPretty (j: Json) : {s:String | s != ""} = native "json.dumps(j, indent=2)"
+
+# Writes a Json value to a file.
+# path: non-empty file path
+def writeFile (path: {p:String | p != ""}) (j: Json) : Unit =
+    native "open(path, 'w').write(json.dumps(j))"
+
+# ── Type queries ───────────────────────────────────────────────────────
+
+def isNull   (j: Json) : Bool = native "j is None"
+def isBool   (j: Json) : Bool = native "isinstance(j, bool)"
+def isNumber (j: Json) : Bool = native "isinstance(j, (int, float)) and not isinstance(j, bool)"
+def isString (j: Json) : Bool = native "isinstance(j, str)"
+def isArray  (j: Json) : Bool = native "isinstance(j, list)"
+def isObject (j: Json) : Bool = native "isinstance(j, dict)"
+
+# ── Coercion (runtime-typed) ───────────────────────────────────────────
+# Each asX raises at runtime if the value is not of that kind.
+
+def asBool (j: Json) : Bool =
+    native "j if isinstance(j, bool) else (_ for _ in ()).throw(TypeError('not a bool'))"
+
+def asInt (j: Json) : Int =
+    native "j if (isinstance(j, int) and not isinstance(j, bool)) else (_ for _ in ()).throw(TypeError('not an int'))"
+
+def asFloat (j: Json) : Float =
+    native "float(j) if (isinstance(j, (int, float)) and not isinstance(j, bool)) else (_ for _ in ()).throw(TypeError('not a number'))"
+
+def asString (j: Json) : String =
+    native "j if isinstance(j, str) else (_ for _ in ()).throw(TypeError('not a string'))"
+
+# ── Object access ──────────────────────────────────────────────────────
+
+# Returns true if j is an object containing key.
+def has (j: Json) (key: String) : Bool = native "isinstance(j, dict) and key in j"
+
+# Looks up a key in a JSON object. Raises at runtime if j is not an
+# object or key is absent.
+def get (j: Json) (key: String) : Json = native "j[key]"
+
+# ── Array access ───────────────────────────────────────────────────────
+
+# Returns the length of an array (or string/object). Raises if j has no len.
+def length (j: Json) : {x:Int | x >= 0} = native "len(j)"
+
+# Indexes into a JSON array. Raises at runtime if i is out of range.
+def at (j: Json) (i: {x:Int | x >= 0}) : Json = native "j[i]"
+
+# ── Construction ───────────────────────────────────────────────────────
+
+def mkNull : Json = native "None"
+
+def mkBool (b: Bool) : Json = native "b"
+
+def mkInt (i: Int) : Json = native "i"
+
+def mkFloat (f: Float) : Json = native "f"
+
+def mkString (s: String) : Json = native "s"
+
+def mkArray (xs: (List Json)) : Json = native "list(xs)"
+
+# An empty JSON object. Use setKey to populate.
+def mkObject : Json = native "{}"
+
+# Returns a new object with key set to value. Raises at runtime if j is
+# not an object.
+def setKey (j: Json) (key: String) (value: Json) : Json =
+    native "({**j, key: value} if isinstance(j, dict) else (_ for _ in ()).throw(TypeError('not an object')))"

--- a/libraries/List.ae
+++ b/libraries/List.ae
@@ -8,23 +8,23 @@ def size: (l:(List a)) -> Int = uninterpreted
 # Returns the length of the list.
 # l: list
 # returns: number of elements in the list
-def length (l:(List a)) : {x:Int | x == size l} = native "len(l)"
+def length (l:(List a)) : {x:Int | x == List.size l} = native "len(l)"
 
 # Creates a new empty list.
 # returns: an empty list
-def new : {x:(List a) | (size x) == 0} = native "[]" ;
+def new : {x:(List a) | List.size x == 0} = native "[]" ;
 
 # Appends an item to the end of the list.
 # l: list
 # i: item to append
 # returns: new list with item appended
-def append (l:(List a)) (i: a) : {l2:(List a) | size l2 == (size l) + 1} = native "l + [i]"
+def append (l:(List a)) (i: a) : {l2:(List a) | List.size l2 == (List.size l) + 1} = native "l + [i]"
 
 # Prepends an item to the start of the list.
 # l: list
 # i: item to prepend
 # returns: new list with item prepended
-def cons (l:(List a)) (i:a) : {l2:(List a) | size l2 == (size l) + 1} = native "[i] + l"
+def cons (l:(List a)) (i:a) : {l2:(List a) | List.size l2 == (List.size l) + 1} = native "[i] + l"
 
 # Applies a recursive reduction over the list.
 # l: list
@@ -41,7 +41,7 @@ def sum (l:(List Int)) : Int = native "sum(l)"
 # Returns the first element of a non-empty list.
 # l: non-empty list
 # returns: first element
-def head (l: {x:(List a) | size x > 0 }) : a = native "l[0]"
+def head (l: {x:(List a) | List.size x > 0 }) : a = native "l[0]"
 
 # Maps a function over the list.
 # f: function to apply
@@ -54,7 +54,7 @@ def map (f: (v:a) -> b) (l:(List a)) : (List b) = native "list(map(f, l))"
 # returns: reversed list
 def reversed (l: (List a)) : (List a) = native "l[::-1]"
 
-def empty (l: (List a)) : {x:Bool | x == ((size l) == 0)} = (length l) == 0
+def empty (l: (List a)) : {x:Bool | x == ((List.size l) == 0)} = (length l) == 0
 
 
 # def List_tail:(l:{x:(List a) | size x > 0 }) -> {l2:(List a) | size l2 ==  (size l) - 1 }  = \xs -> native "xs[1:]"

--- a/libraries/List.ae
+++ b/libraries/List.ae
@@ -54,7 +54,7 @@ def map (f: (v:a) -> b) (l:(List a)) : (List b) = native "list(map(f, l))"
 # returns: reversed list
 def reversed (l: (List a)) : (List a) = native "l[::-1]"
 
-def empty (l: (List a)) : {x:Bool | x == ((List.size l) == 0)} = (length l) == 0
+def empty (l: (List a)) : {x:Bool | x == ((List.size l) == 0)} = (List.length l) == 0
 
 
 # def List_tail:(l:{x:(List a) | size x > 0 }) -> {l2:(List a) | size l2 ==  (size l) - 1 }  = \xs -> native "xs[1:]"

--- a/libraries/Map.ae
+++ b/libraries/Map.ae
@@ -4,7 +4,7 @@ type Map k v
 def size: (m: (Map k v)) -> Int = uninterpreted
 
 # Creates a new empty map.
-def new : {m: (Map k v) | size m == 0} = native "{}";
+def new : {m: (Map k v) | Map.size m == 0} = native "{}";
 
 # Sets the value for a key in the map.
 # m: map

--- a/libraries/Path.ae
+++ b/libraries/Path.ae
@@ -1,0 +1,117 @@
+open List
+
+type Path
+
+def pathlib : Unit = native_import "pathlib"
+def shutil  : Unit = native_import "shutil"
+
+# ── Construction ───────────────────────────────────────────────────────
+
+# Builds a Path from a non-empty string.
+def mk (s: {x:String | x != ""}) : Path = native "pathlib.Path(s)"
+
+# Returns the current working directory. Thunked so each call returns
+# the cwd at call time (which can change after os.chdir).
+def cwd (_: Unit) : Path = native "pathlib.Path.cwd()"
+
+# Returns the current user's home directory.
+def home (_: Unit) : Path = native "pathlib.Path.home()"
+
+# Renders a Path to its string form.
+def toString (p: Path) : String = native "str(p)"
+
+# ── Pure path operations ───────────────────────────────────────────────
+
+# The parent directory of p. The parent of a root path is itself.
+def parent (p: Path) : Path = native "p.parent"
+
+# The final path component (e.g. the filename).
+def name (p: Path) : String = native "p.name"
+
+# The filename without its suffix (e.g. "report" for "report.txt").
+def stem (p: Path) : String = native "p.stem"
+
+# The file suffix including the leading dot (e.g. ".txt"), or "" if none.
+def suffix (p: Path) : String = native "p.suffix"
+
+# Appends a non-empty segment to p, producing a new Path.
+def join (p: Path) (segment: {s:String | s != ""}) : Path = native "p / segment"
+
+# Returns a copy of p with a different suffix. The new suffix must
+# start with "." or be empty (to strip).
+def withSuffix (p: Path) (newSuffix: String) : Path =
+    native "p.with_suffix(newSuffix)"
+
+# Returns the absolute form of p, anchored at the current working dir.
+def absolute (p: Path) : Path = native "p.absolute()"
+
+# Returns the canonical absolute path with symlinks resolved. Raises
+# if the path does not exist on Python 3.6+ when strict=True; here we
+# default to permissive (strict=False).
+def resolve (p: Path) : Path = native "p.resolve()"
+
+# ── Predicates ─────────────────────────────────────────────────────────
+
+# True if p exists on the filesystem.
+def exists (p: Path) : Bool = native "p.exists()"
+
+# True if p exists and is a regular file.
+def isFile (p: Path) : Bool = native "p.is_file()"
+
+# True if p exists and is a directory.
+def isDir (p: Path) : Bool = native "p.is_dir()"
+
+# True if p is anchored at a root (has a drive or starts with "/").
+def isAbsolute (p: Path) : Bool = native "p.is_absolute()"
+
+# True if p is not absolute.
+def isRelative (p: Path) : Bool = native "not p.is_absolute()"
+
+# ── File I/O ───────────────────────────────────────────────────────────
+
+# Reads a text file as a String. Raises if p is not a readable file.
+def read (p: Path) : String = native "p.read_text()"
+
+# Writes content to p, overwriting any existing file.
+def write (p: Path) (content: String) : Unit = native "p.write_text(content)"
+
+# Appends content to p. Creates the file if it does not exist.
+def appendTo (p: Path) (content: String) : Unit =
+    native "open(str(p), 'a').write(content)"
+
+# ── Directory I/O ──────────────────────────────────────────────────────
+
+# Creates the directory at p. Raises if p already exists or its parent
+# is missing.
+def mkdir (p: Path) : Unit = native "p.mkdir()"
+
+# Creates the directory at p along with any missing parents. Does not
+# raise if p already exists. Equivalent to mkdir -p.
+def mkdirAll (p: Path) : Unit = native "p.mkdir(parents=True, exist_ok=True)"
+
+# Lists immediate children of p as a list of names. Raises if p is not
+# a directory.
+def listDir (p: Path) : (List String) =
+    native "[child.name for child in p.iterdir()]"
+
+# Returns paths matching pattern relative to p (e.g. "*.py").
+def glob (p: Path) (pattern: {s:String | s != ""}) : (List Path) =
+    native "list(p.glob(pattern))"
+
+# ── Mutations ──────────────────────────────────────────────────────────
+
+# Deletes the file at p. Raises if p is a directory or does not exist.
+def remove (p: Path) : Unit = native "p.unlink()"
+
+# Deletes an empty directory at p. Raises if p is not empty.
+def removeDir (p: Path) : Unit = native "p.rmdir()"
+
+# Recursively deletes a directory and its contents. Raises if p is
+# not a directory.
+def removeAll (p: Path) : Unit = native "shutil.rmtree(str(p))"
+
+# Renames or moves p to dst. Returns the new Path.
+def rename (p: Path) (dst: Path) : Path = native "p.rename(dst)"
+
+# Copies a file from src to dst, preserving metadata.
+def copy (src: Path) (dst: Path) : Unit = native "shutil.copy2(str(src), str(dst))"

--- a/libraries/Plot.ae
+++ b/libraries/Plot.ae
@@ -1,7 +1,7 @@
+open List
+
 # Represents a Plot object. Internally, this would correspond to a Matplotlib Figure.
 type Plot
-
-type List a; # Assuming this is how you define generic lists
 
 def plt : Unit = native_import "matplotlib.pyplot"
 

--- a/libraries/Random.ae
+++ b/libraries/Random.ae
@@ -8,8 +8,8 @@ def seed (seed: Int) : Unit = native "random.seed(seed)"
 # Returns a random integer N such that a <= N <= b.
 def randint (a: Int) (b: Int) : {r:Int | r >= a && r <= b} = native "random.randint(a, b)"
 
-# Returns a random float in the range [0.0, 1.0).
-def random : {r:Float | r >= 0.0 && r < 1.0} = native "random.random()";
+# Returns a random float in the range [0.0, 1.0). Thunked to defer evaluation.
+def random (_: Unit) : {r:Float | r >= 0.0 && r < 1.0} = native "random.random()";
 
 # Returns a random float N such that a <= N < b.
 def uniform (a: Float) (b: Float) : {r:Float | r >= a && r < b} = native "random.uniform(a, b)"

--- a/libraries/Sys.ae
+++ b/libraries/Sys.ae
@@ -44,21 +44,21 @@ def flushStderr (_: Unit) : Unit = native "sys.stderr.flush()"
 def environ (_: Unit) : (Map String String) = native "dict(os.environ)"
 
 # Looks up an environment variable, returning default if unset.
-# name: non-empty environment variable name
+# name: environment variable name
 # default: value to return if the variable is unset
-def getenv (name: {s:String | s != ""}) (default: String) : String =
+def getenv (name: String) (default: String) : String =
     native "os.environ.get(name, default)"
 
 # Returns true if the environment variable is set.
-# name: non-empty environment variable name
-def hasenv (name: {s:String | s != ""}) : Bool =
+# name: environment variable name
+def hasenv (name: String) : Bool =
     native "name in os.environ"
 
 # Sets an environment variable and returns a snapshot of the new environment.
-# name: non-empty environment variable name
+# name: environment variable name
 # value: value to assign
 # returns: a Map of the environment after the update
-def setenv (name: {s:String | s != ""}) (value: String) : (Map String String) =
+def setenv (name: String) (value: String) : (Map String String) =
     native "(os.environ.__setitem__(name, value), dict(os.environ))[1]"
 
 # ── Platform info ──────────────────────────────────────────────────────

--- a/libraries/Sys.ae
+++ b/libraries/Sys.ae
@@ -1,8 +1,5 @@
 open List
-
-# Map is referenced by type only; we declare it locally to avoid a clash
-# between Map.size and List.size when both are opened.
-type Map k v;
+open Map
 
 def sys : Unit = native_import "sys"
 def os : Unit = native_import "os"

--- a/libraries/Sys.ae
+++ b/libraries/Sys.ae
@@ -44,21 +44,21 @@ def flushStderr (_: Unit) : Unit = native "sys.stderr.flush()"
 def environ (_: Unit) : (Map String String) = native "dict(os.environ)"
 
 # Looks up an environment variable, returning default if unset.
-# name: environment variable name
+# name: non-empty environment variable name
 # default: value to return if the variable is unset
-def getenv (name: String) (default: String) : String =
+def getenv (name: {s:String | s != ""}) (default: String) : String =
     native "os.environ.get(name, default)"
 
 # Returns true if the environment variable is set.
-# name: environment variable name
-def hasenv (name: String) : Bool =
+# name: non-empty environment variable name
+def hasenv (name: {s:String | s != ""}) : Bool =
     native "name in os.environ"
 
 # Sets an environment variable and returns a snapshot of the new environment.
-# name: environment variable name
+# name: non-empty environment variable name
 # value: value to assign
 # returns: a Map of the environment after the update
-def setenv (name: String) (value: String) : (Map String String) =
+def setenv (name: {s:String | s != ""}) (value: String) : (Map String String) =
     native "(os.environ.__setitem__(name, value), dict(os.environ))[1]"
 
 # ── Platform info ──────────────────────────────────────────────────────

--- a/libraries/Sys.ae
+++ b/libraries/Sys.ae
@@ -1,0 +1,76 @@
+open List
+
+# Map is referenced by type only; we declare it locally to avoid a clash
+# between Map.size and List.size when both are opened.
+type Map k v;
+
+def sys : Unit = native_import "sys"
+def os : Unit = native_import "os"
+
+# ── Process arguments ──────────────────────────────────────────────────
+
+# The list of command-line arguments. argv[0] is the program name, so
+# the list is always non-empty.
+def argv : {l: (List String) | List.size l >= 1} = native "sys.argv"
+
+# Command-line arguments without the program name. May be empty.
+def args : (List String) = native "sys.argv[1:]"
+
+# The number of command-line arguments. Always >= 1 (argv[0] is the program).
+def argc : {x:Int | x >= 1} = native "len(sys.argv)"
+
+# The program name (argv[0]).
+def progName : String = native "sys.argv[0]"
+
+# ── Exit ───────────────────────────────────────────────────────────────
+
+# Exits the process. Conventionally 0 = success, 1-255 = error.
+def exit (code: {x:Int | x >= 0 && x <= 255}) : Unit = native "sys.exit(code)"
+
+# ── Standard streams ───────────────────────────────────────────────────
+
+# Reads a line from stdin (newline stripped). Thunked to defer the read.
+def readLine (_: Unit) : String = native "input()"
+
+# Prints a string to stderr followed by a newline.
+def eprint (s: String) : Unit = native "print(s, file=sys.stderr)"
+
+# Flushes the standard output buffer.
+def flushStdout (_: Unit) : Unit = native "sys.stdout.flush()"
+
+# Flushes the standard error buffer.
+def flushStderr (_: Unit) : Unit = native "sys.stderr.flush()"
+
+# ── Environment ────────────────────────────────────────────────────────
+
+# Returns a snapshot of the current environment as a Map.
+def environ (_: Unit) : (Map String String) = native "dict(os.environ)"
+
+# Looks up an environment variable, returning default if unset.
+# name: non-empty environment variable name
+# default: value to return if the variable is unset
+def getenv (name: {s:String | s != ""}) (default: String) : String =
+    native "os.environ.get(name, default)"
+
+# Returns true if the environment variable is set.
+# name: non-empty environment variable name
+def hasenv (name: {s:String | s != ""}) : Bool =
+    native "name in os.environ"
+
+# Sets an environment variable and returns a snapshot of the new environment.
+# name: non-empty environment variable name
+# value: value to assign
+# returns: a Map of the environment after the update
+def setenv (name: {s:String | s != ""}) (value: String) : (Map String String) =
+    native "(os.environ.__setitem__(name, value), dict(os.environ))[1]"
+
+# ── Platform info ──────────────────────────────────────────────────────
+
+# A string identifying the platform (e.g. "linux", "darwin", "win32").
+def platform : String = native "sys.platform"
+
+# The Python version string of the underlying interpreter.
+def pythonVersion : String = native "sys.version"
+
+# The path to the Python executable.
+def executable : String = native "sys.executable"


### PR DESCRIPTION
## Summary

Bundles four new standard libraries that share a common foundation (the typeinfer fix below) and a few small library cleanups. Squash-merging is fine; the per-library commits are kept for review.

### New libraries (all in `libraries/`)
- **[`Sys.ae`](libraries/Sys.ae)** — wraps `sys`/`os`. `argv` (non-empty), `argc`, `args`, `progName`, `exit` (refined `[0,255]`), `readLine`, `eprint`, `flushStdout`/`flushStderr`, `getenv`/`hasenv`/`setenv` (non-empty key), `environ` returning `Map String String`, `platform`/`pythonVersion`/`executable`.
- **[`Args.ae`](libraries/Args.ae)** — argparse wrapper. Build via `newParser` → `addArg`/`addIntArg`/`addFloatArg`/`addFlag`/`addOption`/`addIntOption`/`addFloatOption`/`addChoice`. Parse via `parse`/`parseList`. Read via `getString`/`getInt`/`getFloat`/`getBool`. All names refined non-empty; `addChoice` requires non-empty options list.
- **[`Json.ae`](libraries/Json.ae)** — `json` wrapper with opaque `Json` type. Parse/build/serialize/query. `parse`/`parseFile`/`writeFile` require non-empty source; `stringify`/`stringifyPretty` return non-empty (so `parse (stringify x)` typechecks).
- **[`Path.ae`](libraries/Path.ae)** — `pathlib`/`shutil` wrapper. Pure ops (`parent`/`name`/`stem`/`suffix`/`join`/`withSuffix`/`absolute`/`resolve`), predicates (`exists`/`isFile`/`isDir`/`isAbsolute`/`isRelative`), file I/O (`read`/`write`/`appendTo`), directory I/O (`mkdir`/`mkdirAll`/`listDir`/`glob`), mutations (`remove`/`removeDir`/`removeAll`/`rename`/`copy`).

### Compiler fix
- [`aeon/typechecking/typeinfer.py`](aeon/typechecking/typeinfer.py): String literals now produce `{v:String | v == "literal"}`, matching what Int/Float/Bool already did via `prim_lit*`. The previous `# TODO: String support` made any `s != ""` refinement unprovable for a concrete literal — i.e. it rejected every call site, not just the empty-string case. With this fix, the libraries above can refine string parameters non-empty without breaking real usage.

### Library cleanups
- [`libraries/List.ae`](libraries/List.ae): qualified `size` and `length` references inside the library so they don't re-resolve when callers `open` another library that exports the same names. Same convention `Statistics.ae` already follows.
- [`libraries/Map.ae`](libraries/Map.ae): same fix for `size`.
- [`libraries/Plot.ae`](libraries/Plot.ae): replaced inline `type List a;` workaround with `open List` (now safe because of the qualifications above).
- [`libraries/Random.ae`](libraries/Random.ae): `random` is now `(_:Unit) -> Float`, evaluating fresh per call. Callable as `Random.random unit` thanks to the literal added in #227.

### Aeon quirks discovered while building this stack
- Qualified calls (e.g. `String.len s > 0`) are not visible to the SMT context across module boundaries. `s != ""` works because equality is built-in. Worth a follow-up.
- `open` must precede `type` declarations in a library file, otherwise types from the opened module aren't visible to subsequent definitions.

## Test plan
- [x] `bash run_examples.sh` — 72/72 pass.
- [x] `uv run pytest tests/` — 424 passed, 9 skipped.
- [x] `Sys.exit 999` rejected at typecheck (out of `[0, 255]`).
- [x] `Sys.hasenv ""` rejected; `Sys.hasenv "PATH"` accepted.
- [x] `List.head Sys.argv` accepted without further annotation.
- [x] `Args.addArg p "" "..."` rejected; `addChoice` with `List.new` rejected.
- [x] `Json.parse ""` rejected; `Json.at j (0 - 1)` rejected.
- [x] Round-trip example: `Json.parse (Json.stringify built)` typechecks via the non-empty refinement on `stringify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)