### PR TITLE
Fix elaboration of implicit refinement abstraction in lambda bodies (closes #209)

### DIFF
--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -377,6 +377,9 @@ def elaborate_check(ctx: ElaborationTypingContext, t: STerm, ty: SType) -> STerm
             nty = substitute_refinement_param_in_stype(tbody, rname, pname)
             nbody = elaborate_check(ctx, body, nty)
             return SRefinementAbstraction(pname, sort, nbody, loc=loc)
+        case (SAbstraction(_, _, loc=loc), SRefinementPolymorphism(rname, rsort, tbody)):
+            nbody = elaborate_check(ctx, t, tbody)
+            return SRefinementAbstraction(rname, rsort, nbody, loc=loc)
         case (SAnonConstructor(cname, loc=loc), _):
             # Resolve anonymous constructor (.cons) using expected type
             base_name = _extract_base_type_name(ty)

--- a/tests/parametric_refinements_test.py
+++ b/tests/parametric_refinements_test.py
@@ -28,6 +28,22 @@ def main (args:Int) : Unit =
     assert check_compile(source, st_top)
 
 
+def test_parametric_explicit_type_explicit_pred_implicit_term_pred_compiles():
+    """Regression for issue #209: explicit `forall <p>` in signature with no
+    matching `Λ <p>` in body should implicitly introduce the refinement abstraction
+    instead of injecting a `_pred` synthesis hole."""
+    source = """
+def wrap : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} =
+    Λ t : B => \\x -> x;
+
+def main (args:Int) : Unit =
+    score : Int | score > 0 = 42;
+    safe_score : Int | safe_score > 0 = wrap[Int] score;
+    print safe_score
+"""
+    assert check_compile(source, st_top)
+
+
 def test_parametric_implicit_type_implicit_refinement_compiles():
     source = f"""
 {ID_IMPLICIT_TYPE_IMPLICIT_REF}


### PR DESCRIPTION
## Summary

Fixes #209 using **Option A** from the issue: when a function signature has an explicit `forall <p : T -> Bool>` but the body is a plain `\x -> x` (no `Λ <p>`), the elaborator now implicitly introduces the refinement abstraction instead of injecting a `_pred` synthesis hole that fails typechecking.

## What changed

`elaborate_check` in `aeon/elaboration/__init__.py` previously had no case for `(SAbstraction, SRefinementPolymorphism)`, so it fell through to `elaborate_synth` + `get_rid_of_polymorphism`, which inserts a `_pred` hole. Since `_pred` holes are excluded from synthesis targets, this produced a type error on a fully-defined function.

The new case is the natural analogue of the existing `(SRefinementAbstraction, SRefinementPolymorphism)` branch: it wraps the body in an `SRefinementAbstraction` using the parameter name and sort from the expected type, then re-checks against the inner body of the polymorphism.

After this fix, the failing example from the issue:

```aeon
def wrap : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} =
    Λ t : B => \x -> x;
```

elaborates and runs correctly.

## Test plan

- [x] Added regression test `test_parametric_explicit_type_explicit_pred_implicit_term_pred_compiles` in `tests/parametric_refinements_test.py` using the exact failing example from the issue
- [x] All 17 tests in `parametric_refinements_test.py` pass
- [x] Full test suite passes (415 passed, 8 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)