### PR TITLE
Image-edit synthesis benchmarks (closes #146)

### DIFF
--- a/examples/synthesis/image_edits/cell_microscopy.ae
+++ b/examples/synthesis/image_edits/cell_microscopy.ae
@@ -1,0 +1,45 @@
+# Image edit benchmark: highlight nuclei within a size interval.
+#
+# Scientific imaging scenario inspired by "Synthesizing Optimal Object
+# Selection Predicates for Image Editing using Lattices" (arXiv:2504.03155).
+#
+# A microscopy image contains segmented cell nuclei, each annotated with
+# its radius (in pixels). The biologist wants to highlight nuclei whose
+# radius falls inside a healthy range; everything smaller (debris) or
+# larger (abnormal) must be left alone.
+#
+# Pure-interval predicate over a single numeric attribute. The optimal
+# selector is a conjunction of two thresholds:
+#   radius n >= 12  &&  radius n <= 25
+
+inductive Nucleus
+| mk (radius : {r:Int | r >= 0 && r <= 100})
+   : {n:Nucleus | (radius_of n == radius)}
++ radius_of (n:Nucleus) : Int
+
+# Positive examples: healthy-range nuclei.
+def healthy1 : Nucleus = .mk 14
+def healthy2 : Nucleus = .mk 18
+def healthy3 : Nucleus = .mk 22
+
+# Negative examples: too small (debris) or too large (abnormal).
+def debris1 : Nucleus = .mk 4
+def debris2 : Nucleus = .mk 9
+def abn1    : Nucleus = .mk 32
+def abn2    : Nucleus = .mk 48
+
+def cost_pos (b:Bool) : Int = if b then 0 else 1
+def cost_neg (b:Bool) : Int = if b then 1 else 0
+
+@minimize_int(
+    cost_pos (highlight healthy1)
+  + cost_pos (highlight healthy2)
+  + cost_pos (highlight healthy3)
+  + cost_neg (highlight debris1)
+  + cost_neg (highlight debris2)
+  + cost_neg (highlight abn1)
+  + cost_neg (highlight abn2)
+)
+@hide(healthy1, healthy2, healthy3, debris1, debris2, abn1, abn2,
+      mk, cost_pos, cost_neg)
+def highlight (n:Nucleus) : Bool = ?hole

--- a/examples/synthesis/image_edits/football_players.ae
+++ b/examples/synthesis/image_edits/football_players.ae
@@ -1,0 +1,50 @@
+# Image edit benchmark: select football players, keep spectators.
+#
+# Motivating example from "Synthesizing Optimal Object Selection Predicates
+# for Image Editing using Lattices" (arXiv:2504.03155).
+#
+# Scene: a football game photo. Person objects have:
+#   - age   (interval attribute, 0..100)
+#   - style (categorical: no_style | stride | logo)
+#
+# Players wear striped or plain jerseys (no logos) and are typically older
+# than the youngest spectators. Spectators in the stands wear team logos
+# or are children. The synthesizer must find a predicate that classifies
+# the 24 visible Persons into players (to remove) vs spectators (to keep)
+# given only the labelled examples below.
+
+inductive TopStyle
+| ts_none   : TopStyle
+| ts_stride : TopStyle
+| ts_logo   : TopStyle
+
+inductive Person
+| mk (age   : {a:Int | a >= 0 && a <= 100})
+     (style : TopStyle)
+   : {p:Person | (p_age p == age) && (p_style p == style)}
++ p_age   (p:Person) : Int
++ p_style (p:Person) : TopStyle
+
+# Positive examples (players to remove, blue marks in the paper).
+def pos1 : Person = .mk 24 .ts_none
+def pos2 : Person = .mk 31 .ts_none
+def pos3 : Person = .mk 42 .ts_stride
+
+# Negative examples (spectators to keep, red marks in the paper).
+def neg1 : Person = .mk 22 .ts_none
+def neg2 : Person = .mk 24 .ts_logo
+def neg3 : Person = .mk 19 .ts_logo
+
+def cost_pos (b:Bool) : Int = if b then 0 else 1
+def cost_neg (b:Bool) : Int = if b then 1 else 0
+
+@minimize_int(
+    cost_pos (is_player pos1)
+  + cost_pos (is_player pos2)
+  + cost_pos (is_player pos3)
+  + cost_neg (is_player neg1)
+  + cost_neg (is_player neg2)
+  + cost_neg (is_player neg3)
+)
+@hide(pos1, pos2, pos3, neg1, neg2, neg3, mk, cost_pos, cost_neg)
+def is_player (p:Person) : Bool = ?hole

--- a/examples/synthesis/image_edits/green_apples.ae
+++ b/examples/synthesis/image_edits/green_apples.ae
@@ -1,0 +1,44 @@
+# Image edit benchmark: recolor green apples to red.
+#
+# Online shop scenario from "Synthesizing Optimal Object Selection Predicates
+# for Image Editing using Lattices" (arXiv:2504.03155).
+#
+# A product photo contains apples of several colors. The seller wants to
+# show what the catalog would look like if every green apple were repainted
+# red. Each apple has a single categorical attribute: its base color.
+#
+# Pure-categorical synthesis task: the optimal predicate is just
+#   color a == .ac_green
+# but the synthesizer must isolate the relevant feature among many.
+
+inductive AppleColor
+| ac_green  : AppleColor
+| ac_red    : AppleColor
+| ac_yellow : AppleColor
+
+inductive Apple
+| mk (color : AppleColor)
+   : {a:Apple | (color_of a == color)}
++ color_of (a:Apple) : AppleColor
+
+# Positive examples: green apples to recolor.
+def green1 : Apple = .mk .ac_green
+def green2 : Apple = .mk .ac_green
+
+# Negative examples: leave other apples untouched.
+def red1    : Apple = .mk .ac_red
+def red2    : Apple = .mk .ac_red
+def yellow1 : Apple = .mk .ac_yellow
+
+def cost_pos (b:Bool) : Int = if b then 0 else 1
+def cost_neg (b:Bool) : Int = if b then 1 else 0
+
+@minimize_int(
+    cost_pos (recolor_target green1)
+  + cost_pos (recolor_target green2)
+  + cost_neg (recolor_target red1)
+  + cost_neg (recolor_target red2)
+  + cost_neg (recolor_target yellow1)
+)
+@hide(green1, green2, red1, red2, yellow1, mk, cost_pos, cost_neg)
+def recolor_target (a:Apple) : Bool = ?hole

--- a/examples/synthesis/image_edits/license_plates.ae
+++ b/examples/synthesis/image_edits/license_plates.ae
@@ -1,0 +1,50 @@
+# Image edit benchmark: blur license plates of every vehicle.
+#
+# Privacy scenario from "Synthesizing Optimal Object Selection Predicates
+# for Image Editing using Lattices" (arXiv:2504.03155).
+#
+# A street photo contains a mix of objects detected by vision models: cars,
+# trucks, motorbikes, pedestrians, traffic signs. The user wants to mosaic
+# the license plate of every wheeled vehicle and leave the rest unchanged.
+#
+# Categorical predicate over a multi-valued attribute. The optimal selector
+# is a disjunction over the three vehicle classes:
+#   class o == .car || class o == .truck || class o == .motorbike
+
+inductive ObjectClass
+| oc_car        : ObjectClass
+| oc_truck      : ObjectClass
+| oc_motorbike  : ObjectClass
+| oc_pedestrian : ObjectClass
+| oc_sign       : ObjectClass
+
+inductive StreetObject
+| mk (klass : ObjectClass)
+   : {o:StreetObject | (class_of o == klass)}
++ class_of (o:StreetObject) : ObjectClass
+
+# Positive examples (vehicles to blur).
+def car1   : StreetObject = .mk .oc_car
+def car2   : StreetObject = .mk .oc_car
+def truck1 : StreetObject = .mk .oc_truck
+def bike1  : StreetObject = .mk .oc_motorbike
+
+# Negative examples (non-vehicles to keep).
+def ped1  : StreetObject = .mk .oc_pedestrian
+def ped2  : StreetObject = .mk .oc_pedestrian
+def sign1 : StreetObject = .mk .oc_sign
+
+def cost_pos (b:Bool) : Int = if b then 0 else 1
+def cost_neg (b:Bool) : Int = if b then 1 else 0
+
+@minimize_int(
+    cost_pos (blur_plate car1)
+  + cost_pos (blur_plate car2)
+  + cost_pos (blur_plate truck1)
+  + cost_pos (blur_plate bike1)
+  + cost_neg (blur_plate ped1)
+  + cost_neg (blur_plate ped2)
+  + cost_neg (blur_plate sign1)
+)
+@hide(car1, car2, truck1, bike1, ped1, ped2, sign1, mk, cost_pos, cost_neg)
+def blur_plate (o:StreetObject) : Bool = ?hole

--- a/examples/synthesis/image_edits/shoe_recolor.ae
+++ b/examples/synthesis/image_edits/shoe_recolor.ae
@@ -1,0 +1,53 @@
+# Image edit benchmark: recolor a specific shoe variant in a catalog.
+#
+# Mixed-attribute scenario inspired by "Synthesizing Optimal Object Selection
+# Predicates for Image Editing using Lattices" (arXiv:2504.03155).
+#
+# A shoe-shop catalog photo contains shoes of two colors (red / blue) in
+# different sizes. The seller wants to preview how blue shoes in adult sizes
+# (>= 38) would look in green, while keeping red shoes and small blue shoes
+# unchanged. Each shoe has:
+#   - shade : categorical (red | blue)
+#   - size  : interval (20..50)
+#
+# The optimal predicate combines a categorical equality with an interval
+# threshold:
+#   shade s == .sc_blue  &&  size s >= 38
+
+inductive ShoeColor
+| sc_red  : ShoeColor
+| sc_blue : ShoeColor
+
+inductive Shoe
+| mk (shade : ShoeColor)
+     (size  : {n:Int | n >= 20 && n <= 50})
+   : {s:Shoe | (shoe_shade s == shade) && (shoe_size s == size)}
++ shoe_shade (s:Shoe) : ShoeColor
++ shoe_size  (s:Shoe) : Int
+
+# Positive examples: blue adult-size shoes.
+def blue_40 : Shoe = .mk .sc_blue 40
+def blue_42 : Shoe = .mk .sc_blue 42
+def blue_45 : Shoe = .mk .sc_blue 45
+
+# Negative examples: red shoes (any size) and blue child-size shoes.
+def red_40    : Shoe = .mk .sc_red 40
+def red_30    : Shoe = .mk .sc_red 30
+def blue_28   : Shoe = .mk .sc_blue 28
+def blue_30   : Shoe = .mk .sc_blue 30
+
+def cost_pos (b:Bool) : Int = if b then 0 else 1
+def cost_neg (b:Bool) : Int = if b then 1 else 0
+
+@minimize_int(
+    cost_pos (recolor blue_40)
+  + cost_pos (recolor blue_42)
+  + cost_pos (recolor blue_45)
+  + cost_neg (recolor red_40)
+  + cost_neg (recolor red_30)
+  + cost_neg (recolor blue_28)
+  + cost_neg (recolor blue_30)
+)
+@hide(blue_40, blue_42, blue_45, red_40, red_30, blue_28, blue_30,
+      mk, cost_pos, cost_neg)
+def recolor (s:Shoe) : Bool = ?hole

--- a/examples/synthesis/image_edits/team_jerseys.ae
+++ b/examples/synthesis/image_edits/team_jerseys.ae
@@ -1,0 +1,65 @@
+# Image edit benchmark: cut out a specific team from a sports photo.
+#
+# Inspired by "Synthesizing Optimal Object Selection Predicates for Image
+# Editing using Lattices" (arXiv:2504.03155).
+#
+# Two football teams share the field. Each Player object is annotated with:
+#   - jersey   : categorical (red | white)
+#   - number   : interval (1..99)
+#   - role     : categorical (forward | defender | goalkeeper)
+#
+# The user wants to extract the red team's outfield players (i.e. anyone
+# wearing a red jersey who is NOT a goalkeeper) so they can be composited
+# over a different background. The goalkeeper of the same team wears red
+# but is excluded; the white team is kept untouched.
+#
+# The optimal predicate is:
+#   jersey p == .jc_red  &&  role p != .pr_goalkeeper
+
+inductive JerseyColor
+| jc_red   : JerseyColor
+| jc_white : JerseyColor
+
+inductive PlayerRole
+| pr_forward    : PlayerRole
+| pr_defender   : PlayerRole
+| pr_goalkeeper : PlayerRole
+
+inductive Player
+| mk (jersey : JerseyColor)
+     (number : {n:Int | n >= 1 && n <= 99})
+     (role   : PlayerRole)
+   : {p:Player |
+        (jersey_of p == jersey) &&
+        (number_of p == number) &&
+        (role_of   p == role)}
++ jersey_of (p:Player) : JerseyColor
++ number_of (p:Player) : Int
++ role_of   (p:Player) : PlayerRole
+
+# Positive examples (red outfield players to cut out).
+def red_fwd1 : Player = .mk .jc_red    9 .pr_forward
+def red_def1 : Player = .mk .jc_red    4 .pr_defender
+def red_fwd2 : Player = .mk .jc_red   11 .pr_forward
+
+# Negative examples.
+def red_gk    : Player = .mk .jc_red    1 .pr_goalkeeper
+def white_fwd : Player = .mk .jc_white  7 .pr_forward
+def white_def : Player = .mk .jc_white  5 .pr_defender
+def white_gk  : Player = .mk .jc_white  1 .pr_goalkeeper
+
+def cost_pos (b:Bool) : Int = if b then 0 else 1
+def cost_neg (b:Bool) : Int = if b then 1 else 0
+
+@minimize_int(
+    cost_pos (cut_out red_fwd1)
+  + cost_pos (cut_out red_def1)
+  + cost_pos (cut_out red_fwd2)
+  + cost_neg (cut_out red_gk)
+  + cost_neg (cut_out white_fwd)
+  + cost_neg (cut_out white_def)
+  + cost_neg (cut_out white_gk)
+)
+@hide(red_fwd1, red_def1, red_fwd2, red_gk, white_fwd, white_def, white_gk,
+      mk, cost_pos, cost_neg)
+def cut_out (p:Player) : Bool = ?hole

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -24,7 +24,7 @@ function run_example {
     fi
 }
 
-for folder in ffi image imports list syntax synthesis "PSB2/solved";
+for folder in ffi image imports list syntax synthesis synthesis/image_edits "PSB2/solved";
 do
     for entry in examples/$folder/*.ae
     do


### PR DESCRIPTION
## Summary

Adds six new predicate-synthesis benchmarks under `examples/synthesis/image_edits/`, inspired by [ManiRender (arXiv:2504.03155)](https://arxiv.org/abs/2504.03155). Each benchmark models an image-editing scenario where the synthesizer must learn an object-selection predicate from a handful of positive and negative examples — the same shape as the lattice-based search problem in the paper, encoded as an Aeon function hole optimised via the existing `@minimize_int` fitness.

| Benchmark | Scenario | Predicate shape |
|---|---|---|
| `football_players.ae` | Remove players, keep spectators (paper's motivating example) | categorical + interval |
| `green_apples.ae` | Recolor green apples in a catalog photo | pure categorical equality |
| `license_plates.ae` | Mosaic license plates on every wheeled vehicle | categorical disjunction |
| `shoe_recolor.ae` | Recolor blue adult-size shoes only | categorical ∧ interval threshold |
| `cell_microscopy.ae` | Highlight nuclei in a healthy radius range | pure interval (both bounds) |
| `team_jerseys.ae` | Cut out the red team's outfield players | three-attribute conjunction with `!=` |

`run_examples.sh` now also iterates over `examples/synthesis/image_edits/`, so CI exercises the new files.

## Test plan

- [x] All six benchmarks parse, elaborate to core, and type-check
- [x] Each benchmark runs `python -m aeon --no-main --budget 10` to completion (exit 0)
- [x] CI loop in `run_examples.sh` reports `(success)` for every benchmark

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)