### PR TITLE
Add Args library: argparse wrapper for CLI building

### DIFF
--- a/examples/imports/args_example.ae
+++ b/examples/imports/args_example.ae
@@ -1,0 +1,18 @@
+open Args
+open List
+
+# Build a parser with a flag and an option-with-default. We use parseList
+# with an explicit empty argv so the example runs cleanly under
+# `aeon args_example.ae` (which doesn't forward CLI args).
+
+def parser : Parser =
+    p0 : Parser = Args.newParser "Demo CLI";
+    p1 : Parser = Args.addOption p0 "greeting" "Hello" "what to say";
+    Args.addFlag p1 "uppercase" "shout instead of say"
+
+def emptyArgs : (List String) = native "[]"
+
+def main (_:Int) : Unit =
+    a : ParsedArgs = Args.parseList parser emptyArgs;
+    g : String = Args.getString a "greeting";
+    print g

--- a/libraries/Args.ae
+++ b/libraries/Args.ae
@@ -1,0 +1,76 @@
+open List
+
+type Parser
+type ParsedArgs
+
+def argparse : Unit = native_import "argparse"
+
+# ── Parser construction ────────────────────────────────────────────────
+
+# Creates a new argument parser with a description shown in --help output.
+def newParser (description: String) : Parser =
+    native "argparse.ArgumentParser(description=description)"
+
+# Adds a required positional string argument.
+def addArg (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument(name, help=help), p)[1]"
+
+# Adds a required positional integer argument.
+def addIntArg (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument(name, type=int, help=help), p)[1]"
+
+# Adds a required positional float argument.
+def addFloatArg (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument(name, type=float, help=help), p)[1]"
+
+# Adds an optional boolean flag (e.g. --verbose). Defaults to false.
+def addFlag (p: Parser) (name: {s:String | s != ""}) (help: String) : Parser =
+    native "(p.add_argument('--' + name, action='store_true', help=help), p)[1]"
+
+# Adds an optional string option, e.g. --output FILE.
+def addOption (p: Parser) (name: {s:String | s != ""}) (default: String) (help: String) : Parser =
+    native "(p.add_argument('--' + name, default=default, help=help), p)[1]"
+
+# Adds an optional integer option.
+def addIntOption (p: Parser) (name: {s:String | s != ""}) (default: Int) (help: String) : Parser =
+    native "(p.add_argument('--' + name, type=int, default=default, help=help), p)[1]"
+
+# Adds an optional float option.
+def addFloatOption (p: Parser) (name: {s:String | s != ""}) (default: Float) (help: String) : Parser =
+    native "(p.add_argument('--' + name, type=float, default=default, help=help), p)[1]"
+
+# Adds an optional argument restricted to a non-empty list of choices.
+def addChoice (p: Parser) (name: {s:String | s != ""}) (options: {l: (List String) | List.size l > 0}) (default: String) (help: String) : Parser =
+    native "(p.add_argument('--' + name, default=default, choices=options, help=help), p)[1]"
+
+# ── Parsing ────────────────────────────────────────────────────────────
+
+# Parses sys.argv[1:] using the configured parser. argparse will call
+# sys.exit on parse error or when --help is passed.
+def parse (p: Parser) : ParsedArgs =
+    native "p.parse_args()"
+
+# Parses an explicit list of strings. Useful for tests and embedding.
+def parseList (p: Parser) (xs: (List String)) : ParsedArgs =
+    native "p.parse_args(xs)"
+
+# ── Reading parsed values ──────────────────────────────────────────────
+# argparse converts dashes in option names to underscores when accessing
+# attributes (e.g. --output-file becomes output_file). Look up names in
+# their underscored form.
+
+# Reads a string value by name.
+def getString (a: ParsedArgs) (name: {s:String | s != ""}) : String =
+    native "getattr(a, name)"
+
+# Reads an integer value by name.
+def getInt (a: ParsedArgs) (name: {s:String | s != ""}) : Int =
+    native "getattr(a, name)"
+
+# Reads a float value by name.
+def getFloat (a: ParsedArgs) (name: {s:String | s != ""}) : Float =
+    native "getattr(a, name)"
+
+# Reads a boolean flag value by name.
+def getBool (a: ParsedArgs) (name: {s:String | s != ""}) : Bool =
+    native "getattr(a, name)"


### PR DESCRIPTION
## Summary
- Adds `libraries/Args.ae` — a thin wrapper over Python's `argparse` for building CLIs from Aeon programs.
- API mirrors argparse: `newParser` → `addArg` / `addIntArg` / `addFloatArg` / `addFlag` / `addOption` / `addIntOption` / `addFloatOption` / `addChoice` → `parse` (or `parseList` for tests). Read parsed values with `getString` / `getInt` / `getFloat` / `getBool`.
- Refinements that earn their keep:
  - All name parameters require `{s:String | s != ""}`. Verified empty-string names are rejected; literals like `"greeting"` pass (relies on the typeinfer fix in #223).
  - `addChoice` requires the options list to be non-empty. Passing `List.new` is rejected at typecheck.

### Note on PR base
Stacked on `feat/sys-library` (PR #223). Once #223 merges this rebases onto `master` cleanly.

### What I considered but didn't do
- Refining "default is one of options" in `addChoice` — would need string-set membership in refinements; Aeon's set support is integer-only.
- Refining "name was registered before reading" — would need dependent typing on parser state; out of scope.

## Test plan
- [x] `examples/imports/args_example.ae` builds a parser with an option and a flag, calls `parseList` with empty argv, prints the default. Runs cleanly.
- [x] Empty-string name (`Args.addArg p "" "..."`) rejected at typecheck.
- [x] `addChoice` with `List.new` rejected at typecheck (`List.size > 0` not provable).
- [x] All 4 imports examples pass with `aeon --no-main --budget 10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)