### PR TITLE
Remove the last ANF vestiges; rely on Form B existentials

### DIFF
--- a/aeon/core/parser.py
+++ b/aeon/core/parser.py
@@ -37,15 +37,6 @@ from aeon.utils.name import Name
 
 
 class TreeToCore(Transformer):
-    counter: int
-
-    def __init__(self, start_counter=0):
-        self.counter = start_counter
-
-    def fresh(self) -> Name:
-        self.counter += 1
-        return Name("anf", self.counter)
-
     def same(self, args):
         return args[0]
 
@@ -79,7 +70,7 @@ class TreeToCore(Transformer):
     def minus(self, args):
         if isinstance(args[0], Literal) and args[0].type == t_int:
             return Literal(-args[0].value, args[0].type)
-        return mk_binop(lambda: self.fresh(), "-", i0, args[0])
+        return mk_binop("-", i0, args[0])
 
     def let_e(self, args):
         return Let(Name(args[0]), args[1], args[2])
@@ -136,7 +127,7 @@ class TreeToCore(Transformer):
         return self.binop(args, "%")
 
     def binop(self, args, op):
-        return mk_binop(lambda: self.fresh(), op, args[0], args[1])
+        return mk_binop(op, args[0], args[1])
 
     def application_e(self, args):
         return Application(args[0], args[1])
@@ -194,9 +185,9 @@ def _get_cached_parser(rule: str) -> Lark:
     return _parser_cache[rule]
 
 
-def mk_parser(rule="start", start_counter=0):
+def mk_parser(rule="start"):
     parser = _get_cached_parser(rule)
-    transf = TreeToCore(start_counter)
+    transf = TreeToCore()
 
     def parse(s: str):
         tree = parser.parse(s)

--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -4,7 +4,7 @@ There are two *registration* phases (usage syntax is always ``@name(...)``):
 
 - **Sugar** (default): runs on the surface ``Definition`` during desugaring,
   before elaboration and typechecking.
-- **Core**: runs after lowering to core, ANF conversion, and typechecking; see
+- **Core**: runs after lowering to core and typechecking; see
   ``aeon.synthesis.core_decorators`` (registry ``core_decorators_environment``) and
   ``apply_core_decorators_phase``.
 """

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -332,15 +332,11 @@ def elaborate_synth(ctx: ElaborationTypingContext, t: STerm) -> tuple[STerm, STy
             match nfun_type:
                 case SAbstractionType(_, arg_type, return_type, loc):
                     narg = elaborate_check(ctx, arg, arg_type)
-                    match narg:
-                        case SLiteral(_) | SVar(_) | SAbstraction(_, _):
-                            return SApplication(nfun, narg), return_type
-                        case _:
-                            nname = Name("_anf", fresh_counter.fresh())
-                            return (
-                                SRec(nname, arg_type, narg, SApplication(nfun, SVar(nname)), decreasing_by=(), loc=loc),
-                                return_type,
-                            )
+                    # No ANF lift: non-trivial arguments are left in place.
+                    # The core typechecker's `synth(Application)` introduces a
+                    # Form B existential binder for them (see typeinfer.py),
+                    # so there is no need to name the argument here.
+                    return SApplication(nfun, narg), return_type
                 case _:
                     assert False, f"Expected an abstraction type, but got {nfun_type} for {nfun}."
         case _:

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -135,16 +135,16 @@ class AeonDriver:
                 self.cfg.synthesis_ui,
             )
 
-            core_ast_anf: Term = self.core
+            synthesized_core: Term = self.core
             for k, v in mapping.items():
                 if v is not None:
-                    core_ast_anf = substitution(core_ast_anf, v, k)
+                    synthesized_core = substitution(synthesized_core, v, k)
 
             sterm_mapping: dict[Name, STerm] = {k: lift(v) for k, v in mapping.items() if v is not None}
 
-            self.cfg.synthesis_ui.display_results(core_ast_anf, sterm_mapping, self.cfg.synthesis_format)
+            self.cfg.synthesis_ui.display_results(synthesized_core, sterm_mapping, self.cfg.synthesis_format)
 
-            return lift(core_ast_anf)
+            return lift(synthesized_core)
 
     def pretty_print(self, filename: str = None, should_be_fixed: bool = False) -> None:
         aeon_code = read_file(filename)

--- a/aeon/llvm/cpu/lowerer.py
+++ b/aeon/llvm/cpu/lowerer.py
@@ -167,7 +167,7 @@ class CPUFunctionCallValidationStep(ValidationStep):
     def validate(self, t: Term, ctx: ValidationContext) -> None:
         assert isinstance(ctx, CPUValidationContext)
         match t:
-            case Var(name) if not name.name.startswith("anf"):
+            case Var(name):
                 self._validate_var_call(name, ctx)
             case Application(fun, arg):
                 self.validate(fun, ctx)
@@ -325,29 +325,6 @@ class CPULLVMLowerer(LLVMLowerer):
         if isinstance(target, LLVMCall):
             return self._get_target_name(target.target)
         return ""
-
-    def _is_inlinable_anf(self, name: Name, val: LLVMTerm) -> bool:
-        if not name.name.startswith("anf"):
-            return False
-        is_partial = isinstance(val, LLVMCall) and isinstance(val.type, LLVMFunctionType)
-        target = self._get_target_name(val) if isinstance(val, LLVMVar) else ""
-        if isinstance(val, LLVMCall):
-            target = self._get_target_name(val.target)
-        # Strip module prefix for builtin lookup
-        bare_target = target.split("_", 1)[1] if "_" in target else target
-        is_op = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and (
-            target in BINARY_OPS or target in UNARY_OPS or bare_target in BINARY_OPS or bare_target in UNARY_OPS
-        )
-        is_vec = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and (
-            target in (VECTOR_OPERATIONS | {"set", "get"}) or bare_target in (VECTOR_OPERATIONS | {"set", "get"})
-        )
-        _MATH_BUILTINS = {"pow", "powf", "sqrt", "sqrtf", "sin", "cos", "exp", "log"}
-        is_math = (isinstance(val, LLVMVar) or (isinstance(val, LLVMCall) and is_partial)) and (
-            target in _MATH_BUILTINS or bare_target in _MATH_BUILTINS
-        )
-        if is_math and is_partial:
-            return False
-        return is_partial or is_op or is_vec or is_math
 
     def _lower_as_standalone(
         self,
@@ -704,16 +681,9 @@ class CPULLVMLowerer(LLVMLowerer):
             lowered_val.name = name
         new_ty_env = {**type_env, name: lowered_val.type if lowered_val else LLVMInt}
         new_env = env.copy()
-        if lowered_val and self._is_inlinable_anf(name, lowered_val):
-            new_env[name] = lowered_val
-        else:
-            new_env[name] = LLVMVar(new_ty_env[name], name)
+        new_env[name] = LLVMVar(new_ty_env[name], name)
         lowered_body = self._lower_term(body, expected, new_ty_env, new_env, allowed, in_vector_op=in_vec)
-        return (
-            lowered_body
-            if self._is_inlinable_anf(name, lowered_val)
-            else LLVMLet(lowered_body.type, name, lowered_val, lowered_body)
-        )
+        return LLVMLet(lowered_body.type, name, lowered_val, lowered_body)
 
     def _lower_rec(
         self,

--- a/aeon/llvm/utils.py
+++ b/aeon/llvm/utils.py
@@ -23,7 +23,7 @@ UNARY_OPS = {"!", "-"}
 
 
 def validate_ops(op: str):
-    if not op.startswith("anf") and op not in BINARY_OPS and op not in UNARY_OPS:
+    if op not in BINARY_OPS and op not in UNARY_OPS:
         raise LLVMValidationError(f"LLVM Backend does not support operation {op}")
 
 

--- a/aeon/sugar/ast_helpers.py
+++ b/aeon/sugar/ast_helpers.py
@@ -1,11 +1,9 @@
-from typing import Callable
-
 from aeon.sugar.program import SApplication, SLiteral, STerm, SVar
 from aeon.sugar.stypes import STypeConstructor
 from aeon.utils.name import Name
 
 
-def mk_binop(fresh: Callable[[], str], op: Name, a1: STerm, a2: STerm) -> STerm:
+def mk_binop(op: Name, a1: STerm, a2: STerm) -> STerm:
     return SApplication(SApplication(SVar(op), a1), a2)
 
 

--- a/aeon/synthesis/core_decorators.py
+++ b/aeon/synthesis/core_decorators.py
@@ -1,8 +1,7 @@
 """Decorators registered with ``DecoratorPhase.CORE`` (see ``aeon.decorators``).
 
-These run after elaboration, lowering, ANF conversion, and typechecking. The
-surface syntax is unchanged: ``@name(...)`` — only the Python registration picks
-the phase.
+These run after elaboration, lowering, and typechecking. The surface syntax is
+unchanged: ``@name(...)`` — only the Python registration picks the phase.
 """
 
 from __future__ import annotations

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -85,9 +85,7 @@ classType = TypingType[HasGetCore]
 
 
 def is_valid_class_name(class_name: str) -> bool:
-    return class_name not in prelude_ops and not class_name.startswith(
-        ("_anf_", "target"),
-    )
+    return class_name not in prelude_ops and not class_name.startswith("target")
 
 
 ae_top = type("ae_top", (ABC,), {})

--- a/aeon/typechecking/termination.py
+++ b/aeon/typechecking/termination.py
@@ -314,8 +314,9 @@ def termination_metric_constraints(rec: Rec, typing_ctx: TypingContext | None = 
     if len(type_formals) != len(formals):
         return LiquidConstraint(LiquidLiteralBool(False))
     entry_refs = entry_refinement_liquids(rec.var_type, formals, type_formals)
-    # ANF introduces `let anf = …` around sub-expressions; inlining exposes call
-    # arguments in terms of parameters so liquefy does not mention ANF temps.
+    # Inline let-bindings so call arguments are expressed in terms of the
+    # function's parameters; otherwise liquefy would mention intermediate
+    # let-bound temporaries instead.
     inner = inline_lets(inner)
     arity = len(formals)
     inner_ctx: TypingContext | None = None

--- a/aeon/utils/ast_helpers.py
+++ b/aeon/utils/ast_helpers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Callable
-
 from aeon.core.terms import Application
 from aeon.core.terms import Literal
 from aeon.core.terms import Term
@@ -11,7 +9,7 @@ from aeon.core.types import t_int
 from aeon.utils.name import Name
 
 
-def mk_binop(fresh: Callable[[], str], op: str, a1: Term, a2: Term) -> Term:
+def mk_binop(op: str, a1: Term, a2: Term) -> Term:
     return Application(Application(Var(Name(op, 0)), a1), a2)
 
 

--- a/aeon/utils/pprint.py
+++ b/aeon/utils/pprint.py
@@ -653,11 +653,6 @@ def normalize_term(term: STerm, context: dict[Name, STerm] = None, seen: set[Nam
             simplified_body = normalize_term(body, context, seen)
             return SAbstraction(var_name=var_name, body=simplified_body)
         case SLet(var_name=var_name, var_value=var_value, body=body):
-            if var_name.pretty() == "anf":
-                context_copy = context.copy()
-                context_copy[var_name] = normalize_term(var_value, context, seen)
-                simplified_body = normalize_term(body, context_copy, seen)
-                return simplified_body
             match body:
                 case SHole(name=name):
                     return SLet(var_name=name, var_value=normalize_term(var_value, context, seen), body=SVar(name=name))
@@ -668,11 +663,6 @@ def normalize_term(term: STerm, context: dict[Name, STerm] = None, seen: set[Nam
                         body=normalize_term(body, context, seen),
                     )
         case SRec(var_name=var_name, var_type=var_type, var_value=var_value, body=body, decreasing_by=db):
-            if var_name.pretty() == "anf":
-                context_copy = context.copy()
-                context_copy[var_name] = normalize_term(var_value, context, seen)
-                simplified_body = normalize_term(body, context_copy, seen)
-                return simplified_body
             match body:
                 case SHole(name=name):
                     return SRec(

--- a/aeon/verification/helpers.py
+++ b/aeon/verification/helpers.py
@@ -223,8 +223,14 @@ def used_variables(c: LiquidTerm) -> set[Name]:
 
 
 def is_synthesized_name(name: Name) -> bool:
-    """Returns True if the variable is ANF/synthesized (anf, _anf)."""
-    return name.name in ("anf", "_anf")
+    """Returns True if the variable is a synthesized Form B existential binder.
+
+    `synth(Application)` introduces `_y` binders for non-trivial arguments
+    (replacing the old ANF `_anf` let-bindings). When such a binder only
+    carries an equality refinement, `simplify_constraint` can substitute it
+    away to keep the SMT query small.
+    """
+    return name.name == "_y"
 
 
 def simplify_constraint(c: Constraint) -> Constraint:
@@ -251,7 +257,7 @@ def simplify_constraint(c: Constraint) -> Constraint:
             if pred == LiquidLiteralBool(True) and seq == LiquidConstraint(LiquidLiteralBool(True)):
                 return seq
 
-            # Remove synthesized (ANF) variables that only have equality: forall v: v == expr => seq
+            # Remove synthesized existential binders that only have equality: forall v: v == expr => seq
             if is_synthesized_name(iname) and isinstance(pred, LiquidApp) and pred.fun == Name("==", 0):
                 if pred.args[0] == LiquidVar(iname):
                     rep = pred.args[1]

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -668,9 +668,7 @@ def translate_liq(t: LiquidTerm, variables: dict[str, Any]):
         case LiquidLiteralString(s):
             # Z3 auto-casts Python int/bool/float into its sorts when a literal
             # appears as an argument, but Python `str` does not auto-cast to
-            # Z3's String sort. Convert explicitly. (Previously hidden because
-            # ANF hoisted every literal into a let-bound name, so the literal
-            # only ever reached SMT through the typed `variables` dict.)
+            # Z3's String sort, so convert explicitly.
             return StringVal(s)
         case LiquidVar(name):
             sname = str(name)

--- a/tests/frontend_test.py
+++ b/tests/frontend_test.py
@@ -83,27 +83,27 @@ def test_literals():
 
 
 def test_operators():
-    assert parse_term("-a") == mk_binop(lambda: "t", "-", i0, Var(Name("a")))
+    assert parse_term("-a") == mk_binop("-", i0, Var(Name("a")))
 
     assert parse_term("!true") == Application(Var(Name("!", 0)), true)
 
-    assert parse_term("1 == 1") == mk_binop(lambda: "t", "==", i1, i1)
-    assert parse_term("1 != 1") == mk_binop(lambda: "t", "!=", i1, i1)
-    assert parse_term("true && true") == mk_binop(lambda: "t", "&&", true, true)
-    assert parse_term("true || true") == mk_binop(lambda: "t", "||", true, true)
+    assert parse_term("1 == 1") == mk_binop("==", i1, i1)
+    assert parse_term("1 != 1") == mk_binop("!=", i1, i1)
+    assert parse_term("true && true") == mk_binop("&&", true, true)
+    assert parse_term("true || true") == mk_binop("||", true, true)
 
-    assert parse_term("0 < 1") == mk_binop(lambda: "t", "<", i0, i1)
-    assert parse_term("0 > 1") == mk_binop(lambda: "t", ">", i0, i1)
-    assert parse_term("0 <= 1") == mk_binop(lambda: "t", "<=", i0, i1)
-    assert parse_term("0 >= 1") == mk_binop(lambda: "t", ">=", i0, i1)
+    assert parse_term("0 < 1") == mk_binop("<", i0, i1)
+    assert parse_term("0 > 1") == mk_binop(">", i0, i1)
+    assert parse_term("0 <= 1") == mk_binop("<=", i0, i1)
+    assert parse_term("0 >= 1") == mk_binop(">=", i0, i1)
 
-    assert parse_term("true --> false") == mk_binop(lambda: "t", "-->", true, false)
+    assert parse_term("true --> false") == mk_binop("-->", true, false)
 
-    assert parse_term("1 + 1") == mk_binop(lambda: "t", "+", i1, i1)
-    assert parse_term("1 - 1") == mk_binop(lambda: "t", "-", i1, i1)
-    assert parse_term("1 * 1") == mk_binop(lambda: "t", "*", i1, i1)
-    assert parse_term("1 / 1") == mk_binop(lambda: "t", "/", i1, i1)
-    assert parse_term("1 % 1") == mk_binop(lambda: "t", "%", i1, i1)
+    assert parse_term("1 + 1") == mk_binop("+", i1, i1)
+    assert parse_term("1 - 1") == mk_binop("-", i1, i1)
+    assert parse_term("1 * 1") == mk_binop("*", i1, i1)
+    assert parse_term("1 / 1") == mk_binop("/", i1, i1)
+    assert parse_term("1 % 1") == mk_binop("%", i1, i1)
 
 
 def test_let():

--- a/tests/simplification_constraints_test.py
+++ b/tests/simplification_constraints_test.py
@@ -60,22 +60,27 @@ def test_simplify_constraint_implication2():
 
 
 def test_simplify_constraint_synthesized_var():
-    """Synthesized (ANF) variables with only equality are substituted away."""
-    anf_name = Name("anf", 1)
+    """Synthesized existential binders (`_y`) with only equality are substituted away.
+
+    `synth(Application)` introduces `_y` binders for non-trivial arguments
+    (the Form B replacement for ANF's `_anf` let-bindings); when such a binder
+    carries only an equality, `simplify_constraint` substitutes it away.
+    """
+    y_name = Name("_y", 1)
     x_name = Name("x", 0)
     z_name = Name("z", 1)
 
-    # forall anf: anf == x, forall z: z == anf + 1, x > 0
-    pred_anf = bind_lq(parse_liquid("anf == x"), [("anf", anf_name), ("x", x_name)])
-    pred_z = bind_lq(parse_liquid("z == anf + 1"), [("z", z_name), ("anf", anf_name), ("x", x_name)])
+    # forall _y: _y == x, forall z: z == _y + 1, x > 0
+    pred_y = bind_lq(parse_liquid("_y == x"), [("_y", y_name), ("x", x_name)])
+    pred_z = bind_lq(parse_liquid("z == _y + 1"), [("z", z_name), ("_y", y_name), ("x", x_name)])
     concl = bind_lq(parse_liquid("x > 0"), [("x", x_name)])
 
     inner = Implication(z_name, t_int, pred_z, LiquidConstraint(concl))
-    c = Implication(anf_name, t_int, pred_anf, inner)
+    c = Implication(y_name, t_int, pred_y, inner)
 
     r = simplify_constraint(c)
 
-    # Should become: forall z: z == x + 1, x > 0 (anf substituted by x)
+    # Should become: forall z: z == x + 1, x > 0 (_y substituted by x)
     expected_pred_z = bind_lq(parse_liquid("z == x + 1"), [("z", z_name), ("x", x_name)])
     expected = Implication(z_name, t_int, expected_pred_z, LiquidConstraint(concl))
     assert r == expected, f"Got {r}, expected {expected}"


### PR DESCRIPTION
## Summary

Follow-up to #226. That PR deleted the ANF conversion *pass* (`anf_converter.py` / `ensure_anf`) and made the core typechecker's `synth(Application)` introduce Form B existential binders for non-trivial arguments. But several ANF vestiges survived in elaboration, the core parser, the LLVM backend, the pretty-printer, and the SMT constraint simplifier. This PR removes them so existentials are the only mechanism.

## What changed

- **`elaboration/__init__.py`** — `elaborate_synth` still rewrote `f arg` → `let _anf = arg in f _anf` for non-trivial args. That's redundant now: `synth(Application)` introduces the binder itself via an `ExistentialType`. The application is now left in place. *(This is the only change with any semantic reach — see "Why it's safe" below.)*
- **`core/parser.py`** — removed the dead `fresh()` / `counter` / `start_counter` that minted `Name("anf", …)` values. `mk_binop` never used its `fresh` callback, so those names were created and immediately discarded.
- **`utils/ast_helpers.py` + `sugar/ast_helpers.py`** — dropped the unused `fresh` parameter from both `mk_binop` definitions.
- **`verification/helpers.py`** — `is_synthesized_name` keyed the equality-elimination simplification on `anf`/`_anf`. Re-keyed to `_y` — the name `synth(Application)` actually gives existential binders — so the simplification keeps shrinking SMT queries for the new binders.
- **`llvm/cpu/lowerer.py` + `llvm/utils.py`** — removed `_is_inlinable_anf` and the `startswith("anf")` guards. These matched only the discarded core-parser `anf` names (never the elaboration's `_anf`), so they were already inert.
- **`utils/pprint.py`** — removed the `var_name.pretty() == "anf"` let-inlining branches (same: matched only discarded names).
- **`synthesis/grammar/grammar_generation.py`** — dropped the dead `_anf_` class-name exclusion.
- Stale comments and the `core_ast_anf` local variable name updated.

## Why it's safe

- `_is_inlinable_anf` only ever matched names starting with `anf` — never the elaboration's `_anf` — so it was already inert; removing it is a no-op.
- The elaboration lift was purely structural: it returned the same `return_type` whether or not it wrapped the argument in a `let`. The dependent-substitution work happens in the core typechecker, which #226 already taught to handle non-Var arguments (`tests/existentials_replace_anf_test.py` proves `id (id 0)` typechecks with ANF deliberately skipped).
- One test — `tests/simplification_constraints_test.py::test_simplify_constraint_synthesized_var` — was asserting the *old* `anf`-keyed behavior; updated to use the `_y` existential-binder name. Its logic is unchanged.

## Test plan

- [x] `uv run pytest` — 489 passed, 9 skipped, 0 failed
- [x] `bash run_examples.sh` — exit 0, every example green end-to-end
- [x] `uvx pre-commit run --files <changed>` — mypy, ruff, ruff-format, pyroma clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)