### PR TITLE
perf: 1.9x nqueens speedup via profile-driven typecheck + pprint fixes

### DIFF
--- a/aeon/core/liquid.py
+++ b/aeon/core/liquid.py
@@ -100,7 +100,7 @@ class LiquidVar(LiquidTerm):
         return f"{self.name}"
 
     def __eq__(self, other):
-        return isinstance(other, LiquidVar) and other.name == self.name
+        return type(other) is LiquidVar and other.name == self.name
 
     def __hash__(self) -> int:
         return hash(self.name)
@@ -122,9 +122,7 @@ class LiquidApp(LiquidTerm):
 
     def __eq__(self, other):
         return (
-            isinstance(other, LiquidApp)
-            and other.fun == self.fun
-            and all(x == y for (x, y) in zip(self.args, other.args))
+            type(other) is LiquidApp and other.fun == self.fun and all(x == y for (x, y) in zip(self.args, other.args))
         )
 
     def __hash__(self) -> int:

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -56,7 +56,7 @@ class TypeVar(Type):
         return f"{self.name}"
 
     def __eq__(self, other):
-        return isinstance(other, TypeVar) and other.name == self.name
+        return type(other) is TypeVar and other.name == self.name
 
     def __hash__(self) -> int:
         return hash(self.name)
@@ -67,7 +67,7 @@ class Top(Type):
         return "⊤"
 
     def __eq__(self, other):
-        return isinstance(other, Top)
+        return type(other) is Top
 
     def __str__(self):
         return repr(self)
@@ -88,7 +88,7 @@ class AbstractionType(Type):
 
     def __eq__(self, other):
         return (
-            isinstance(other, AbstractionType)
+            type(other) is AbstractionType
             and self.var_name == other.var_name
             and self.var_type == other.var_type
             and self.type == other.type
@@ -110,7 +110,7 @@ class RefinedType(Type):
 
     def __eq__(self, other):
         return (
-            isinstance(other, RefinedType)
+            type(other) is RefinedType
             and self.name == other.name
             and self.type == other.type
             and self.refinement == other.refinement
@@ -159,7 +159,7 @@ class TypeConstructor(Type):
         return f"{self.name} {args}"
 
     def __eq__(self, other):
-        return isinstance(other, TypeConstructor) and other.name == self.name and self.args == other.args
+        return type(other) is TypeConstructor and other.name == self.name and self.args == other.args
 
     def __hash__(self) -> int:
         return hash(self.name) + sum(hash(a) for a in self.args)

--- a/aeon/utils/name.py
+++ b/aeon/utils/name.py
@@ -39,7 +39,10 @@ class Name:
         return str(self)
 
     def __eq__(self, other):
-        return isinstance(other, Name) and self.name == other.name and self.id == other.id
+        # `type() is` rather than `isinstance` to skip the ABC/MRO walk.
+        # `Name` has no subclasses; compare `id` first since it's a cheap int
+        # check that short-circuits the more expensive string comparison.
+        return type(other) is Name and self.id == other.id and self.name == other.name
 
     def __lt__(self, other):
         return self.id < other.id

--- a/aeon/utils/pprint_helpers.py
+++ b/aeon/utils/pprint_helpers.py
@@ -1,11 +1,17 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Callable, Iterable
 
 DEFAULT_NEW_LINE_CHAR = "\n"
 DEFAULT_SPACE_CHAR = " "
 DEFAULT_WIDTH = 120
 DEFAULT_TAB_SIZE = 4
+
+# Memoization cache size. The Wadler-Leijen pretty printer is exponential
+# without it: `Concat.best` and `Concat.fits` repeatedly traverse the same
+# subtrees with the same `(width, current_length)` pair.
+_PPRINT_CACHE_SIZE = 2**16
 
 
 class Doc(ABC):
@@ -27,6 +33,7 @@ class Doc(ABC):
     def __add__(self, other):
         return Concat(self, other)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def calculate_new_length(self, current_length: int) -> int:
         match self:
             case Line():
@@ -112,9 +119,11 @@ class Concat(Doc):
     left: Doc
     right: Doc
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def layout(self, indent: int) -> str:
         return self.left.layout(indent) + self.right.layout(indent)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def fits(self, width: int, current_length: int) -> bool:
         if not self.left.fits(width, current_length):
             return False
@@ -123,6 +132,7 @@ class Concat(Doc):
 
         return self.right.fits(width, new_length)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def best(self, width: int, current_length: int) -> "Doc":
         left_best = self.left.best(width, current_length)
 
@@ -131,6 +141,7 @@ class Concat(Doc):
         right_best = self.right.best(width, new_length)
         return Concat(left_best, right_best)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def flatten(self) -> "Doc":
         return self.left.flatten() + self.right.flatten()
 
@@ -139,12 +150,15 @@ class Concat(Doc):
 class MultiUnion(Doc):
     alternatives_fn: Callable[[], Iterable[Doc]]
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def layout(self, indent: int) -> str:
         return self.best(DEFAULT_WIDTH, 0).layout(indent)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def fits(self, width: int, current_length: int) -> bool:
         return any(doc.fits(width, current_length) for doc in self.alternatives_fn())
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def best(self, width: int, current_length: int) -> "Doc":
         default_document = None
         for doc in self.alternatives_fn():
@@ -153,6 +167,7 @@ class MultiUnion(Doc):
             default_document = doc
         return default_document.best(width, current_length)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def flatten(self) -> "Doc":
         for doc in self.alternatives_fn():
             return doc.flatten()
@@ -164,15 +179,19 @@ class Nest(Doc):
     indent: int
     doc: Doc
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def layout(self, indent: int) -> str:
         return self.doc.layout(indent + self.indent)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def fits(self, width: int, current_length: int) -> bool:
         return self.doc.fits(width, current_length)
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def best(self, width: int, current_length: int) -> "Doc":
         return Nest(self.indent, self.doc.best(width, current_length + self.indent))
 
+    @lru_cache(maxsize=_PPRINT_CACHE_SIZE)
     def flatten(self) -> "Doc":
         return Nest(self.indent, self.doc.flatten())
 

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -512,9 +512,34 @@ def type_of_variable(variables: list[tuple[str, Any]], name: str) -> Any:
 
 sort_cache: dict[str, SortRef] = {}
 
+# Caches for the SMT-context helpers. Within a single solve, `translate` is
+# called repeatedly with constraints that share the same underlying SMTContext,
+# so the `variables`, `functions`, and `sorts` collections are the same Python
+# objects across many calls. We key by `id` because dict/list are not hashable;
+# the cached dict is held strongly so the id cannot be reused while cached.
+_mk_vars_cache: dict[int, tuple[dict[str, TypeConstructor], dict[str, Any]]] = {}
+_mk_funs_cache: dict[int, tuple[dict[str, AbstractionType], dict[str, Any]]] = {}
+_mk_sorts_cache: dict[tuple[str, ...], dict[str, SortRef]] = {}
+_SMT_HELPER_CACHE_MAX = 1024
+
+
+def _bound(cache: dict, limit: int = _SMT_HELPER_CACHE_MAX) -> None:
+    if len(cache) > limit:
+        # Drop ~10% oldest entries (insertion order in CPython dicts).
+        drop = max(1, limit // 10)
+        for k in list(cache.keys())[:drop]:
+            del cache[k]
+
 
 def mk_vars(variables: dict[str, TypeConstructor], sorts: dict[str, SortRef]) -> dict[str, Any]:
-    return {name: make_variable(name, base) for name, base in variables.items()}
+    key = id(variables)
+    hit = _mk_vars_cache.get(key)
+    if hit is not None and hit[0] is variables:
+        return hit[1]
+    result = {name: make_variable(name, base) for name, base in variables.items()}
+    _mk_vars_cache[key] = (variables, result)
+    _bound(_mk_vars_cache)
+    return result
 
 
 def get_sort(base: Type) -> SortRef:
@@ -664,10 +689,21 @@ def translate_liq(t: LiquidTerm, variables: dict[str, Any]):
 
 
 def mk_sorts(sorts: list[str]) -> dict[str, SortRef]:
-    return {name: get_sort(TypeConstructor(Name(name, 0))) for name in sorts}
+    key = tuple(sorts)
+    hit = _mk_sorts_cache.get(key)
+    if hit is not None:
+        return hit
+    result = {name: get_sort(TypeConstructor(Name(name, 0))) for name in sorts}
+    _mk_sorts_cache[key] = result
+    _bound(_mk_sorts_cache)
+    return result
 
 
 def mk_funs(functions: dict[str, AbstractionType], sorts: dict[str, SortRef]) -> dict[str, Any]:
+    key = id(functions)
+    hit = _mk_funs_cache.get(key)
+    if hit is not None and hit[0] is functions:
+        return hit[1]
     funs = {}
     for name, ty in functions.items():
         input_types, output_type = uncurry(ty)
@@ -675,6 +711,8 @@ def mk_funs(functions: dict[str, AbstractionType], sorts: dict[str, SortRef]) ->
             sorts.get(str(output_type), get_sort(output_type))
         ]
         funs[name] = Function(name, *args)
+    _mk_funs_cache[key] = (functions, funs)
+    _bound(_mk_funs_cache)
     return funs
 
 
@@ -705,8 +743,9 @@ def translate(
     sorts = mk_sorts(c.sorts)
     functions = mk_funs(c.functions, sorts)
     variables = mk_vars(c.variables, sorts)
-    e1 = translate_liq(c.premise, variables | functions)
-    e2 = translate_liq(c.conclusion, variables | functions)
+    env = variables | functions
+    e1 = translate_liq(c.premise, env)
+    e2 = translate_liq(c.conclusion, env)
     if isinstance(e2, bool) and e2 is True:
         return False
     if isinstance(e1, bool) and isinstance(e2, bool):


### PR DESCRIPTION
## Summary

Profiled `tdsyn` on `examples/synthesis/nqueens.ae` (cProfile, 15s budget) and applied three targeted fixes for the hotspots that actually showed up. End-to-end wall time on that workload drops from **38.4s → 20.2s (1.9× faster)**; per-call inner-loop costs drop much more (see table below).

## What changed

1. **Memoize the Wadler-Leijen pretty printer** (`aeon/utils/pprint_helpers.py`)
   `Concat`/`MultiUnion`/`Nest` traversed the same subtrees with the same `(width, current_length)` pair over and over (7M+ recursive `layout` calls for one nqueens output). All `Doc` subclasses are `frozen=True` dataclasses → hashable → add `@lru_cache` per method.

2. **Cache `mk_sorts` / `mk_funs` / `mk_vars` and hoist `variables | functions`** (`aeon/verification/smt.py`)
   Within a single solve, `translate(CanonicConstraint)` is called many times with constraints that share the same underlying `SMTContext`. Keyed the cache by `id` (with the source object held strongly so the id cannot be reused while cached) for the unhashable dict args, and by `tuple(sorts)` for the list. The `variables | functions` merge in `translate` now happens once per call instead of twice.

3. **`type(x) is Cls` in hot `__eq__` paths** (`aeon/core/types.py`, `aeon/core/liquid.py`, `aeon/utils/name.py`)
   Replaced `isinstance` with `type() is` in the most-hit equality methods: `Name.__eq__` (1.9M calls), `TypeVar` / `Top` / `AbstractionType` / `RefinedType` / `TypeConstructor.__eq__`, `LiquidVar` / `LiquidApp.__eq__`. All target classes have no subclasses, so behavior is identical; this skips the MRO/ABC walk that `isinstance` does. `Name.__eq__` also compares `id` (int) before `name` (str) to short-circuit faster.

## Numbers (cProfile cumulative time on \`--budget 15 -s tdsyn examples/synthesis/nqueens.ae\`)

| metric                      | baseline | step 1 | step 2 | step 3 |
|---|---:|---:|---:|---:|
| **Total wall**              | **38.41s** | **21.20s** | 20.28s | 20.21s |
| `pretty_print_sterm`        | 11.87s | **0.37s** (32×) | 0.32s | 0.32s |
| `smt.translate`             | 8.40s  | 8.55s  | **0.33s** (26×) | 0.33s |
| `smt_valid`                 | 11.77s | 11.90s | 9.70s  | 9.83s |
| `horn.solve`                | 11.88s | 12.02s | 9.83s  | 9.99s |
| `entailment.entailment`     | 13.64s | 13.77s | 12.17s | 12.54s |
| `builtins.isinstance` calls | 6.64M  | 6.64M  | 7.56M  | **4.49M** (-3.1M) |

## Why wall-time doesn't shrink further at steps 2 and 3

`tdsyn` is **budget-bound**: it runs until `--budget` seconds elapse regardless of speed. Step 1's wins show up at wall time because pretty-printing happens *after* synthesis in `main()`. Steps 2 and 3 speed up the per-typecheck inner loop, but the synthesizer reinvests every saved microsecond into exploring more candidates within the same budget. The cProfile numbers above prove the per-call speedups are real; they would show as wall-time wins on a workload that completes before the budget or with a synthesizer that exposes "candidates evaluated" counters.

## Test plan

- [x] Full test suite: `uv run pytest` — **415 passed, 9 skipped** (no regressions)
- [x] Pre-commit hooks: mypy, ruff, ruff format all pass
- [x] Each optimization verified individually with cProfile (table above) before moving to the next

🤖 Generated with [Claude Code](https://claude.com/claude-code)