### PR TITLE
Close synth-mode gaps for If and refinement abstraction (#258, #259)

### DIFF
--- a/aeon/logger/logger.py
+++ b/aeon/logger/logger.py
@@ -13,22 +13,31 @@ def levels_filter(levels):
     return filter
 
 
-def setup_logger():
-    for name, kwargs in [
-        ("TYPECHECKER", {"no": 35, "color": "<magenta>", "icon": "🔍"}),
-        ("SYNTH_TYPE", {"no": 36, "color": "<magenta>"}),
-        ("CONSTRAINT", {"no": 37, "color": "<cyan>", "icon": "🔒"}),
-        ("SYNTHESIZER", {"no": 38, "color": "<red>"}),
-        ("TIME", {"no": 39, "color": "<green>"}),
-    ]:
+_CUSTOM_LEVELS = [
+    ("TYPECHECKER", {"no": 35, "color": "<magenta>", "icon": "🔍"}),
+    ("SYNTH_TYPE", {"no": 36, "color": "<magenta>"}),
+    ("CONSTRAINT", {"no": 37, "color": "<cyan>", "icon": "🔒"}),
+    ("SYNTHESIZER", {"no": 38, "color": "<red>"}),
+    ("TIME", {"no": 39, "color": "<green>"}),
+]
+
+
+def _register_levels():
+    for name, kwargs in _CUSTOM_LEVELS:
         try:
             logger.level(name, **kwargs)
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
-    # Setup the logger
+
+# Eagerly register at import so library consumers (tests, LSP, benchmarks)
+# can use these levels without first calling setup_logger().
+_register_levels()
+
+
+def setup_logger():
+    _register_levels()
     logger.remove()
-    # logger.add(sys.stderr, level="DEBUG")
     return logger
 
 

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -9,6 +9,8 @@ from typing import TypeAlias
 import multiprocess as mp
 from loguru import logger
 
+import aeon.logger.logger  # noqa: F401  — registers custom levels (SYNTHESIZER etc.) at import.
+
 from aeon.backend.evaluator import EvaluationContext
 from aeon.core.substitutions import substitution
 from aeon.core.terms import Term, Var

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -3,6 +3,8 @@ from typing import Iterable
 
 from loguru import logger
 
+import aeon.logger.logger  # noqa: F401  — registers custom levels (SYNTH_TYPE etc.) at import.
+
 from aeon.core.instantiation import type_substitution
 from aeon.core.liquid import LiquidApp, LiquidTerm, liquid_free_vars
 from aeon.core.types import LiquidHornApplication, RefinementPolymorphism, StarKind
@@ -425,6 +427,69 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             c_ref = check(ctx, refinement, pred_type)
             nty = instantiate_refinement_in_type(rp.body, rp.name, refinement)
             return (Conjunction(c, c_ref), nty)
+
+        case RefinementAbstraction(pname, psort, inner):
+            # Synth-mode Λρ: mirror Chk-RAbs (lines 505-512) but without an expected type.
+            # Introduce fκ : psort -> bool, synth the body, wrap the resulting type with
+            # RefinementPolymorphism and gate the constraint behind the UF declaration.
+            fk_type = AbstractionType(Name("_", fresh_counter.fresh()), psort, t_bool)
+            ctx_ext = ctx.with_var(pname, fk_type)
+            (c_body, body_ty) = synth(ctx_ext, inner)
+            return (
+                UninterpretedFunctionDeclaration(pname, fk_type, c_body),
+                RefinementPolymorphism(pname, psort, body_ty),
+            )
+
+        case If(cond, then, otherwise):
+            # Synth-mode If: mirror check-mode (lines 472-493), but the branches don't
+            # share an expected type — synth each under its guard and join refinements.
+            liq_cond = liquefy(cond)
+            assert liq_cond is not None, f"Could not liquefy if-condition {cond}"
+            c_cond = check(ctx, cond, t_bool)
+
+            y = Name("_cond", fresh_counter.fresh())
+            (c1_inner, t1) = synth(ctx, then)
+            c1 = implication_constraint(
+                y,
+                RefinedType(Name("branch_pos", fresh_counter.fresh()), t_int, liq_cond),
+                c1_inner,
+                then.loc,
+            )
+            (c2_inner, t2) = synth(ctx, otherwise)
+            c2 = implication_constraint(
+                y,
+                RefinedType(
+                    Name("branch_neg", fresh_counter.fresh()),
+                    t_int,
+                    LiquidApp(Name("!", 0), [liq_cond]),
+                ),
+                c2_inner,
+                otherwise.loc,
+            )
+
+            t1_r = ensure_refined(t1)
+            t2_r = ensure_refined(t2)
+            if isinstance(t1_r, RefinedType) and isinstance(t2_r, RefinedType) and t1_r.type == t2_r.type:
+                v = Name("v_if", fresh_counter.fresh())
+                r1 = substitution_in_liquid(t1_r.refinement, LiquidVar(v), t1_r.name)
+                r2 = substitution_in_liquid(t2_r.refinement, LiquidVar(v), t2_r.name)
+                joined: Type = RefinedType(
+                    v,
+                    t1_r.type,
+                    LiquidApp(
+                        Name("&&", 0),
+                        [
+                            LiquidApp(Name("-->", 0), [liq_cond, r1]),
+                            LiquidApp(Name("-->", 0), [LiquidApp(Name("!", 0), [liq_cond]), r2]),
+                        ],
+                    ),
+                )
+            elif t1 == t2:
+                # Same non-refinable type (e.g., function type) on both branches.
+                joined = t1
+            else:
+                raise CoreSubtypingError(ctx, t, t1, t2)
+            return (Conjunction(c_cond, Conjunction(c1, c2)), joined)
 
         case Hole(hole_name):
             name_a = Name(hole_name.name, fresh_counter.fresh())

--- a/aeon/utils/time_utils.py
+++ b/aeon/utils/time_utils.py
@@ -6,6 +6,8 @@ from time import perf_counter
 
 from loguru import logger
 
+import aeon.logger.logger  # noqa: F401  — registers custom levels (TIME etc.) at import.
+
 
 def measure(func):
     @wraps(func)

--- a/tests/synth_gaps_test.py
+++ b/tests/synth_gaps_test.py
@@ -1,0 +1,119 @@
+"""Regression tests for synth-mode gaps in aeon.typechecking.typeinfer.
+
+Covers:
+- #258 — `synth(If)` (path-sensitive refinement join).
+- #259 — `synth(RefinementAbstraction)` (Λρ introduction in synth mode).
+"""
+
+from __future__ import annotations
+
+from aeon.core.terms import (
+    If,
+    Literal,
+    RefinementAbstraction,
+    Var,
+)
+from aeon.core.types import (
+    AbstractionType,
+    RefinedType,
+    RefinementPolymorphism,
+    t_bool,
+    t_int,
+)
+from aeon.sugar.parser import parse_type
+from aeon.typechecking.context import TypingContext
+from aeon.typechecking.typeinfer import synth
+from aeon.utils.name import Name
+from aeon.verification.smt import smt_valid
+from tests.driver import check_compile_expr
+
+
+# ---------------------------------------------------------------------------
+# #258 — synth(If)
+# ---------------------------------------------------------------------------
+
+
+def test_synth_if_in_application_arg_typechecks():
+    """An if-expression used as an Application argument is ANF-lifted onto a let-RHS,
+    which forces synth-mode on the If."""
+    source = r"""let f : (x:Int) -> Int = \x -> x in f (if 0 < 1 then 1 else 2)"""
+    assert check_compile_expr(source, parse_type("Int"))
+
+
+def test_synth_if_directly_returns_joined_refinement():
+    """`synth` on `if true then 1 else 10` returns an Int refined by the path-sensitive join."""
+    ctx = TypingContext()
+    term = If(
+        Literal(True, t_bool),
+        Literal(1, t_int),
+        Literal(10, t_int),
+    )
+    (constraint, ty) = synth(ctx, term)
+    # Base type is preserved.
+    assert isinstance(ty, RefinedType)
+    assert ty.type == t_int
+    # The generated VC must be valid (the join is consistent).
+    assert smt_valid(constraint)
+
+
+def test_synth_if_preserves_branch_information_in_join():
+    """After synth(If), the result type must imply the disjunction of branch values."""
+    # `let r = if (0 < 1) then 1 else 2 in r` should check against `{v:Int | (v == 1) || (v == 2)}`.
+    source = r"""let r = (if 0 < 1 then 1 else 2) in r"""
+    assert check_compile_expr(source, parse_type("{v:Int | (v == 1) || (v == 2)}"))
+
+
+def test_synth_if_rejects_unrelated_postcondition():
+    """The join doesn't manufacture facts: `{v:Int | v > 100}` is not derivable from
+    branches that return 1 or 2."""
+    source = r"""let r = (if 0 < 1 then 1 else 2) in r"""
+    assert not check_compile_expr(source, parse_type("{v:Int | v > 100}"))
+
+
+# ---------------------------------------------------------------------------
+# #259 — synth(RefinementAbstraction)
+# ---------------------------------------------------------------------------
+
+
+def test_synth_refinement_abstraction_wraps_with_polymorphism():
+    """`synth(Λρ:S. e)` returns `forall <ρ:S->Bool>, synth(e)`. We use a literal body so
+    we don't depend on the still-open `synth(Abstraction)` gap (#207)."""
+    ctx = TypingContext()
+    p = Name("p")
+    term = RefinementAbstraction(p, t_int, Literal(0, t_int))
+    (_, ty) = synth(ctx, term)
+    assert isinstance(ty, RefinementPolymorphism)
+    assert ty.name == p
+    assert ty.sort == t_int
+    assert isinstance(ty.body, RefinedType)
+    assert ty.body.type == t_int
+
+
+def test_synth_refinement_abstraction_introduces_fresh_uf_in_context():
+    """The bound predicate name becomes an uninterpreted function (sort → Bool) inside
+    the body. Synth-ing a body that references `p` must succeed."""
+    ctx = TypingContext()
+    p = Name("p")
+    # Λρ:Int. p   — Var(p) reads the UF symbol.
+    body = Var(p)
+    term = RefinementAbstraction(p, t_int, body)
+    (constraint, ty) = synth(ctx, term)
+    assert isinstance(ty, RefinementPolymorphism)
+    # Body type is the UF type `(_:Int) -> Bool`, lifted through Var-selfification.
+    body_ty = ty.body
+    # Var-synth wraps with selfification if the type is base/refined; here it's
+    # AbstractionType, which is returned as-is.
+    assert isinstance(body_ty, AbstractionType)
+    assert body_ty.var_type == t_int
+    assert body_ty.type == t_bool
+
+
+def test_synth_refinement_abstraction_constraint_is_valid():
+    """The constraint produced by synth(Λρ) must remain SMT-valid (no spurious obligations
+    introduced by the new arm)."""
+    ctx = TypingContext()
+    p = Name("p")
+    # Λρ:Int. 0  — body is a trivially well-typed literal.
+    term = RefinementAbstraction(p, t_int, Literal(0, t_int))
+    (constraint, _) = synth(ctx, term)
+    assert smt_valid(constraint)


### PR DESCRIPTION
## Summary

`synth()` in [aeon/typechecking/typeinfer.py](aeon/typechecking/typeinfer.py) was missing introduction-form arms that `check()` already handled, so any path that fed an `If` or `Λρ` term to `synth` hit the wildcard assertion. This PR adds the two missing arms and fixes a related diagnostic bug.

- **#258** — `synth(If)`: liquefies the condition, synths each branch under its guard hypothesis, and forms the path-sensitive refinement join `{v:τ | (cond ⇒ r₁[v]) ∧ (¬cond ⇒ r₂[v])}` when both branches share a base type. Mirrors the symmetric `check(If)` arm.
- **#259** — `synth(RefinementAbstraction)`: binds the predicate name to a fresh uninterpreted function type `(_:S) → Bool`, synths the body, and wraps the result with `RefinementPolymorphism`. The body constraint is gated behind `UninterpretedFunctionDeclaration`. Mirrors the symmetric `check(_, RefinementPolymorphism)` arm.

### Related diagnostic fix

The wildcard arm of `synth()` calls `logger.log("SYNTH_TYPE", ...)` before its assertion, but loguru custom levels (`SYNTH_TYPE`, `TYPECHECKER`, `CONSTRAINT`, `SYNTHESIZER`, `TIME`) were only registered inside `setup_logger()` — which is only called from the CLI entry point. Library consumers (tests, LSP, benchmarks) hit `ValueError: Level 'SYNTH_TYPE' does not exist`, masking the underlying assertion. Levels are now registered eagerly at module import.

This unmasks the still-open #207 (`synth(Abstraction)` gap): triggers like `let f = (\x -> x) in 0` now produce `AssertionError: Unhandled term (\x -> x) in synth.` instead of the opaque loguru error.

## Test plan

- [x] 7 new tests in [tests/synth_gaps_test.py](tests/synth_gaps_test.py) covering both unit-level synth behaviour (direct construction, refinement join structure, UF context introduction) and end-to-end typechecking through let-RHS synth mode.
- [x] Full suite passes: **415 passed, 4 skipped** (no regressions).
- [x] mypy + ruff via pre-commit.

Closes #258
Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)