### PR TITLE
PR 7/N: Rust-port PLE unfolding — z3-free slice of the SMT encoder

### DIFF
--- a/aeon-rs/src/lib.rs
+++ b/aeon-rs/src/lib.rs
@@ -14,6 +14,7 @@ mod liquefy;
 mod liquid;
 mod loc;
 mod name;
+mod ple;
 mod substitutions;
 mod sugar;
 mod term_subst;
@@ -134,6 +135,9 @@ fn aeon_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<sugar::Decorator>()?;
     m.add_class::<sugar::Definition>()?;
     m.add_class::<sugar::Program>()?;
+
+    // SMT encoder — PLE unfolding (z3-free slice)
+    m.add_function(wrap_pyfunction!(ple::ple_unfold_fixpoint, m)?)?;
 
     Ok(())
 }

--- a/aeon-rs/src/ple.rs
+++ b/aeon-rs/src/ple.rs
@@ -1,0 +1,126 @@
+//! PLE (Proof by Logical Evaluation) unfolding from aeon.verification.smt.
+//!
+//! `ple_unfold_fixpoint` repeatedly inlines reflected-function applications
+//! in a LiquidTerm until a fixpoint (or a guard) is reached. It's invoked
+//! once per premise and once per conclusion in `flatten`, and showed up
+//! heavily in compile-time profiling.
+//!
+//! This is the z3-free slice of the SMT encoder — pure LiquidTerm rewriting.
+//! The z3-touching `translate` / `smt_valid` path remains in Python.
+
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList, PyTuple};
+use std::collections::HashSet;
+
+use crate::builders::new_liquid_app;
+use crate::liquid::LiquidApp;
+use crate::name::Name;
+use crate::substitutions::substitution_in_liquid;
+
+/// One PLE step. Returns (new_term, changed).
+///
+/// Mirrors aeon.verification.smt._ple_unfold_once: recurse into LiquidApp
+/// args; if the application head is a reflected function with a matching
+/// arity, inline its body with the args substituted for the params.
+fn ple_unfold_once(
+    py: Python<'_>,
+    t: PyObject,
+    reflected: &Bound<'_, PyDict>,
+) -> PyResult<(PyObject, bool)> {
+    let bound = t.bind(py);
+    if let Ok(app) = bound.downcast::<LiquidApp>() {
+        let app = app.borrow();
+        let args = app.args.bind(py);
+        let n_args = PyList::empty_bound(py);
+        let mut changed = false;
+        for i in 0..args.len() {
+            let arg = args.get_item(i)?;
+            let (n_arg, arg_changed) = ple_unfold_once(py, arg.into(), reflected)?;
+            n_args.append(n_arg)?;
+            changed = changed || arg_changed;
+        }
+        // key = str(fun)
+        let key = app.fun.borrow(py).__str__();
+        if let Some(entry) = reflected.get_item(&key)? {
+            let tup = entry.downcast::<PyTuple>().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err("reflected_functions value must be a tuple")
+            })?;
+            let params = tup.get_item(0)?;
+            let params = params.downcast::<PyTuple>().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err("reflected_functions params must be a tuple")
+            })?;
+            if params.len() == n_args.len() {
+                let mut unfolded: PyObject = tup.get_item(1)?.into();
+                for j in 0..params.len() {
+                    let param: Py<Name> = params.get_item(j)?.extract()?;
+                    let arg: PyObject = n_args.get_item(j)?.into();
+                    unfolded = substitution_in_liquid(py, unfolded, arg, param)?;
+                }
+                return Ok((unfolded, true));
+            }
+        }
+        if changed {
+            let r = new_liquid_app(
+                py,
+                app.fun.clone_ref(py),
+                n_args.unbind(),
+                app.loc.clone_ref(py),
+            )?;
+            return Ok((r, true));
+        }
+        return Ok((t, false));
+    }
+    Ok((t, false))
+}
+
+/// term_size: 1 + sum of children sizes for LiquidApp, else 1.
+fn term_size(py: Python<'_>, node: &Bound<'_, PyAny>) -> PyResult<usize> {
+    if let Ok(app) = node.downcast::<LiquidApp>() {
+        let app = app.borrow();
+        let args = app.args.bind(py);
+        let mut s = 1usize;
+        for i in 0..args.len() {
+            s += term_size(py, &args.get_item(i)?)?;
+        }
+        Ok(s)
+    } else {
+        Ok(1)
+    }
+}
+
+/// Repeatedly apply ple_unfold_once until no change, a size guard, a
+/// seen-before guard, or max_steps. Mirrors smt.ple_unfold_fixpoint.
+///
+/// The Python original emits a `logger.debug` line per call; that's
+/// intentionally dropped — it's debug-level and has no observable effect.
+#[pyfunction]
+#[pyo3(signature = (t, reflected_functions, max_steps = 256))]
+pub fn ple_unfold_fixpoint(
+    py: Python<'_>,
+    t: PyObject,
+    reflected_functions: &Bound<'_, PyDict>,
+    max_steps: usize,
+) -> PyResult<PyObject> {
+    const MAX_TERM_SIZE: usize = 4096;
+
+    let mut current = t;
+    let mut seen: HashSet<String> = HashSet::new();
+    seen.insert(current.bind(py).repr()?.to_string());
+
+    for _ in 0..max_steps {
+        let (next, changed) = ple_unfold_once(py, current, reflected_functions)?;
+        current = next;
+        if !changed {
+            break;
+        }
+        if term_size(py, current.bind(py))? > MAX_TERM_SIZE {
+            break;
+        }
+        let signature = current.bind(py).repr()?.to_string();
+        if seen.contains(&signature) {
+            break;
+        }
+        seen.insert(signature);
+    }
+    Ok(current)
+}

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -28,6 +28,8 @@ from z3.z3 import SortRef
 from z3.z3types import Z3Exception
 from z3 import Distinct, EmptySet, SetAdd, SetUnion, SetIntersect, SetDifference, IsMember, IsSubset, SetSort
 
+from aeon_rs import ple_unfold_fixpoint as ple_unfold_fixpoint
+
 from aeon.core.liquid import LiquidApp
 from aeon.core.types import LiquidHornApplication, TypeConstructor
 from aeon.core.liquid import LiquidLiteralBool
@@ -174,74 +176,9 @@ class SMTContext:
         )
 
 
-def _ple_unfold_once(
-    t: LiquidTerm,
-    reflected_functions: dict[str, tuple[tuple[Name, ...], LiquidTerm]],
-) -> tuple[LiquidTerm, bool]:
-    match t:
-        case LiquidApp(fun, args, loc):
-            n_args: list[LiquidTerm] = []
-            changed = False
-            for arg in args:
-                n_arg, arg_changed = _ple_unfold_once(arg, reflected_functions)
-                n_args.append(n_arg)
-                changed = changed or arg_changed
-            key = str(fun)
-            if key in reflected_functions:
-                params, body = reflected_functions[key]
-                if len(params) == len(n_args):
-                    unfolded = body
-                    for param, arg in zip(params, n_args):
-                        unfolded = substitution_in_liquid(unfolded, arg, param)
-                    return unfolded, True
-            if changed:
-                return LiquidApp(fun, n_args, loc=loc), True
-            return t, False
-        case _:
-            return t, False
-
-
-def ple_unfold_fixpoint(
-    t: LiquidTerm,
-    reflected_functions: dict[str, tuple[tuple[Name, ...], LiquidTerm]],
-    max_steps: int = 256,
-) -> LiquidTerm:
-    def term_size(node: LiquidTerm) -> int:
-        match node:
-            case LiquidApp(_, args):
-                return 1 + sum(term_size(a) for a in args)
-            case _:
-                return 1
-
-    max_term_size = 4096
-    current = t
-    start_size = term_size(current)
-    seen: set[str] = {repr(current)}
-    unfolded_steps = 0
-    stop_reason = "fixpoint"
-    for _ in range(max_steps):
-        current, changed = _ple_unfold_once(current, reflected_functions)
-        if not changed:
-            stop_reason = "no_change"
-            break
-        unfolded_steps += 1
-        if term_size(current) > max_term_size:
-            stop_reason = "size_guard"
-            break
-        signature = repr(current)
-        if signature in seen:
-            stop_reason = "seen_guard"
-            break
-        seen.add(signature)
-    logger.debug(
-        "PLE unfold: steps={} start_size={} final_size={} stop={} reflected_funs={}",
-        unfolded_steps,
-        start_size,
-        term_size(current),
-        stop_reason,
-        len(reflected_functions),
-    )
-    return current
+# _ple_unfold_once and ple_unfold_fixpoint are implemented in the Rust core
+# (aeon_rs.ple_unfold_fixpoint, imported above). They are the z3-free slice
+# of the SMT encoder — pure LiquidTerm rewriting.
 
 
 def _specialize_type(ty: Type, mapping: dict[str, TypeConstructor]) -> Type:


### PR DESCRIPTION
## Summary

Builds on #250. Ports `aeon.verification.smt`'s PLE (Proof by Logical Evaluation) unfolding to Rust (`aeon-rs/src/ple.rs`):

- `_ple_unfold_once` (internal) — one inlining step over a LiquidTerm
- `ple_unfold_fixpoint` (exposed) — iterate to fixpoint / size guard / seen guard / `max_steps`

`ple_unfold_fixpoint` runs once per premise and once per conclusion inside `flatten`, and showed up heavily in compile-time profiling (hundreds of calls per typecheck — it's the `"PLE unfold: ..."` debug spam). It's **pure LiquidTerm rewriting, no z3**, so it ports cleanly: `LiquidTerm` and `substitution_in_liquid` are already Rust (PRs 1 & 4).

## Scope: this is the z3-*free* slice

The user picked "SMT encoder" as the next target. The SMT encoder splits cleanly into two halves:

- **z3-free** (this PR): PLE unfolding — pure term rewriting.
- **z3-touching** (future): `translate` / `translate_liq` / `make_variable` / `get_sort` / `mk_funs` / `smt_valid`. Porting that means either driving z3 from Rust (the `z3` crate, with a context separate from Python's z3 — fine since `smt_valid` only returns a `bool`) or also porting `aeon.verification.vcs`'s `Constraint` hierarchy. That's a larger, higher-risk initiative — flagged for a dedicated follow-up rather than rushed in here.

Shipping the clean half now de-risks and keeps the stack green.

## Behavioral note

The Python `ple_unfold_fixpoint` emitted a per-call `logger.debug` line. Dropped — debug-level, no observable effect on compilation or tests. `smt.py` still imports `logger` (used by `type_of_variable`).

## Results

- All **415 tests pass** (9 skipped). Full suite ~112s.
- Pre-commit (mypy, ruff, pyroma) pass.
- Net: +135 / −68.

## Roadmap

| PR | Scope | Status |
|---|---|---|
| 1–5 | core AST + substitution layer (100% Rust) | #237 #239 #244 #246 #248 |
| 6 | sugar AST | #250 |
| 7 | PLE unfolding (z3-free SMT slice) — this | here |
| 8+ | SMT translate/solve (z3-touching) — needs z3.rs + vcs.py | |
| 9+ | parser, interpreter | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)