### PR TITLE
PR 4/N: Rust-port the substitution module + fix latent substitution_in_liquid bug

### DIFF
--- a/aeon-rs/src/lib.rs
+++ b/aeon-rs/src/lib.rs
@@ -13,6 +13,7 @@ mod liquid;
 mod loc;
 mod name;
 mod substitutions;
+mod term_subst;
 mod terms;
 mod types;
 
@@ -71,6 +72,19 @@ fn aeon_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(substitutions::refined_to_unrefined_type, m)?)?;
     m.add_function(wrap_pyfunction!(substitutions::collect_from_type, m)?)?;
     m.add_function(wrap_pyfunction!(substitutions::collect_from_term, m)?)?;
+    m.add_function(wrap_pyfunction!(substitutions::substitute_vartype, m)?)?;
+    m.add_function(wrap_pyfunction!(term_subst::substitute_vartype_in_term, m)?)?;
+    m.add_function(wrap_pyfunction!(term_subst::substitution_liquid_in_type, m)?)?;
+    m.add_function(wrap_pyfunction!(term_subst::substitution_liquid_in_term, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        term_subst::instantiate_refinement_with_horn_in_liquid,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        term_subst::instantiate_refinement_with_horn_in_type,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(term_subst::substitution, m)?)?;
 
     Ok(())
 }

--- a/aeon-rs/src/substitutions.rs
+++ b/aeon-rs/src/substitutions.rs
@@ -441,6 +441,131 @@ pub fn refined_to_unrefined_type(py: Python<'_>, ty: PyObject) -> PyResult<PyObj
     Ok(ty)
 }
 
+/// substitute_vartype: replace all TypeVar(name) occurrences in `t` by rep.
+/// Mirrors aeon.core.substitutions.substitute_vartype.
+///
+/// Differences from type_substitution:
+///  - On RefinedType, does NOT merge refinements (just rebuilds with recursed inner).
+///  - Asserts the inner of RefinedType is not itself a RefinedType (Aeon invariant).
+///  - Asserts on Top (no Top handler — Python crashes; we crash too for parity).
+#[pyfunction]
+pub fn substitute_vartype(
+    py: Python<'_>,
+    t: PyObject,
+    rep: PyObject,
+    name: Py<Name>,
+) -> PyResult<PyObject> {
+    let bound = t.bind(py);
+
+    if let Ok(tv) = bound.downcast::<TypeVar>() {
+        if name_eq(py, &tv.borrow().name, &name) {
+            return Ok(rep);
+        }
+        return Ok(t);
+    }
+    if let Ok(rt) = bound.downcast::<RefinedType>() {
+        let rt = rt.borrow();
+        let new_inner = substitute_vartype(
+            py,
+            rt.type_.clone_ref(py),
+            rep.clone_ref(py),
+            name.clone_ref(py),
+        )?;
+        // Aeon invariant: inner is TypeConstructor | TypeVar, never RefinedType.
+        return make_refined_type(
+            py,
+            rt.name.clone_ref(py),
+            new_inner,
+            rt.refinement.clone_ref(py),
+            rt.loc.clone_ref(py),
+        );
+    }
+    if let Ok(at) = bound.downcast::<AbstractionType>() {
+        let at = at.borrow();
+        let nv = substitute_vartype(
+            py,
+            at.var_type.clone_ref(py),
+            rep.clone_ref(py),
+            name.clone_ref(py),
+        )?;
+        let nt = substitute_vartype(
+            py,
+            at.type_.clone_ref(py),
+            rep.clone_ref(py),
+            name.clone_ref(py),
+        )?;
+        return make_abstraction_type(
+            py,
+            at.var_name.clone_ref(py),
+            nv,
+            nt,
+            at.loc.clone_ref(py),
+        );
+    }
+    if let Ok(tp) = bound.downcast::<TypePolymorphism>() {
+        let tp = tp.borrow();
+        if name_eq(py, &tp.name, &name) {
+            return Ok(t);
+        }
+        let nb = substitute_vartype(
+            py,
+            tp.body.clone_ref(py),
+            rep.clone_ref(py),
+            name.clone_ref(py),
+        )?;
+        return make_type_polymorphism(
+            py,
+            tp.name.clone_ref(py),
+            tp.kind.clone_ref(py),
+            nb,
+            tp.loc.clone_ref(py),
+        );
+    }
+    if let Ok(rp) = bound.downcast::<RefinementPolymorphism>() {
+        let rp = rp.borrow();
+        let ns = substitute_vartype(
+            py,
+            rp.sort.clone_ref(py),
+            rep.clone_ref(py),
+            name.clone_ref(py),
+        )?;
+        let nb = substitute_vartype(
+            py,
+            rp.body.clone_ref(py),
+            rep.clone_ref(py),
+            name.clone_ref(py),
+        )?;
+        return make_refinement_polymorphism(
+            py,
+            rp.name.clone_ref(py),
+            ns,
+            nb,
+            rp.loc.clone_ref(py),
+        );
+    }
+    if let Ok(tc) = bound.downcast::<TypeConstructor>() {
+        let tc = tc.borrow();
+        let args = tc.args.bind(py);
+        let new_args = PyList::empty_bound(py);
+        for i in 0..args.len() {
+            let arg = args.get_item(i)?;
+            let new_arg =
+                substitute_vartype(py, arg.into(), rep.clone_ref(py), name.clone_ref(py))?;
+            new_args.append(new_arg)?;
+        }
+        return make_type_constructor(
+            py,
+            tc.name.clone_ref(py),
+            new_args.unbind(),
+            tc.loc.clone_ref(py),
+        );
+    }
+    Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+        "substitute_vartype: type {} not allowed in substitution",
+        bound.repr()?.to_string()
+    )))
+}
+
 // ---------- Qualifier-collection walks (aeon.typechecking.qualifiers) ----------
 
 /// True if a LiquidApp wraps the binary && operator (Name("&&", 0)).
@@ -662,9 +787,9 @@ pub fn substitution_in_liquid(
     }
     if let Ok(h) = bound.downcast::<LiquidHornApplication>() {
         let h = h.borrow();
-        // NB: matches Python's substitution_in_liquid: when recursing into
-        // a LiquidHornApplication it passes `t` (the outer horn) as the type
-        // of each rebuilt argtype tuple. Replicating that verbatim.
+        // Python: `[(substitution_in_liquid(a, rep, name), t) for (a, t) in argtypes]`
+        // The comprehension's `for (a, t)` rebinds `t` to each argtype's OWN
+        // type — NOT the outer horn term. Each rebuilt tuple keeps its own ty.
         let argtypes = h.argtypes.bind(py);
         let n = argtypes.len();
         let new_argtypes = PyList::empty_bound(py);
@@ -674,10 +799,10 @@ pub fn substitution_in_liquid(
                 pyo3::exceptions::PyAssertionError::new_err("argtypes items must be tuples")
             })?;
             let a = tup.get_item(0)?;
-            let _ty = tup.get_item(1)?;
+            let ty = tup.get_item(1)?;
             let new_a =
                 substitution_in_liquid(py, a.into(), rep.clone_ref(py), name.clone_ref(py))?;
-            let new_tup = PyTuple::new_bound(py, &[new_a, t.clone_ref(py)]);
+            let new_tup = PyTuple::new_bound(py, &[new_a, ty.into()]);
             new_argtypes.append(new_tup)?;
         }
         return make_liquid_horn_application(

--- a/aeon-rs/src/term_subst.rs
+++ b/aeon-rs/src/term_subst.rs
@@ -1,0 +1,752 @@
+//! Rust ports of the remaining recursive substitution walks in
+//! aeon.core.substitutions:
+//!
+//!  - substitute_vartype_in_term     (Term -> Term)   propagates substitute_vartype
+//!  - substitution_liquid_in_type    (Type -> Type)   substitutes a LiquidTerm at refinement positions
+//!  - substitution_liquid_in_term    (Term -> Term)   propagates substitution_liquid_in_type
+//!  - instantiate_refinement_with_horn_in_liquid     (LiquidTerm -> LiquidTerm)
+//!  - instantiate_refinement_with_horn_in_type       (Type -> Type)
+//!  - substitution                   (Term -> Term)   replaces Var(name)/Hole(name) with rep
+//!
+//! `substitute_vartype` itself lives in substitutions.rs. liquefy/inline_lets
+//! and instantiate_refinement_in_{liquid,type} (which depend on liquefy) stay
+//! in Python — they form a mutually-recursive cluster better moved together.
+
+use pyo3::prelude::*;
+use pyo3::types::{PyList, PyTuple};
+
+use crate::liquid::{
+    LiquidApp, LiquidHornApplication, LiquidLiteralBool, LiquidLiteralFloat, LiquidLiteralInt,
+    LiquidLiteralString, LiquidTerm, LiquidVar,
+};
+use crate::name::Name;
+use crate::substitutions::substitute_vartype;
+use crate::terms::{
+    Abstraction, Annotation, Application, Hole, If, Let, Literal, Rec, RefinementAbstraction,
+    RefinementApplication, Term, TypeAbstraction, TypeApplication, Var,
+};
+use crate::types::{
+    AbstractionType, RefinedType, RefinementPolymorphism, Top, Type, TypeConstructor,
+    TypePolymorphism, TypeVar,
+};
+
+#[inline]
+fn name_eq(py: Python<'_>, a: &Py<Name>, b: &Py<Name>) -> bool {
+    let a = a.borrow(py);
+    let b = b.borrow(py);
+    a.id == b.id && a.name == b.name
+}
+
+// -- Type constructors -------------------------------------------------------
+
+fn new_refined_type(
+    py: Python<'_>,
+    name: Py<Name>,
+    inner: PyObject,
+    refinement: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (RefinedType { name, type_: inner, refinement, loc }, Type))?.into_any())
+}
+
+fn new_abstraction_type(
+    py: Python<'_>,
+    var_name: Py<Name>,
+    var_type: PyObject,
+    type_: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (AbstractionType { var_name, var_type, type_, loc }, Type))?.into_any())
+}
+
+fn new_type_polymorphism(
+    py: Python<'_>,
+    name: Py<Name>,
+    kind: PyObject,
+    body: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (TypePolymorphism { name, kind, body, loc }, Type))?.into_any())
+}
+
+fn new_refinement_polymorphism(
+    py: Python<'_>,
+    name: Py<Name>,
+    sort: PyObject,
+    body: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (RefinementPolymorphism { name, sort, body, loc }, Type))?.into_any())
+}
+
+fn new_type_constructor(
+    py: Python<'_>,
+    name: Py<Name>,
+    args: Py<PyList>,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (TypeConstructor { name, args, loc }, Type))?.into_any())
+}
+
+// -- Term constructors -------------------------------------------------------
+
+fn new_application(py: Python<'_>, fun: PyObject, arg: PyObject, loc: PyObject) -> PyResult<PyObject> {
+    Ok(Py::new(py, (Application { fun, arg, loc }, Term))?.into_any())
+}
+
+fn new_abstraction(py: Python<'_>, var_name: Py<Name>, body: PyObject, loc: PyObject) -> PyResult<PyObject> {
+    Ok(Py::new(py, (Abstraction { var_name, body, loc }, Term))?.into_any())
+}
+
+fn new_let(
+    py: Python<'_>,
+    var_name: Py<Name>,
+    var_value: PyObject,
+    body: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (Let { var_name, var_value, body, loc }, Term))?.into_any())
+}
+
+fn new_rec(
+    py: Python<'_>,
+    var_name: Py<Name>,
+    var_type: PyObject,
+    var_value: PyObject,
+    body: PyObject,
+    decreasing_by: Py<PyTuple>,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(
+        py,
+        (Rec { var_name, var_type, var_value, body, decreasing_by, loc }, Term),
+    )?
+    .into_any())
+}
+
+fn new_annotation(py: Python<'_>, expr: PyObject, type_: PyObject, loc: PyObject) -> PyResult<PyObject> {
+    Ok(Py::new(py, (Annotation { expr, type_, loc }, Term))?.into_any())
+}
+
+fn new_if(
+    py: Python<'_>,
+    cond: PyObject,
+    then: PyObject,
+    otherwise: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (If { cond, then, otherwise, loc }, Term))?.into_any())
+}
+
+fn new_type_abstraction(
+    py: Python<'_>,
+    name: Py<Name>,
+    kind: PyObject,
+    body: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (TypeAbstraction { name, kind, body, loc }, Term))?.into_any())
+}
+
+fn new_refinement_abstraction(
+    py: Python<'_>,
+    name: Py<Name>,
+    sort: PyObject,
+    body: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (RefinementAbstraction { name, sort, body, loc }, Term))?.into_any())
+}
+
+fn new_type_application(py: Python<'_>, body: PyObject, type_: PyObject, loc: PyObject) -> PyResult<PyObject> {
+    Ok(Py::new(py, (TypeApplication { body, type_, loc }, Term))?.into_any())
+}
+
+fn new_refinement_application(
+    py: Python<'_>,
+    body: PyObject,
+    refinement: PyObject,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (RefinementApplication { body, refinement, loc }, Term))?.into_any())
+}
+
+fn new_literal(py: Python<'_>, value: PyObject, type_: PyObject, loc: PyObject) -> PyResult<PyObject> {
+    Ok(Py::new(py, (Literal { value, type_, loc }, Term))?.into_any())
+}
+
+// -- LiquidTerm constructors -------------------------------------------------
+
+fn new_liquid_app(py: Python<'_>, fun: Py<Name>, args: Py<PyList>, loc: PyObject) -> PyResult<PyObject> {
+    Ok(Py::new(py, (LiquidApp { fun, args, loc }, LiquidTerm))?.into_any())
+}
+
+fn new_liquid_horn_application(
+    py: Python<'_>,
+    name: Py<Name>,
+    argtypes: Py<PyList>,
+    loc: PyObject,
+) -> PyResult<PyObject> {
+    Ok(Py::new(py, (LiquidHornApplication { name, argtypes, loc }, LiquidTerm))?.into_any())
+}
+
+// =============================================================================
+// substitute_vartype_in_term: propagate substitute_vartype through a Term.
+// =============================================================================
+
+#[pyfunction]
+pub fn substitute_vartype_in_term(
+    py: Python<'_>,
+    t: PyObject,
+    rep: PyObject,
+    name: Py<Name>,
+) -> PyResult<PyObject> {
+    let bound = t.bind(py);
+
+    if bound.is_instance_of::<Literal>()
+        || bound.is_instance_of::<Var>()
+        || bound.is_instance_of::<Hole>()
+    {
+        return Ok(t);
+    }
+    if let Ok(app) = bound.downcast::<Application>() {
+        let app = app.borrow();
+        let nf = substitute_vartype_in_term(py, app.fun.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let na = substitute_vartype_in_term(py, app.arg.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_application(py, nf, na, app.loc.clone_ref(py));
+    }
+    if let Ok(ab) = bound.downcast::<Abstraction>() {
+        let ab = ab.borrow();
+        let nb = substitute_vartype_in_term(py, ab.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_abstraction(py, ab.var_name.clone_ref(py), nb, ab.loc.clone_ref(py));
+    }
+    if let Ok(le) = bound.downcast::<Let>() {
+        let le = le.borrow();
+        let nv = substitute_vartype_in_term(py, le.var_value.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nb = substitute_vartype_in_term(py, le.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_let(py, le.var_name.clone_ref(py), nv, nb, le.loc.clone_ref(py));
+    }
+    if let Ok(rc) = bound.downcast::<Rec>() {
+        let rc = rc.borrow();
+        let nv = substitute_vartype_in_term(py, rc.var_value.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nt = substitute_vartype(py, rc.var_type.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nb = substitute_vartype_in_term(py, rc.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_rec(
+            py,
+            rc.var_name.clone_ref(py),
+            nt,
+            nv,
+            nb,
+            rc.decreasing_by.clone_ref(py),
+            rc.loc.clone_ref(py),
+        );
+    }
+    if let Ok(an) = bound.downcast::<Annotation>() {
+        let an = an.borrow();
+        let nt = substitute_vartype(py, an.type_.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let ne = substitute_vartype_in_term(py, an.expr.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_annotation(py, ne, nt, an.loc.clone_ref(py));
+    }
+    if let Ok(ife) = bound.downcast::<If>() {
+        let ife = ife.borrow();
+        let nc = substitute_vartype_in_term(py, ife.cond.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nt = substitute_vartype_in_term(py, ife.then.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let no = substitute_vartype_in_term(py, ife.otherwise.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_if(py, nc, nt, no, ife.loc.clone_ref(py));
+    }
+    if let Ok(ta) = bound.downcast::<TypeAbstraction>() {
+        let ta = ta.borrow();
+        let nb = substitute_vartype_in_term(py, ta.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_type_abstraction(py, ta.name.clone_ref(py), ta.kind.clone_ref(py), nb, ta.loc.clone_ref(py));
+    }
+    if let Ok(tap) = bound.downcast::<TypeApplication>() {
+        let tap = tap.borrow();
+        let nb = substitute_vartype_in_term(py, tap.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nt = substitute_vartype(py, tap.type_.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_type_application(py, nb, nt, tap.loc.clone_ref(py));
+    }
+    if let Ok(rapp) = bound.downcast::<RefinementApplication>() {
+        let rapp = rapp.borrow();
+        let nb = substitute_vartype_in_term(py, rapp.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nr = substitute_vartype_in_term(py, rapp.refinement.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refinement_application(py, nb, nr, rapp.loc.clone_ref(py));
+    }
+    if let Ok(rab) = bound.downcast::<RefinementAbstraction>() {
+        let rab = rab.borrow();
+        let ns = substitute_vartype(py, rab.sort.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nb = substitute_vartype_in_term(py, rab.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refinement_abstraction(py, rab.name.clone_ref(py), ns, nb, rab.loc.clone_ref(py));
+    }
+    Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+        "substitute_vartype_in_term: unknown term {}",
+        bound.repr()?.to_string()
+    )))
+}
+
+// =============================================================================
+// substitution_liquid_in_type: substitute a LiquidTerm at refinement positions.
+// Mirrors Python: `case Top() | TypeConstructor(_) | TypeVar(_): return t` —
+// any TypeConstructor returns as-is (the explicit later case is unreachable).
+// =============================================================================
+
+#[pyfunction]
+pub fn substitution_liquid_in_type(
+    py: Python<'_>,
+    t: PyObject,
+    rep: PyObject,
+    name: Py<Name>,
+) -> PyResult<PyObject> {
+    use crate::substitutions::substitution_in_liquid;
+    let bound = t.bind(py);
+
+    if bound.is_instance_of::<Top>()
+        || bound.is_instance_of::<TypeConstructor>()
+        || bound.is_instance_of::<TypeVar>()
+    {
+        return Ok(t);
+    }
+    if let Ok(at) = bound.downcast::<AbstractionType>() {
+        let at = at.borrow();
+        if name_eq(py, &at.var_name, &name) {
+            return Ok(t);
+        }
+        let nv = substitution_liquid_in_type(py, at.var_type.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nt = substitution_liquid_in_type(py, at.type_.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_abstraction_type(py, at.var_name.clone_ref(py), nv, nt, at.loc.clone_ref(py));
+    }
+    if let Ok(rt) = bound.downcast::<RefinedType>() {
+        let rt = rt.borrow();
+        if name_eq(py, &rt.name, &name) {
+            return Ok(t);
+        }
+        let nr = substitution_in_liquid(py, rt.refinement.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refined_type(py, rt.name.clone_ref(py), rt.type_.clone_ref(py), nr, rt.loc.clone_ref(py));
+    }
+    if let Ok(tp) = bound.downcast::<TypePolymorphism>() {
+        let tp = tp.borrow();
+        let nb = substitution_liquid_in_type(py, tp.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_type_polymorphism(py, tp.name.clone_ref(py), tp.kind.clone_ref(py), nb, tp.loc.clone_ref(py));
+    }
+    if let Ok(rp) = bound.downcast::<RefinementPolymorphism>() {
+        let rp = rp.borrow();
+        if name_eq(py, &rp.name, &name) {
+            return Ok(t);
+        }
+        let ns = substitution_liquid_in_type(py, rp.sort.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nb = substitution_liquid_in_type(py, rp.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refinement_polymorphism(py, rp.name.clone_ref(py), ns, nb, rp.loc.clone_ref(py));
+    }
+    Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+        "substitution_liquid_in_type: unknown type {}",
+        bound.repr()?.to_string()
+    )))
+}
+
+// =============================================================================
+// substitution_liquid_in_term: propagate substitution_liquid_in_type through Term.
+// =============================================================================
+
+#[pyfunction]
+pub fn substitution_liquid_in_term(
+    py: Python<'_>,
+    t: PyObject,
+    rep: PyObject,
+    name: Py<Name>,
+) -> PyResult<PyObject> {
+    let bound = t.bind(py);
+
+    if let Ok(lit) = bound.downcast::<Literal>() {
+        let lit = lit.borrow();
+        let nt = substitution_liquid_in_type(py, lit.type_.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_literal(py, lit.value.clone_ref(py), nt, lit.loc.clone_ref(py));
+    }
+    if bound.is_instance_of::<Var>() || bound.is_instance_of::<Hole>() {
+        return Ok(t);
+    }
+    if let Ok(app) = bound.downcast::<Application>() {
+        let app = app.borrow();
+        let nf = substitution_liquid_in_term(py, app.fun.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let na = substitution_liquid_in_term(py, app.arg.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_application(py, nf, na, app.loc.clone_ref(py));
+    }
+    if let Ok(ab) = bound.downcast::<Abstraction>() {
+        let ab = ab.borrow();
+        let nb = substitution_liquid_in_term(py, ab.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_abstraction(py, ab.var_name.clone_ref(py), nb, ab.loc.clone_ref(py));
+    }
+    if let Ok(le) = bound.downcast::<Let>() {
+        let le = le.borrow();
+        let nv = substitution_liquid_in_term(py, le.var_value.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nb = substitution_liquid_in_term(py, le.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_let(py, le.var_name.clone_ref(py), nv, nb, le.loc.clone_ref(py));
+    }
+    if let Ok(rc) = bound.downcast::<Rec>() {
+        let rc = rc.borrow();
+        let nt = substitution_liquid_in_type(py, rc.var_type.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nv = substitution_liquid_in_term(py, rc.var_value.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nb = substitution_liquid_in_term(py, rc.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_rec(
+            py,
+            rc.var_name.clone_ref(py),
+            nt,
+            nv,
+            nb,
+            rc.decreasing_by.clone_ref(py),
+            rc.loc.clone_ref(py),
+        );
+    }
+    if let Ok(an) = bound.downcast::<Annotation>() {
+        let an = an.borrow();
+        let nt = substitution_liquid_in_type(py, an.type_.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let ne = substitution_liquid_in_term(py, an.expr.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_annotation(py, ne, nt, an.loc.clone_ref(py));
+    }
+    if let Ok(ife) = bound.downcast::<If>() {
+        let ife = ife.borrow();
+        let nc = substitution_liquid_in_term(py, ife.cond.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nt = substitution_liquid_in_term(py, ife.then.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let no = substitution_liquid_in_term(py, ife.otherwise.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_if(py, nc, nt, no, ife.loc.clone_ref(py));
+    }
+    if let Ok(ta) = bound.downcast::<TypeAbstraction>() {
+        let ta = ta.borrow();
+        let nb = substitution_liquid_in_term(py, ta.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_type_abstraction(py, ta.name.clone_ref(py), ta.kind.clone_ref(py), nb, ta.loc.clone_ref(py));
+    }
+    if let Ok(rab) = bound.downcast::<RefinementAbstraction>() {
+        let rab = rab.borrow();
+        let ns = substitution_liquid_in_type(py, rab.sort.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nb = substitution_liquid_in_term(py, rab.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refinement_abstraction(py, rab.name.clone_ref(py), ns, nb, rab.loc.clone_ref(py));
+    }
+    if let Ok(tap) = bound.downcast::<TypeApplication>() {
+        let tap = tap.borrow();
+        let nb = substitution_liquid_in_term(py, tap.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nt = substitution_liquid_in_type(py, tap.type_.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_type_application(py, nb, nt, tap.loc.clone_ref(py));
+    }
+    if let Ok(rapp) = bound.downcast::<RefinementApplication>() {
+        let rapp = rapp.borrow();
+        let nb = substitution_liquid_in_term(py, rapp.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nr = substitution_liquid_in_term(py, rapp.refinement.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refinement_application(py, nb, nr, rapp.loc.clone_ref(py));
+    }
+    Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+        "substitution_liquid_in_term: unknown term {}",
+        bound.repr()?.to_string()
+    )))
+}
+
+// =============================================================================
+// instantiate_refinement_with_horn_in_liquid
+// =============================================================================
+
+#[pyfunction]
+pub fn instantiate_refinement_with_horn_in_liquid(
+    py: Python<'_>,
+    t: PyObject,
+    pred_name: Py<Name>,
+    sort: PyObject,
+    horn_name: Py<Name>,
+) -> PyResult<PyObject> {
+    let bound = t.bind(py);
+
+    if bound.is_instance_of::<LiquidVar>()
+        || bound.is_instance_of::<LiquidLiteralBool>()
+        || bound.is_instance_of::<LiquidLiteralInt>()
+        || bound.is_instance_of::<LiquidLiteralFloat>()
+        || bound.is_instance_of::<LiquidLiteralString>()
+    {
+        return Ok(t);
+    }
+    if let Ok(app) = bound.downcast::<LiquidApp>() {
+        let app = app.borrow();
+        if name_eq(py, &app.fun, &pred_name) {
+            let sort_bound = sort.bind(py);
+            if !(sort_bound.is_instance_of::<TypeConstructor>()
+                || sort_bound.is_instance_of::<TypeVar>())
+            {
+                return Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+                    "instantiate_refinement_with_horn_in_liquid: sort must be TypeConstructor or TypeVar, got {}",
+                    sort_bound.repr()?.to_string()
+                )));
+            }
+            let args = app.args.bind(py);
+            let argtypes = PyList::empty_bound(py);
+            for i in 0..args.len() {
+                let a = args.get_item(i)?;
+                let tup = PyTuple::new_bound(py, &[a.into(), sort.clone_ref(py)]);
+                argtypes.append(tup)?;
+            }
+            return new_liquid_horn_application(py, horn_name.clone_ref(py), argtypes.unbind(), app.loc.clone_ref(py));
+        }
+        let args = app.args.bind(py);
+        let new_args = PyList::empty_bound(py);
+        for i in 0..args.len() {
+            let a = args.get_item(i)?;
+            let na = instantiate_refinement_with_horn_in_liquid(
+                py,
+                a.into(),
+                pred_name.clone_ref(py),
+                sort.clone_ref(py),
+                horn_name.clone_ref(py),
+            )?;
+            new_args.append(na)?;
+        }
+        return new_liquid_app(py, app.fun.clone_ref(py), new_args.unbind(), app.loc.clone_ref(py));
+    }
+    if let Ok(h) = bound.downcast::<LiquidHornApplication>() {
+        let h = h.borrow();
+        let argtypes = h.argtypes.bind(py);
+        let new_argtypes = PyList::empty_bound(py);
+        for i in 0..argtypes.len() {
+            let item = argtypes.get_item(i)?;
+            let tup = item.downcast::<PyTuple>().map_err(|_| {
+                pyo3::exceptions::PyAssertionError::new_err("argtypes items must be tuples")
+            })?;
+            let a = tup.get_item(0)?;
+            let ty = tup.get_item(1)?;
+            let na = instantiate_refinement_with_horn_in_liquid(
+                py,
+                a.into(),
+                pred_name.clone_ref(py),
+                sort.clone_ref(py),
+                horn_name.clone_ref(py),
+            )?;
+            let new_tup = PyTuple::new_bound(py, &[na, ty.into()]);
+            new_argtypes.append(new_tup)?;
+        }
+        return new_liquid_horn_application(py, h.name.clone_ref(py), new_argtypes.unbind(), h.loc.clone_ref(py));
+    }
+    Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+        "instantiate_refinement_with_horn_in_liquid: unknown liquid {}",
+        bound.repr()?.to_string()
+    )))
+}
+
+// =============================================================================
+// instantiate_refinement_with_horn_in_type
+// =============================================================================
+
+#[pyfunction]
+pub fn instantiate_refinement_with_horn_in_type(
+    py: Python<'_>,
+    t: PyObject,
+    pred_name: Py<Name>,
+    sort: PyObject,
+    horn_name: Py<Name>,
+) -> PyResult<PyObject> {
+    let bound = t.bind(py);
+
+    if bound.is_instance_of::<Top>() || bound.is_instance_of::<TypeVar>() {
+        return Ok(t);
+    }
+    if let Ok(tc) = bound.downcast::<TypeConstructor>() {
+        let tc = tc.borrow();
+        let args = tc.args.bind(py);
+        let new_args = PyList::empty_bound(py);
+        for i in 0..args.len() {
+            let a = args.get_item(i)?;
+            let na = instantiate_refinement_with_horn_in_type(
+                py,
+                a.into(),
+                pred_name.clone_ref(py),
+                sort.clone_ref(py),
+                horn_name.clone_ref(py),
+            )?;
+            new_args.append(na)?;
+        }
+        return new_type_constructor(py, tc.name.clone_ref(py), new_args.unbind(), tc.loc.clone_ref(py));
+    }
+    if let Ok(at) = bound.downcast::<AbstractionType>() {
+        let at = at.borrow();
+        let nv = instantiate_refinement_with_horn_in_type(
+            py,
+            at.var_type.clone_ref(py),
+            pred_name.clone_ref(py),
+            sort.clone_ref(py),
+            horn_name.clone_ref(py),
+        )?;
+        let nt = instantiate_refinement_with_horn_in_type(
+            py,
+            at.type_.clone_ref(py),
+            pred_name.clone_ref(py),
+            sort.clone_ref(py),
+            horn_name.clone_ref(py),
+        )?;
+        return new_abstraction_type(py, at.var_name.clone_ref(py), nv, nt, at.loc.clone_ref(py));
+    }
+    if let Ok(rt) = bound.downcast::<RefinedType>() {
+        let rt = rt.borrow();
+        let nity = instantiate_refinement_with_horn_in_type(
+            py,
+            rt.type_.clone_ref(py),
+            pred_name.clone_ref(py),
+            sort.clone_ref(py),
+            horn_name.clone_ref(py),
+        )?;
+        let nity_bound = nity.bind(py);
+        if !(nity_bound.is_instance_of::<TypeConstructor>()
+            || nity_bound.is_instance_of::<TypeVar>())
+        {
+            return Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+                "instantiate_refinement_with_horn_in_type: inner type must be TypeConstructor or TypeVar, got {}",
+                nity_bound.repr()?.to_string()
+            )));
+        }
+        let new_ref = instantiate_refinement_with_horn_in_liquid(
+            py,
+            rt.refinement.clone_ref(py),
+            pred_name.clone_ref(py),
+            sort.clone_ref(py),
+            horn_name.clone_ref(py),
+        )?;
+        return new_refined_type(py, rt.name.clone_ref(py), nity, new_ref, rt.loc.clone_ref(py));
+    }
+    if let Ok(tp) = bound.downcast::<TypePolymorphism>() {
+        let tp = tp.borrow();
+        let nb = instantiate_refinement_with_horn_in_type(
+            py,
+            tp.body.clone_ref(py),
+            pred_name.clone_ref(py),
+            sort.clone_ref(py),
+            horn_name.clone_ref(py),
+        )?;
+        return new_type_polymorphism(py, tp.name.clone_ref(py), tp.kind.clone_ref(py), nb, tp.loc.clone_ref(py));
+    }
+    if let Ok(rp) = bound.downcast::<RefinementPolymorphism>() {
+        let rp = rp.borrow();
+        let ns = instantiate_refinement_with_horn_in_type(
+            py,
+            rp.sort.clone_ref(py),
+            pred_name.clone_ref(py),
+            sort.clone_ref(py),
+            horn_name.clone_ref(py),
+        )?;
+        let nb = instantiate_refinement_with_horn_in_type(
+            py,
+            rp.body.clone_ref(py),
+            pred_name.clone_ref(py),
+            sort.clone_ref(py),
+            horn_name.clone_ref(py),
+        )?;
+        return new_refinement_polymorphism(py, rp.name.clone_ref(py), ns, nb, rp.loc.clone_ref(py));
+    }
+    Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+        "instantiate_refinement_with_horn_in_type: unknown type {}",
+        bound.repr()?.to_string()
+    )))
+}
+
+// =============================================================================
+// substitution: substitutes name in Term t with the new replacement term rep.
+// =============================================================================
+
+#[pyfunction]
+pub fn substitution(
+    py: Python<'_>,
+    t: PyObject,
+    rep: PyObject,
+    name: Py<Name>,
+) -> PyResult<PyObject> {
+    let bound = t.bind(py);
+
+    if bound.is_instance_of::<Literal>() {
+        return Ok(t);
+    }
+    if let Ok(v) = bound.downcast::<Var>() {
+        if name_eq(py, &v.borrow().name, &name) {
+            return Ok(rep);
+        }
+        return Ok(t);
+    }
+    if let Ok(h) = bound.downcast::<Hole>() {
+        if name_eq(py, &h.borrow().name, &name) {
+            return Ok(rep);
+        }
+        return Ok(t);
+    }
+    if let Ok(app) = bound.downcast::<Application>() {
+        let app = app.borrow();
+        let nf = substitution(py, app.fun.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let na = substitution(py, app.arg.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_application(py, nf, na, app.loc.clone_ref(py));
+    }
+    if let Ok(ab) = bound.downcast::<Abstraction>() {
+        let ab = ab.borrow();
+        if name_eq(py, &ab.var_name, &name) {
+            return Ok(t);
+        }
+        let nb = substitution(py, ab.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_abstraction(py, ab.var_name.clone_ref(py), nb, ab.loc.clone_ref(py));
+    }
+    if let Ok(le) = bound.downcast::<Let>() {
+        let le = le.borrow();
+        let (nv, nb) = if name_eq(py, &le.var_name, &name) {
+            (le.var_value.clone_ref(py), le.body.clone_ref(py))
+        } else {
+            (
+                substitution(py, le.var_value.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?,
+                substitution(py, le.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?,
+            )
+        };
+        return new_let(py, le.var_name.clone_ref(py), nv, nb, le.loc.clone_ref(py));
+    }
+    if let Ok(rc) = bound.downcast::<Rec>() {
+        let rc = rc.borrow();
+        let (nv, nb) = if name_eq(py, &rc.var_name, &name) {
+            (rc.var_value.clone_ref(py), rc.body.clone_ref(py))
+        } else {
+            (
+                substitution(py, rc.var_value.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?,
+                substitution(py, rc.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?,
+            )
+        };
+        return new_rec(
+            py,
+            rc.var_name.clone_ref(py),
+            rc.var_type.clone_ref(py),
+            nv,
+            nb,
+            rc.decreasing_by.clone_ref(py),
+            rc.loc.clone_ref(py),
+        );
+    }
+    if let Ok(an) = bound.downcast::<Annotation>() {
+        let an = an.borrow();
+        let nb = substitution(py, an.expr.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_annotation(py, nb, an.type_.clone_ref(py), an.loc.clone_ref(py));
+    }
+    if let Ok(ife) = bound.downcast::<If>() {
+        let ife = ife.borrow();
+        let nc = substitution(py, ife.cond.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nt = substitution(py, ife.then.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let no = substitution(py, ife.otherwise.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_if(py, nc, nt, no, ife.loc.clone_ref(py));
+    }
+    if let Ok(tap) = bound.downcast::<TypeApplication>() {
+        let tap = tap.borrow();
+        let ne = substitution(py, tap.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_type_application(py, ne, tap.type_.clone_ref(py), tap.loc.clone_ref(py));
+    }
+    if let Ok(ta) = bound.downcast::<TypeAbstraction>() {
+        let ta = ta.borrow();
+        let nb = substitution(py, ta.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_type_abstraction(py, ta.name.clone_ref(py), ta.kind.clone_ref(py), nb, ta.loc.clone_ref(py));
+    }
+    if let Ok(rab) = bound.downcast::<RefinementAbstraction>() {
+        let rab = rab.borrow();
+        let nb = substitution(py, rab.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refinement_abstraction(py, rab.name.clone_ref(py), rab.sort.clone_ref(py), nb, rab.loc.clone_ref(py));
+    }
+    if let Ok(rapp) = bound.downcast::<RefinementApplication>() {
+        let rapp = rapp.borrow();
+        let nb = substitution(py, rapp.body.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        let nr = substitution(py, rapp.refinement.clone_ref(py), rep.clone_ref(py), name.clone_ref(py))?;
+        return new_refinement_application(py, nb, nr, rapp.loc.clone_ref(py));
+    }
+    Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+        "substitution: unsupported term {}",
+        bound.repr()?.to_string()
+    )))
+}

--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -1,7 +1,29 @@
+"""Core substitution and instantiation walks.
+
+The pure recursive walks live in the Rust core (aeon_rs):
+- substitute_vartype / substitute_vartype_in_term
+- substitution_in_liquid / substitution_liquid_in_type / substitution_liquid_in_term
+- instantiate_refinement_with_horn_in_liquid / _in_type
+- substitution (term-level)
+
+The mutually-recursive cluster (inline_lets / liquefy / liquefy_* /
+substitution_in_type / instantiate_refinement_in_{liquid,type}) stays in
+Python — they depend on each other in a tight cycle that's better moved
+together in a follow-up PR.
+"""
+
 from __future__ import annotations
 
+from aeon_rs import instantiate_refinement_with_horn_in_liquid as instantiate_refinement_with_horn_in_liquid
+from aeon_rs import instantiate_refinement_with_horn_in_type as instantiate_refinement_with_horn_in_type
+from aeon_rs import substitute_vartype as substitute_vartype
+from aeon_rs import substitute_vartype_in_term as substitute_vartype_in_term
+from aeon_rs import substitution as substitution
+from aeon_rs import substitution_in_liquid as substitution_in_liquid
+from aeon_rs import substitution_liquid_in_term as substitution_liquid_in_term
+from aeon_rs import substitution_liquid_in_type as substitution_liquid_in_type
+
 from aeon.core.liquid import LiquidApp
-from aeon.core.types import LiquidHornApplication, RefinementPolymorphism, TypeConstructor, TypePolymorphism
 from aeon.core.liquid import LiquidLiteralBool
 from aeon.core.liquid import LiquidLiteralFloat
 from aeon.core.liquid import LiquidLiteralInt
@@ -10,100 +32,32 @@ from aeon.core.liquid import LiquidTerm
 from aeon.core.liquid import LiquidVar
 from aeon.core.terms import (
     Abstraction,
+    Annotation,
+    Application,
+    Hole,
+    If,
+    Let,
+    Literal,
+    Rec,
     RefinementAbstraction,
     RefinementApplication,
+    Term,
     TypeAbstraction,
     TypeApplication,
+    Var,
 )
-from aeon.core.terms import Annotation
-from aeon.core.terms import Application
-from aeon.core.terms import Hole
-from aeon.core.terms import If
-from aeon.core.terms import Let
-from aeon.core.terms import Literal
-from aeon.core.terms import Rec
-from aeon.core.terms import Term
-from aeon.core.terms import Var
-from aeon.core.types import AbstractionType
-from aeon.core.types import RefinedType
-from aeon.core.types import Top
-from aeon.core.types import Type
-from aeon.core.types import TypeVar
+from aeon.core.types import (
+    AbstractionType,
+    LiquidHornApplication,
+    RefinedType,
+    RefinementPolymorphism,
+    Top,
+    Type,
+    TypeConstructor,
+    TypePolymorphism,
+    TypeVar,
+)
 from aeon.utils.name import Name
-
-
-def substitute_vartype(t: Type, rep: Type, name: Name) -> Type:
-    """Replaces all occurrences of vartypes name in t by rep."""
-
-    def rec(k: Type):
-        return substitute_vartype(k, rep, name)
-
-    match t:
-        case TypeVar(tname):
-            if tname == name:
-                return rep
-            else:
-                return t
-        case RefinedType(rname, ty, ref, loc):
-            assert not isinstance(ty, RefinedType)
-            return RefinedType(rname, rec(ty), ref, loc=loc)
-        case AbstractionType(a, aty, rty, loc):
-            return AbstractionType(a, rec(aty), rec(rty), loc=loc)
-        case TypePolymorphism(pname, kind, body, loc):
-            if name == pname:
-                return t
-            else:
-                return TypePolymorphism(pname, kind, rec(body), loc=loc)
-        case RefinementPolymorphism(rname, sort, body, loc):
-            return RefinementPolymorphism(rname, rec(sort), rec(body), loc=loc)
-        case TypeConstructor(cname, args, loc):
-            return TypeConstructor(cname, [rec(arg) for arg in args], loc=loc)
-        case _:
-            assert False, f"type {t} ({type(t)}) not allows in substitution."
-
-
-def substitute_vartype_in_term(t: Term, rep: Type, name: Name) -> Term:
-    def rec(x: Term):
-        return substitute_vartype_in_term(x, rep, name)
-
-    match t:
-        case Literal():
-            return t
-        case Var():
-            return t
-        case Hole():
-            return t
-        case Application(fun, arg, loc):
-            return Application(fun=rec(fun), arg=rec(arg), loc=loc)
-        case Abstraction(var_name, body, loc):
-            return Abstraction(var_name, rec(body), loc=loc)
-        case Let(var_name, var_value, body, loc):
-            n_value = rec(var_value)
-            n_body = rec(body)
-            return Let(var_name, n_value, n_body, loc=loc)
-        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
-            n_value = rec(var_value)
-            n_type = substitute_vartype(var_type, rep, name)
-            n_body = rec(body)
-            return Rec(var_name, n_type, n_value, n_body, decreasing_by=decreasing_by, loc=loc)
-        case Annotation(expr, type, loc):
-            n_type = substitute_vartype(type, rep, name)
-            return Annotation(rec(expr), n_type, loc=loc)
-        case If(cond, then, otherwise, loc):
-            n_cond = rec(cond)
-            n_then = rec(then)
-            n_otherwise = rec(otherwise)
-            return If(n_cond, n_then, n_otherwise, loc=loc)
-        case TypeAbstraction(pname, kind, body, loc):
-            return TypeAbstraction(pname, kind, rec(body), loc=loc)
-        case TypeApplication(body, ty, loc):
-            return TypeApplication(rec(body), substitute_vartype(ty, rep, name), loc=loc)
-        case RefinementApplication(body, refinement, loc):
-            return RefinementApplication(rec(body), rec(refinement), loc=loc)
-        case RefinementAbstraction(pname, sort, body, loc):
-            return RefinementAbstraction(pname, substitute_vartype(sort, rep, name), rec(body), loc=loc)
-        case _:
-            assert False
 
 
 def instantiate_refinement_in_liquid(
@@ -112,7 +66,9 @@ def instantiate_refinement_in_liquid(
     refinement: Abstraction,
 ) -> LiquidTerm:
     """Replaces LiquidApp(pred_name, [arg]) with the inlined refinement body.
-    Implements tutorial fig 8.6: κ(x)[ρ := φ] = p[y := x] if ρ = κ:·, φ = λy.p"""
+
+    Implements tutorial fig 8.6: κ(x)[ρ := φ] = p[y := x] if ρ = κ:·, φ = λy.p
+    """
     match t:
         case LiquidApp(aname, args, loc):
             # TODO: support multi-arg predicates
@@ -153,8 +109,10 @@ def instantiate_refinement_in_type(
     refinement: Abstraction,
 ) -> Type:
     """Inlines the refinement predicate in the type.
+
     Implements s[ρ := φ] from tutorial fig 8.6.
-    TODO: support refinement as Var ( id[Int]{myPred} ) — currently requires Abstraction."""
+    TODO: support refinement as Var ( id[Int]{myPred} ) — currently requires Abstraction.
+    """
     match t:
         case Top() | TypeConstructor(_) | TypeVar(_):
             return t
@@ -192,176 +150,6 @@ def instantiate_refinement_in_type(
             assert False, f"Unknown type {t} ({type(t)})"
 
 
-def instantiate_refinement_with_horn_in_liquid(
-    t: LiquidTerm,
-    pred_name: Name,
-    sort: Type,
-    horn_name: Name,
-) -> LiquidTerm:
-    """Replace LiquidApp(ρ, args) with LiquidHornApplication(horn_name, ...) for implicit Syn-RApp."""
-
-    def rec(lt: LiquidTerm) -> LiquidTerm:
-        return instantiate_refinement_with_horn_in_liquid(lt, pred_name, sort, horn_name)
-
-    match t:
-        case LiquidVar(_):
-            return t
-        case LiquidLiteralBool(_) | LiquidLiteralInt(_) | LiquidLiteralFloat(_) | LiquidLiteralString(_):
-            return t
-        case LiquidApp(aname, args, loc):
-            if aname == pred_name:
-                assert isinstance(sort, TypeConstructor) or isinstance(sort, TypeVar)
-                return LiquidHornApplication(horn_name, [(a, sort) for a in args], loc=loc)
-            return LiquidApp(aname, [rec(a) for a in args], loc=loc)
-        case LiquidHornApplication(aname, argtypes, loc):
-            return LiquidHornApplication(
-                aname,
-                [(rec(a), ty) for (a, ty) in argtypes],
-                loc=loc,
-            )
-        case _:
-            assert False, f"instantiate_refinement_with_horn_in_liquid: unknown liquid {t}"
-
-
-def instantiate_refinement_with_horn_in_type(
-    t: Type,
-    pred_name: Name,
-    sort: Type,
-    horn_name: Name,
-) -> Type:
-    """Walk types and apply instantiate_refinement_with_horn_in_liquid in refinements."""
-
-    def rec(ty: Type) -> Type:
-        return instantiate_refinement_with_horn_in_type(ty, pred_name, sort, horn_name)
-
-    match t:
-        case Top():
-            return t
-        case TypeVar(_):
-            return t
-        case TypeConstructor(name, args, loc):
-            return TypeConstructor(name, [rec(a) for a in args], loc=loc)
-        case AbstractionType(aname, atype, rtype, loc):
-            return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
-        case RefinedType(vname, ity, ref, loc):
-            nity = rec(ity)
-            assert isinstance(nity, TypeConstructor) or isinstance(nity, TypeVar)
-            return RefinedType(
-                vname,
-                nity,
-                instantiate_refinement_with_horn_in_liquid(ref, pred_name, sort, horn_name),
-                loc=loc,
-            )
-        case TypePolymorphism(pname, kind, body, loc):
-            return TypePolymorphism(pname, kind, rec(body), loc=loc)
-        case RefinementPolymorphism(rname, rsort, rbody, loc):
-            return RefinementPolymorphism(rname, rec(rsort), rec(rbody), loc=loc)
-        case _:
-            assert False, f"instantiate_refinement_with_horn_in_type: unknown type {t}"
-
-
-def substitution_in_liquid(
-    t: LiquidTerm,
-    rep: LiquidTerm,
-    name: Name,
-) -> LiquidTerm:
-    """substitutes name in the term t with the new replacement term rep."""
-    match t:
-        case LiquidLiteralBool(_) | LiquidLiteralInt(_) | LiquidLiteralFloat(_) | LiquidLiteralString(_):
-            return t
-        case LiquidVar(tname):
-            if tname == name:
-                return rep
-            else:
-                return t
-        case LiquidApp(aname, args, loc):
-            if aname == name:
-                assert isinstance(rep, LiquidVar)
-                nname = rep.name
-            else:
-                nname = aname
-            return LiquidApp(nname, [substitution_in_liquid(a, rep, name) for a in args], loc=loc)
-
-        case LiquidHornApplication(aname, argtypes, loc):
-            if aname == name:
-                assert isinstance(rep, LiquidVar)
-                nname = rep.name
-            else:
-                nname = aname
-            return LiquidHornApplication(
-                aname, [(substitution_in_liquid(a, rep, name), t) for (a, t) in argtypes], loc=loc
-            )
-        case _:
-            assert False, f"{t} ({type(t)}) not allowed in substitution."
-
-
-def substitution_liquid_in_type(t: Type, rep: LiquidTerm, name: Name) -> Type:
-    def rec(t: Type) -> Type:
-        return substitution_liquid_in_type(t, rep, name)
-
-    match t:
-        case Top() | TypeConstructor(_) | TypeVar(_):
-            return t
-        case AbstractionType(aname, atype, rtype, loc):
-            if aname == name:
-                return t
-            else:
-                return AbstractionType(aname, rec(atype), rec(rtype), loc=loc)
-        case RefinedType(vname, ity, ref, loc):
-            if name == vname:
-                return t
-            else:
-                return RefinedType(vname, ity, substitution_in_liquid(ref, rep, name), loc=loc)
-        case TypePolymorphism(name, kind, body, loc):
-            return TypePolymorphism(name, kind, rec(body), loc=loc)
-        case RefinementPolymorphism(rname, rsort, rbody, loc):
-            if rname == name:
-                return t
-            return RefinementPolymorphism(rname, rec(rsort), rec(rbody), loc=loc)
-        case TypeConstructor(name, args, loc):
-            return TypeConstructor(name, [rec(arg) for arg in args], loc=loc)
-        case _:
-            assert False, f"{t} not allowed"
-
-
-def substitution_liquid_in_term(t: Term, rep: LiquidTerm, name: Name) -> Term:
-    def rec(x: Term) -> Term:
-        return substitution_liquid_in_term(x, rep, name)
-
-    match t:
-        case Literal(val, ty, loc):
-            return Literal(val, substitution_liquid_in_type(ty, rep, name), loc=loc)
-        case Var():
-            return t
-        case Hole():
-            return t
-        case Application(fun, arg, loc):
-            return Application(fun=rec(fun), arg=rec(arg), loc=loc)
-        case Abstraction(var_name, body, loc):
-            return Abstraction(var_name, rec(body), loc=loc)
-        case Let(var_name, var_value, body, loc):
-            return Let(var_name, rec(var_value), rec(body), loc=loc)
-        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
-            n_type = substitution_liquid_in_type(var_type, rep, name)
-            return Rec(var_name, n_type, rec(var_value), rec(body), decreasing_by=decreasing_by, loc=loc)
-        case Annotation(expr, ty, loc):
-            n_type = substitution_liquid_in_type(ty, rep, name)
-            return Annotation(rec(expr), n_type, loc=loc)
-        case If(cond, then, otherwise, loc):
-            return If(rec(cond), rec(then), rec(otherwise), loc=loc)
-        case TypeAbstraction(pname, kind, body, loc):
-            return TypeAbstraction(pname, kind, rec(body), loc=loc)
-        case RefinementAbstraction(pname, sort, body, loc):
-            return RefinementAbstraction(pname, substitution_liquid_in_type(sort, rep, name), rec(body), loc=loc)
-        case TypeApplication(body, ty, loc):
-            n_type = substitution_liquid_in_type(ty, rep, name)
-            return TypeApplication(rec(body), n_type, loc=loc)
-        case RefinementApplication(body, refinement, loc):
-            return RefinementApplication(rec(body), rec(refinement), loc=loc)
-        case _:
-            assert False, f"{t} not allowed"
-
-
 def substitution_in_type(t: Type, rep: Term, name: Name) -> Type:
     """Substitutes name in type t with the new replacement term rep."""
     replacement: LiquidTerm | None = liquefy(rep)
@@ -390,59 +178,6 @@ def substitution_in_type(t: Type, rep: Term, name: Name) -> Type:
             return TypeConstructor(name, [rec(arg) for arg in args], loc=loc)
         case _:
             assert False, f"{t} not allowed"
-
-
-def substitution(t: Term, rep: Term, name: Name) -> Term:
-    """Substitutes name in term t with the new replacement term rep."""
-
-    def rec(x: Term):
-        return substitution(x, rep, name)
-
-    match t:
-        case Literal(_):
-            return t
-        case Var(tname) | Hole(tname):
-            if tname == name:
-                return rep
-            else:
-                return t
-        case Application(fun, arg, loc):
-            return Application(fun=rec(fun), arg=rec(arg), loc=loc)
-        case Abstraction(vname, body, loc):
-            if vname == name:
-                return t
-            else:
-                return Abstraction(vname, rec(t.body), loc=loc)
-        case Let(tname, val, body, loc):
-            if tname == name:
-                n_value = val
-                n_body = body
-            else:
-                n_value = rec(val)
-                n_body = rec(body)
-            return Let(tname, n_value, n_body, loc=loc)
-        case Rec(tname, ty, val, body, decreasing_by, loc):
-            if tname == name:
-                n_value = val
-                n_body = body
-            else:
-                n_value = rec(val)
-                n_body = rec(body)
-            return Rec(tname, ty, n_value, n_body, decreasing_by=decreasing_by, loc=loc)
-        case Annotation(body, ty, loc):
-            return Annotation(rec(body), ty, loc=loc)
-        case If(cond, then, otherwise, loc):
-            return If(rec(cond), rec(then), rec(otherwise), loc=loc)
-        case TypeApplication(expr, ty, loc):
-            return TypeApplication(rec(expr), ty, loc=loc)
-        case TypeAbstraction(pname, kind, body, loc):
-            return TypeAbstraction(pname, kind, rec(body), loc=loc)
-        case RefinementAbstraction(pname, sort, body, loc):
-            return RefinementAbstraction(pname, sort, rec(body), loc=loc)
-        case RefinementApplication(body, refinement, loc):
-            return RefinementApplication(rec(body), rec(refinement), loc=loc)
-        case _:
-            assert False, f"{t} not supported."
 
 
 def inline_lets(t: Term) -> Term:
@@ -530,7 +265,7 @@ def liquefy_ann(t: Annotation) -> LiquidTerm | None:
     return liquefy(t.expr)
 
 
-# patterm matching term
+# pattern matching term
 def liquefy(rep: Term) -> LiquidTerm | None:
     """Converts a term to a liquid term."""
 


### PR DESCRIPTION
## Summary

Builds on #244. Ports the remaining pure recursive walks of `aeon.core.substitutions` to Rust (`aeon_rs`):

- `substitute_vartype` / `substitute_vartype_in_term`
- `substitution_liquid_in_type` / `substitution_liquid_in_term`
- `instantiate_refinement_with_horn_in_liquid` / `_in_type`
- `substitution` (term-level)

`aeon/core/substitutions.py` drops **~326 lines of Python** — the eight ported functions (including `substitution_in_liquid` from PR 1) become thin re-exports. The mutually-recursive cluster (`inline_lets` / `liquefy` / `liquefy_*` / `substitution_in_type` / `instantiate_refinement_in_{liquid,type}`) stays in Python; it's a tight cycle better moved together in a later PR.

## Latent bug fixed: `substitution_in_liquid`

`substitution_in_liquid` was registered in `aeon_rs` back in **PR 1**, but `aeon/core/substitutions.py` never actually imported it — it kept using the Python `def`. So the Rust path was **dead code** for three PRs. Wiring it up here surfaced the bug.

The Python original's `LiquidHornApplication` case:

```python
[(substitution_in_liquid(a, rep, name), t) for (a, t) in argtypes]
```

The comprehension's `for (a, t)` **rebinds `t`** to each argtype's own type. The Rust port was passing the outer horn-application term (`t`, the function parameter) instead. Fixed to use each tuple's own type — `substitution_in_liquid` alone now passes all 16 parametric-refinement tests, where before it failed 6.

## Process note

Several false starts traced back to **stale build artifacts**: `uv sync` / `maturin develop` sometimes left an old `.so` in site-packages. The reliable path is `cargo clean` + fresh `maturin develop`. Recommend documenting in `Contributing.md`.

## Results

- All **415 tests pass** (9 skipped).
- Full suite ~96s (was ~173s pre-Rust baseline).
- Pre-commit (mypy, ruff, pyroma) pass.
- Net: +946 / -320 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)