### PR TITLE
Resolve qualified names inside decorator arguments (closes #222)

### DIFF
--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -17,6 +17,7 @@ from aeon.elaboration.context import (
 from aeon.prelude.prelude import typing_vars
 from aeon.sugar.parser import mk_parser
 from aeon.sugar.program import (
+    Decorator,
     Definition,
     SAbstraction,
     SAnonConstructor,
@@ -340,9 +341,26 @@ def resolve_qualified_names_in_definition(
         if d.type
         else d.type
     )
-    if new_body is d.body and new_args == d.args and new_type is d.type:
+    new_decorators = [
+        Decorator(
+            name=dec.name,
+            macro_args=[
+                resolve_qualified_names_in_sterm(a, qualified_scope, unqualified_scope, constructor_defs)
+                for a in dec.macro_args
+            ],
+            named_args={
+                k: resolve_qualified_names_in_sterm(v, qualified_scope, unqualified_scope, constructor_defs)
+                for k, v in dec.named_args.items()
+            },
+            loc=dec.loc,
+        )
+        for dec in d.decorators
+    ]
+    if new_body is d.body and new_args == d.args and new_type is d.type and new_decorators == d.decorators:
         return d
-    return Definition(d.name, d.foralls, new_args, new_type, new_body, d.decorators, d.rforalls, d.decreasing_by, d.loc)
+    return Definition(
+        d.name, d.foralls, new_args, new_type, new_body, new_decorators, d.rforalls, d.decreasing_by, d.loc
+    )
 
 
 def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType] | None = None) -> DesugaredProgram:


### PR DESCRIPTION
## Summary
- Fixes [#222](https://github.com/alcides/aeon/issues/222): `Math.abs` (and any namespace-qualified name) failed to resolve inside decorator arguments such as `@minimize_int(Math.abs(...))`, even though the same expression worked in regular code.
- Root cause: `resolve_qualified_names_in_definition` in `aeon/sugar/desugar.py` walked the body, args, and return type of each definition but passed `d.decorators` through unchanged. `SQualifiedVar` nodes inside decorator args survived into `apply_decorators_in_definitions`, where the dotted name was treated as a bare variable and elaboration reported `Variable Math.abs? does not exist in context.`
- Fix: rebuild each `Decorator` with `resolve_qualified_names_in_sterm` applied to every entry of `macro_args` and `named_args`.

## Test plan
- [x] `uv run python -m aeon --budget 1 -s gp examples/synthesis/hole_refined_synthesis.ae` (the issue's repro) now elaborates and runs synthesis instead of erroring on `Math.abs`.
- [x] `uv run pytest -q` — 415 passed, 9 skipped (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)