### PR TITLE
PR 3/N: Rust-port collect_from_term — completes qualifier collection

### DIFF
--- a/aeon-rs/src/lib.rs
+++ b/aeon-rs/src/lib.rs
@@ -70,6 +70,7 @@ fn aeon_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(substitutions::substitution_in_liquid, m)?)?;
     m.add_function(wrap_pyfunction!(substitutions::refined_to_unrefined_type, m)?)?;
     m.add_function(wrap_pyfunction!(substitutions::collect_from_type, m)?)?;
+    m.add_function(wrap_pyfunction!(substitutions::collect_from_term, m)?)?;
 
     Ok(())
 }

--- a/aeon-rs/src/substitutions.rs
+++ b/aeon-rs/src/substitutions.rs
@@ -499,6 +499,79 @@ pub fn collect_from_type(py: Python<'_>, ty: PyObject, sink: &Bound<'_, PySet>) 
     collect_from_type_inner(py, ty, sink)
 }
 
+/// Walk a term tree, collecting qualifier atoms from every type annotation it
+/// touches. Mirrors aeon.typechecking.qualifiers._collect_from_term.
+#[pyfunction]
+pub fn collect_from_term(py: Python<'_>, t: PyObject, sink: &Bound<'_, PySet>) -> PyResult<()> {
+    use crate::terms::{
+        Abstraction, Annotation, Application, If, Let, Literal, Rec, RefinementApplication,
+        TypeAbstraction, TypeApplication, Var,
+    };
+
+    let bound = t.bind(py);
+
+    if let Ok(an) = bound.downcast::<Annotation>() {
+        let an = an.borrow();
+        collect_from_type_inner(py, an.type_.clone_ref(py), sink)?;
+        collect_from_term(py, an.expr.clone_ref(py), sink)?;
+        return Ok(());
+    }
+    if let Ok(app) = bound.downcast::<Application>() {
+        let app = app.borrow();
+        collect_from_term(py, app.fun.clone_ref(py), sink)?;
+        collect_from_term(py, app.arg.clone_ref(py), sink)?;
+        return Ok(());
+    }
+    if let Ok(ab) = bound.downcast::<Abstraction>() {
+        let ab = ab.borrow();
+        return collect_from_term(py, ab.body.clone_ref(py), sink);
+    }
+    if let Ok(le) = bound.downcast::<Let>() {
+        let le = le.borrow();
+        collect_from_term(py, le.var_value.clone_ref(py), sink)?;
+        collect_from_term(py, le.body.clone_ref(py), sink)?;
+        return Ok(());
+    }
+    if let Ok(rc) = bound.downcast::<Rec>() {
+        let rc = rc.borrow();
+        collect_from_type_inner(py, rc.var_type.clone_ref(py), sink)?;
+        collect_from_term(py, rc.var_value.clone_ref(py), sink)?;
+        collect_from_term(py, rc.body.clone_ref(py), sink)?;
+        return Ok(());
+    }
+    if let Ok(ife) = bound.downcast::<If>() {
+        let ife = ife.borrow();
+        collect_from_term(py, ife.cond.clone_ref(py), sink)?;
+        collect_from_term(py, ife.then.clone_ref(py), sink)?;
+        collect_from_term(py, ife.otherwise.clone_ref(py), sink)?;
+        return Ok(());
+    }
+    if let Ok(ta) = bound.downcast::<TypeAbstraction>() {
+        let ta = ta.borrow();
+        return collect_from_term(py, ta.body.clone_ref(py), sink);
+    }
+    if let Ok(tap) = bound.downcast::<TypeApplication>() {
+        let tap = tap.borrow();
+        collect_from_term(py, tap.body.clone_ref(py), sink)?;
+        collect_from_type_inner(py, tap.type_.clone_ref(py), sink)?;
+        return Ok(());
+    }
+    if let Ok(rapp) = bound.downcast::<RefinementApplication>() {
+        let rapp = rapp.borrow();
+        return collect_from_term(py, rapp.body.clone_ref(py), sink);
+    }
+    if let Ok(lit) = bound.downcast::<Literal>() {
+        let lit = lit.borrow();
+        return collect_from_type_inner(py, lit.type_.clone_ref(py), sink);
+    }
+    if bound.is_instance_of::<Var>() {
+        return Ok(());
+    }
+    // Everything else (Hole, RefinementAbstraction): no atoms — mirrors the
+    // Python's `case _: pass` fallback.
+    Ok(())
+}
+
 fn collect_from_type_inner(py: Python<'_>, ty: PyObject, sink: &Bound<'_, PySet>) -> PyResult<()> {
     let bound = ty.bind(py);
     if let Ok(rt) = bound.downcast::<RefinedType>() {

--- a/aeon/typechecking/qualifiers.py
+++ b/aeon/typechecking/qualifiers.py
@@ -9,8 +9,7 @@ PLDI 2016 Synquid).
 from __future__ import annotations
 
 from aeon.core.liquid import LiquidTerm
-from aeon.core.terms import Abstraction, Annotation, Application, If, Let, Literal, Rec, RefinementApplication
-from aeon.core.terms import Term, TypeAbstraction, TypeApplication, Var
+from aeon.core.terms import Term
 from aeon.core.types import Type
 from aeon.typechecking.context import (
     TypeBinder,
@@ -19,43 +18,8 @@ from aeon.typechecking.context import (
     UninterpretedBinder,
     VariableBinder,
 )
+from aeon_rs import collect_from_term as _collect_from_term
 from aeon_rs import collect_from_type as _collect_from_type
-
-
-def _collect_from_term(t: Term, sink: set[LiquidTerm]) -> None:
-    match t:
-        case Annotation(_, ty):
-            _collect_from_type(ty, sink)
-            _collect_from_term(t.expr, sink)
-        case Application(f, a):
-            _collect_from_term(f, sink)
-            _collect_from_term(a, sink)
-        case Abstraction(_, b):
-            _collect_from_term(b, sink)
-        case Let(_, v, b):
-            _collect_from_term(v, sink)
-            _collect_from_term(b, sink)
-        case Rec(_, vty, vv, b, _, _):
-            _collect_from_type(vty, sink)
-            _collect_from_term(vv, sink)
-            _collect_from_term(b, sink)
-        case If(cond, then, otherwise):
-            _collect_from_term(cond, sink)
-            _collect_from_term(then, sink)
-            _collect_from_term(otherwise, sink)
-        case TypeAbstraction(_, _, b):
-            _collect_from_term(b, sink)
-        case TypeApplication(b, ty):
-            _collect_from_term(b, sink)
-            _collect_from_type(ty, sink)
-        case RefinementApplication(b, _):
-            _collect_from_term(b, sink)
-        case Literal(type=lit_ty):
-            _collect_from_type(lit_ty, sink)
-        case Var():
-            pass
-        case _:
-            pass
 
 
 def extract_qualifier_atoms(


### PR DESCRIPTION
## Summary

Builds on [#239](https://github.com/alcides/aeon/pull/239). Adds the Term-walking sibling of \`collect_from_type\` to \`aeon_rs\`. Together with \`collect_from_type\` (PR 2), this puts the entire qualifier-extraction pipeline that \`extract_qualifier_atoms\` walks on each synthesis call into Rust.

\`aeon.typechecking.qualifiers\` shrinks by ~38 LOC: the Python \`_collect_from_term\` implementation is gone, replaced by a single re-export of \`aeon_rs.collect_from_term\`. Python imports of \`Term\` variants are no longer needed in this file either.

## What's in the box

- \`aeon-rs/src/substitutions.rs\`: new \`collect_from_term\` function (~70 LOC). Pure recursive walk over \`Term\` variants, mutating the supplied Python \`set[LiquidTerm]\` via PyO3's \`PySet\` bindings. Calls into the existing \`collect_from_type_inner\` for embedded types (Annotation, Rec, TypeApplication, Literal).
- \`aeon/typechecking/qualifiers.py\`: 40 LOC of Python removed, 1 LOC of re-export added.

## Results

- All 415 tests pass (9 skipped, pre-existing).
- Test suite: 91s → 89s. Modest because \`collect_from_term\` is hit only when a term is passed to \`extract_qualifier_atoms\`, which is optional.
- Pre-commit (mypy, ruff, pyroma) all pass.

## What didn't ship (and why)

An earlier attempt at PR 3 tried to port the full substitution module: \`substitute_vartype\`, \`substitute_vartype_in_term\`, \`substitution\`, \`substitution_liquid_in_{type,term}\`, \`instantiate_refinement_with_horn_in_{liquid,type}\`. The ports compiled and passed direct equality tests against the Python originals on hand-built inputs — but **six parametric-refinement tests broke** under \`check_compile\` (which type-checks programs after lowering).

The bug is a downstream type-check divergence: my Rust output \`==\` Python's output by every check I ran, but the type checker rejects programs Python accepts. That's the hardest kind of bug to triangulate — identical-under-equality but not identical-in-the-checker. After ~30 minutes of bisecting, I reverted to ship something small and safe.

A future PR can revisit using a more rigorous tactic: instrument both Python and Rust ports to log every call during a failing test, diff the AST output deeply (object identity, hash, internal field-by-field), and bail on first divergence. The \`aeon_rs\` crate already has the unwired ports as a starting point; they just need debug.

## Roadmap status

| PR | Scope | Status |
|---|---|---|
| 1 | aeon-rs crate + AST + 2 functions | [#237](https://github.com/alcides/aeon/pull/237) shipped |
| 2 | refined_to_unrefined, type_variable_instantiation, collect_from_type | [#239](https://github.com/alcides/aeon/pull/239) shipped |
| 3 | collect_from_term (this) | here |
| 4+ | substitution module (deferred — needs more careful debug) | not started |
| 5+ | parser (replace lark) | not started |
| 6+ | typechecker + SMT encoder | not started |
| 7+ | tree-walking interpreter | not started |

## Test plan

- [x] All 415 tests pass
- [x] Pre-commit hooks pass
- [ ] CI green
- [ ] Reviewer agrees the scope-cut decision was right (ship the safe slice now, defer the unsafe slice with a clear plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)