### PR TITLE
Add Json library: json wrapper for parsing, building, querying

### DIFF
--- a/examples/imports/json_example.ae
+++ b/examples/imports/json_example.ae
@@ -1,0 +1,15 @@
+open Json
+
+# Round-trip: build an object via mk + setKey, stringify, parse, query.
+
+def built : Json =
+    o0 : Json = Json.mkObject;
+    o1 : Json = Json.setKey o0 "name" (Json.mkString "Aeon");
+    Json.setKey o1 "version" (Json.mkInt 4)
+
+# stringify is refined non-empty, so it can be passed directly to parse.
+def decoded : Json = Json.parse (Json.stringify built)
+
+def name : String = Json.asString (Json.get decoded "name")
+
+def main (_:Int) : Unit = print name

--- a/libraries/Json.ae
+++ b/libraries/Json.ae
@@ -1,0 +1,91 @@
+open List
+
+type Json
+
+def json : Unit = native_import "json"
+
+# ── Parsing / serialization ────────────────────────────────────────────
+
+# Parses a JSON string. Raises at runtime on malformed input.
+# s: non-empty JSON source
+def parse (s: {x:String | x != ""}) : Json = native "json.loads(s)"
+
+# Parses a JSON file at path.
+# path: non-empty file path
+def parseFile (path: {p:String | p != ""}) : Json =
+    native "json.load(open(path))"
+
+# Serializes a Json value to its string form. The result is always
+# non-empty (json.dumps(None) yields "null").
+def stringify (j: Json) : {s:String | s != ""} = native "json.dumps(j)"
+
+# Pretty-prints a Json value with 2-space indentation. Always non-empty.
+def stringifyPretty (j: Json) : {s:String | s != ""} = native "json.dumps(j, indent=2)"
+
+# Writes a Json value to a file.
+# path: non-empty file path
+def writeFile (path: {p:String | p != ""}) (j: Json) : Unit =
+    native "open(path, 'w').write(json.dumps(j))"
+
+# ── Type queries ───────────────────────────────────────────────────────
+
+def isNull   (j: Json) : Bool = native "j is None"
+def isBool   (j: Json) : Bool = native "isinstance(j, bool)"
+def isNumber (j: Json) : Bool = native "isinstance(j, (int, float)) and not isinstance(j, bool)"
+def isString (j: Json) : Bool = native "isinstance(j, str)"
+def isArray  (j: Json) : Bool = native "isinstance(j, list)"
+def isObject (j: Json) : Bool = native "isinstance(j, dict)"
+
+# ── Coercion (runtime-typed) ───────────────────────────────────────────
+# Each asX raises at runtime if the value is not of that kind.
+
+def asBool (j: Json) : Bool =
+    native "j if isinstance(j, bool) else (_ for _ in ()).throw(TypeError('not a bool'))"
+
+def asInt (j: Json) : Int =
+    native "j if (isinstance(j, int) and not isinstance(j, bool)) else (_ for _ in ()).throw(TypeError('not an int'))"
+
+def asFloat (j: Json) : Float =
+    native "float(j) if (isinstance(j, (int, float)) and not isinstance(j, bool)) else (_ for _ in ()).throw(TypeError('not a number'))"
+
+def asString (j: Json) : String =
+    native "j if isinstance(j, str) else (_ for _ in ()).throw(TypeError('not a string'))"
+
+# ── Object access ──────────────────────────────────────────────────────
+
+# Returns true if j is an object containing key.
+def has (j: Json) (key: String) : Bool = native "isinstance(j, dict) and key in j"
+
+# Looks up a key in a JSON object. Raises at runtime if j is not an
+# object or key is absent.
+def get (j: Json) (key: String) : Json = native "j[key]"
+
+# ── Array access ───────────────────────────────────────────────────────
+
+# Returns the length of an array (or string/object). Raises if j has no len.
+def length (j: Json) : {x:Int | x >= 0} = native "len(j)"
+
+# Indexes into a JSON array. Raises at runtime if i is out of range.
+def at (j: Json) (i: {x:Int | x >= 0}) : Json = native "j[i]"
+
+# ── Construction ───────────────────────────────────────────────────────
+
+def mkNull : Json = native "None"
+
+def mkBool (b: Bool) : Json = native "b"
+
+def mkInt (i: Int) : Json = native "i"
+
+def mkFloat (f: Float) : Json = native "f"
+
+def mkString (s: String) : Json = native "s"
+
+def mkArray (xs: (List Json)) : Json = native "list(xs)"
+
+# An empty JSON object. Use setKey to populate.
+def mkObject : Json = native "{}"
+
+# Returns a new object with key set to value. Raises at runtime if j is
+# not an object.
+def setKey (j: Json) (key: String) (value: Json) : Json =
+    native "({**j, key: value} if isinstance(j, dict) else (_ for _ in ()).throw(TypeError('not an object')))"


### PR DESCRIPTION
## Summary
- Adds `libraries/Json.ae` — an opaque `Json` type wrapping Python's `json` module. Parse, build, query, and serialize.
- API surface mirrors typical JSON usage:
  - **Parse / serialize**: `parse`, `parseFile`, `stringify`, `stringifyPretty`, `writeFile`.
  - **Type queries**: `isNull` / `isBool` / `isNumber` / `isString` / `isArray` / `isObject`.
  - **Coerce** (raise at runtime if mismatched): `asBool` / `asInt` / `asFloat` / `asString`.
  - **Object access**: `get`, `has`, `setKey`. JSON keys can be empty (`{"": 1}` is legal), so key parameters are unrefined.
  - **Array access**: `length`, `at`.
  - **Construct**: `mkNull` / `mkBool` / `mkInt` / `mkFloat` / `mkString` / `mkArray` / `mkObject`.

### Refinements that earn their keep
- `parse` / `parseFile` / `writeFile` require non-empty source / path. `json.loads("")` and `open("")` both raise; the refinement turns those into typecheck errors. (Verified `Json.parse ""` is rejected.)
- `stringify` / `stringifyPretty` return `{s:String | s != ""}`. The smallest possible output is `"null"` / `"true"` / `"0"`, so this is sound. Demonstrated by `Json.parse (Json.stringify built)` typechecking without an explicit annotation in the example.
- `length` returns `{x:Int | x >= 0}`; `at` requires `i >= 0`. (Upper bound on `i` would need a runtime length comparison and is left out.)

### Why opaque, not inductive
Aeon now has inductive types (Color, Pizza), so an inductive `Json` with `JNull | JBool Bool | JNum Float | JStr String | JArr (List Json) | JObj ...` is technically possible. I went opaque because:
1. The Python bridge stays trivial (`json.loads` returns the right Python types directly; no per-node conversion).
2. Matches the precedent set by `Table.ae`'s row-as-dict.
3. Inductive Json + native interop can land later as a nicer-but-bigger PR.

### Note on PR base
Stacked on `feat/sys-library` (PR #223) because it relies on the typeinfer fix there for `s != ""` refinements on parse / file paths. Parallel to PR #225 (Args). Once #223 merges this rebases onto `master` cleanly.

## Test plan
- [x] `examples/imports/json_example.ae` round-trips a built object through `stringify` → `parse` → `get` / `asString`. Runs cleanly.
- [x] `Json.parse ""` rejected at typecheck (non-empty refinement).
- [x] `Json.at j (0 - 1)` rejected at typecheck (`i >= 0` refinement).
- [x] `bash run_examples.sh` — 67/67 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)