### PR TITLE
Phase 1: QTT multiplicity foundation (semiring + grammar + AST)

### DIFF
--- a/aeon/core/bind.py
+++ b/aeon/core/bind.py
@@ -125,7 +125,9 @@ def bind_type(ty: Type, subs: RenamingSubstitions) -> Type:
         case AbstractionType(aname, atype, rtype, loc):
             nname, nsubs = check_name(aname, subs)
 
-            return AbstractionType(nname, bind_type(atype, subs), bind_type(rtype, nsubs), loc=loc)
+            return AbstractionType(
+                nname, bind_type(atype, subs), bind_type(rtype, nsubs), loc=loc, multiplicity=ty.multiplicity
+            )
         case RefinedType(name, ty, ref, loc):
             nty = bind_type(ty, subs)
             nname, nsubs = check_name(name, subs)

--- a/aeon/core/instantiation.py
+++ b/aeon/core/instantiation.py
@@ -35,7 +35,7 @@ def type_substitution(t: Type, alpha: Name, beta: Type) -> Type:
                 case city:
                     return RefinedType(name, city, ref, loc=loc)
         case AbstractionType(aname, aty, rty, loc):
-            return AbstractionType(aname, rec(aty), rec(rty), loc=loc)
+            return AbstractionType(aname, rec(aty), rec(rty), loc=loc, multiplicity=t.multiplicity)
         case TypePolymorphism(name, kind, body, loc):
             if name == alpha:
                 return t
@@ -79,7 +79,7 @@ def type_variable_instantiation(t: Type, alpha: Name, beta: Type) -> Type:
         case RefinedType(name, inner, ref, loc):
             return RefinedType(name, rec(inner), ref, loc)
         case AbstractionType(vn, vt, rt, loc):
-            return AbstractionType(vn, rec(vt), rec(rt), loc)
+            return AbstractionType(vn, rec(vt), rec(rt), loc, multiplicity=t.multiplicity)
         case TypePolymorphism(name, kind, body, loc):
             return TypePolymorphism(name, kind, rec(body), loc)
         case RefinementPolymorphism(name, sort, body, loc):

--- a/aeon/core/multiplicity.py
+++ b/aeon/core/multiplicity.py
@@ -1,0 +1,111 @@
+"""Multiplicities (Quantitative Type Theory).
+
+Each binder in Aeon may carry a *multiplicity* drawn from a small semiring
+``{0, 1, ω}`` that records how many times the bound name must be used
+within its scope:
+
+- ``M0``: erased — the name does not exist at run time. Useful for
+  proof-only / ghost bindings that show up in refinements but never in
+  the runtime term.
+- ``M1``: linear — the name must be consumed exactly once. Passing a
+  ``1``-bound value to a function that expects a ``1`` parameter
+  transfers the obligation; passing it to an ``ω`` parameter is a type
+  error.
+- ``MOmega``: unrestricted — the name may be used any number of times,
+  including zero. This is the default; existing programs that omit a
+  multiplicity continue to behave identically.
+
+This module only defines the algebra and the parser-facing tokens.
+The linearity check that consumes these annotations lives in a later
+phase; for now the type checker treats ``MOmega`` everywhere and the
+new fields are inert.
+
+The semiring laws (Atkey, *Syntax and Semantics of Quantitative Type
+Theory*, LICS 2018):
+
+- *Addition* combines the multiplicities of two uses in a single scope::
+
+      0 + μ = μ + 0 = μ
+      1 + 1 = ω
+      1 + ω = ω + 1 = ω
+      ω + ω = ω
+
+- *Multiplication* combines the multiplicity of an outer binder with an
+  inner one (e.g. multiplying the parameter's declared multiplicity by
+  the argument's tally during application)::
+
+      0 * μ = μ * 0 = 0
+      1 * μ = μ * 1 = μ
+      ω * 1 = ω = 1 * ω
+      ω * ω = ω
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Multiplicity(Enum):
+    """The QTT multiplicity semiring ``{0, 1, ω}``."""
+
+    M0 = "0"  # erased
+    M1 = "1"  # linear (use exactly once)
+    MOmega = "ω"  # unrestricted (use any number of times)
+
+    def __repr__(self) -> str:
+        return self.value
+
+    def __str__(self) -> str:
+        return self.value
+
+
+M0 = Multiplicity.M0
+M1 = Multiplicity.M1
+MOmega = Multiplicity.MOmega
+
+
+def add(a: Multiplicity, b: Multiplicity) -> Multiplicity:
+    """Semiring addition — combine usage tallies in a single scope.
+
+    ``0`` is the identity, ``1 + 1`` saturates to ``ω``, and ``ω`` is
+    absorbing for any non-zero argument.
+    """
+    if a is M0:
+        return b
+    if b is M0:
+        return a
+    if a is MOmega or b is MOmega:
+        return MOmega
+    # both are M1
+    return MOmega
+
+
+def mul(a: Multiplicity, b: Multiplicity) -> Multiplicity:
+    """Semiring multiplication — combine an outer multiplicity with an
+    inner one (e.g. parameter multiplicity ⊗ argument tally during
+    application).
+
+    ``0`` is absorbing, ``1`` is the identity, and ``ω`` is absorbing
+    for anything other than ``0``.
+    """
+    if a is M0 or b is M0:
+        return M0
+    if a is M1:
+        return b
+    if b is M1:
+        return a
+    return MOmega  # both are MOmega
+
+
+def from_token(tok: str) -> Multiplicity:
+    """Parse a surface-syntax multiplicity token (``"0"``, ``"1"``, or
+    ``"omega"`` / ``"ω"``). Raises ``ValueError`` for anything else."""
+    match tok:
+        case "0":
+            return M0
+        case "1":
+            return M1
+        case "omega" | "ω":
+            return MOmega
+        case _:
+            raise ValueError(f"Not a multiplicity token: {tok!r}")

--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -49,7 +49,7 @@ def substitute_vartype(t: Type, rep: Type, name: Name) -> Type:
             assert not isinstance(ty, RefinedType)
             return RefinedType(rname, rec(ty), ref, loc=loc)
         case AbstractionType(a, aty, rty, loc):
-            return AbstractionType(a, rec(aty), rec(rty), loc=loc)
+            return AbstractionType(a, rec(aty), rec(rty), loc=loc, multiplicity=t.multiplicity)
         case ExistentialType(binders, body, loc):
             return ExistentialType(tuple((bn, rec(bt)) for (bn, bt) in binders), rec(body), loc=loc)
         case TypePolymorphism(pname, kind, body, loc):
@@ -167,6 +167,7 @@ def instantiate_refinement_in_type(
                 instantiate_refinement_in_type(atype, pred_name, refinement),
                 instantiate_refinement_in_type(rtype, pred_name, refinement),
                 loc=loc,
+                multiplicity=t.multiplicity,
             )
         # b{ν:p}[ρ := φ] = b[ρ := φ]{ν:p[ρ := φ]} per tutorial fig 8.6
         case RefinedType(vname, ity, ref, loc):
@@ -251,7 +252,7 @@ def instantiate_refinement_with_horn_in_type(
         case TypeConstructor(name, args, loc):
             return TypeConstructor(name, [rec(a) for a in args], loc=loc)
         case AbstractionType(aname, atype, rtype, loc):
-            return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
+            return AbstractionType(aname, rec(atype), rec(rtype), loc=loc, multiplicity=t.multiplicity)
         case RefinedType(vname, ity, ref, loc):
             nity = rec(ity)
             assert isinstance(nity, TypeConstructor) or isinstance(nity, TypeVar)
@@ -317,7 +318,7 @@ def substitution_liquid_in_type(t: Type, rep: LiquidTerm, name: Name) -> Type:
             if aname == name:
                 return t
             else:
-                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
+                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc, multiplicity=t.multiplicity)
         case RefinedType(vname, ity, ref, loc):
             if name == vname:
                 return t
@@ -401,7 +402,7 @@ def substitution_in_type(t: Type, rep: Term, name: Name) -> Type:
             if aname == name:
                 return t
             else:
-                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
+                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc, multiplicity=t.multiplicity)
         case RefinedType(vname, ity, ref, loc):
             if name == vname:
                 return t

--- a/aeon/core/terms.py
+++ b/aeon/core/terms.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from aeon.core.multiplicity import Multiplicity, MOmega
 from aeon.core.types import Kind
 from aeon.core.types import t_string
 from aeon.core.types import Type
@@ -123,9 +124,11 @@ class Let(Term):
     var_value: Term
     body: Term
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    multiplicity: Multiplicity = MOmega
 
     def __str__(self):
-        return f"(let {self.var_name} = {self.var_value} in\n\t{self.body})"
+        prefix = "" if self.multiplicity is MOmega else f"{self.multiplicity} "
+        return f"(let {prefix}{self.var_name} = {self.var_value} in\n\t{self.body})"
 
     def __eq__(self, other):
         return (
@@ -133,6 +136,7 @@ class Let(Term):
             and self.var_name == other.var_name
             and self.var_value == other.var_value
             and self.body == other.body
+            and self.multiplicity is other.multiplicity
         )
 
 
@@ -144,12 +148,15 @@ class Rec(Term):
     body: Term
     decreasing_by: tuple[Term, ...] = field(default_factory=tuple)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    multiplicity: Multiplicity = MOmega
 
     def __repr__(self):
         return str(self)
 
     def __str__(self):
-        return "(let {} : {} = {} in\n\t{})".format(
+        prefix = "" if self.multiplicity is MOmega else f"{self.multiplicity} "
+        return "(let {}{} : {} = {} in\n\t{})".format(
+            prefix,
             self.var_name,
             self.var_type,
             self.var_value,
@@ -164,6 +171,7 @@ class Rec(Term):
             and self.var_value == other.var_value
             and self.body == other.body
             and self.decreasing_by == other.decreasing_by
+            and self.multiplicity is other.multiplicity
         )
 
 

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -7,6 +7,7 @@ from aeon.core.liquid import LiquidLiteralFloat, LiquidLiteralInt, LiquidLiteral
 from aeon.core.liquid import LiquidHole
 from aeon.core.liquid import LiquidLiteralBool
 from aeon.core.liquid import LiquidTerm
+from aeon.core.multiplicity import Multiplicity, MOmega
 from aeon.utils.location import Location, SynthesizedLocation
 from aeon.utils.name import fresh_counter, Name
 
@@ -82,9 +83,11 @@ class AbstractionType(Type):
     var_type: Type
     type: Type
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    multiplicity: Multiplicity = MOmega
 
     def __repr__(self):
-        return f"({self.var_name}:{self.var_type}) -> {self.type}"
+        prefix = "" if self.multiplicity is MOmega else f"{self.multiplicity} "
+        return f"({prefix}{self.var_name}:{self.var_type}) -> {self.type}"
 
     def __eq__(self, other):
         return (
@@ -92,10 +95,11 @@ class AbstractionType(Type):
             and self.var_name == other.var_name
             and self.var_type == other.var_type
             and self.type == other.type
+            and self.multiplicity is other.multiplicity
         )
 
     def __hash__(self) -> int:
-        return hash(self.var_name) + hash(self.var_type) + hash(self.type)
+        return hash(self.var_name) + hash(self.var_type) + hash(self.type) + hash(self.multiplicity)
 
 
 @dataclass

--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -117,6 +117,7 @@ def collect_core_decorator_queue(
                         rforalls,
                         decreasing_by,
                         loc,
+                        arg_multiplicities=d.arg_multiplicities,
                     )
                 )
             case _:

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -211,6 +211,7 @@ def remove_unions_and_intersections(ctx: ElaborationTypingContext, ty: SType) ->
                 var_type=remove_unions_and_intersections(ctx, vtype),
                 type=remove_unions_and_intersections(ctx, rtype),
                 loc=loc,
+                multiplicity=ty.multiplicity,
             )
         case STypePolymorphism(name, kind, body, loc):
             return STypePolymorphism(
@@ -444,7 +445,13 @@ def replace_unification_variables(
             case STypeVar(_):
                 return ty
             case SAbstractionType(name, vty, rty, loc=loc):
-                return SAbstractionType(name, go(ctx, vty, not polarity), go(ctx, rty, polarity), loc=loc)
+                return SAbstractionType(
+                    name,
+                    go(ctx, vty, not polarity),
+                    go(ctx, rty, polarity),
+                    loc=loc,
+                    multiplicity=ty.multiplicity,
+                )
             case SRefinedType(name, ity, ref, loc=loc):
                 nt = go(ctx, ity, polarity)
                 return SRefinedType(name, nt, ref, loc=loc)

--- a/aeon/elaboration/instantiation.py
+++ b/aeon/elaboration/instantiation.py
@@ -30,7 +30,7 @@ def type_substitution(ty: SType, alpha: Name, beta: SType) -> SType:
         case SRefinedType(name, ity, ref, loc):
             return normalize(SRefinedType(name, rec(ity), ref, loc=loc))
         case SAbstractionType(name, vty, rty, loc):
-            return SAbstractionType(name, rec(vty), rec(rty), loc=loc)
+            return SAbstractionType(name, rec(vty), rec(rty), loc=loc, multiplicity=ty.multiplicity)
         case STypePolymorphism(name, kind, body, loc):
             # TODO: Double-check alpha_renaming in substitution
             if name == alpha:
@@ -63,7 +63,7 @@ def type_variable_instantiation(ty: SType, alpha: str, beta: SType) -> SType:
         case SRefinedType(name, ity, ref, loc):
             return normalize(SRefinedType(name, rec(ity), ref, loc=loc))
         case SAbstractionType(var_name, var_type, ret_type, loc):
-            return SAbstractionType(var_name, rec(var_type), rec(ret_type), loc=loc)
+            return SAbstractionType(var_name, rec(var_type), rec(ret_type), loc=loc, multiplicity=ty.multiplicity)
         case STypePolymorphism(name, kind, body, loc):
             if name == alpha:
                 return ty

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -52,13 +52,21 @@ macro_arg : ID "=" expression           -> named_macro_arg
 args :                          -> empty_list
      | arg (arg)*           -> args
 
-arg : "(" ID ":" type ")"                       -> arg
-    | "(" ID ":" type _PIPE expression ")"      -> refined_arg
+// QTT multiplicity prefix on a binder. Optional; default ω (unrestricted).
+//   (1 x: T)      → linear  : x must be consumed exactly once
+//   (0 x: T)      → erased  : x is compile-time only
+//   (omega x: T)  → unrestricted (same as omitting the prefix)
+arg : "(" ID ":" type ")"                                       -> arg
+    | "(" ID ":" type _PIPE expression ")"                      -> refined_arg
+    | "(" MULT ID ":" type ")"                                  -> mult_arg
+    | "(" MULT ID ":" type _PIPE expression ")"                 -> mult_refined_arg
 
 
 type : "{" ID ":" type _PIPE expression "}"                -> refined_t // TODO delete later
      | "(" ID ":" type ")" "->" type                       -> abstraction_t
+     | "(" MULT ID ":" type ")" "->" type                  -> mult_abstraction_t
      | "(" ID ":" type _PIPE expression ")" "->" type      -> abstraction_refined_t
+     | "(" MULT ID ":" type _PIPE expression ")" "->" type -> mult_abstraction_refined_t
      | "forall" ID ":" kind "," type                       -> polymorphism_t // TODO: desugar
      | "forall" "<" ID ":" type "->" "Bool" ">" "," type   -> refinement_polymorphism_t
      | ID "<" ID ">"                                       -> base_angle_refined_t
@@ -70,12 +78,17 @@ type : "{" ID ":" type _PIPE expression "}"                -> refined_t // TODO 
 expression : "-" expression_i                           -> minus
            | expression_i                               -> same
 
+// `let` may carry an optional QTT multiplicity prefix:
+//   let 1 f = open path in close f
 expression_i : "by" by_body                                  -> by_e
           | "let" ID "=" expression  ("in"|";") expression           -> let_e
+          | "let" MULT ID "=" expression  ("in"|";") expression           -> mult_let_e
           | ID "=" expression  ("in"|";") expression           -> let_e
           | "let" ID ":" type "=" expression  ("in"|";") expression     -> rec_e
+          | "let" MULT ID ":" type "=" expression  ("in"|";") expression     -> mult_rec_e
           | ID ":" type "=" expression  ("in"|";") expression     -> rec_e
           | "let" ID ":" type _PIPE expression "=" expression  ("in"|";") expression     -> rec_refined_e
+          | "let" MULT ID ":" type _PIPE expression "=" expression  ("in"|";") expression     -> mult_rec_refined_e
           | ID ":" type _PIPE expression "=" expression  ("in"|";") expression     -> rec_refined_e
           | "if" expression "then" expression "else" expression    -> if_e
           | "match" expression "with" match_branches              -> match_e
@@ -151,6 +164,10 @@ kind : "B" -> base_kind
 
 
 BOOLLIT.5 : "true" | "false"
+// QTT multiplicities. The contextual LALR lexer routes to ``MULT`` only
+// in binder positions (after `let`, after `(`); in regular expression
+// positions ``0`` and ``1`` continue to be ``INTLIT``.
+MULT.6 : "0" | "1" | "omega" | "ω"
 INTLIT : /[0-9][0-9]*/
 FLOATLIT : SIGNED_FLOAT
 

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -103,7 +103,9 @@ def bind_stype(ty: SType, subs: RenamingSubstitions) -> SType:
         case SAbstractionType(aname, atype, rtype):
             nname, nsubs = check_name(aname, subs)
 
-            return SAbstractionType(nname, bind_stype(atype, subs), bind_stype(rtype, nsubs))
+            return SAbstractionType(
+                nname, bind_stype(atype, subs), bind_stype(rtype, nsubs), multiplicity=ty.multiplicity
+            )
         case SRefinedType(name, ty, ref):
             nty = bind_stype(ty, subs)
             nname, nsubs = check_name(name, subs)
@@ -212,7 +214,16 @@ def _bind_definition(
         ndargs = {name: bind_sterm(da, nsubs) for name, da in dec.named_args.items()}
         decorators.append(Decorator(dec.name, dargs, ndargs))
     return Definition(
-        name, foralls, args, ntype, body, decorators, rforalls, decreasing_by=decreasing, loc=df.loc
+        name,
+        foralls,
+        args,
+        ntype,
+        body,
+        decorators,
+        rforalls,
+        decreasing_by=decreasing,
+        loc=df.loc,
+        arg_multiplicities=df.arg_multiplicities,
     ), nsubs
 
 

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -225,6 +225,7 @@ def lower_by_blocks_in_definitions(
                         rforalls,
                         decreasing_by,
                         loc,
+                        arg_multiplicities=d.arg_multiplicities,
                     )
                 )
             case _:
@@ -313,7 +314,9 @@ def resolve_qualified_names_in_stype(
         case SRefinedType(name, inner_ty, refinement, loc):
             return SRefinedType(name, rec_ty(inner_ty), rec_term(refinement), loc=loc)
         case SAbstractionType(var_name, var_type, body_type, loc):
-            return SAbstractionType(var_name, rec_ty(var_type), rec_ty(body_type), loc=loc)
+            return SAbstractionType(
+                var_name, rec_ty(var_type), rec_ty(body_type), loc=loc, multiplicity=ty.multiplicity
+            )
         case STypePolymorphism(name, kind, body, loc):
             return STypePolymorphism(name, kind, rec_ty(body), loc=loc)
         case SRefinementPolymorphism(name, sort, body, loc):
@@ -359,7 +362,16 @@ def resolve_qualified_names_in_definition(
     if new_body is d.body and new_args == d.args and new_type is d.type and new_decorators == d.decorators:
         return d
     return Definition(
-        d.name, d.foralls, new_args, new_type, new_body, new_decorators, d.rforalls, d.decreasing_by, d.loc
+        d.name,
+        d.foralls,
+        new_args,
+        new_type,
+        new_body,
+        new_decorators,
+        d.rforalls,
+        d.decreasing_by,
+        d.loc,
+        arg_multiplicities=d.arg_multiplicities,
     )
 
 
@@ -790,6 +802,7 @@ def introduce_forall_in_types(defs: list[Definition], type_decls: list[TypeDecl]
                         rforalls,
                         decreasing_by,
                         loc,
+                        arg_multiplicities=d.arg_multiplicities,
                     )
                 )
     return ndefs
@@ -874,6 +887,7 @@ def introduce_rforall_in_types(defs: list[Definition]) -> list[Definition]:
                         final_rforalls,
                         decreasing_by,
                         loc,
+                        arg_multiplicities=d.arg_multiplicities,
                     )
                 )
     return ndefs
@@ -963,6 +977,7 @@ def handle_imports(
                 d.rforalls,
                 d.decreasing_by,
                 d.loc,
+                arg_multiplicities=d.arg_multiplicities,
             )
             prefixed_definitions.append(prefixed_d)
 
@@ -1049,8 +1064,10 @@ def type_of_definition(d: Definition) -> SType:
     match d:
         case Definition(_, foralls, args, rtype, _, _, rforalls, _, loc):
             ntype = rtype
-            for name, atype in reversed(args):
-                ntype = SAbstractionType(name, atype, ntype, loc)
+            n_args = len(args)
+            for i, (name, atype) in enumerate(reversed(args)):
+                mult = d.multiplicity_of(n_args - 1 - i)
+                ntype = SAbstractionType(name, atype, ntype, loc, multiplicity=mult)
             for name, sort in reversed(rforalls):
                 ntype = SRefinementPolymorphism(name, sort, ntype, loc)
             for name, kind in reversed(foralls):
@@ -1066,8 +1083,10 @@ def convert_definition_to_srec(prog: STerm, d: Definition) -> STerm:
         case Definition(dname, foralls, args, rtype, body, _, rforalls, decreasing_by, loc):
             ntype = rtype
             nbody = body
-            for name, atype in reversed(args):
-                ntype = SAbstractionType(name, atype, ntype, loc=loc)
+            n_args = len(args)
+            for i, (name, atype) in enumerate(reversed(args)):
+                mult = d.multiplicity_of(n_args - 1 - i)
+                ntype = SAbstractionType(name, atype, ntype, loc=loc, multiplicity=mult)
                 nbody = SAbstraction(name, nbody, loc=loc)
             for name, sort in reversed(rforalls):
                 ntype = SRefinementPolymorphism(name, sort, ntype, loc=loc)

--- a/aeon/sugar/lifting.py
+++ b/aeon/sugar/lifting.py
@@ -91,7 +91,7 @@ def lift_type(ty: Type) -> SType:
         case TypeConstructor(name, args, loc):
             return STypeConstructor(name, [lift_type(arg) for arg in args], loc=loc)
         case AbstractionType(name, atype, rtype, loc):
-            return SAbstractionType(name, lift_type(atype), lift_type(rtype), loc=loc)
+            return SAbstractionType(name, lift_type(atype), lift_type(rtype), loc=loc, multiplicity=ty.multiplicity)
         case RefinedType(name, typ, ref, loc):
             from aeon.core.types import LiquidHornApplication
 

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -1,3 +1,4 @@
+from aeon.core.multiplicity import MOmega
 from aeon.core.liquid import (
     LiquidApp,
     LiquidLiteralBool,
@@ -208,7 +209,13 @@ def type_to_core(ty: SType, available_vars: list[tuple[Name, TypeConstructor | T
                 nrty = substitution_sterm_in_stype(rty, SVar(nname), name)
             else:
                 nrty = rty
-            return AbstractionType(nname, at, type_to_core(nrty, available_vars), loc=loc)
+            return AbstractionType(
+                nname,
+                at,
+                type_to_core(nrty, available_vars),
+                loc=loc,
+                multiplicity=getattr(ty, "multiplicity", MOmega),
+            )
         case STypePolymorphism(name, kind, rty, loc):
             return TypePolymorphism(name, kind, type_to_core(rty, available_vars), loc=loc)
         case SRefinementPolymorphism(name, sort, body, loc):

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -5,6 +5,7 @@ from typing import Callable
 
 from lark import Lark, Transformer, v_args
 
+from aeon.core.multiplicity import from_token, Multiplicity, MOmega
 from aeon.core.types import BaseKind, StarKind
 from aeon.sugar.program import (
     Decorator,
@@ -56,6 +57,23 @@ def ensure_list(a):
         return a
     else:
         return [a]
+
+
+def _split_arg_multiplicities(fn_args):
+    """Each entry in ``fn_args`` is either a ``(name, type)`` 2-tuple from
+    the plain-arg productions or a ``(name, type, multiplicity)`` 3-tuple
+    from the ``mult_arg`` productions. Return a list of 2-tuples and a
+    parallel tuple of multiplicities (defaulting to ``MOmega``)."""
+    plain: list = []
+    mults: list[Multiplicity] = []
+    for a in fn_args:
+        if isinstance(a, tuple) and len(a) == 3:
+            plain.append((a[0], a[1]))
+            mults.append(a[2])
+        else:
+            plain.append(a)
+            mults.append(MOmega)
+    return plain, tuple(mults)
 
 
 class AnnotatedStr(str):
@@ -132,14 +150,47 @@ class TreeToSugar(Transformer):
         return SLet(Name(args[0]), args[1], args[2], loc=self._loc(meta))
 
     @v_args(meta=True)
+    def mult_let_e(self, meta, args):
+        # `let MULT ID = value in body`
+        return SLet(Name(args[1]), args[2], args[3], loc=self._loc(meta), multiplicity=from_token(str(args[0])))
+
+    @v_args(meta=True)
     def rec_e(self, meta, args):
         return SRec(Name(args[0]), args[1], args[2], args[3], decreasing_by=(), loc=self._loc(meta))
+
+    @v_args(meta=True)
+    def mult_rec_e(self, meta, args):
+        # `let MULT ID : type = value in body`
+        return SRec(
+            Name(args[1]),
+            args[2],
+            args[3],
+            args[4],
+            decreasing_by=(),
+            loc=self._loc(meta),
+            multiplicity=from_token(str(args[0])),
+        )
 
     @v_args(meta=True)
     def rec_refined_e(self, meta, args):
         name = Name(args[0])
         refined_type = SRefinedType(name, args[1], args[2])
         return SRec(name, refined_type, args[3], args[4], decreasing_by=(), loc=self._loc(meta))
+
+    @v_args(meta=True)
+    def mult_rec_refined_e(self, meta, args):
+        # `let MULT ID : type | refinement = value in body`
+        name = Name(args[1])
+        refined_type = SRefinedType(name, args[2], args[3])
+        return SRec(
+            name,
+            refined_type,
+            args[4],
+            args[5],
+            decreasing_by=(),
+            loc=self._loc(meta),
+            multiplicity=from_token(str(args[0])),
+        )
 
     @v_args(meta=True)
     def if_e(self, meta, args):
@@ -384,7 +435,16 @@ class TreeToSugar(Transformer):
 
     @v_args(meta=True)
     def def_ind_cons(self, meta, args):
-        return Definition(Name(args[0]), [], args[1], args[2], SLiteral(None, st_unit), loc=self._loc(meta))
+        plain_args, mults = _split_arg_multiplicities(args[1])
+        return Definition(
+            Name(args[0]),
+            [],
+            plain_args,
+            args[2],
+            SLiteral(None, st_unit),
+            loc=self._loc(meta),
+            arg_multiplicities=mults,
+        )
 
     def decreasing_by_none(self, args):
         return []
@@ -400,27 +460,31 @@ class TreeToSugar(Transformer):
     def def_fun(self, meta, args):
         if len(args) == 5:
             name, fn_args, rtype, decr, body = args
+            plain_args, mults = _split_arg_multiplicities(fn_args)
             return Definition(
                 Name(name),
                 [],
-                fn_args,
+                plain_args,
                 rtype,
                 body,
                 decreasing_by=ensure_list(decr),
                 loc=self._loc(meta),
+                arg_multiplicities=mults,
             )
         if len(args) == 6:
             decorators, name, fn_args, rtype, decr, body = args
+            plain_args, mults = _split_arg_multiplicities(fn_args)
             return Definition(
                 Name(name),
                 [],
-                fn_args,
+                plain_args,
                 rtype,
                 body,
                 decorators,
                 [],
                 decreasing_by=ensure_list(decr),
                 loc=self._loc(meta),
+                arg_multiplicities=mults,
             )
         raise AssertionError(f"def_fun: unexpected args {args!r}")
 
@@ -468,9 +532,28 @@ class TreeToSugar(Transformer):
     def refined_arg(self, args):
         return Name(args[0]), SRefinedType(Name(args[0]), args[1], args[2])
 
+    def mult_arg(self, args):
+        # (MULT ID : type) — multiplicity-annotated parameter.
+        # Returns a 3-tuple so def_fun can pick up the multiplicity.
+        return (Name(args[1]), args[2], from_token(str(args[0])))
+
+    def mult_refined_arg(self, args):
+        # (MULT ID : type | refinement)
+        ty = SRefinedType(Name(args[1]), args[2], args[3])
+        return (Name(args[1]), ty, from_token(str(args[0])))
+
     def abstraction_refined_t(self, args):
         type = SRefinedType(Name(args[0]), args[1], args[2])
         return SAbstractionType(Name(args[0]), type, args[3])
+
+    def mult_abstraction_t(self, args):
+        # (MULT ID : type) -> type
+        return SAbstractionType(Name(args[1]), args[2], args[3], multiplicity=from_token(str(args[0])))
+
+    def mult_abstraction_refined_t(self, args):
+        # (MULT ID : type | refinement) -> type
+        ty = SRefinedType(Name(args[1]), args[2], args[3])
+        return SAbstractionType(Name(args[1]), ty, args[4], multiplicity=from_token(str(args[0])))
 
     def abstraction_et(self, args):
         return SAnnotation(

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field
 
+from aeon.core.multiplicity import Multiplicity, MOmega
 from aeon.utils.name import Name
 from aeon.core.types import Kind
 from aeon.sugar.stypes import SType, STypeConstructor
@@ -152,9 +153,11 @@ class SLet(STerm):
     var_value: STerm
     body: STerm
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    multiplicity: Multiplicity = MOmega
 
     def __str__(self):
-        return f"(let {self.var_name} = {self.var_value} in\n\t{self.body})"
+        prefix = "" if self.multiplicity is MOmega else f"{self.multiplicity} "
+        return f"(let {prefix}{self.var_name} = {self.var_value} in\n\t{self.body})"
 
     def __eq__(self, other):
         return (
@@ -162,6 +165,7 @@ class SLet(STerm):
             and self.var_name == other.var_name
             and self.var_value == other.var_value
             and self.body == other.body
+            and self.multiplicity is other.multiplicity
         )
 
 
@@ -173,12 +177,15 @@ class SRec(STerm):
     body: STerm
     decreasing_by: tuple[STerm, ...] = field(default_factory=tuple)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    multiplicity: Multiplicity = MOmega
 
     def __repr__(self):
         return str(self)
 
     def __str__(self):
-        return "(let {} : {} = {} in\n\t{})".format(
+        prefix = "" if self.multiplicity is MOmega else f"{self.multiplicity} "
+        return "(let {}{} : {} = {} in\n\t{})".format(
+            prefix,
             self.var_name,
             self.var_type,
             self.var_value,
@@ -193,6 +200,7 @@ class SRec(STerm):
             and self.var_value == other.var_value
             and self.body == other.body
             and self.decreasing_by == other.decreasing_by
+            and self.multiplicity is other.multiplicity
         )
 
 
@@ -400,6 +408,15 @@ class Definition(Node):
     rforalls: list[tuple[Name, SType]] = field(default_factory=list)
     decreasing_by: list[STerm] = field(default_factory=list)
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    # Parallel to ``args``: the QTT multiplicity declared for each parameter.
+    # Empty tuple ⇔ all parameters default to ``MOmega`` (the value used by
+    # callers that don't track multiplicities yet).
+    arg_multiplicities: tuple[Multiplicity, ...] = field(default_factory=tuple)
+
+    def multiplicity_of(self, i: int) -> Multiplicity:
+        if i < len(self.arg_multiplicities):
+            return self.arg_multiplicities[i]
+        return MOmega
 
     def __post_init__(self):
         assert isinstance(self.type, SType)
@@ -408,7 +425,12 @@ class Definition(Node):
         if not self.args:
             return f"def {self.name} : {self.type} = {self.body};"
         else:
-            args = ", ".join([f"{n}:{t}" for (n, t) in self.args])
+            args = ", ".join(
+                [
+                    f"{'' if self.multiplicity_of(i) is MOmega else str(self.multiplicity_of(i)) + ' '}{n}:{t}"
+                    for i, (n, t) in enumerate(self.args)
+                ]
+            )
             foralls = " ".join([f"∀{n}:{k}" for (n, k) in self.foralls])
             rforalls = " ".join([f"∀<{n}:{s} -> Bool>" for (n, s) in self.rforalls])
             sep = " " if (foralls or rforalls) else ""

--- a/aeon/sugar/stypes.py
+++ b/aeon/sugar/stypes.py
@@ -2,6 +2,7 @@ from abc import ABC
 from dataclasses import dataclass, field
 from functools import reduce
 
+from aeon.core.multiplicity import Multiplicity, MOmega
 from aeon.core.types import Kind
 
 from typing import TYPE_CHECKING
@@ -46,9 +47,11 @@ class SAbstractionType(SType):
     var_type: SType
     type: SType
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    multiplicity: Multiplicity = MOmega
 
     def __str__(self):
-        return f"({self.var_name} : {self.var_type}) -> {self.type}"
+        prefix = "" if self.multiplicity is MOmega else f"{self.multiplicity} "
+        return f"({prefix}{self.var_name} : {self.var_type}) -> {self.type}"
 
 
 @dataclass(unsafe_hash=True)

--- a/aeon/sugar/substitutions.py
+++ b/aeon/sugar/substitutions.py
@@ -1,3 +1,4 @@
+from aeon.core.multiplicity import MOmega
 from aeon.utils.name import Name
 from aeon.sugar.stypes import (
     SAbstractionType,
@@ -61,7 +62,9 @@ def substitute_svartype_in_stype(ty: SType, beta: SType, alpha: Name):
         case SRefinedType(name, ty, ref):
             return SRefinedType(name, rec(ty), ref)
         case SAbstractionType(var_name, var_type, return_type):
-            return SAbstractionType(var_name, rec(var_type), rec(return_type))
+            return SAbstractionType(
+                var_name, rec(var_type), rec(return_type), multiplicity=getattr(ty, "multiplicity", MOmega)
+            )
         case STypePolymorphism(tname, kind, body):
             if tname == alpha:
                 return ty
@@ -85,7 +88,9 @@ def substitution_sterm_in_stype(ty: SType, beta: STerm, alpha: Name) -> SType:
         case SRefinedType(name, ty, ref):
             return SRefinedType(name, rec(ty), substitution_sterm_in_sterm(ref, beta, alpha))
         case SAbstractionType(var_name, var_type, return_type):
-            return SAbstractionType(var_name, rec(var_type), rec(return_type))
+            return SAbstractionType(
+                var_name, rec(var_type), rec(return_type), multiplicity=getattr(ty, "multiplicity", MOmega)
+            )
         case STypePolymorphism(tname, kind, body):
             return STypePolymorphism(tname, kind, rec(body))
         case SRefinementPolymorphism(name, sort, body):
@@ -182,7 +187,9 @@ def substitute_refinement_param_in_stype(ty: SType, old: Name, new: Name) -> STy
         case SRefinedType(name, ity, ref):
             return SRefinedType(name, rec(ity), substitution_sterm_in_sterm(ref, SVar(new), old))
         case SAbstractionType(var_name, var_type, return_type):
-            return SAbstractionType(var_name, rec(var_type), rec(return_type))
+            return SAbstractionType(
+                var_name, rec(var_type), rec(return_type), multiplicity=getattr(ty, "multiplicity", MOmega)
+            )
         case STypePolymorphism(tname, kind, body):
             return STypePolymorphism(tname, kind, rec(body))
         case SRefinementPolymorphism(rname, sort, body):

--- a/aeon/verification/horn.py
+++ b/aeon/verification/horn.py
@@ -77,7 +77,7 @@ def fresh(context: TypingContext, ty: Type) -> Type:
         case AbstractionType(name, aty, rty):
             sp = fresh(context, aty)
             tp = fresh(context.with_var(name, aty), rty)
-            return AbstractionType(name, sp, tp)
+            return AbstractionType(name, sp, tp, multiplicity=ty.multiplicity)
         case TypePolymorphism(name, kind, body):
             return TypePolymorphism(name, kind, fresh(context, body))
         case RefinementPolymorphism(name, sort, body):

--- a/tests/multiplicity_test.py
+++ b/tests/multiplicity_test.py
@@ -1,0 +1,217 @@
+"""Phase 1 — Multiplicity (QTT) infrastructure.
+
+These tests verify:
+
+1. The semiring algebra (`add`, `mul`) behaves as Atkey 2018 specifies.
+2. The grammar accepts the new ``MULT`` prefix on parameters
+   (`(1 x:T)`, `(0 x:T)`, `(omega x:T)` and the unicode `ω` form), on
+   let-binders (`let 1 x = …`), and on let-binders with a type
+   annotation.
+3. The parsed multiplicity reaches the relevant AST nodes
+   (`Definition.arg_multiplicities`, `SLet.multiplicity`,
+   `SRec.multiplicity`) and survives desugaring/lowering down to
+   ``AbstractionType.multiplicity``.
+4. Programs that *omit* multiplicities continue to default to
+   ``MOmega``: there is no behavioural change for existing code.
+
+The actual linearity check that *consumes* these annotations is a
+follow-up phase. For now the type-checker treats ``MOmega`` everywhere
+and the new fields are inert.
+"""
+
+from __future__ import annotations
+
+from aeon.core.bind import bind_ids
+from aeon.core.multiplicity import M0, M1, MOmega, Multiplicity, add, from_token, mul
+from aeon.core.terms import Rec
+from aeon.core.types import AbstractionType
+from aeon.elaboration import elaborate
+from aeon.sugar.desugar import desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_program
+
+
+# ---------------------------------------------------------------------------
+# Semiring laws
+# ---------------------------------------------------------------------------
+
+
+def test_add_zero_is_identity():
+    for m in (M0, M1, MOmega):
+        assert add(M0, m) is m
+        assert add(m, M0) is m
+
+
+def test_add_one_plus_one_saturates_to_omega():
+    assert add(M1, M1) is MOmega
+
+
+def test_add_omega_is_absorbing_for_nonzero():
+    assert add(MOmega, M1) is MOmega
+    assert add(M1, MOmega) is MOmega
+    assert add(MOmega, MOmega) is MOmega
+
+
+def test_mul_zero_is_absorbing():
+    for m in (M0, M1, MOmega):
+        assert mul(M0, m) is M0
+        assert mul(m, M0) is M0
+
+
+def test_mul_one_is_identity():
+    for m in (M0, M1, MOmega):
+        assert mul(M1, m) is m
+        assert mul(m, M1) is m
+
+
+def test_mul_omega_omega():
+    assert mul(MOmega, MOmega) is MOmega
+
+
+# ---------------------------------------------------------------------------
+# from_token
+# ---------------------------------------------------------------------------
+
+
+def test_from_token_accepts_canonical_forms():
+    assert from_token("0") is M0
+    assert from_token("1") is M1
+    assert from_token("omega") is MOmega
+    assert from_token("ω") is MOmega
+
+
+def test_from_token_rejects_garbage():
+    import pytest
+
+    with pytest.raises(ValueError):
+        from_token("two")
+
+
+# ---------------------------------------------------------------------------
+# Grammar / parser plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_parser_records_arg_multiplicities():
+    src = """
+def f (1 x: Int) (y: Int) (0 z: Int) : Int = x;
+"""
+    prog = parse_program(src)
+    f = next(d for d in prog.definitions if d.name.name == "f")
+    assert f.arg_multiplicities == (M1, MOmega, M0)
+
+
+def test_parser_omitting_multiplicity_defaults_to_omega():
+    src = """
+def f (x: Int) (y: Int) : Int = x;
+"""
+    prog = parse_program(src)
+    f = next(d for d in prog.definitions if d.name.name == "f")
+    assert f.arg_multiplicities == (MOmega, MOmega)
+
+
+def test_parser_omega_unicode_is_accepted():
+    src = """
+def f (ω x: Int) : Int = x;
+"""
+    prog = parse_program(src)
+    f = next(d for d in prog.definitions if d.name.name == "f")
+    assert f.arg_multiplicities == (MOmega,)
+
+
+def test_parser_records_mult_let_e():
+    """`let 1 x = e in body` records multiplicity on the SLet node."""
+    from aeon.sugar.program import SLet, SRec
+
+    src = """
+def main (i: Int) : Int =
+    let 1 a = 5 in
+    let b = a in
+    b;
+"""
+    prog = parse_program(src)
+    main = next(d for d in prog.definitions if d.name.name == "main")
+    body = main.body
+
+    # Walk SLet/SRec chain looking for `a` and `b`.
+    binders: dict[str, Multiplicity] = {}
+    cur = body
+    while isinstance(cur, (SLet, SRec)):
+        binders[cur.var_name.name] = cur.multiplicity
+        cur = cur.body
+    assert binders["a"] is M1
+    assert binders["b"] is MOmega
+
+
+def test_parser_records_mult_rec_e():
+    """`let MULT x : T = …` records on SRec."""
+    from aeon.sugar.program import SLet, SRec
+
+    src = """
+def main (i: Int) : Int =
+    let 1 a : Int = 5 in
+    a;
+"""
+    prog = parse_program(src)
+    main = next(d for d in prog.definitions if d.name.name == "main")
+    cur = main.body
+    while isinstance(cur, (SLet, SRec)):
+        if cur.var_name.name == "a":
+            assert isinstance(cur, SRec)
+            assert cur.multiplicity is M1
+            return
+        cur = cur.body
+    assert False, "no binder for `a` found"
+
+
+# ---------------------------------------------------------------------------
+# Desugaring / lowering preservation
+# ---------------------------------------------------------------------------
+
+
+def _find_rec(t, name: str):
+    if isinstance(t, Rec):
+        if t.var_name.name == name:
+            return t
+        return _find_rec(t.var_value, name) or _find_rec(t.body, name)
+    return None
+
+
+def test_arg_multiplicity_reaches_core_abstraction_type():
+    """A `(1 x: T)` parameter survives desugaring + lowering and ends up
+    on the corresponding ``AbstractionType.multiplicity``."""
+    src = """
+def f (1 x: Int) : Int = x;
+def main (_:Int) : Int = f 5;
+"""
+    prog = parse_program(src)
+    desugared = desugar(prog, is_main_hole=False)
+    sterm = elaborate(desugared.elabcontext, desugared.program)
+    core = lower_to_core(sterm)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    typing_ctx, core = bind_ids(typing_ctx, core)
+
+    f_rec = _find_rec(core, "f")
+    assert f_rec is not None
+    assert isinstance(f_rec.var_type, AbstractionType)
+    assert f_rec.var_type.multiplicity is M1
+
+
+def test_omitted_multiplicity_lowers_to_omega():
+    """Existing-style programs (no multiplicity) lower to ``MOmega`` —
+    no behavioural change."""
+    src = """
+def f (x: Int) : Int = x;
+def main (_:Int) : Int = f 5;
+"""
+    prog = parse_program(src)
+    desugared = desugar(prog, is_main_hole=False)
+    sterm = elaborate(desugared.elabcontext, desugared.program)
+    core = lower_to_core(sterm)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    typing_ctx, core = bind_ids(typing_ctx, core)
+
+    f_rec = _find_rec(core, "f")
+    assert f_rec is not None
+    assert isinstance(f_rec.var_type, AbstractionType)
+    assert f_rec.var_type.multiplicity is MOmega


### PR DESCRIPTION
## Summary

First phase of the QTT linear-types plan we sketched in #216's review thread. Lays the AST and grammar groundwork **with no behavioural change** — every existing program continues to type-check identically because every new field defaults to `MOmega` (unrestricted). The linearity check that *consumes* these annotations is a follow-up phase; this PR just gives that future check a stable substrate.

**Test impact**: 440 tests pass, 9 skipped, no regressions. `run_examples.sh` still green.

## What you can write after this lands

```aeon
# QTT multiplicity prefix on a parameter — three variants of the same idea.
def consume   (1 x: File)              : Unit  = close x;       # linear
def proof_arg (0 evidence: { p: Bool | p }) : Int = 42;         # erased
def safe_inc  (omega x: Int)           : Int   = x + 1;         # explicit ω

# … and on let-binders and let-binders with annotations:
let 1 f = open "/tmp/data" in close f;
let 1 a : Int = 5 in a + 1;
```

The grammar accepts the Unicode `ω` form too (`(ω x: T)`).

## What's added

- **`aeon/core/multiplicity.py`** — `Multiplicity = {M0, M1, MOmega}` enum, semiring `add`/`mul` (Atkey, *Syntax and Semantics of Quantitative Type Theory*, LICS 2018), and `from_token` for the parser. Module docstring derives the algebra from first principles.
- **AST fields, all defaulted to `MOmega`** so existing code is unaffected:
  - `Definition.arg_multiplicities: tuple[Multiplicity, ...]` — parallel to `args`.
  - `SAbstractionType.multiplicity` and core `AbstractionType.multiplicity`.
  - `SLet`/`SRec` and core `Let`/`Rec` `multiplicity` field.
- **Grammar** (`aeon_sugar.lark`): a `MULT` terminal at priority 6 (lark's contextual lexer routes to it only in binder positions, so `0` and `1` continue to lex as `INTLIT` everywhere else); productions for the new prefix on every binder form.
- **Parser handlers**: `mult_arg`, `mult_refined_arg`, `mult_abstraction_t`, `mult_abstraction_refined_t`, `mult_let_e`, `mult_rec_e`, `mult_rec_refined_e`, plus `_split_arg_multiplicities` that splits the parser's per-arg 3-tuple back into the legacy `Definition.args` 2-tuple list and a parallel multiplicity tuple.
- **Plumbing**: every site that reconstructs an `AbstractionType` / `SAbstractionType` now preserves `multiplicity`. Same surface area as the destructive-args PR — six `Definition` reconstruction sites, three sugar substitutions, four core substitutions, two instantiations, plus `bind`, `lifting`, `lowering`, `fresh`, and the elaboration unification path.

## Tests

`tests/multiplicity_test.py` — 15 cases covering:
- Semiring laws (`0` is identity for `+`, `1+1 → ω`, `ω` absorbing for non-zero; `0` absorbing for `*`, `1` identity for `*`).
- `from_token` accepts `"0"`, `"1"`, `"omega"`, `"ω"` and rejects garbage.
- Parser records multiplicity on parameters, `let`-binders, and `let : T`-binders.
- Both ASCII `omega` and Unicode `ω` work.
- Defaulting: omitting the prefix leaves everything at `MOmega`.
- Lowering: a `(1 x: T)` parameter survives desugaring + lowering and lands on `AbstractionType.multiplicity` of the core type.

## Branch base & interaction with #216 / #226

This branch is built on top of `claude/existentials-replace-anf` (#226), so it carries the existentials work. **Once #216 (destructive args) also merges**, the natural follow-up is to fold its `destructive: bool` field on `AbstractionType` into this PR's `multiplicity: Multiplicity` (`M1` ⇔ destructive) and have the parser's `!` token desugar to a `MULT` of `"1"`. That cleanup is intentionally not in this PR — the foundation should land first so the merge order is decoupled.

## Test plan

- [x] `uv run pytest tests/multiplicity_test.py -v` — 15 passed.
- [x] `uv run pytest` — 440 passed, 9 skipped, no regressions.
- [x] `bash run_examples.sh` — every example still succeeds (multiplicity defaulting preserves all existing behaviour).
- [x] `uvx pre-commit run` — mypy, ruff, ruff-format, pyroma all clean.

## Next phases (not in this PR)

- **Phase 2**: linearity-checking pass over the typed core AST (`tally == budget` at every binder).
- **Phase 3**: move semantics for `let 1 y = x` (Latte alias-class hookup).
- **Phase 4**: `0`-erasure pass before evaluation.
- **Phase 5**: `linear type File` declarations.
- **Phase 6** (deferred): multiplicity polymorphism (`forall μ:Mult. …`).

https://claude.ai/code/session_014Yvu5rQaY8SAGbsW7c36dU

---
_Generated by [Claude Code](https://claude.ai/code/session_014Yvu5rQaY8SAGbsW7c36dU)_