### PR TITLE
Add 39 Ninety-Nine-Problems examples (closes #56)

### DIFF
--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -744,16 +744,20 @@ def expand_inductive_decls(p: Program) -> Program:
                         rty = SAbstractionType(aname, aty, rty, multiplicity=m)
                     return rty
 
-                def case_for(cname: Name, cargs: list[tuple[Name, SType]]) -> str:
-                    pargs = ", ".join(f"{arg.name}" for (arg, _) in cargs)
-                    args = "".join(f"({arg.name})" for (arg, _) in cargs)
-                    return f"\tcase ('{key_for(name, cname)}', {pargs}):\n\t\treturn case_{cname.name}{args}"
+                # Emit the recursor body as a Python *expression* (chain of
+                # conditional expressions) rather than a `match` statement,
+                # so it round-trips cleanly through `eval` at runtime.
+                def branch_for(cname: Name, cargs: list[tuple[Name, SType]]) -> tuple[str, str]:
+                    body = f"case_{cname.name}" + "".join(f"(this[{i + 1}])" for i in range(len(cargs)))
+                    guard = f"this[0] == '{key_for(name, cname)}'"
+                    return body, guard
 
-                cases = "\n".join(case_for(cons.name, cons.args) for cons in constructors)
-                catchall = "\n\tcase _:\n\t\traise Exception('Invalid constructor')"
-                rec_body: STerm = SApplication(
-                    SVar(Name("native", 0)), SLiteral(f"""match this:\n{cases}{catchall}\n""", st_string)
-                )
+                branches = [branch_for(cons.name, cons.args) for cons in constructors]
+                # Catchall raises via a generator-throw trick so it remains an expression.
+                rec_expr = "(_ for _ in ()).throw(Exception('Invalid constructor'))"
+                for body, guard in reversed(branches):
+                    rec_expr = f"({body} if {guard} else {rec_expr})"
+                rec_body: STerm = SApplication(SVar(Name("native", 0)), SLiteral(rec_expr, st_string))
 
                 foralls: list[tuple[Name, Kind]] = [(a, BaseKind()) for a in args]
                 rec_args: list[tuple[Name, SType]] = []

--- a/examples/99problems/README.md
+++ b/examples/99problems/README.md
@@ -65,9 +65,6 @@ suite.
   (e.g. `p10_encode.ae` uses `itertools.groupby`).  This is in the
   spirit of Aeon's Python FFI: the *types* are still checked by Aeon,
   including refinements, while the implementation reuses Python.
-* The current Aeon evaluator has a known limitation when executing
-  `match` on inductive types (problems 55–56), so those files demonstrate
-  the typing only and avoid calling the predicates from `main`.
 
 ## Mapping to the original 99 problems
 

--- a/examples/99problems/README.md
+++ b/examples/99problems/README.md
@@ -1,0 +1,85 @@
+# Ninety-Nine Problems in Aeon
+
+This directory contains Aeon solutions to a subset of the classic
+[Ninety-Nine Lisp Problems](https://www.ic.unicamp.br/~meidanis/courses/mc336/2009s2/prolog/problemas/)
+(also adapted for Lean as
+[Lean99](https://lean-ja.github.io/lean99/)).  They serve as a small
+showcase of how expressive Aeon is — and in particular how its
+**Liquid (refinement) types** let us encode safety properties directly
+in function signatures.
+
+This addresses [issue #56](https://github.com/alcides/aeon/issues/56).
+
+## Coverage
+
+| Range       | Topic                       | Notes                                            |
+| ----------- | --------------------------- | ------------------------------------------------ |
+| 1–10        | Basic list operations       | last, kth, reverse, palindrome, flatten, …       |
+| 11–13       | Run-length encoding         | direct, modified and decode variants             |
+| 14–21       | List transforms             | duplicate, replicate, drop, split, slice, rotate |
+| 22–26       | Ranges & random selection   | range, random sample, lotto, permutation, combos |
+| 31–34       | Number theory predicates    | primality, gcd, coprime, Euler totient           |
+| 35–36       | Prime factorization         | flat and multiplicity forms (uses `sympy`)       |
+| 39–41       | Primes & Goldbach           | prime ranges, Goldbach decomposition             |
+| 46, 49      | Logic & codes               | truth tables, Gray codes                         |
+| 55–56       | Binary trees                | inductive type + recursive predicates            |
+
+## Highlights of Aeon expressiveness
+
+Several problems use refinement types to encode preconditions and
+post-conditions that would have to be runtime checks or comments in
+mainstream languages:
+
+* `p01_last.ae` — the input list must be non-empty
+  (`{x:(List a) | List.size x > 0}`)
+* `p03_kth.ae` — the index must be in range
+  (`{n:Int | n >= 0 && n < List.size l}`)
+* `p04_length.ae` — the return value is provably equal to the list size
+  (`{n:Int | n == List.size l}`)
+* `p05_reverse.ae` — the result has the same size as the input
+* `p14_duplicate.ae`, `p15_replicate.ae` — the output size is exactly
+  `n * size l`
+* `p17_split.ae`, `p18_slice.ae`, `p20_remove_at.ae`, `p21_insert_at.ae`
+  — valid index range and exact output size
+* `p32_gcd.ae` — recursive gcd with a `decreasing_by` clause for
+  termination
+* `p55_balanced_tree.ae`, `p56_symmetric_tree.ae` — user-defined
+  inductive `Tree` / `BTree` types with structurally-recursive predicates
+
+## Running
+
+```bash
+uv run python -m aeon examples/99problems/p01_last.ae
+```
+
+The CI smoke-test script `run_examples.sh` exercises the whole folder
+via the `--no-main --budget 10` mode used for the rest of the example
+suite.
+
+## Notes / limitations
+
+* Aeon's primitive `List` is monomorphic at runtime — the parametric
+  refinement `List a` is only fully exploited in some examples; in
+  others we use `List Int` directly to keep the type checker happy.
+* Several problems delegate to a single Python expression via `native`
+  (e.g. `p10_encode.ae` uses `itertools.groupby`).  This is in the
+  spirit of Aeon's Python FFI: the *types* are still checked by Aeon,
+  including refinements, while the implementation reuses Python.
+* The current Aeon evaluator has a known limitation when executing
+  `match` on inductive types (problems 55–56), so those files demonstrate
+  the typing only and avoid calling the predicates from `main`.
+
+## Mapping to the original 99 problems
+
+```
+1-Last          11-EncodeMod   21-InsertAt    33-Coprime      46-TruthTable
+2-SecondLast    12-Decode      22-Range       34-Totient      49-GrayCode
+3-Kth           13-EncodeDir   23-RndSelect   35-PrimeFactors 55-Balanced
+4-Length        14-Duplicate   24-Lotto       36-PrimeFactMul 56-Symmetric
+5-Reverse       15-Replicate   25-RndPerm     39-PrimesRange
+6-Palindrome    16-DropEvery   26-Combine     40-Goldbach
+7-Flatten       17-Split       31-IsPrime     41-GoldbachList
+8-Compress      18-Slice       32-Gcd
+9-Pack          19-Rotate
+10-Encode       20-RemoveAt
+```

--- a/examples/99problems/p01_last.ae
+++ b/examples/99problems/p01_last.ae
@@ -1,0 +1,10 @@
+# Problem 1: Find the last element of a list.
+# Uses a refinement to require the input list to be non-empty.
+
+open List
+
+def last (l: {x:(List a) | List.size x > 0}) : a = native "l[-1]"
+
+def main (args:Int) : Unit =
+    xs = List.append (List.append (List.append (List.new[Int]) 1) 2) 3;
+    print (last xs);

--- a/examples/99problems/p02_secondLast.ae
+++ b/examples/99problems/p02_secondLast.ae
@@ -1,0 +1,10 @@
+# Problem 2: Find the second-to-last element of a list.
+# Refinement requires at least two elements.
+
+open List
+
+def secondLast (l: {x:(List a) | List.size x > 1}) : a = native "l[-2]"
+
+def main (args:Int) : Unit =
+    xs = List.append (List.append (List.append (List.new[Int]) 1) 2) 3;
+    print (secondLast xs);

--- a/examples/99problems/p03_kth.ae
+++ b/examples/99problems/p03_kth.ae
@@ -1,0 +1,10 @@
+# Problem 3: Find the K'th element of a list (0-indexed).
+# Refinement enforces that k is a valid index.
+
+open List
+
+def kth (l: (List a)) (k: {n:Int | n >= 0 && n < List.size l}) : a = native "l[k]"
+
+def main (args:Int) : Unit =
+    xs = List.append (List.append (List.append (List.append (List.new[Int]) 10) 20) 30) 40;
+    print (kth xs 2);

--- a/examples/99problems/p04_length.ae
+++ b/examples/99problems/p04_length.ae
@@ -1,0 +1,10 @@
+# Problem 4: Find the number of elements of a list.
+# The result is exactly the abstract size of the list (refinement-tracked).
+
+open List
+
+def myLength (l: (List a)) : {n:Int | n == List.size l} = List.length l
+
+def main (args:Int) : Unit =
+    xs = List.append (List.append (List.append (List.new[Int]) 1) 2) 3;
+    print (myLength xs);

--- a/examples/99problems/p05_reverse.ae
+++ b/examples/99problems/p05_reverse.ae
@@ -1,0 +1,11 @@
+# Problem 5: Reverse a list.
+# Refinement: output has the same size as input.
+
+open List
+
+def myReverse (l: (List a)) : {r:(List a) | List.size r == List.size l} = native "l[::-1]"
+
+def main (args:Int) : Unit =
+    xs = List.append (List.append (List.append (List.new[Int]) 1) 2) 3;
+    rs : (List Int) = myReverse xs;
+    print rs;

--- a/examples/99problems/p06_palindrome.ae
+++ b/examples/99problems/p06_palindrome.ae
@@ -1,0 +1,14 @@
+# Problem 6: Detect whether a list is a palindrome.
+# A list is a palindrome if it reads the same forwards and backwards.
+
+open List
+
+def listEq (xs: (List Int)) (ys: (List Int)) : Bool = native "xs == ys"
+
+def isPalindrome (l: (List Int)) : Bool = listEq l (List.reversed l)
+
+def main (args:Int) : Unit =
+    pal = List.append (List.append (List.append (List.new[Int]) 1) 2) 1;
+    notpal = List.append (List.append (List.append (List.new[Int]) 1) 2) 3;
+    _ = print (isPalindrome pal);
+    print (isPalindrome notpal)

--- a/examples/99problems/p07_flatten.ae
+++ b/examples/99problems/p07_flatten.ae
@@ -1,0 +1,15 @@
+# Problem 7: Flatten a nested list one level deep.
+# Aeon lists are homogeneous, so we flatten a List of Lists into a single List.
+
+open List
+
+def flatten (l: (List (List Int))) : (List Int) = native "[x for sub in l for x in sub]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.new[Int]) 1) 2;
+    b : (List Int) = List.append (List.new[Int]) 3;
+    c : (List Int) = List.append (List.append (List.new[Int]) 4) 5;
+    n1 : (List (List Int)) = List.append (List.new[(List Int)]) a;
+    n2 : (List (List Int)) = List.append n1 b;
+    nested : (List (List Int)) = List.append n2 c;
+    print (flatten nested)

--- a/examples/99problems/p08_compress.ae
+++ b/examples/99problems/p08_compress.ae
@@ -1,0 +1,11 @@
+# Problem 8: Eliminate consecutive duplicates of list elements.
+# The compressed list cannot grow.
+
+open List
+
+def compress (l: (List Int)) : {r:(List Int) | List.size r <= List.size l} =
+    native "[x for i, x in enumerate(l) if i == 0 or x != l[i-1]]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 1) 2) 3) 3;
+    print (compress a)

--- a/examples/99problems/p09_pack.ae
+++ b/examples/99problems/p09_pack.ae
@@ -1,0 +1,12 @@
+# Problem 9: Pack consecutive duplicates of list elements into sublists.
+
+open List
+
+def itertools : Unit = native_import "itertools"
+
+def pack (l: (List Int)) : (List (List Int)) =
+    native "[list(g) for k, g in itertools.groupby(l)]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 1) 1) 2) 3) 3;
+    print (pack a)

--- a/examples/99problems/p10_encode.ae
+++ b/examples/99problems/p10_encode.ae
@@ -1,0 +1,13 @@
+# Problem 10: Run-length encoding of a list.
+# Each group is encoded as a [count, value] pair represented as a 2-element list.
+
+open List
+
+def itertools : Unit = native_import "itertools"
+
+def encode (l: (List Int)) : (List (List Int)) =
+    native "[[len(list(g)), k] for k, g in itertools.groupby(l)]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 1) 1) 2) 3) 3;
+    print (encode a)

--- a/examples/99problems/p11_encode_modified.ae
+++ b/examples/99problems/p11_encode_modified.ae
@@ -1,0 +1,14 @@
+# Problem 11: Modified run-length encoding.
+# Singletons are kept as a 1-element list [value]; groups become [count, value].
+# This approximates Lean's ``Either α (Nat × α)`` using a length-1 or length-2 list.
+
+open List
+
+def itertools : Unit = native_import "itertools"
+
+def encode_modified (l: (List Int)) : (List (List Int)) =
+    native "[(lambda gl: [k] if len(gl) == 1 else [len(gl), k])(list(g)) for k, g in itertools.groupby(l)]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 1) 1) 2) 3) 3;
+    print (encode_modified a)

--- a/examples/99problems/p12_decode.ae
+++ b/examples/99problems/p12_decode.ae
@@ -1,0 +1,16 @@
+# Problem 12: Decode a run-length encoded list.
+# Inverse of Problem 10: each [count, value] pair expands to ``count`` copies of ``value``.
+
+open List
+
+def decode (l: (List (List Int))) : (List Int) =
+    native "[pair[1] for pair in l for _ in range(pair[0])]"
+
+def main (args:Int) : Unit =
+    p1 : (List Int) = List.append (List.append (List.new[Int]) 3) 1;
+    p2 : (List Int) = List.append (List.append (List.new[Int]) 1) 2;
+    p3 : (List Int) = List.append (List.append (List.new[Int]) 2) 3;
+    enc1 : (List (List Int)) = List.append (List.new[(List Int)]) p1;
+    enc2 : (List (List Int)) = List.append enc1 p2;
+    enc : (List (List Int)) = List.append enc2 p3;
+    print (decode enc)

--- a/examples/99problems/p13_encode_direct.ae
+++ b/examples/99problems/p13_encode_direct.ae
@@ -1,0 +1,13 @@
+# Problem 13: Run-length encoding (direct version).
+# Same result as Problem 10 but built directly with a fold, not groupby.
+
+open List
+
+def functools : Unit = native_import "functools"
+
+def encode_direct (l: (List Int)) : (List (List Int)) =
+    native "functools.reduce(lambda acc, x: acc + [[1, x]] if not acc or acc[-1][1] != x else acc[:-1] + [[acc[-1][0]+1, x]], l, [])"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 1) 1) 2) 3) 3;
+    print (encode_direct a)

--- a/examples/99problems/p14_duplicate.ae
+++ b/examples/99problems/p14_duplicate.ae
@@ -1,0 +1,11 @@
+# Problem 14: Duplicate the elements of a list.
+# Refinement: the output has exactly twice the size of the input.
+
+open List
+
+def duplicate (l: (List Int)) : {r:(List Int) | List.size r == 2 * List.size l} =
+    native "[x for x in l for _ in range(2)]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.new[Int]) 1) 2) 3;
+    print (duplicate a)

--- a/examples/99problems/p15_replicate.ae
+++ b/examples/99problems/p15_replicate.ae
@@ -1,0 +1,11 @@
+# Problem 15: Replicate the elements of a list a given number of times.
+# Refinement: the output has size n * input_size.
+
+open List
+
+def replicate (l: (List Int)) (n: {k:Int | k >= 0}) : {r:(List Int) | List.size r == n * List.size l} =
+    native "[x for x in l for _ in range(n)]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.new[Int]) 1) 2;
+    print (replicate a 3)

--- a/examples/99problems/p16_drop_every.ae
+++ b/examples/99problems/p16_drop_every.ae
@@ -1,0 +1,11 @@
+# Problem 16: Drop every N'th element from a list.
+# n must be at least 1 to make sense.
+
+open List
+
+def drop_every (l: (List Int)) (n: {k:Int | k >= 1}) : (List Int) =
+    native "[x for i, x in enumerate(l) if (i + 1) % n != 0]"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 3) 4) 5) 6) 7) 8;
+    print (drop_every a 3)

--- a/examples/99problems/p17_split.ae
+++ b/examples/99problems/p17_split.ae
@@ -1,0 +1,12 @@
+# Problem 17: Split a list into two parts at the given position.
+# Refinement: n must be a valid split point (0 <= n <= size l).
+
+open List
+
+def split (l: (List Int)) (n: {k:Int | k >= 0 && k <= List_size l}) : (List (List Int)) =
+    native "[l[:n], l[n:]]"
+
+def main (args:Int) : Unit =
+    a : {x:(List Int) | List_size x == 5} =
+        List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 3) 4) 5;
+    print (split a 2)

--- a/examples/99problems/p18_slice.ae
+++ b/examples/99problems/p18_slice.ae
@@ -1,0 +1,14 @@
+# Problem 18: Extract a slice from a list.
+# Given indices i and k (1-indexed, inclusive), return l[i..k].
+
+open List
+
+def slice (l: (List Int))
+          (i: {x:Int | x >= 1 && x <= List_size l})
+          (k: {y:Int | y >= i && y <= List_size l}) : (List Int) =
+    native "l[i-1:k]"
+
+def main (args:Int) : Unit =
+    a : {x:(List Int) | List_size x == 7} =
+        List.append (List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 3) 4) 5) 6) 7;
+    print (slice a 3 5)

--- a/examples/99problems/p19_rotate.ae
+++ b/examples/99problems/p19_rotate.ae
@@ -1,0 +1,11 @@
+# Problem 19: Rotate a list n positions to the left.
+# Refinement: output has the same size as input. Negative n rotates right.
+
+open List
+
+def rotate (l: (List Int)) (n: Int) : {r:(List Int) | List_size r == List_size l} =
+    native "l[n % len(l):] + l[:n % len(l)] if l else l"
+
+def main (args:Int) : Unit =
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 3) 4) 5) 6) 7) 8;
+    print (rotate a 3)

--- a/examples/99problems/p20_remove_at.ae
+++ b/examples/99problems/p20_remove_at.ae
@@ -1,0 +1,13 @@
+# Problem 20: Remove the K'th element from a list (0-indexed).
+# Refinement: k is a valid index, and output has size one less than input.
+
+open List
+
+def remove_at (l: (List Int)) (k: {x:Int | x >= 0 && x < List_size l}) :
+        {r:(List Int) | List_size r == List_size l - 1} =
+    native "l[:k] + l[k+1:]"
+
+def main (args:Int) : Unit =
+    a : {x:(List Int) | List_size x == 5} =
+        List.append (List.append (List.append (List.append (List.append (List.new[Int]) 10) 20) 30) 40) 50;
+    print (remove_at a 2)

--- a/examples/99problems/p21_insert_at.ae
+++ b/examples/99problems/p21_insert_at.ae
@@ -1,0 +1,13 @@
+# Problem 21: Insert an element at a given position into a list (0-indexed).
+# Refinement: position is in range, output size is exactly one larger.
+
+open List
+
+def insert_at (x: Int) (l: (List Int)) (k: {n:Int | n >= 0 && n <= List_size l}) :
+        {r:(List Int) | List_size r == List_size l + 1} =
+    native "l[:k] + [x] + l[k:]"
+
+def main (args:Int) : Unit =
+    a : {x:(List Int) | List_size x == 4} =
+        List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 4) 5;
+    print (insert_at 3 a 2)

--- a/examples/99problems/p22_range.ae
+++ b/examples/99problems/p22_range.ae
@@ -1,0 +1,10 @@
+# Problem 22: Create a list containing all integers within a given range.
+# Refinement: when low <= high, the output size is exactly (high - low + 1).
+
+open List
+
+def intRange (low: Int) (high: {n:Int | n >= low}) : {r:(List Int) | List_size r == high - low + 1} =
+    native "list(range(low, high + 1))"
+
+def main (args:Int) : Unit =
+    print (intRange 4 9)

--- a/examples/99problems/p23_random_select.ae
+++ b/examples/99problems/p23_random_select.ae
@@ -1,0 +1,16 @@
+# Problem 23: Select n random elements from a list (without replacement).
+# Refinement: n must be at most the size of the list; output has size n.
+
+open List
+
+def random : Unit = native_import "random"
+
+def rndSelect (l: (List Int)) (n: {k:Int | k >= 0 && k <= List_size l}) :
+        {r:(List Int) | List_size r == n} =
+    native "random.sample(l, n)"
+
+def main (args:Int) : Unit =
+    _ = native "random.seed(42)";
+    a : {x:(List Int) | List_size x == 6} =
+        List.append (List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 3) 4) 5) 6;
+    print (rndSelect a 3)

--- a/examples/99problems/p24_lotto.ae
+++ b/examples/99problems/p24_lotto.ae
@@ -1,0 +1,14 @@
+# Problem 24: Draw n different random numbers from the set 1..m (a lotto draw).
+# Refinement: n must not exceed m; output has size n.
+
+open List
+
+def random : Unit = native_import "random"
+
+def lotto (n: {k:Int | k >= 0}) (m: {x:Int | x >= n}) :
+        {r:(List Int) | List_size r == n} =
+    native "random.sample(range(1, m + 1), n)"
+
+def main (args:Int) : Unit =
+    _ = native "random.seed(42)";
+    print (lotto 6 49)

--- a/examples/99problems/p25_random_permutation.ae
+++ b/examples/99problems/p25_random_permutation.ae
@@ -1,0 +1,14 @@
+# Problem 25: Generate a random permutation of the elements of a list.
+# Refinement: output has the same size as input.
+
+open List
+
+def random : Unit = native_import "random"
+
+def rndPermutation (l: (List Int)) : {r:(List Int) | List_size r == List_size l} =
+    native "random.sample(l, len(l))"
+
+def main (args:Int) : Unit =
+    _ = native "random.seed(7)";
+    a : (List Int) = List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 3) 4) 5;
+    print (rndPermutation a)

--- a/examples/99problems/p26_combinations.ae
+++ b/examples/99problems/p26_combinations.ae
@@ -1,0 +1,14 @@
+# Problem 26: Generate all combinations of K distinct objects from a list.
+# Refinement: K must be a valid size (0 <= k <= size l).
+
+open List
+
+def itertools : Unit = native_import "itertools"
+
+def combinations (k: {n:Int | n >= 0}) (l: {x:(List Int) | List_size x >= k}) : (List (List Int)) =
+    native "[list(c) for c in itertools.combinations(l, k)]"
+
+def main (args:Int) : Unit =
+    a : {x:(List Int) | List_size x == 5} =
+        List.append (List.append (List.append (List.append (List.append (List.new[Int]) 1) 2) 3) 4) 5;
+    print (combinations 3 a)

--- a/examples/99problems/p31_is_prime.ae
+++ b/examples/99problems/p31_is_prime.ae
@@ -1,0 +1,9 @@
+# Problem 31: Determine whether a given integer (>= 2) is prime.
+
+def isPrime (n: {x:Int | x >= 2}) : Bool =
+    native "all(n % i != 0 for i in range(2, int(n ** 0.5) + 1))"
+
+def main (args:Int) : Unit =
+    _ = print (isPrime 7);
+    _ = print (isPrime 9);
+    print (isPrime 97)

--- a/examples/99problems/p32_gcd.ae
+++ b/examples/99problems/p32_gcd.ae
@@ -1,0 +1,12 @@
+# Problem 32: Determine the greatest common divisor using Euclid's algorithm.
+# Implemented recursively in Aeon, using a decreasing metric for termination.
+
+def absInt (n: Int) : {v:Int | v >= 0} = if n >= 0 then n else 0 - n
+
+def myGcd (a: {x:Int | x >= 0}) (b: {y:Int | y >= 0}) : {v:Int | v >= 0} decreasing_by [b] =
+    if b == 0 then a else myGcd b (a % b)
+
+def main (args:Int) : Unit =
+    _ = print (myGcd 36 63);
+    _ = print (myGcd 1071 462);
+    print (myGcd 17 13)

--- a/examples/99problems/p33_coprime.ae
+++ b/examples/99problems/p33_coprime.ae
@@ -1,0 +1,12 @@
+# Problem 33: Determine whether two positive integers are coprime.
+# Two numbers are coprime iff their gcd is 1.
+
+def myGcd (a: {x:Int | x >= 0}) (b: {y:Int | y >= 0}) : {v:Int | v >= 0} decreasing_by [b] =
+    if b == 0 then a else myGcd b (a % b)
+
+def coprime (a: {x:Int | x >= 0}) (b: {y:Int | y >= 0}) : Bool =
+    myGcd a b == 1
+
+def main (args:Int) : Unit =
+    _ = print (coprime 35 64);
+    print (coprime 35 49)

--- a/examples/99problems/p34_totient.ae
+++ b/examples/99problems/p34_totient.ae
@@ -1,0 +1,13 @@
+# Problem 34: Calculate Euler's totient function phi(m).
+# phi(m) is the number of positive integers <= m that are coprime to m.
+
+def myGcd (a: {x:Int | x >= 0}) (b: {y:Int | y >= 0}) : {v:Int | v >= 0} decreasing_by [b] =
+    if b == 0 then a else myGcd b (a % b)
+
+def totient (m: {x:Int | x >= 1}) : {v:Int | v >= 1} =
+    native "sum(1 for k in range(1, m + 1) if __import__('math').gcd(k, m) == 1)"
+
+def main (args:Int) : Unit =
+    _ = print (totient 1);
+    _ = print (totient 10);
+    print (totient 36)

--- a/examples/99problems/p35_prime_factors.ae
+++ b/examples/99problems/p35_prime_factors.ae
@@ -1,0 +1,12 @@
+# Problem 35: Determine the prime factors of a given positive integer.
+# Returns the factors in ascending order, with multiplicity.
+
+open List
+
+def sympy : Unit = native_import "sympy"
+
+def primeFactors (n: {x:Int | x >= 2}) : (List Int) =
+    native "sympy.factorint(n, multiple=True)"
+
+def main (args:Int) : Unit =
+    print (primeFactors 315)

--- a/examples/99problems/p36_prime_factors_mult.ae
+++ b/examples/99problems/p36_prime_factors_mult.ae
@@ -1,0 +1,12 @@
+# Problem 36: Prime factors with multiplicity.
+# Each [prime, exponent] pair is represented as a 2-element list of Ints.
+
+open List
+
+def sympy : Unit = native_import "sympy"
+
+def primeFactorsMult (n: {x:Int | x >= 2}) : (List (List Int)) =
+    native "[[p, e] for p, e in sorted(sympy.factorint(n).items())]"
+
+def main (args:Int) : Unit =
+    print (primeFactorsMult 315)

--- a/examples/99problems/p39_primes_range.ae
+++ b/examples/99problems/p39_primes_range.ae
@@ -1,0 +1,10 @@
+# Problem 39: Construct a list of prime numbers in a given range.
+# Returns the primes p with low <= p <= high (low >= 2).
+
+open List
+
+def primesR (low: {x:Int | x >= 2}) (high: {y:Int | y >= low}) : (List Int) =
+    native "[n for n in range(low, high + 1) if all(n % d != 0 for d in range(2, int(n ** 0.5) + 1))]"
+
+def main (args:Int) : Unit =
+    print (primesR 10 50)

--- a/examples/99problems/p40_goldbach.ae
+++ b/examples/99problems/p40_goldbach.ae
@@ -1,0 +1,12 @@
+# Problem 40: Goldbach's conjecture.
+# Every even integer > 2 can be written as the sum of two primes.
+# Returns a 2-element list [p, q] with p + q = n, p and q prime.
+
+open List
+
+def goldbach (n: {x:Int | x > 2 && x % 2 == 0}) : (List Int) =
+    native "[[p, n - p] for p in range(2, n) if all(p % d != 0 for d in range(2, int(p ** 0.5) + 1)) and all((n - p) % d != 0 for d in range(2, int((n - p) ** 0.5) + 1))][0]"
+
+def main (args:Int) : Unit =
+    _ = print (goldbach 28);
+    print (goldbach 100)

--- a/examples/99problems/p41_goldbach_list.ae
+++ b/examples/99problems/p41_goldbach_list.ae
@@ -1,0 +1,13 @@
+# Problem 41: Goldbach decomposition for every even number in a range.
+# Returns a list of [n, p, q] entries.
+
+open List
+
+def isPrime (n: Int) : Bool =
+    native "n >= 2 and all(n % d != 0 for d in range(2, int(n ** 0.5) + 1))"
+
+def goldbachList (low: {a:Int | a >= 2}) (high: {b:Int | b >= low}) : (List (List Int)) =
+    native "[(lambda nn: (lambda p: [nn, p, nn - p])(next(p for p in range(2, nn) if all(p % d != 0 for d in range(2, int(p ** 0.5) + 1)) and all((nn - p) % d != 0 for d in range(2, int((nn - p) ** 0.5) + 1)))))(n) for n in range(low if low % 2 == 0 else low + 1, high + 1, 2) if n > 2]"
+
+def main (args:Int) : Unit =
+    print (goldbachList 9 20)

--- a/examples/99problems/p46_truth_table.ae
+++ b/examples/99problems/p46_truth_table.ae
@@ -1,0 +1,26 @@
+# Problem 46: Print a truth table for a logical expression of two variables.
+# We tabulate a 2-argument boolean function by evaluating it on all four inputs.
+
+def myAnd (a: Bool) (b: Bool) : Bool = a && b
+def myOr (a: Bool) (b: Bool) : Bool = a || b
+def myNand (a: Bool) (b: Bool) : Bool = !(a && b)
+def myXor (a: Bool) (b: Bool) : Bool = a != b
+
+def rowStr (a: Bool) (b: Bool) (r: Bool) : String =
+    native "('T ' if a else 'F ') + ('T ' if b else 'F ') + ('T' if r else 'F')"
+
+def table (f: (x:Bool) -> (y:Bool) -> Bool) : Unit =
+    _ = print (rowStr true true (f true true));
+    _ = print (rowStr true false (f true false));
+    _ = print (rowStr false true (f false true));
+    print (rowStr false false (f false false))
+
+def main (args:Int) : Unit =
+    _ = print "--- AND ---";
+    _ = table myAnd;
+    _ = print "--- OR ---";
+    _ = table myOr;
+    _ = print "--- NAND ---";
+    _ = table myNand;
+    _ = print "--- XOR ---";
+    table myXor

--- a/examples/99problems/p49_gray_code.ae
+++ b/examples/99problems/p49_gray_code.ae
@@ -1,0 +1,12 @@
+# Problem 49: Generate Gray codes of length n.
+# Output has 2^n strings, each of length n.
+
+open List
+
+def gray (n: {x:Int | x >= 1 && x <= 20}) : (List String) =
+    native "[bin(i ^ (i >> 1))[2:].zfill(n) for i in range(2 ** n)]"
+
+def main (args:Int) : Unit =
+    _ = print (gray 1);
+    _ = print (gray 2);
+    print (gray 3)

--- a/examples/99problems/p55_balanced_tree.ae
+++ b/examples/99problems/p55_balanced_tree.ae
@@ -1,0 +1,30 @@
+# Problem 55: Define completely balanced binary trees.
+# We give an inductive type for binary trees together with a recursive
+# ``isBalanced`` predicate.  The type system accepts trees built only with
+# the constructors ``leaf`` and ``node``, and the predicate is total over
+# any such tree.  We do not invoke the predicate at runtime because the
+# current Aeon evaluator has a known limitation with ``match`` evaluation;
+# the file is intended to be type-checked (and is exercised by the CI
+# script's ``--no-main`` smoke test).
+
+inductive Tree
+| leaf : Tree
+| node (v: Int) (l: Tree) (r: Tree) : Tree
+
+def absInt (n: Int) : Int = if n >= 0 then n else 0 - n
+
+def treeSize (t: Tree) : Int =
+    match t with
+    | .leaf => 0
+    | .node v l r => 1 + treeSize l + treeSize r
+
+def isBalanced (t: Tree) : Bool =
+    match t with
+    | .leaf => true
+    | .node v l r => absInt (treeSize l - treeSize r) <= 1 && isBalanced l && isBalanced r
+
+# Two example trees:
+def empty_tree : Tree = .leaf
+def balanced_tree : Tree = .node 1 (.node 2 .leaf .leaf) (.node 3 .leaf .leaf)
+
+def main (args:Int) : Unit = print "tree types defined"

--- a/examples/99problems/p55_balanced_tree.ae
+++ b/examples/99problems/p55_balanced_tree.ae
@@ -2,10 +2,7 @@
 # We give an inductive type for binary trees together with a recursive
 # ``isBalanced`` predicate.  The type system accepts trees built only with
 # the constructors ``leaf`` and ``node``, and the predicate is total over
-# any such tree.  We do not invoke the predicate at runtime because the
-# current Aeon evaluator has a known limitation with ``match`` evaluation;
-# the file is intended to be type-checked (and is exercised by the CI
-# script's ``--no-main`` smoke test).
+# any such tree.
 
 inductive Tree
 | leaf : Tree
@@ -27,4 +24,7 @@ def isBalanced (t: Tree) : Bool =
 def empty_tree : Tree = .leaf
 def balanced_tree : Tree = .node 1 (.node 2 .leaf .leaf) (.node 3 .leaf .leaf)
 
-def main (args:Int) : Unit = print "tree types defined"
+def main (args:Int) : Unit =
+    _ = print (treeSize balanced_tree);
+    _ = print (isBalanced balanced_tree);
+    print (isBalanced empty_tree)

--- a/examples/99problems/p56_symmetric_tree.ae
+++ b/examples/99problems/p56_symmetric_tree.ae
@@ -1,0 +1,34 @@
+# Problem 56: Detect symmetric binary trees.
+# A tree is symmetric iff its left and right subtrees are mirror images
+# of each other.  The predicate ``mirror`` does structural recursion
+# over two trees in lockstep.
+#
+# The runtime evaluator currently has a known limitation with ``match``;
+# this file defines the type and predicate (which type-check fully) and
+# avoids invoking them from ``main``.
+
+inductive BTree
+| empty : BTree
+| node  (v: Int) (l: BTree) (r: BTree) : BTree
+
+def mirror (a: BTree) (b: BTree) : Bool =
+    match a with
+    | .empty =>
+        (match b with
+         | .empty => true
+         | .node v l r => false)
+    | .node va la ra =>
+        (match b with
+         | .empty => false
+         | .node vb lb rb => mirror la rb && mirror ra lb)
+
+def isSymmetric (t: BTree) : Bool =
+    match t with
+    | .empty => true
+    | .node v l r => mirror l r
+
+def sym_tree : BTree =
+    .node 1 (.node 2 .empty (.node 4 .empty .empty))
+            (.node 3 (.node 5 .empty .empty) .empty)
+
+def main (args:Int) : Unit = print "symmetric-tree predicate defined"

--- a/examples/99problems/p56_symmetric_tree.ae
+++ b/examples/99problems/p56_symmetric_tree.ae
@@ -2,10 +2,6 @@
 # A tree is symmetric iff its left and right subtrees are mirror images
 # of each other.  The predicate ``mirror`` does structural recursion
 # over two trees in lockstep.
-#
-# The runtime evaluator currently has a known limitation with ``match``;
-# this file defines the type and predicate (which type-check fully) and
-# avoids invoking them from ``main``.
 
 inductive BTree
 | empty : BTree
@@ -31,4 +27,10 @@ def sym_tree : BTree =
     .node 1 (.node 2 .empty (.node 4 .empty .empty))
             (.node 3 (.node 5 .empty .empty) .empty)
 
-def main (args:Int) : Unit = print "symmetric-tree predicate defined"
+def asym_tree : BTree =
+    .node 1 (.node 2 .empty .empty)
+            (.node 3 (.node 5 .empty .empty) .empty)
+
+def main (args:Int) : Unit =
+    _ = print (isSymmetric sym_tree);
+    print (isSymmetric asym_tree)

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -24,7 +24,7 @@ function run_example {
     fi
 }
 
-for folder in ffi image imports list syntax synthesis synthesis/image_edits "PSB2/solved";
+for folder in ffi image imports list syntax synthesis synthesis/image_edits "PSB2/solved" 99problems;
 do
     for entry in examples/$folder/*.ae
     do


### PR DESCRIPTION
## Summary
- Ports 39 problems from the classic [Ninety-Nine Problems](https://lean-ja.github.io/lean99/) list (numbers 1-26, 31-41, 46, 49, 55-56) to Aeon under a new `examples/99problems/` folder, addressing #56.
- Several files use **refinement types** to encode safety properties directly in signatures (non-empty inputs, in-range indices, size-preserving outputs, exact output sizes, totient/Goldbach domain constraints, recursive `decreasing_by` termination metrics, user-defined inductive `Tree`/`BTree` types).
- Fixes a `match`-codegen bug: the auto-generated `<Type>_rec` eliminator emitted a Python `match` statement, which `eval()` can't accept, so calling match-based predicates over inductive types crashed at runtime. The desugarer now emits the recursor body as a chain of conditional expressions, which round-trips cleanly through the existing `eval()` runtime path.
- Adds the new folder to `run_examples.sh` so it is exercised by the CI smoke-test.
- Adds an [examples/99problems/README.md](https://github.com/alcides/aeon/blob/claude/zealous-spence-884486/examples/99problems/README.md) summarising the problem mapping and Aeon-specific highlights.

## Highlights

| File | What the type encodes |
| --- | --- |
| `p01_last.ae` | Input must be non-empty: `{x:(List a) \| List.size x > 0}` |
| `p03_kth.ae` | Index in range: `{n:Int \| n >= 0 && n < List.size l}` |
| `p04_length.ae` | Result is exactly the abstract size: `{n:Int \| n == List.size l}` |
| `p14/p15` | Output size is exactly `n * size l` |
| `p17/p18/p20/p21` | Chained refined preconditions and size-preserving postconditions |
| `p32_gcd.ae` | Recursive definition with `decreasing_by [b]` termination metric |
| `p55/p56` | User-defined inductive trees with structurally-recursive `match` predicates, invoked at runtime |

## Notes for reviewers
- All 39 files pass the same `--no-main --budget 10` smoke test used for the rest of the example suite, and each also runs end-to-end with `uv run python -m aeon <file>`.
- The only non-example code change is `aeon/sugar/desugar.py`: the inductive recursor body now reads `(case_node(this[1])(this[2])(this[3]) if this[0] == 'Tree_node' else case_leaf if this[0] == 'Tree_leaf' else (_ for _ in ()).throw(Exception('Invalid constructor')))` instead of a `match` statement. The full test suite (534 passed, 9 skipped) passes; existing inductive examples (`pizza_check`, `mylist`, `supermario`, `circle_points`, `stock_profit`, `pizza`, `distinct_triples`) all still run.
- A handful of problems delegate the algorithm to a single Python expression via Aeon's `native` FFI (e.g., `itertools.groupby` for run-length encoding, `sympy.factorint` for factorisation). The *types* are still checked by Aeon.

## Test plan
- [x] `uv run pytest tests/` — 534 passed, 9 skipped, 0 failed
- [x] `bash run_examples.sh` (locally - 99problems folder added)
- [x] Each `examples/99problems/p*.ae` runs end-to-end with `uv run python -m aeon <file>`
- [x] `p55`/`p56` invoke their `match` predicates at runtime and produce correct results
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)