### PR TITLE
PR 8/N: Rust-port unrefine_type + uncurry — remaining z3-free smt.py helpers

### DIFF
--- a/aeon-rs/src/lib.rs
+++ b/aeon-rs/src/lib.rs
@@ -15,6 +15,7 @@ mod liquid;
 mod loc;
 mod name;
 mod ple;
+mod smt_helpers;
 mod substitutions;
 mod sugar;
 mod term_subst;
@@ -136,8 +137,10 @@ fn aeon_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<sugar::Definition>()?;
     m.add_class::<sugar::Program>()?;
 
-    // SMT encoder — PLE unfolding (z3-free slice)
+    // SMT encoder — z3-free slices
     m.add_function(wrap_pyfunction!(ple::ple_unfold_fixpoint, m)?)?;
+    m.add_function(wrap_pyfunction!(smt_helpers::unrefine_type, m)?)?;
+    m.add_function(wrap_pyfunction!(smt_helpers::uncurry, m)?)?;
 
     Ok(())
 }

--- a/aeon-rs/src/smt_helpers.rs
+++ b/aeon-rs/src/smt_helpers.rs
@@ -1,0 +1,156 @@
+//! Pure (z3-free) helper walks from aeon.verification.smt:
+//!
+//!  - unrefine_type   (Type -> Type)   strip refinements everywhere
+//!  - uncurry         (AbstractionType -> ([TypeConstructor], TypeConstructor))
+//!
+//! These feed make_variable / mk_funs (which stay in Python because they
+//! build z3 objects). Porting them here removes the recursive Python walks
+//! from the hot encoding path without pulling in z3.
+
+use pyo3::prelude::*;
+use pyo3::types::{PyList, PyTuple};
+
+use crate::builders::{
+    new_abstraction_type, new_type_constructor, new_type_polymorphism,
+};
+use crate::name::Name;
+use crate::types::{
+    AbstractionType, RefinedType, RefinementPolymorphism, Top, TypeConstructor, TypePolymorphism,
+    TypeVar,
+};
+
+/// A fresh `TypeConstructor(Name(name, 0), [])` — mirrors aeon.core.types.t_*.
+fn base_tc(py: Python<'_>, name: &str) -> PyResult<PyObject> {
+    let n = Py::new(py, Name { name: name.to_string(), id: 0 })?;
+    let empty = PyList::empty_bound(py).unbind();
+    let loc = crate::loc::default_location(py);
+    new_type_constructor(py, n, empty, loc)
+}
+
+/// unrefine_type: drop refinements throughout a type.
+/// Mirrors aeon.verification.smt.unrefine_type.
+#[pyfunction]
+pub fn unrefine_type(py: Python<'_>, base: PyObject) -> PyResult<PyObject> {
+    let bound = base.bind(py);
+
+    if let Ok(rt) = bound.downcast::<RefinedType>() {
+        return Ok(rt.borrow().type_.clone_ref(py));
+    }
+    if let Ok(at) = bound.downcast::<AbstractionType>() {
+        let at = at.borrow();
+        let nv = unrefine_type(py, at.var_type.clone_ref(py))?;
+        let nt = unrefine_type(py, at.type_.clone_ref(py))?;
+        return new_abstraction_type(py, at.var_name.clone_ref(py), nv, nt, at.loc.clone_ref(py));
+    }
+    if let Ok(tp) = bound.downcast::<TypePolymorphism>() {
+        let tp = tp.borrow();
+        let nb = unrefine_type(py, tp.body.clone_ref(py))?;
+        return new_type_polymorphism(py, tp.name.clone_ref(py), tp.kind.clone_ref(py), nb, tp.loc.clone_ref(py));
+    }
+    if let Ok(tc) = bound.downcast::<TypeConstructor>() {
+        let tc = tc.borrow();
+        let args = tc.args.bind(py);
+        let new_args = PyList::empty_bound(py);
+        for i in 0..args.len() {
+            let a = args.get_item(i)?;
+            new_args.append(unrefine_type(py, a.into())?)?;
+        }
+        return new_type_constructor(py, tc.name.clone_ref(py), new_args.unbind(), tc.loc.clone_ref(py));
+    }
+    // Top, TypeVar, anything else: returned as-is.
+    Ok(base)
+}
+
+/// uncurry: flatten an AbstractionType into (input base types, output type),
+/// collapsing higher-rank / type-constructor arguments to scalar tokens.
+/// Mirrors aeon.verification.smt.uncurry.
+#[pyfunction]
+pub fn uncurry<'py>(py: Python<'py>, base: PyObject) -> PyResult<Bound<'py, PyTuple>> {
+    let mut current = unrefine_type(py, base.clone_ref(py))?;
+    let inputs = PyList::empty_bound(py);
+    let mut vars_to_remove: Vec<(String, i64)> = Vec::new();
+
+    // Peel TypePolymorphism wrappers, recording bound type-var names.
+    loop {
+        let cur = current.bind(py);
+        if let Ok(tp) = cur.downcast::<TypePolymorphism>() {
+            let tp = tp.borrow();
+            {
+                let n = tp.name.borrow(py);
+                vars_to_remove.push((n.name.clone(), n.id));
+            }
+            let body = tp.body.clone_ref(py);
+            drop(tp);
+            current = body;
+        } else {
+            break;
+        }
+    }
+
+    // Walk the AbstractionType spine, classifying each var_type.
+    loop {
+        let cur = current.bind(py);
+        let at = match cur.downcast::<AbstractionType>() {
+            Ok(at) => at,
+            Err(_) => break,
+        };
+        let at = at.borrow();
+        let vt = at.var_type.bind(py);
+
+        if let Ok(tc) = vt.downcast::<TypeConstructor>() {
+            if tc.borrow().args.bind(py).len() == 0 {
+                // TypeConstructor(_, []) — keep as-is
+                inputs.append(at.var_type.clone_ref(py))?;
+            } else {
+                // TypeConstructor(_, non-empty) — scalar token
+                inputs.append(base_tc(py, "Int")?)?;
+            }
+        } else if vt.is_instance_of::<Top>() {
+            inputs.append(base_tc(py, "Unit")?)?;
+        } else if let Ok(tvar) = vt.downcast::<TypeVar>() {
+            let tvar = tvar.borrow();
+            let n = tvar.name.borrow(py);
+            let bound_here = vars_to_remove.iter().any(|(nm, id)| *nm == n.name && *id == n.id);
+            if bound_here {
+                inputs.append(base_tc(py, "Int")?)?;
+            } else {
+                // TypeConstructor(name)
+                let nm = tvar.name.clone_ref(py);
+                let empty = PyList::empty_bound(py).unbind();
+                let loc = crate::loc::default_location(py);
+                inputs.append(new_type_constructor(py, nm, empty, loc)?)?;
+            }
+        } else if vt.is_instance_of::<AbstractionType>()
+            || vt.is_instance_of::<TypePolymorphism>()
+            || vt.is_instance_of::<RefinementPolymorphism>()
+        {
+            inputs.append(base_tc(py, "Int")?)?;
+        } else {
+            return Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+                "uncurry: unknown SMT type {}",
+                vt.repr()?.to_string()
+            )));
+        }
+
+        let next = at.type_.clone_ref(py);
+        drop(at);
+        current = next;
+    }
+
+    // Output type: Top collapses to Unit; must end at a TypeConstructor.
+    let out = {
+        let cur = current.bind(py);
+        if cur.is_instance_of::<Top>() {
+            base_tc(py, "Unit")?
+        } else if cur.is_instance_of::<TypeConstructor>() {
+            current.clone_ref(py)
+        } else {
+            return Err(pyo3::exceptions::PyAssertionError::new_err(format!(
+                "uncurry: unknown SMT output type {}",
+                cur.repr()?.to_string()
+            )));
+        }
+    };
+
+    Ok(PyTuple::new_bound(py, &[inputs.into_any().unbind(), out]))
+}

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -29,6 +29,8 @@ from z3.z3types import Z3Exception
 from z3 import Distinct, EmptySet, SetAdd, SetUnion, SetIntersect, SetDifference, IsMember, IsSubset, SetSort
 
 from aeon_rs import ple_unfold_fixpoint as ple_unfold_fixpoint
+from aeon_rs import uncurry as uncurry
+from aeon_rs import unrefine_type as unrefine_type
 
 from aeon.core.liquid import LiquidApp
 from aeon.core.types import LiquidHornApplication, TypeConstructor
@@ -43,7 +45,7 @@ from aeon.core.substitutions import substitution_in_liquid
 from aeon.core.types import AbstractionType, RefinedType, RefinementPolymorphism, Top, TypePolymorphism
 from aeon.core.types import Type
 from aeon.core.types import TypeVar
-from aeon.core.types import t_bool, t_int, t_float, t_set, t_string, t_unit
+from aeon.core.types import t_bool, t_int, t_float, t_set, t_string
 from aeon.verification.sub import lower_constraint_type
 from aeon.verification.vcs import Conjunction
 from aeon.verification.vcs import alpha_key
@@ -523,54 +525,9 @@ def get_sort(base: Type) -> SortRef:
             raise Exception(f"SMT sort of {base} not implemented.")
 
 
-def unrefine_type(base: Type):
-    """Removes refinements from type."""
-    match base:
-        case RefinedType(_, ty, _):
-            return ty
-        case AbstractionType(name, aty, rty):
-            return AbstractionType(name, unrefine_type(aty), unrefine_type(rty))
-        case TypePolymorphism(name, kind, body):
-            return TypePolymorphism(name, kind, unrefine_type(body))
-        case TypeConstructor(name, args):
-            return TypeConstructor(name, [unrefine_type(a) for a in args])
-
-        case _:
-            return base
-
-
-def uncurry(base: AbstractionType) -> tuple[list[TypeConstructor], TypeConstructor]:
-    current: Type = unrefine_type(base)
-    inputs = []
-    vars_to_remove = []
-
-    while isinstance(current, TypePolymorphism):
-        vars_to_remove.append(current.name)
-        current = current.body
-
-    while isinstance(current, AbstractionType):
-        match current.var_type:
-            case TypeConstructor(_, []):
-                inputs.append(current.var_type)
-            case TypeConstructor(_, _):
-                inputs.append(t_int)
-            case Top():
-                inputs.append(t_unit)
-            case TypeVar(name):
-                if name in vars_to_remove:
-                    inputs.append(t_int)
-                else:
-                    inputs.append(TypeConstructor(name))
-            case AbstractionType(_, _, _) | TypePolymorphism(_, _, _) | RefinementPolymorphism(_, _, _):
-                inputs.append(t_int)
-            case _:
-                assert False, f"Unknown SMT type {current.var_type} in {base}."
-        current = current.type
-
-    if isinstance(current, Top):
-        current = t_unit
-    assert isinstance(current, TypeConstructor), f"Unknown SMT type {current} in {base}."
-    return (inputs, current)
+# unrefine_type and uncurry are implemented in the Rust core
+# (aeon_rs.unrefine_type / aeon_rs.uncurry, imported above) — pure, z3-free
+# Type walks feeding make_variable / mk_funs.
 
 
 _make_variable_cache: dict[tuple[str, int], Any] = {}


### PR DESCRIPTION
## Summary

Builds on #252. Ports the last two pure (z3-free) recursive walks from `aeon.verification.smt` to Rust (`aeon-rs/src/smt_helpers.rs`):

- `unrefine_type` (Type → Type) — strip refinements throughout a type
- `uncurry` (AbstractionType → ([TypeConstructor], TypeConstructor)) — flatten a function type into SMT input/output base types, collapsing higher-rank / parametric args to scalar tokens

Both feed `make_variable` / `mk_funs`, which stay in Python (they build z3 objects).

## SMT encoder status

With PR 7 (PLE unfolding), this completes the **z3-free** portion of the SMT encoder. The z3-touching remainder (`translate` / `translate_liq` / `make_variable` / `get_sort` / `mk_funs` / `smt_valid`) is a separate, larger initiative — needs the `z3` Rust crate (a context independent from Python's z3 is safe since `smt_valid` only returns a `bool`) plus a port of `aeon.verification.vcs`'s `Constraint` hierarchy. libz3 + headers are present on this machine, so it's feasible — just out of scope for one PR.

## Results

- All **415 tests pass** (9 skipped). Full suite ~101s.
- Pre-commit (mypy, ruff, pyroma) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)