### PR TITLE
Fix core term pretty-printer for prelude operator applications

### DIFF
--- a/aeon/core/pprint.py
+++ b/aeon/core/pprint.py
@@ -23,21 +23,6 @@ from aeon.core.types import RefinedType
 from aeon.core.types import Type
 from aeon.core.types import TypeVar
 from aeon.core.types import type_free_term_vars
-from aeon.utils.name import Name
-
-ops_to_abstraction: dict[str, str] = {
-    "%": "Int) -> Int",
-    "/": "Int) -> Int",
-    "*": "Int) -> Int",
-    "-": "Int) -> Int",
-    "+": "Int) -> Int",
-    ">=": "Int) -> Bool",
-    ">": "Int) -> Bool",
-    "<=": "Int) -> Bool",
-    "<": "Int) -> Bool",
-    "!=": "Int) -> Bool",
-    "==": "Int) -> Bool",
-}
 
 aeon_prelude_ops_to_text = {
     "%": "mod",
@@ -89,26 +74,43 @@ def pretty_print_term(term: Term):
     print(term_str)
 
 
+def operator_name(term: Term) -> str | None:
+    """The prelude operator name if `term` is a (possibly type-applied) operator variable."""
+    inner: Term = term
+    while isinstance(inner, TypeApplication):
+        inner = inner.body
+    if isinstance(inner, Var) and inner.name.name in aeon_prelude_ops_to_text:
+        return inner.name.name
+    return None
+
+
 def custom_preludes_ops_representation(term: Term, counter: int = 0) -> tuple[str, int]:
-    prelude_operations: dict[str, str] = aeon_prelude_ops_to_text
     match term:
-        case Application(fun=Var(name=Name(var_name, _)), arg=arg) if var_name in prelude_operations.keys():
-            op = var_name
+        # Fully applied binary operator: ((op left) right) -> (left op right)
+        case Application(fun=Application(fun=opfun, arg=left), arg=right) if (
+            op := operator_name(opfun)
+        ) is not None and op != "!":
+            left_str, counter = custom_preludes_ops_representation(left, counter)
+            right_str, counter = custom_preludes_ops_representation(right, counter)
+            return f"({left_str} {op} {right_str})", counter
+
+        # Fully applied unary operator: (! arg)
+        case Application(fun=opfun, arg=arg) if operator_name(opfun) == "!":
             arg_str, counter = custom_preludes_ops_representation(arg, counter)
+            return f"(!{arg_str})", counter
+
+        # Partially applied binary operator: (op left) -> (\v -> left op v)
+        case Application(fun=opfun, arg=left) if (op := operator_name(opfun)) is not None and op != "!":
+            left_str, counter = custom_preludes_ops_representation(left, counter)
             counter += 1
-            new_var_name = f"__{prelude_operations[op]}_{counter}__"
-            abstraction_type_str = f"({new_var_name}:{ops_to_abstraction[op]}"
-            personalized_op = f": {abstraction_type_str} = (\\{new_var_name} -> {arg_str} {op} {new_var_name})"
-            return personalized_op, counter
+            assert op is not None
+            new_var_name = f"__{aeon_prelude_ops_to_text[op]}_{counter}__"
+            return f"(\\{new_var_name} -> {left_str} {op} {new_var_name})", counter
 
         case Application(fun=fun, arg=arg):
             fun_str, counter = custom_preludes_ops_representation(fun, counter)
             arg_str, counter = custom_preludes_ops_representation(arg, counter)
-            return (
-                f"""= ({fun_str} {arg_str}
-            )""",
-                counter,
-            )
+            return f"({fun_str} {arg_str})", counter
 
         case Annotation(expr=expr, type=type):
             expr_str, counter = custom_preludes_ops_representation(expr, counter)
@@ -119,10 +121,9 @@ def custom_preludes_ops_representation(term: Term, counter: int = 0) -> tuple[st
             return f"""(\\{var_name} -> {body_str})""", counter
 
         case Let(var_name=var_name, var_value=var_value, body=body):
-            var_value_prefix = "= " if not isinstance(var_value, Application) else ""
             var_value_str, counter = custom_preludes_ops_representation(var_value, counter)
             body_str, counter = custom_preludes_ops_representation(body, counter)
-            return f"""(let {var_name} {var_value_prefix}{var_value_str} in\n {body_str})""", counter
+            return f"""(let {var_name} = {var_value_str} in\n {body_str})""", counter
 
         case Rec(var_name=var_name, var_type=var_type, var_value=var_value, body=body, decreasing_by=_):
             var_value_str, counter = custom_preludes_ops_representation(var_value, counter)

--- a/tests/pprint_term_test.py
+++ b/tests/pprint_term_test.py
@@ -3,10 +3,25 @@ from aeon.core.terms import Var, Application
 from aeon.utils.name import Name
 
 
-def test_rewrite_op_term():
-    initial_term = Application(fun=Var(Name("*")), arg=Var(Name("x")))
+def test_partial_operator_application_is_eta_expanded():
+    # (* x) is a partially applied operator and must render as a lambda.
+    term = Application(fun=Var(Name("*", 0)), arg=Var(Name("x", 0)))
+    result, _ = custom_preludes_ops_representation(term)
+    assert result == "(\\__mul_1__ -> x * __mul_1__)"
 
-    custom_preludes_ops_representation(initial_term)[0]
-    # Todo: fix this test
-    # assert final_term == "(\\__mult_1__ -> x * __mult_1__)"
-    assert True
+
+def test_full_operator_application_renders_infix_in_source_order():
+    # ((>= a) b) must render as (a >= b), with operands in source order.
+    term = Application(
+        fun=Application(fun=Var(Name(">=", 0)), arg=Var(Name("a", 0))),
+        arg=Var(Name("b", 0)),
+    )
+    result, _ = custom_preludes_ops_representation(term)
+    assert result == "(a >= b)"
+
+
+def test_unary_operator_application():
+    # (! b) is a fully applied unary operator.
+    term = Application(fun=Var(Name("!", 0)), arg=Var(Name("b", 0)))
+    result, _ = custom_preludes_ops_representation(term)
+    assert result == "(!b)"


### PR DESCRIPTION
## Summary

`custom_preludes_ops_representation` in `aeon/core/pprint.py` rendered prelude operator applications incorrectly. It treated *every* `Application(Var(op), x)` as a partial application needing eta-expansion, so a *fully* applied operator `((op left) right)` fell through to the generic `Application` case and produced malformed output — a nested `: type = (\v -> left op v)` fragment applied to the second operand. It also emitted stray `= ` / `: ... =` prefixes that leaked `let`-binding syntax into plain terms.

Operator applications are now matched explicitly:
- fully applied binary operator → `(left op right)` (operands in source order)
- fully applied unary `!` → `(!arg)`
- partially applied binary operator → `(\v -> left op v)` (eta-expansion)

Operators wrapped in `TypeApplication` (polymorphic operators in ANF core) are unwrapped via the new `operator_name` helper. The unused, incomplete `ops_to_abstraction` table is removed.

This printer is currently only reachable from a commented-out call site (`aeon/synthesis/uis/api.py`), so there is no user-facing behaviour change today — the fix makes it correct for when it is used again, and gives it real test coverage.

Follow-up cleanup spun out of the review for #249 (the comparison-operand pretty-printer fix), which surfaced this function as a second, latent operand-handling bug.

## Test plan
- [x] `uv run pytest` — 417 passed, 9 skipped
- [x] Re-enabled `tests/pprint_term_test.py` (previously `assert True` with a disabled assertion) with three real tests: partial application eta-expansion, full binary application infix rendering in source order, and unary operator application
- [x] Manually verified realistic core terms: `((+[Int] x) 1)` → `(x + 1)`, `map (+1) xs` → `((map (\__add_1__ -> 1 + __add_1__)) xs)`, `let` bindings render without stray prefixes
- [x] `uvx pre-commit run` (ruff, ruff-format, mypy) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)