### PR TITLE
Probabilistic refinements + Float SMT sort fix

### DIFF
--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -364,13 +364,20 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             (c, ty) = synth(ctx, fun)
             # Lift any binders from the function's type to the outer scope so
             # the body underneath can be matched as an AbstractionType.
-            outer_binders: tuple[tuple[Name, Type], ...] = ()
+            fun_binders: tuple[tuple[Name, Type], ...] = ()
             if isinstance(ty, ExistentialType):
-                outer_binders = ty.binders
+                fun_binders = ty.binders
                 ty = ty.body
+            # Binders just lifted from the function's type are in scope for
+            # the argument check and any inner synth: atype may reference
+            # them (e.g. dependent parameter types like {t:Float | t >= y}).
+            ctx_inner = ctx
+            for bn, bt in fun_binders:
+                ctx_inner = ctx_inner.with_var(bn, bt)
+            outer_binders: tuple[tuple[Name, Type], ...] = fun_binders
             match ty:
                 case AbstractionType(aname, atype, rtype):
-                    cp = check(ctx, arg, atype)
+                    cp = check(ctx_inner, arg, atype)
                     # Abstractions can't be synthesised on their own (no
                     # annotation), and Var/Literal liquefy directly. In all
                     # three cases the existing direct substitution path is
@@ -386,7 +393,7 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                         # binder name into the result type. Any binders
                         # already on the argument's type lift to the outer
                         # scope (binders are always flat).
-                        (_, ty_arg) = synth(ctx, arg)
+                        (_, ty_arg) = synth(ctx_inner, arg)
                         if isinstance(ty_arg, ExistentialType):
                             outer_binders = outer_binders + ty_arg.binders
                             ty_arg = ty_arg.body
@@ -398,7 +405,15 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                             binder_ty = RefinedType(y, binder_ty.type, renamed)
                         outer_binders = outer_binders + ((y, binder_ty),)
                         t_subs = substitution_in_type(rtype, Var(y), aname)
-                    c0 = Conjunction(c, cp)
+                    # cp may reference the function's lifted binders through
+                    # atype; wrap c0 in implications over them so those
+                    # references are bound when the constraint reaches SMT.
+                    # Argument-side binders propagate to the caller via the
+                    # existential type and get their implication wrap there
+                    # (e.g. in Let's opened_binders loop).
+                    c0: Constraint = Conjunction(c, cp)
+                    for bn, bt in reversed(fun_binders):
+                        c0 = implication_constraint(bn, bt, c0, t.loc)
                     return (c0, with_binders(outer_binders, t_subs))
                 case _:
                     raise CoreInvalidApplicationError(t, ty)

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -18,9 +18,9 @@ from z3.z3 import BoolRef
 from z3.z3 import BoolSort
 from z3.z3 import Const
 from z3.z3 import DeclareSort
-from z3.z3 import Float64
 from z3.z3 import Implies
 from z3.z3 import IntSort
+from z3.z3 import RealSort
 from z3.z3 import Not
 from z3.z3 import Or
 from z3.z3 import String
@@ -527,7 +527,7 @@ def get_sort(base: Type) -> SortRef:
         case TypeConstructor(Name("Bool", _)):
             return BoolSort()
         case TypeConstructor(Name("Float", _)):
-            return Float64()
+            return RealSort()
         case TypeConstructor(Name("String", _)):
             return StringSort()
         case TypeConstructor(Name("Set", _)):

--- a/examples/probabilistic/distributions_demo.ae
+++ b/examples/probabilistic/distributions_demo.ae
@@ -1,0 +1,31 @@
+open List
+open Math
+open Statistics
+open Distributions
+
+# Consumer requiring 99% of values below 7.
+def expectMostlyBelow7
+    (xs: {ys: (List Float) | List.size ys > 0 && fracBelow ys 7.0 >= 0.99})
+    : Unit
+    = print "ok: 99% of values below 7"
+
+# Consumer requiring 95% of values above 0 (i.e., positivity bound).
+def expectMostlyPositive
+    (xs: {ys: (List Float) | List.size ys > 0 && fracAbove ys 0.0 >= 0.95})
+    : Unit
+    = print "ok: 95% of values above 0"
+
+# Demo: pull samples from several distributions and feed them to the
+# consumers, widening as needed.
+def main (_: Int) : Unit =
+    let g     = normalSample 2.0 1.0 100 in
+    let gThr  = 2.0 + 2.33 * 1.0 in
+    let g7    = widenBelow g gThr 7.0 in
+    let r1    = expectMostlyBelow7 g7 in
+    let u     = uniformSample 0.0 5.0 100 in
+    let u7    = widenBelow u 5.0 7.0 in
+    let r2    = expectMostlyBelow7 u7 in
+    let e     = exponentialSample 1.0 100 in
+    let r3    = expectMostlyPositive e in
+    let b     = betaSample 2.0 5.0 100 in
+    expectMostlyPositive b

--- a/examples/probabilistic/distributions_demo.ae
+++ b/examples/probabilistic/distributions_demo.ae
@@ -18,14 +18,13 @@ def expectMostlyPositive
 # Demo: pull samples from several distributions and feed them to the
 # consumers, widening as needed.
 def main (_: Int) : Unit =
-    let g     = normalSample 2.0 1.0 100 in
-    let gThr  = 2.0 + 2.33 * 1.0 in
-    let g7    = widenBelow g gThr 7.0 in
-    let r1    = expectMostlyBelow7 g7 in
-    let u     = uniformSample 0.0 5.0 100 in
-    let u7    = widenBelow u 5.0 7.0 in
-    let r2    = expectMostlyBelow7 u7 in
-    let e     = exponentialSample 1.0 100 in
-    let r3    = expectMostlyPositive e in
-    let b     = betaSample 2.0 5.0 100 in
+    let g  = normalSample 2.0 1.0 100 in
+    let g7 = widenBelow g (2.0 + 2.33 * 1.0) 7.0 in
+    let r1 = expectMostlyBelow7 g7 in
+    let u  = uniformSample 0.0 5.0 100 in
+    let u7 = widenBelow u 5.0 7.0 in
+    let r2 = expectMostlyBelow7 u7 in
+    let e  = exponentialSample 1.0 100 in
+    let r3 = expectMostlyPositive e in
+    let b  = betaSample 2.0 5.0 100 in
     expectMostlyPositive b

--- a/examples/probabilistic/normal_below_7_bad.ae
+++ b/examples/probabilistic/normal_below_7_bad.ae
@@ -1,0 +1,44 @@
+open List
+open Math
+
+# ─── Probabilistic refinement scaffolding ──────────────────────────────
+
+# Uninterpreted symbol: fraction of xs strictly below threshold t.
+def fracBelow : (xs: (List Float)) -> (t: Float) -> Float = uninterpreted
+
+# Monotonicity axiom for fracBelow.  Runtime no-op; the return refinement
+# is the postulate Z3 uses (correctly: t1 <= t2 ⇒ frac(t1) <= frac(t2)).
+def widenThreshold
+    (xs: {x: (List Float) | List.size x > 0})
+    (t1: Float)
+    (t2: {t: Float | t >= t1})
+    : {r: (List Float) | List.size r > 0 && fracBelow r t2 >= fracBelow xs t1}
+    = native "xs"
+
+# ─── Producer: normal samples around (a, b) ────────────────────────────
+
+def normalSample
+    (a: Float)
+    (b: {y: Float | y > 0.0})
+    (n: {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracBelow xs (a + 2.33 * b) >= 0.99 }
+    = native "list(__import__('numpy').random.normal(a, b, n))"
+
+# ─── Consumer: requires 99% below 7 ────────────────────────────────────
+
+def expectMostlyBelow7
+    (xs: {ys: (List Float)
+         | List.size ys > 0
+           && fracBelow ys 7.0 >= 0.99})
+    : Unit
+    = print "ok: list satisfies P(< 7) >= 0.99"
+
+# ─── Driver: BAD case  (a=6, b=1  ⇒  threshold=8.33 > 7) ───────────────
+# widenThreshold requires t2 >= t1; here t1 = 8.33, t2 = 7.0  →  fails.
+
+def main (_: Int) : Unit =
+    let bad = normalSample 6.0 1.0 100 in
+    let widened = widenThreshold bad 8.33 7.0 in
+    expectMostlyBelow7 widened

--- a/examples/probabilistic/normal_below_7_good.ae
+++ b/examples/probabilistic/normal_below_7_good.ae
@@ -1,0 +1,47 @@
+open List
+open Math
+
+# ─── Probabilistic refinement scaffolding ──────────────────────────────
+
+# Uninterpreted symbol: fraction of xs strictly below threshold t.
+# Lives in the refinement language; Z3 reasons about it abstractly.
+def fracBelow : (xs: (List Float)) -> (t: Float) -> Float = uninterpreted
+
+# Monotonicity axiom for fracBelow:  t1 <= t2  ⟹  frac(t1) <= frac(t2).
+# Implemented as a runtime no-op (returns xs unchanged); the return
+# refinement is the postulate the SMT solver gets to use at call sites.
+def widenThreshold
+    (xs: {x: (List Float) | List.size x > 0})
+    (t1: Float)
+    (t2: {t: Float | t >= t1})
+    : {r: (List Float) | List.size r > 0 && fracBelow r t2 >= fracBelow xs t1}
+    = native "xs"
+
+# ─── Producer: normal samples around (a, b) ────────────────────────────
+
+# By calibration of N(a, b), Pr(X <= a + 2.33·b) ≈ 0.99.
+# Encoded as the producer's postcondition (trusted, since native).
+def normalSample
+    (a: Float)
+    (b: {y: Float | y > 0.0})
+    (n: {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracBelow xs (a + 2.33 * b) >= 0.99 }
+    = native "list(__import__('numpy').random.normal(a, b, n))"
+
+# ─── Consumer: requires 99% below 7 ────────────────────────────────────
+
+def expectMostlyBelow7
+    (xs: {ys: (List Float)
+         | List.size ys > 0
+           && fracBelow ys 7.0 >= 0.99})
+    : Unit
+    = print "ok: list satisfies P(< 7) >= 0.99"
+
+# ─── Driver: GOOD case  (a=2, b=1  ⇒  threshold=4.33 <= 7) ─────────────
+
+def main (_: Int) : Unit =
+    let good = normalSample 2.0 1.0 100 in
+    let widened = widenThreshold good 4.33 7.0 in
+    expectMostlyBelow7 widened

--- a/libraries/Distributions.ae
+++ b/libraries/Distributions.ae
@@ -1,0 +1,159 @@
+# Distributions.ae
+#
+# Probability distribution producers paired with quantile-bound postulates.
+# Refinement-language predicates (fracBelow, fracAbove, sampleMean, ...) and
+# their monotonicity axioms (widenBelow, widenAbove, ...) live in Statistics.
+#
+# Each producer is `native` (numpy under the hood). Its return refinement
+# is a *postulate* asserting the true distributional quantiles. For finite
+# samples these are expected-value claims; we treat them as trusted facts
+# since the FFI is on the user's honor.
+#
+# Constants are CDF-inverse evaluations (z-scores, ln(1-p), etc.) hardcoded.
+
+open List
+open Math
+open Statistics
+
+# ─── Normal distribution N(mu, sigma) ──────────────────────────────────
+# z-scores: 1.282 (90%), 1.645 (95%), 2.33 (99%).
+
+def normalSample
+    (mu: Float)
+    (sigma: {s: Float | s > 0.0})
+    (n: {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracBelow xs (mu + 2.33 * sigma)  >= 0.99
+        && fracBelow xs (mu + 1.645 * sigma) >= 0.95
+        && fracBelow xs (mu + 1.282 * sigma) >= 0.90
+        && fracBelow xs mu                    >= 0.50
+        && fracAbove xs (mu - 1.282 * sigma) >= 0.90
+        && fracAbove xs (mu - 1.645 * sigma) >= 0.95
+        && fracAbove xs (mu - 2.33 * sigma)  >= 0.99 }
+    = native "list(__import__('numpy').random.normal(mu, sigma, n))"
+
+# ─── Standard normal Z ~ N(0, 1) ───────────────────────────────────────
+
+def standardNormalSample
+    (n: {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracBelow xs 2.33  >= 0.99
+        && fracBelow xs 1.645 >= 0.95
+        && fracBelow xs 1.282 >= 0.90
+        && fracBelow xs 0.0   >= 0.50
+        && fracAbove xs 0.0    >= 0.50
+        && fracAbove xs (0.0 - 1.282) >= 0.90
+        && fracAbove xs (0.0 - 2.33)  >= 0.99 }
+    = native "list(__import__('numpy').random.standard_normal(n))"
+
+# ─── Uniform distribution U(a, b) ──────────────────────────────────────
+# Quantile p is exactly a + p*(b - a). Support is [a, b].
+
+def uniformSample
+    (a: Float)
+    (b: {bb: Float | bb > a})
+    (n: {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracAbove xs a >= 1.0
+        && fracBelow xs b >= 1.0
+        && fracBelow xs (a + 0.99 * (b - a)) >= 0.99
+        && fracBelow xs (a + 0.95 * (b - a)) >= 0.95
+        && fracBelow xs (a + 0.50 * (b - a)) >= 0.50
+        && fracBelow xs (a + 0.10 * (b - a)) >= 0.10 }
+    = native "list(__import__('numpy').random.uniform(a, b, n))"
+
+# ─── Exponential distribution Exp(rate = lambda) ───────────────────────
+# Quantile p:  -ln(1 - p) / lambda.   Support [0, ∞).
+# Constants: 0.6931 (50%), 2.3026 (90%), 2.9957 (95%), 4.6052 (99%).
+
+def exponentialSample
+    (lam: {l: Float | l > 0.0})
+    (n: {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracAbove xs 0.0 >= 1.0
+        && fracBelow xs (4.6052 / lam) >= 0.99
+        && fracBelow xs (2.9957 / lam) >= 0.95
+        && fracBelow xs (2.3026 / lam) >= 0.90
+        && fracBelow xs (0.6931 / lam) >= 0.50 }
+    = native "list(__import__('numpy').random.exponential(1.0 / lam, n))"
+
+# ─── Beta distribution Beta(alpha, beta) ───────────────────────────────
+# Support is (0, 1). Mean = alpha / (alpha + beta).
+
+def betaSample
+    (alpha: {a: Float | a > 0.0})
+    (beta:  {b: Float | b > 0.0})
+    (n:     {m: Int   | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracAbove xs 0.0 >= 1.0
+        && fracBelow xs 1.0 >= 1.0
+        && ((sampleMean xs) == (alpha / (alpha + beta))) }
+    = native "list(__import__('numpy').random.beta(alpha, beta, n))"
+
+# ─── Gamma distribution Gamma(shape k, scale theta) ────────────────────
+# Support [0, ∞). Mean = k * theta. Var = k * theta * theta.
+
+def gammaSample
+    (k:     {kk: Float | kk > 0.0})
+    (theta: {th: Float | th > 0.0})
+    (n:     {m:  Int   | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracAbove xs 0.0 >= 1.0
+        && ((sampleMean xs) == (k * theta))
+        && ((sampleVar  xs) == (k * (theta * theta))) }
+    = native "list(__import__('numpy').random.gamma(k, theta, n))"
+
+# ─── Chi-squared distribution Chi²(k) ──────────────────────────────────
+# Support [0, ∞). Mean = k.  Var = 2k.
+
+def chiSquaredSample
+    (k: {kk: Int | kk > 0})
+    (n: {m: Int  | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracAbove xs 0.0 >= 1.0 }
+    = native "list(__import__('numpy').random.chisquare(k, n))"
+
+# ─── Bernoulli distribution Ber(p) ─────────────────────────────────────
+# Values are 0.0 or 1.0. Mean = p.
+
+def bernoulliSample
+    (p: {pp: Float | pp >= 0.0 && pp <= 1.0})
+    (n: {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracBelow xs 0.5 >= (1.0 - p)
+        && fracAbove xs 0.5 >= p
+        && fracBelow xs 1.5 >= 1.0
+        && fracAbove xs (0.0 - 0.5) >= 1.0 }
+    = native "list(map(float, __import__('numpy').random.binomial(1, p, n)))"
+
+# ─── Binomial distribution Bin(trials, p) ──────────────────────────────
+# Support {0, 1, ..., trials}. Mean = trials * p.
+
+def binomialSample
+    (trials: {t: Int | t > 0})
+    (p:      {pp: Float | pp >= 0.0 && pp <= 1.0})
+    (n:      {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracAbove xs (0.0 - 0.5) >= 1.0 }
+    = native "list(map(float, __import__('numpy').random.binomial(trials, p, n)))"
+
+# ─── Poisson distribution Pois(lambda) ─────────────────────────────────
+# Support {0, 1, 2, ...}. Mean = Var = lambda.
+
+def poissonSample
+    (lam: {l: Float | l > 0.0})
+    (n:   {m: Int | m > 0})
+    : { xs: (List Float)
+      | List.size xs > 0
+        && fracAbove xs (0.0 - 0.5) >= 1.0
+        && ((sampleMean xs) == lam) }
+    = native "list(map(float, __import__('numpy').random.poisson(lam, n)))"

--- a/libraries/Statistics.ae
+++ b/libraries/Statistics.ae
@@ -1,9 +1,67 @@
 open List
 
+# ─── Uninterpreted refinement-language symbols ─────────────────────────
+# These live in the refinement language so Z3 can reason about them as
+# abstract symbols. Runtime providers below tie concrete values back to
+# them via refined return types.
+
+# Fraction of xs strictly below threshold t.
+def fracBelow : (xs: (List Float)) -> (t: Float) -> Float = uninterpreted
+
+# Fraction of xs strictly above threshold t.
+def fracAbove : (xs: (List Float)) -> (t: Float) -> Float = uninterpreted
+
+# Fraction of xs in the open interval (lo, hi).
+def fracBetween : (xs: (List Float)) -> (lo: Float) -> (hi: Float) -> Float = uninterpreted
+
+# Sample summary statistics as abstract symbols.
+def sampleMean : (xs: (List Float)) -> Float = uninterpreted
+def sampleVar  : (xs: (List Float)) -> Float = uninterpreted
+def sampleStd  : (xs: (List Float)) -> Float = uninterpreted
+def sampleMin  : (xs: (List Float)) -> Float = uninterpreted
+def sampleMax  : (xs: (List Float)) -> Float = uninterpreted
+
+# ─── Axioms (encoded as native no-op castings) ─────────────────────────
+# Each helper is a runtime no-op (returns its input); the return refinement
+# encodes a math fact the SMT solver gets to use at the call site.
+
+# Monotonicity below:  t1 <= t2  ⇒  fracBelow xs t1 <= fracBelow xs t2.
+def widenBelow
+    (xs: {x: (List Float) | List.size x > 0})
+    (t1: Float)
+    (t2: {t: Float | t >= t1})
+    : {r: (List Float) | List.size r > 0 && fracBelow r t2 >= fracBelow xs t1}
+    = native "xs"
+
+# Monotonicity above:  t1 <= t2  ⇒  fracAbove xs t1 >= fracAbove xs t2.
+def widenAbove
+    (xs: {x: (List Float) | List.size x > 0})
+    (t1: Float)
+    (t2: {t: Float | t <= t1})
+    : {r: (List Float) | List.size r > 0 && fracAbove r t2 >= fracAbove xs t1}
+    = native "xs"
+
+# Complement at a non-atomic point:  fracBelow + fracAbove = 1.
+def belowComplement
+    (xs: {x: (List Float) | List.size x > 0})
+    (t: Float)
+    : {r: (List Float) | List.size r > 0 && ((fracBelow r t) == (1.0 - fracAbove xs t))}
+    = native "xs"
+
+# Between bound: fracBetween lo hi >= fracBelow hi - fracBelow lo (slack covers atoms).
+def betweenFromBelow
+    (xs: {x: (List Float) | List.size x > 0})
+    (lo: Float)
+    (hi: {h: Float | h >= lo})
+    : {r: (List Float) | List.size r > 0 && fracBetween r lo hi >= fracBelow xs hi - fracBelow xs lo}
+    = native "xs"
+
+# ─── Runtime statistics ────────────────────────────────────────────────
+
 # Returns the mean (average) of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: mean of the numbers
-def mean(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').mean(xs)"
+def mean(xs: {x: (List Float) | List.size x > 0}): {m: Float | m == sampleMean xs} = native "__import__('numpy').mean(xs)"
 
 # Returns the median (middle value) of a non-empty list of numbers.
 # xs: non-empty list of numbers
@@ -13,22 +71,22 @@ def median(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__(
 # Returns the sample standard deviation of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: standard deviation
-def std(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').std(xs, ddof=1)"
+def std(xs: {x: (List Float) | List.size x > 0}): {s: Float | s == sampleStd xs} = native "__import__('numpy').std(xs, ddof=1)"
 
 # Returns the sample variance of a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: variance
-def var(xs: {x: (List Float) | List.size x > 0}): Float = native "__import__('numpy').var(xs, ddof=1)"
+def var(xs: {x: (List Float) | List.size x > 0}): {v: Float | v == sampleVar xs} = native "__import__('numpy').var(xs, ddof=1)"
 
 # Returns the minimum value in a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: minimum value
-def min(xs: {x: (List Float) | List.size x > 0}): Float = native "min(xs)"
+def min(xs: {x: (List Float) | List.size x > 0}): {m: Float | m == sampleMin xs} = native "min(xs)"
 
 # Returns the maximum value in a non-empty list of numbers.
 # xs: non-empty list of numbers
 # returns: maximum value
-def max(xs: {x: (List Float) | List.size x > 0}): Float = native "max(xs)"
+def max(xs: {x: (List Float) | List.size x > 0}): {m: Float | m == sampleMax xs} = native "max(xs)"
 
 # Returns the sum of a non-empty list of numbers.
 # xs: non-empty list of numbers
@@ -93,3 +151,23 @@ def corrcoef(xs: {x: (List Float) | List.size x > 0}) (ys: {y: (List Float) | Li
 # ys: non-empty list of numbers, same length as xs
 # returns: covariance
 def cov(xs: {x: (List Float) | List.size x > 0}) (ys: {y: (List Float) | List.size y == List.size xs}): Float = native "__import__('numpy').cov(xs, ys, ddof=1)[0,1]"
+
+# ─── Runtime providers for fraction predicates ────────────────────────
+# Compute the abstract fraction symbols at runtime; the refined return type
+# ties the concrete value back to the SMT-level symbol so it can flow into
+# subsequent refinements.
+
+# Proportion of values strictly below a threshold.
+def proportionBelow (xs: {x: (List Float) | List.size x > 0}) (t: Float)
+    : {f: Float | (f == fracBelow xs t) && 0.0 <= f && f <= 1.0}
+    = native "(sum(1 for v in xs if v < t) / len(xs))"
+
+# Proportion of values strictly above a threshold.
+def proportionAbove (xs: {x: (List Float) | List.size x > 0}) (t: Float)
+    : {f: Float | (f == fracAbove xs t) && 0.0 <= f && f <= 1.0}
+    = native "(sum(1 for v in xs if v > t) / len(xs))"
+
+# Proportion of values strictly inside the open interval (lo, hi).
+def proportionBetween (xs: {x: (List Float) | List.size x > 0}) (lo: Float) (hi: {h: Float | h >= lo})
+    : {f: Float | (f == fracBetween xs lo hi) && 0.0 <= f && f <= 1.0}
+    = native "(sum(1 for v in xs if lo < v and v < hi) / len(xs))"


### PR DESCRIPTION
## Summary

Three related changes for reasoning about probability/quantile claims in refinement types.

### `ed70c766` — Fix sort mismatch for uninterpreted functions over Float

`get_sort(Float)` returned `Float64()` (FloatingPointSort) while `make_variable(Float)` returned `Real(name)`, so declaring an uninterpreted function over `Float` and applying it to a `Float` variable triggered a Z3 sort mismatch. Aligned both paths on `RealSort`. Float arithmetic operators are polymorphic Python lambdas in `base_functions`, so they continue working unchanged.

Resolves a TODO at the original `Float64()` site.

### `fb750566` — Probabilistic refinement library

A library for sampling from common distributions where each producer commits to per-quantile bounds in its return refinement, and consumers can require aggregate guarantees like "≥99% of values below threshold". Bridging is via axiomatic monotonicity helpers encoded as native no-op casts.

**`libraries/Statistics.ae` additions:**
- Uninterpreted refinement-language symbols: `fracBelow`, `fracAbove`, `fracBetween`, `sampleMean`, `sampleVar`, `sampleStd`, `sampleMin`, `sampleMax`
- Axiom helpers: `widenBelow`, `widenAbove`, `belowComplement`, `betweenFromBelow`
- Runtime providers: `proportionBelow`, `proportionAbove`, `proportionBetween`
- Tightened return types on existing `mean` / `var` / `std` / `min` / `max` to connect their runtime values to the new uninterpreted symbols

**`libraries/Distributions.ae`** (new): ten producers — `normalSample`, `standardNormalSample`, `uniformSample`, `exponentialSample`, `betaSample`, `gammaSample`, `chiSquaredSample`, `bernoulliSample`, `binomialSample`, `poissonSample`. Quantile constants are CDF-inverse evaluations (z-scores, ln(1−p), etc.) hardcoded.

**`examples/probabilistic/`:**
- `normal_below_7_good.ae` / `normal_below_7_bad.ae` — self-contained MVP showing how a producer's per-call probability bin composes with a consumer's aggregate-fraction precondition; the bad case fails verification at the widening site with a precise error location.
- `distributions_demo.ae` — multi-distribution pipeline against the library.

### `e1e2ad29` — Fix typeinfer scope leak in Application

Regression from the Form B / existentials-replace-ANF rewrite (#226). In `synth(Application)`, binders lifted from the function's existential type were unwrapped but not added to the context used for the argument check, so a refinement on the parameter type that referenced one of those binders — e.g. a dependent `{t: Float | t >= y}` — would raise `Variable y not in context` from `wellformed()`.

Two changes in the `Application` case of `aeon/typechecking/typeinfer.py`:
1. Build `ctx_inner = ctx + lifted function-type binders` and use it for the inner `check(arg, atype)` and Form B `synth(arg)`. Mirrors what `Let` already does when opening an existential into its body's context.
2. Wrap the resulting application constraint in implication constraints over those binders, so references from `cp` (and any nested `c`) bind correctly when the constraint reaches SMT.

Manifests on compound arithmetic in dependent argument positions, e.g. `widenBelow g (2.0 + 2.33 * 1.0) 7.0`. The demo file reverts the let-binding workaround introduced during the earlier rebase.

## Caveats

- Producers are `native`, so their refinements are postulates (we trust the FFI and the math). For finite samples these are expected-value claims.
- Callers must explicitly invoke `widenBelow` / `widenAbove` to bridge thresholds; Z3 has no built-in axioms about `fracBelow`. Implicit widening would need a subtyping-time hook in the verifier.
- A separate parser-precedence issue (`&&` binds tighter than `==` in refinement expressions) forces defensive parenthesization around equalities in this PR. Tracked as a follow-up; once landed, the parens can be removed.

## Test plan

- [x] `uv run pytest` — 489 passed, 9 skipped (the full suite, including the Form B existential-replace-anf tests).
- [x] `uv run python -m aeon examples/probabilistic/normal_below_7_good.ae` — typechecks and prints expected output.
- [x] `uv run python -m aeon examples/probabilistic/normal_below_7_bad.ae` — fails verification at the widening call (`7.0 >= 8.33`), pointing at the offending literal.
- [x] `uv run python -m aeon examples/probabilistic/distributions_demo.ae` — four producer→consumer pipelines (Normal, Uniform, Exponential, Beta) typecheck and run, including the `widenBelow g (2.0 + 2.33 * 1.0) 7.0` form that exercises the typeinfer fix.
- [ ] Reviewer: check whether tightening `Statistics.mean`/`var`/`std`/`min`/`max` return types affects any downstream consumer; grep within the worktree finds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)