### PR TITLE
Drop pyRAPL: cross-platform resource_meters for @minimize_cputime / @minimize_energy

### DIFF
--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib
 import sys
 import time
 from typing import Any, Optional
@@ -27,6 +26,7 @@ from aeon.synthesis.api import ErrorInSynthesis, Synthesizer, TimeoutInEvaluatio
 from aeon.synthesis.tactics.explicit_synth import ExplicitTacticSynthesizer
 
 from aeon.synthesis.decorators import Goal
+from aeon.synthesis.resource_meters import measure_cputime, measure_energy
 
 
 def make_program(whole_program: Term, hole_name: Name) -> Callable[[Term], Term]:
@@ -47,40 +47,6 @@ def make_validator(ctx: TypingContext, replace: Callable[[Term], Term]) -> Calla
 Evaluators: TypeAlias = list[Callable[[Term], float]]
 
 
-def _measure_cputime(thunk: Callable[[], Any]) -> float:
-    """Run ``thunk`` and return the CPU time it consumed, in seconds."""
-    start = time.process_time()
-    thunk()
-    return time.process_time() - start
-
-
-# Fallback power estimate (in watts) used to convert CPU time to a joules-like
-# proxy when no hardware energy counter is available. The exact value matters
-# less than monotonicity: faster candidates score better.
-_DEFAULT_PROXY_POWER_W = 15.0
-
-
-def _measure_energy(thunk: Callable[[], Any]) -> float:
-    """Run ``thunk`` and return the energy it consumed, in joules.
-
-    Uses Intel RAPL via ``pyRAPL`` when importable and supported; otherwise
-    falls back to ``cpu_time * _DEFAULT_PROXY_POWER_W``.
-    """
-    try:
-        pyRAPL = importlib.import_module("pyRAPL")
-
-        pyRAPL.setup()
-        meter = pyRAPL.Measurement("aeon_synth")
-        meter.begin()
-        thunk()
-        meter.end()
-        # pyRAPL reports per-package energy in microjoules.
-        pkg = meter.result.pkg if meter.result and meter.result.pkg else [0.0]
-        return float(sum(pkg)) / 1e6
-    except Exception:
-        return _measure_cputime(thunk) * _DEFAULT_PROXY_POWER_W
-
-
 def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float]:
     """Build a fitness function for a single goal, dispatching on ``goal.kind``."""
 
@@ -88,9 +54,9 @@ def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float
         program_for_fitness = substitution(v, Var(goal.function), Name("main", 0))
         try:
             if goal.kind == "cputime":
-                return _measure_cputime(lambda: eval(program_for_fitness, ectx))
+                return measure_cputime(lambda: eval(program_for_fitness, ectx))
             if goal.kind == "energy":
-                return _measure_energy(lambda: eval(program_for_fitness, ectx))
+                return measure_energy(lambda: eval(program_for_fitness, ectx))
             return eval(program_for_fitness, ectx)
         except Exception:
             return sys.maxsize

--- a/aeon/synthesis/resource_meters.py
+++ b/aeon/synthesis/resource_meters.py
@@ -1,0 +1,116 @@
+"""Resource measurement helpers used by synthesis fitness functions.
+
+This is the single place where Aeon decides *how* it measures CPU time and
+energy for candidate programs evaluated by the synthesizer. Two metrics are
+exposed:
+
+- :func:`measure_cputime` — CPU time consumed by a thunk, in seconds.
+- :func:`measure_energy`  — energy consumed by a thunk, in joules.
+
+Energy measurement picks the most accurate backend available at runtime and
+caches the choice. Backends are tried in order:
+
+1. **Linux powercap** (``/sys/class/powercap/intel-rapl:*/energy_uj``). Works
+   for both Intel (``intel_rapl_*`` drivers) and modern AMD CPUs (the
+   ``rapl_msr`` / ``amd_energy`` driver, kernel 5.8+) when the relevant
+   module is loaded. No third-party dependency required.
+2. **CPU-time proxy** (``cpu_time * DEFAULT_POWER_W``). Universal fallback
+   used on macOS (Intel and Apple Silicon), Windows, and Linux machines
+   without exposed RAPL counters. The proxy is monotonic in CPU time, so
+   the search signal is preserved even though absolute joules are not.
+
+To add a new backend, implement :class:`EnergyMeter` and prepend it to
+``_BACKENDS`` below.
+"""
+
+from __future__ import annotations
+
+import functools
+import glob
+import time
+from typing import Callable, Protocol
+
+
+# Watts. Used by the CPU-time proxy. The exact value is unimportant; the
+# search only needs a monotonic energy estimate, not an absolute one.
+DEFAULT_POWER_W = 15.0
+
+
+Thunk = Callable[[], object]
+
+
+def measure_cputime(thunk: Thunk) -> float:
+    """Run ``thunk`` and return CPU time consumed, in seconds."""
+    start = time.process_time()
+    thunk()
+    return time.process_time() - start
+
+
+class EnergyMeter(Protocol):
+    """Backend that measures the energy consumed running a thunk, in joules."""
+
+    def available(self) -> bool: ...
+
+    def measure(self, thunk: Thunk) -> float: ...
+
+
+class PowercapMeter:
+    """Linux powercap RAPL reader (Intel + AMD).
+
+    Reads ``energy_uj`` (microjoules) for every powercap zone matching
+    ``intel-rapl:*`` before and after the thunk and sums the deltas. The
+    counters can wrap around at the value advertised in
+    ``max_energy_range_uj`` next to each ``energy_uj`` file, but for the
+    sub-second evaluations a synthesizer performs that's vanishingly rare;
+    we clamp negative deltas to 0 to stay safe.
+    """
+
+    PATTERN = "/sys/class/powercap/intel-rapl:*/energy_uj"
+
+    def _files(self) -> list[str]:
+        return sorted(glob.glob(self.PATTERN))
+
+    def available(self) -> bool:
+        return bool(self._files())
+
+    @staticmethod
+    def _read(path: str) -> int:
+        with open(path) as f:
+            return int(f.read().strip())
+
+    def measure(self, thunk: Thunk) -> float:
+        files = self._files()
+        before = [self._read(p) for p in files]
+        thunk()
+        after = [self._read(p) for p in files]
+        delta_uj = sum(max(0, a - b) for a, b in zip(after, before))
+        return delta_uj / 1e6
+
+
+class CPUTimeProxyMeter:
+    """Universal fallback: ``energy ≈ cpu_time * DEFAULT_POWER_W``."""
+
+    def available(self) -> bool:
+        return True
+
+    def measure(self, thunk: Thunk) -> float:
+        return measure_cputime(thunk) * DEFAULT_POWER_W
+
+
+# Ordered from most accurate to least. ``CPUTimeProxyMeter`` is always the
+# last entry, so ``default_energy_meter`` is guaranteed to return something.
+_BACKENDS: list[EnergyMeter] = [PowercapMeter(), CPUTimeProxyMeter()]
+
+
+@functools.lru_cache(maxsize=1)
+def default_energy_meter() -> EnergyMeter:
+    """Return the best energy meter available on this machine (cached)."""
+    for m in _BACKENDS:
+        if m.available():
+            return m
+    raise RuntimeError("no energy meter available")  # unreachable
+
+
+def measure_energy(thunk: Thunk) -> float:
+    """Run ``thunk`` and return joules consumed, using the best backend."""
+    return default_energy_meter().measure(thunk)

--- a/tests/optimization_decorators_test.py
+++ b/tests/optimization_decorators_test.py
@@ -1,15 +1,15 @@
-from unittest import mock
-
-from aeon.synthesis.entrypoint import (
-    _DEFAULT_PROXY_POWER_W,
-    _measure_cputime,
-    _measure_energy,
-    make_evaluators,
-    synthesize_holes,
-)
+from aeon.synthesis.entrypoint import make_evaluators, synthesize_holes
 from aeon.synthesis.decorators import Goal
 from aeon.synthesis.grammar.ge_synthesis import GESynthesizer, create_problem
 from aeon.synthesis.identification import incomplete_functions_and_holes, iterate_top_level
+from aeon.synthesis.resource_meters import (
+    DEFAULT_POWER_W,
+    CPUTimeProxyMeter,
+    PowercapMeter,
+    default_energy_meter,
+    measure_cputime,
+    measure_energy,
+)
 from aeon.sugar.ast_helpers import st_top
 from aeon.utils.name import Name
 
@@ -119,23 +119,38 @@ def test_cputime_and_energy_make_two_evaluators_and_minimize_problem():
 
 
 def test_measure_cputime_is_nonnegative():
-    cheap = _measure_cputime(lambda: None)
-    busy = _measure_cputime(lambda: sum(range(200_000)))
+    cheap = measure_cputime(lambda: None)
+    busy = measure_cputime(lambda: sum(range(200_000)))
     assert cheap >= 0.0
     assert busy >= 0.0
 
 
-def test_measure_energy_falls_back_to_proxy_without_pyrapl():
-    # Force the pyRAPL import to fail and verify we hit the CPU-time proxy.
-    with mock.patch.dict("sys.modules", {"pyRAPL": None}):
-
-        def work():
-            sum(range(50_000))
-
-        joules = _measure_energy(work)
-
+def test_measure_energy_returns_finite_nonnegative():
+    joules = measure_energy(lambda: sum(range(50_000)))
     assert joules >= 0.0
-    assert joules < _DEFAULT_PROXY_POWER_W * 10.0
+    # Sanity bound: synth-sized thunks shouldn't burn kilojoules.
+    assert joules < 1000.0
+
+
+def test_cputime_proxy_meter_uses_default_power():
+    meter = CPUTimeProxyMeter()
+    assert meter.available()
+    # A no-op thunk should consume ~0 J under the proxy.
+    assert meter.measure(lambda: None) < DEFAULT_POWER_W
+
+
+def test_default_energy_meter_picks_powercap_or_proxy():
+    meter = default_energy_meter()
+    assert isinstance(meter, (PowercapMeter, CPUTimeProxyMeter))
+    # The chosen meter's `available()` must return True.
+    assert meter.available()
+
+
+def test_powercap_meter_availability_matches_filesystem():
+    import glob
+
+    expected = bool(glob.glob(PowercapMeter.PATTERN))
+    assert PowercapMeter().available() is expected
 
 
 def test_cputime_synthesis_smoke():


### PR DESCRIPTION
## Summary

Extracts energy / CPU-time measurement out of `aeon/synthesis/entrypoint.py` and into a small dedicated module, `aeon/synthesis/resource_meters.py`, that picks the best measurement backend at runtime.

PR #217 added `@minimize_cputime` / `@minimize_energy` with inline helpers that depend on **`pyRAPL`** — which is Linux + Intel only. This PR removes that dependency and adds:

1. **`PowercapMeter`** — reads `/sys/class/powercap/intel-rapl:*/energy_uj` directly. Works for Intel (`intel_rapl_*`) and modern AMD (`rapl_msr` / `amd_energy`, kernel ≥ 5.8) without any third-party dependency.
2. **`CPUTimeProxyMeter`** — universal fallback `cpu_time × DEFAULT_POWER_W`. Used on macOS (Intel + Apple Silicon), Windows, and Linux machines without exposed RAPL counters. Monotonic in CPU time, so the search signal is preserved even though absolute joules aren't.

Backends are an ordered list; `default_energy_meter()` picks the first available and caches it. Adding a new one (e.g. `nvml`, `powermetrics`) is a one-line prepend to `_BACKENDS`.

## What changes in entrypoint.py

`_make_fitness` now calls `measure_cputime` / `measure_energy` from `resource_meters` — the dispatch on `goal.kind` (`"cputime"` / `"energy"` / `"expression"`) is unchanged. The 35-line block of inline `_measure_cputime`, `_DEFAULT_PROXY_POWER_W`, `_measure_energy` (with the `pyRAPL` try/except) is removed; so is the now-unused `import importlib`.

## Tests

`tests/optimization_decorators_test.py`:
- Import from `aeon.synthesis.resource_meters`.
- `test_measure_cputime_is_nonnegative` uses `measure_cputime` from the new module.
- The `pyRAPL`-mock test is replaced by three tests that cover the actual backend-selection logic:
  - `test_cputime_proxy_meter_uses_default_power`
  - `test_default_energy_meter_picks_powercap_or_proxy`
  - `test_powercap_meter_availability_matches_filesystem`

## Test plan

- [x] `uv run pytest tests/optimization_decorators_test.py` — 14 passed
- [x] Full suite — **469 passed, 9 skipped** on Linux + Intel + powercap available

## Files

- `aeon/synthesis/resource_meters.py` (new)
- `aeon/synthesis/entrypoint.py` (replace inline helpers with imports)
- `tests/optimization_decorators_test.py` (re-target imports + replace pyRAPL-mock test)

Closes a follow-up to #217 — the same `@minimize_cputime` / `@minimize_energy` decorators, now usable on every platform Aeon runs on.

https://claude.ai/code/session_01AnWitZnys9bp4Q5MJnuqBs