### PR TITLE
Fix pretty-printer rendering binary comparison operands swapped

### DIFF
--- a/aeon/sugar/lifting.py
+++ b/aeon/sugar/lifting.py
@@ -74,8 +74,10 @@ def lift_liquid(ref: LiquidTerm) -> STerm:
         case LiquidVar(name, loc):
             return SVar(name, loc)
         case LiquidApp(fun, args, loc):
+            # args are stored in source order; a curried application fun a b
+            # is App(App(Var(fun), a), b), so fold left-to-right.
             v: STerm = SVar(fun, loc=loc)
-            for arg in args[::-1]:
+            for arg in args:
                 v = SApplication(v, lift_liquid(arg), loc=loc)
             return v
         case _:

--- a/tests/pprint_test.py
+++ b/tests/pprint_test.py
@@ -1,13 +1,26 @@
 from abc import abstractmethod, ABC
 from dataclasses import dataclass
 
-from aeon.utils.pprint import Associativity, Side, needs_parens_aux, ParenthesisContext, Precedence
+from aeon.sugar.lifting import lift_type
+from aeon.sugar.lowering import type_to_core
+from aeon.sugar.parser import parse_type
+from aeon.utils.pprint import Associativity, Side, needs_parens_aux, ParenthesisContext, Precedence, stype_pretty
 from aeon.utils.pprint_helpers import (
     Doc,
     text,
     concat,
     parens,
 )
+
+
+def test_refinement_comparison_operand_order():
+    # Regression: lift_liquid reversed curried application args, so a refinement
+    # written `y >= 5` printed as `5 >= y` after a round-trip through the core AST.
+    sugar_ty = parse_type("{y:Int | y >= 5}")
+    core_ty = type_to_core(sugar_ty)
+    rendered = str(stype_pretty(lift_type(core_ty)))
+    assert "y >= 5" in rendered
+    assert "5 >= y" not in rendered
 
 
 def test_simple_pprint_1():


### PR DESCRIPTION
## Summary

The pretty-printer rendered binary comparison operators with operands swapped: a refinement written `{y:Int | y >= 5}` printed as `{y : Int | 5 >= y}` after a round-trip through the core AST. Synthesis and the SMT layer were already correct — this was display-only.

Root cause: `lift_liquid` in `aeon/sugar/lifting.py` folded `LiquidApp` arguments in **reverse** order (`args[::-1]`). Every other layer stores comparison operands in source order — the parser builds `App(App(Var(op), left), right)`, `liquefy_app` produces `LiquidApp(op, [left, right])`, and `smt.py` applies `lambda x, y: x op y` to `[left, right]`. Lifting back to sugar must therefore fold left-to-right.

The fix is a one-line change (fold `args` instead of `args[::-1]`).

### Verification
- `def positive (x:Int) : {y:Int | y >= 5}` now pretty-prints `y >= 5` (was `5 >= y`).
- `def must_be_big (x:Int) : {y:Int | y >= 100}` still synthesizes `104` — semantics unchanged, only display fixed.
- Full suite green: 415 passed, 9 skipped.
- `uvx pre-commit run` (ruff, ruff-format, mypy) passes on changed files.

Split out of #245 (the Vericoding benchmark harness), which surfaced the bug.

## Test plan
- [x] `uv run pytest` — 415 passed, 9 skipped
- [x] New regression test `test_refinement_comparison_operand_order` in `tests/pprint_test.py`: parses `{y:Int | y >= 5}`, round-trips through core, asserts the pretty-printed output reads `y >= 5` and not `5 >= y`
- [x] Manual repro from the bug report confirmed fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)