### PR TITLE
Fix CLI dispatch: empty errors list never reached driver.run

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -154,9 +154,6 @@ def main() -> None:
     errors = driver.parse(args.filename)
 
     match errors:
-        case [*_]:
-            for err in errors:
-                handle_error(err)
         case []:
             match (args.format, driver.has_synth()):
                 case (True, _):
@@ -174,6 +171,9 @@ def main() -> None:
                     print(pretty_print_sterm(term))
                 case (False, False):
                     driver.run()
+        case [*_]:
+            for err in errors:
+                handle_error(err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Reorders the `match errors:` arms in [aeon/__main__.py:156](aeon/__main__.py:156) so `case []` precedes `case [*_]`. The previous order made `driver.run()`, `driver.synth()`, and `driver.pretty_print()` unreachable on a clean parse.
- Root cause: `[*_]` matches the empty list (zero-or-more capture), so for an error-free file the first arm fired with an empty for loop and the CLI silently exited 0.

## Reproduce on master
```
$ uv run python -m aeon examples/factorial.ae
$ echo $?
0
```
(no `6` printed)

## After fix
```
$ uv run python -m aeon examples/factorial.ae
6
```
Error path is unchanged — files with type errors still print `>>> Error at …`.

Regression introduced in [#218](https://github.com/alcides/aeon/pull/218); identified via `git bisect`.

## Test plan
- [x] `uv run python -m aeon examples/factorial.ae` prints `6`
- [x] A file with a type error still prints the error and exits
- [x] `uv run pytest` — 424 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)