### PR TITLE
Add Z3-derived synthesis benchmarks (closes #140)

### DIFF
--- a/examples/synthesis/bank_deposit.ae
+++ b/examples/synthesis/bank_deposit.ae
@@ -1,0 +1,32 @@
+# Minimum Annual Bank Deposit - from https://www.hillelwayne.com/post/z3-examples/
+#
+# How much money must I deposit each year to reach a $10,000 goal in 20 years,
+# at 1% annual interest, with deposits made at the end of each year?
+#
+# Compound formula (year 20 balance):
+#   balance_20 = d * ((1.01^20 - 1) / 0.01)
+# where d is the annual deposit. We want balance_20 >= 10000.
+#
+# The exact answer is d ≈ 453.4.  We use integer cents (i.e. d in dollars)
+# and require: d * SUMS == TARGET, where SUMS is a precomputed integer
+# approximation of the compound factor scaled by 1000.
+#
+# Scaled compound factor over 20 years at 1% (rounded): 21900 (i.e. ~21.9).
+# So we need: d * 21900 >= 10_000_000  (since target = 10000 dollars
+# scaled by 1000), giving d_min = 457 dollars/year (with rounding slack).
+
+def TARGET_SCALED : {n:Int | n == 10000000} = 10000000   # $10,000 * 1000
+def FACTOR_SCALED : {n:Int | n == 21900} = 21900          # ((1.01^20 - 1) / 0.01) * 1000 ≈ 21.9
+
+# Find the minimum annual deposit that reaches the goal.
+@minimize_int(deposit_hole)
+def deposit_hole : {d:Int |
+    d > 0 &&
+    d * FACTOR_SCALED >= TARGET_SCALED
+} = ?hole
+
+# Verification: 457 should satisfy the constraint (457 * 21900 == 10_008_300).
+def deposit_known : {d:Int |
+    d > 0 &&
+    d * FACTOR_SCALED >= TARGET_SCALED
+} = 457

--- a/examples/synthesis/circle_points.ae
+++ b/examples/synthesis/circle_points.ae
@@ -1,0 +1,20 @@
+# Integer Points on a Circle - from https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/
+#
+# Find integer coordinates (x, y) such that x^2 + y^2 == 25.
+# The circle of radius 5 has 12 such integer (lattice) points, e.g.:
+#   (0,  5), ( 3,  4), ( 4,  3), ( 5, 0)
+#   (0, -5), (-3, -4), (-4, -3), (-5, 0)
+#   ...
+
+inductive Point
+| mk (x:Int) (y:Int) :
+     {p:Point | (px p == x) && (py p == y)}
++ px (p:Point) : Int
++ py (p:Point) : Int
+
+def lattice_point_hole : {p:Point |
+    px p * px p + py p * py p == 25
+} = ?hole
+
+# Verification: a known lattice point should type-check.
+def lattice_point : {p:Point | px p * px p + py p * py p == 25} = .mk 3 4

--- a/examples/synthesis/distinct_triples.ae
+++ b/examples/synthesis/distinct_triples.ae
@@ -1,0 +1,56 @@
+# Two Distinct Triples with Equal Sums and Products
+# from https://www.hillelwayne.com/post/z3-examples/
+#
+# Find six distinct positive integers forming two triples (a,b,c) and (d,e,f)
+# such that:
+#   a + b + c == d + e + f
+#   a * b * c == d * e * f
+#   {a, b, c} ∩ {d, e, f} == ∅
+#
+# Known solution: (7, 8, 15) and (14, 6, 10) with sum=30 and product=840.
+
+inductive Triples
+| mk (a:Int | a > 0) (b:Int | b > 0) (c:Int | c > 0)
+     (d:Int | d > 0) (e:Int | e > 0) (f:Int | f > 0) :
+     {t:Triples |
+        (ta t == a) && (tb t == b) && (tc t == c) &&
+        (td t == d) && (te t == e) && (tf t == f)}
++ ta (t:Triples) : Int
++ tb (t:Triples) : Int
++ tc (t:Triples) : Int
++ td (t:Triples) : Int
++ te (t:Triples) : Int
++ tf (t:Triples) : Int
+
+@minimize_int(1)
+def triples_solution_hole : {t:Triples |
+    (ta t > 0) && (tb t > 0) && (tc t > 0) &&
+    (td t > 0) && (te t > 0) && (tf t > 0) &&
+    (ta t + tb t + tc t == td t + te t + tf t) &&
+    (ta t * tb t * tc t == td t * te t * tf t) &&
+    # All six values distinct (15 pairs)
+    (ta t != tb t) && (ta t != tc t) && (ta t != td t) &&
+    (ta t != te t) && (ta t != tf t) &&
+    (tb t != tc t) && (tb t != td t) && (tb t != te t) &&
+    (tb t != tf t) &&
+    (tc t != td t) && (tc t != te t) && (tc t != tf t) &&
+    (td t != te t) && (td t != tf t) &&
+    (te t != tf t)
+} = ?hole
+
+# Verification: (7, 8, 15) and (14, 6, 10) should type-check.
+#   sum:     7 + 8 + 15 = 30 = 14 + 6 + 10
+#   product: 7 * 8 * 15 = 840 = 14 * 6 * 10
+def triples_solution : {t:Triples |
+    (ta t > 0) && (tb t > 0) && (tc t > 0) &&
+    (td t > 0) && (te t > 0) && (tf t > 0) &&
+    (ta t + tb t + tc t == td t + te t + tf t) &&
+    (ta t * tb t * tc t == td t * te t * tf t) &&
+    (ta t != tb t) && (ta t != tc t) && (ta t != td t) &&
+    (ta t != te t) && (ta t != tf t) &&
+    (tb t != tc t) && (tb t != td t) && (tb t != te t) &&
+    (tb t != tf t) &&
+    (tc t != td t) && (tc t != te t) && (tc t != tf t) &&
+    (td t != te t) && (td t != tf t) &&
+    (te t != tf t)
+} = .mk 7 8 15 14 6 10

--- a/examples/synthesis/linear_equation.ae
+++ b/examples/synthesis/linear_equation.ae
@@ -1,0 +1,9 @@
+# Linear Equation - from https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/
+#
+# Find x such that x + 4 = 7.
+# Expected solution: x = 3.
+
+def x_solution : {n:Int | n + 4 == 7} = ?hole
+
+# Verification: the known solution should type-check.
+def x_solution_known : {n:Int | n + 4 == 7} = 3

--- a/examples/synthesis/page_layout.ae
+++ b/examples/synthesis/page_layout.ae
@@ -1,0 +1,73 @@
+# Page Layout - from https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/
+#
+# Place three rectangular boxes on a 190 x 270 page so that
+#   - each box is fully inside the page,
+#   - no two boxes overlap.
+#
+# Box dimensions (width x height):
+#   box1: 105 x 140
+#   box2:  85 x 135
+#   box3: 120 x 110
+#
+# We use integer positions (top-left corner) measured in millimeters.
+
+inductive Layout
+| mk (x1:Int) (y1:Int)
+     (x2:Int) (y2:Int)
+     (x3:Int) (y3:Int) :
+     {l:Layout |
+        (lx1 l == x1) && (ly1 l == y1) &&
+        (lx2 l == x2) && (ly2 l == y2) &&
+        (lx3 l == x3) && (ly3 l == y3)}
++ lx1 (l:Layout) : Int
++ ly1 (l:Layout) : Int
++ lx2 (l:Layout) : Int
++ ly2 (l:Layout) : Int
++ lx3 (l:Layout) : Int
++ ly3 (l:Layout) : Int
+
+def PAGE_W : {n:Int | n == 190} = 190
+def PAGE_H : {n:Int | n == 270} = 270
+
+def W1 : {n:Int | n == 105} = 105
+def H1 : {n:Int | n == 140} = 140
+def W2 : {n:Int | n == 85}  = 85
+def H2 : {n:Int | n == 135} = 135
+def W3 : {n:Int | n == 120} = 120
+def H3 : {n:Int | n == 110} = 110
+
+# Two axis-aligned boxes overlap iff their x and y projections both overlap.
+# We forbid overlap by requiring at least one axis to be disjoint.
+
+@minimize_int(1)
+def layout_hole : {l:Layout |
+    # Each box fits on the page.
+    (lx1 l >= 0) && (ly1 l >= 0) && (lx1 l + W1 <= PAGE_W) && (ly1 l + H1 <= PAGE_H) &&
+    (lx2 l >= 0) && (ly2 l >= 0) && (lx2 l + W2 <= PAGE_W) && (ly2 l + H2 <= PAGE_H) &&
+    (lx3 l >= 0) && (ly3 l >= 0) && (lx3 l + W3 <= PAGE_W) && (ly3 l + H3 <= PAGE_H) &&
+    # box1 vs box2: disjoint on x or on y.
+    ((lx1 l + W1 <= lx2 l) || (lx2 l + W2 <= lx1 l) ||
+     (ly1 l + H1 <= ly2 l) || (ly2 l + H2 <= ly1 l)) &&
+    # box1 vs box3.
+    ((lx1 l + W1 <= lx3 l) || (lx3 l + W3 <= lx1 l) ||
+     (ly1 l + H1 <= ly3 l) || (ly3 l + H3 <= ly1 l)) &&
+    # box2 vs box3.
+    ((lx2 l + W2 <= lx3 l) || (lx3 l + W3 <= lx2 l) ||
+     (ly2 l + H2 <= ly3 l) || (ly3 l + H3 <= ly2 l))
+} = ?hole
+
+# Verification: a hand-crafted non-overlapping layout should type-check.
+#   box1 in the top-left:                 (0,   0)  – occupies rows 0..140, cols 0..105
+#   box2 to the right of box1:           (105, 0)  – occupies rows 0..135, cols 105..190
+#   box3 below box1 and box2:            (0, 140)  – occupies rows 140..250, cols 0..120
+def layout_known : {l:Layout |
+    (lx1 l >= 0) && (ly1 l >= 0) && (lx1 l + W1 <= PAGE_W) && (ly1 l + H1 <= PAGE_H) &&
+    (lx2 l >= 0) && (ly2 l >= 0) && (lx2 l + W2 <= PAGE_W) && (ly2 l + H2 <= PAGE_H) &&
+    (lx3 l >= 0) && (ly3 l >= 0) && (lx3 l + W3 <= PAGE_W) && (ly3 l + H3 <= PAGE_H) &&
+    ((lx1 l + W1 <= lx2 l) || (lx2 l + W2 <= lx1 l) ||
+     (ly1 l + H1 <= ly2 l) || (ly2 l + H2 <= ly1 l)) &&
+    ((lx1 l + W1 <= lx3 l) || (lx3 l + W3 <= lx1 l) ||
+     (ly1 l + H1 <= ly3 l) || (ly3 l + H3 <= ly1 l)) &&
+    ((lx2 l + W2 <= lx3 l) || (lx3 l + W3 <= lx2 l) ||
+     (ly2 l + H2 <= ly3 l) || (ly3 l + H3 <= ly2 l))
+} = .mk 0 0 105 0 0 140

--- a/examples/synthesis/quadratic.ae
+++ b/examples/synthesis/quadratic.ae
@@ -1,0 +1,10 @@
+# Quadratic Equation - from https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/
+#
+# Find x such that x * x == 4.
+# Expected solutions: x = 2 or x = -2.
+
+def x_solution : {n:Int | n * n == 4} = ?hole
+
+# Verification: both known integer solutions should type-check.
+def x_pos : {n:Int | n * n == 4} = 2
+def x_neg : {n:Int | n * n == 4} = 0 - 2

--- a/examples/synthesis/stock_profit.ae
+++ b/examples/synthesis/stock_profit.ae
@@ -1,0 +1,43 @@
+# Stock Trading Profit - from https://www.hillelwayne.com/post/z3-examples/
+#
+# Given the price array  [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8]
+# find buy/sell indices that maximise (sell_price - buy_price), with buy < sell.
+#
+# Maximum profit is 8: buy at index 1 (price 1), sell at index 5 (price 9).
+
+inductive Trade
+| mk (buy:Int | 0 <= buy && buy < 12)
+     (sell:Int | 0 <= sell && sell < 12) :
+     {t:Trade | (buy_idx t == buy) && (sell_idx t == sell) &&
+                (0 <= buy_idx t) && (buy_idx t < 12) &&
+                (0 <= sell_idx t) && (sell_idx t < 12)}
++ buy_idx  (t:Trade) : Int
++ sell_idx (t:Trade) : Int
+
+# Price table for the array [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8].
+def price_at (i:Int) : Int =
+    if i == 0  then 3
+    else if i == 1  then 1
+    else if i == 2  then 4
+    else if i == 3  then 1
+    else if i == 4  then 5
+    else if i == 5  then 9
+    else if i == 6  then 2
+    else if i == 7  then 6
+    else if i == 8  then 5
+    else if i == 9  then 3
+    else if i == 10 then 5
+    else 8;
+
+# Match-based profit calculation: extract buy and sell indices via pattern matching.
+def profit (t:Trade) : Int =
+    match t with
+    | mk b s => price_at s - price_at b;
+
+# Synthesize a valid trade that maximizes profit.
+@hide(price_at, profit)
+@maximize_int(profit trade_hole)
+def trade_hole : {t:Trade | buy_idx t < sell_idx t} = ?hole
+
+# Verification: the known optimal trade (buy=1, sell=5) should type-check.
+def trade_known : {t:Trade | buy_idx t < sell_idx t} = .mk 1 5

--- a/examples/synthesis/system_equations.ae
+++ b/examples/synthesis/system_equations.ae
@@ -1,0 +1,23 @@
+# System of Linear Equations - from https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/
+#
+# Find integers x and y such that:
+#   x + y == 18
+#   y == 2 * x
+# Expected solution: x = 6, y = 12.
+
+inductive Pair
+| mk (x:Int) (y:Int) :
+     {p:Pair | (px p == x) && (py p == y)}
++ px (p:Pair) : Int
++ py (p:Pair) : Int
+
+def system_solution_hole : {p:Pair |
+    (px p + py p == 18) &&
+    (py p == 2 * px p)
+} = ?hole
+
+# Verification: the known solution should type-check.
+def system_solution : {p:Pair |
+    (px p + py p == 18) &&
+    (py p == 2 * px p)
+} = .mk 6 12


### PR DESCRIPTION
## Summary

Adds 8 new synthesis benchmarks under `examples/synthesis/`, drawn from the two articles referenced in [issue #140](https://github.com/alcides/aeon/issues/140):

**From [Hillel Wayne's z3 post](https://www.hillelwayne.com/post/z3-examples/):**
- `bank_deposit.ae` — minimum annual deposit to reach a \$10k goal over 20 years (compound interest, scaled to integers)
- `stock_profit.ae` — buy/sell indices maximizing profit on `[3,1,4,1,5,9,2,6,5,3,5,8]`
- `distinct_triples.ae` — two disjoint integer triples with equal sum and product

**From [a gentle introduction to Z3](https://ar-ms.me/thoughts/a-gentle-introduction-to-z3/):**
- `linear_equation.ae` — `x + 4 = 7`
- `quadratic.ae` — `x * x = 4`
- `system_equations.ae` — `x + y = 18` and `y = 2x`
- `circle_points.ae` — integer lattice points on `x² + y² = 25`
- `page_layout.ae` — non-overlapping placement of three rectangles on a 190×270 page

Each file follows the style of `coin.ae` / `pizza.ae`: a refinement-typed `?hole` for the synthesizer plus a known-good solution that type-checks as a verification anchor.

## Test plan

- [x] All 8 files parse and type-check
- [x] All 8 known-good solutions verify via Aeon's liquid type checker
- [x] All 8 pass `run_examples.sh`'s gate at the standard 10s budget (5 synthesise a solution, 3 return "no solution found, but OK" — the same exit-code semantics CI already accepts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)