### PR TITLE
PSB2 stubs (gcd, snow_day, fuel_cost) + parametric multi_minimize decorators

### DIFF
--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -32,6 +32,7 @@ from aeon.synthesis.decorators import (
     minimize_float,
     minimize_int,
     multi_minimize_float,
+    multi_minimize_int,
     prompt,
 )
 from aeon.typechecking.context import TypingContext
@@ -43,6 +44,7 @@ sugar_decorators_environment: dict[str, DecoratorType] = {
     "minimize_float": minimize_float,
     "maximize_float": maximize_float,
     "multi_minimize_float": multi_minimize_float,
+    "multi_minimize_int": multi_minimize_int,
     "hide": hide,
     "hide_types": hide_types,
     "allow_recursion": allow_recursion,

--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -94,7 +94,7 @@ def multi_minimize_float(
     fun: Definition,
     metadata: Metadata,
 ) -> tuple[Definition, list[Definition], Metadata]:
-    """This decorator expects a single argument (the body of the definition)."""
+    """Minimize a fitness function that returns ``(List Float)`` of per-objective errors."""
     assert len(decorator.macro_args) == 2, "multi_minimize_float decorator expects two arguments"
     assert isinstance(decorator.macro_args[1], SLiteral)
     assert isinstance(decorator.macro_args[1].value, int), "multi_minimize_float decorator expects an integer argument"
@@ -103,7 +103,27 @@ def multi_minimize_float(
         [decorator.macro_args[0]],
         fun,
         metadata,
-        STypeConstructor(Name("List", 0)),
+        STypeConstructor(Name("List", 0), [st_float]),
+        minimize=True,
+        length=number_of_objectives,
+    )
+
+
+def multi_minimize_int(
+    decorator: Decorator,
+    fun: Definition,
+    metadata: Metadata,
+) -> tuple[Definition, list[Definition], Metadata]:
+    """Minimize a fitness function that returns ``(List Int)`` of per-objective errors."""
+    assert len(decorator.macro_args) == 2, "multi_minimize_int decorator expects two arguments"
+    assert isinstance(decorator.macro_args[1], SLiteral)
+    assert isinstance(decorator.macro_args[1].value, int), "multi_minimize_int decorator expects an integer argument"
+    number_of_objectives = decorator.macro_args[1].value
+    return make_optimizer(
+        [decorator.macro_args[0]],
+        fun,
+        metadata,
+        STypeConstructor(Name("List", 0), [st_int]),
         minimize=True,
         length=number_of_objectives,
     )

--- a/examples/PSB2/fuel_cost.ae
+++ b/examples/PSB2/fuel_cost.ae
@@ -1,0 +1,16 @@
+# Fuel Cost: Given a vector of positive integers, divide each by 3,
+# round down, and subtract 2. Return the sum of all values >= 0.
+# input  : vector of integers (length [1, 20]) in [6, 100000]
+# output : integer
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def train : TrainData = extract_train_data (load_dataset "fuel-cost" 200 200)
+
+def calculate_fuel_cost_errors : (train: TrainData) -> (f: (a: {l:(List Int) | 1 <= List.size l && List.size l <= 20}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_fuel_cost_errors)
+@multi_minimize_int(calculate_fuel_cost_errors train synth, 1)
+def synth (xs : {l:(List Int) | 1 <= List.size l && List.size l <= 20}) : {r:Int | 0 <= r} = (?hole: {r:Int | 0 <= r});

--- a/examples/PSB2/gcd.ae
+++ b/examples/PSB2/gcd.ae
@@ -1,0 +1,16 @@
+# Given two positive integers, return their greatest common divisor.
+# input  : 2 integers in [1, 1000000]
+# output : integer in [1, 1000000]
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def train : TrainData = extract_train_data (load_dataset "gcd" 200 200)
+
+def calculate_gcd_errors : (train: TrainData) -> (f: (a: {x:Int | 1 <= x && x <= 1000000}) -> (b: {y:Int | 1 <= y && y <= 1000000}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1]) - x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_gcd_errors)
+@multi_minimize_int(calculate_gcd_errors train synth, 1)
+def synth (n : {x:Int | 1 <= x && x <= 1000000})
+          (z : {y:Int | 1 <= y && y <= 1000000}) : {r:Int | 1 <= r} = (?hole: {r:Int | 1 <= r});

--- a/examples/PSB2/snow_day.ae
+++ b/examples/PSB2/snow_day.ae
@@ -1,0 +1,29 @@
+# Snow Day (HW): Given an integer number of hours and 3 floats
+# representing the snow currently on the ground, the rate of
+# snowfall, and the proportion of snow melting per hour, return
+# the amount of snow on the ground after the given number of hours.
+# Each hour is a discrete add-then-melt event, not continuous.
+# input  : integer in [0, 20],
+#          float   in [0.0, 20.0],
+#          float   in [0.0, 10.0],
+#          float   in [0.0, 1.0]
+# output : float
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def train : TrainData = extract_train_data (load_dataset "snow-day" 200 200)
+
+def calculate_snow_day_errors : (train: TrainData) -> (f: (a: {x:Int   |  0   <= x && x <= 20})
+                                                       -> (b: {y:Float |  0.0 <= y && y <= 20.0})
+                                                       -> (c: {z:Float |  0.0 <= z && z <= 10.0})
+                                                       -> (d: {w:Float |  0.0 <= w && w <= 1.0})
+                                                       -> Float) -> (List Float) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1])(x[0][2])(x[0][3]) - x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_snow_day_errors)
+@multi_minimize_float(calculate_snow_day_errors train synth, 1)
+def synth (n : {x:Int   |  0   <= x && x <= 20})
+          (m : {a:Float |  0.0 <= a && a <= 20.0})
+          (t : {b:Float |  0.0 <= b && b <= 10.0})
+          (p : {c:Float |  0.0 <= c && c <= 1.0}) : {r:Float | 0.0 <= r} = (?hole: {r:Float | 0.0 <= r});


### PR DESCRIPTION
## Summary
- Adds three new top-level PSB2 synthesis stubs (`gcd`, `snow_day`, `fuel_cost`) with refinement-biased holes and PSB2-spec input ranges.
- Changes `@multi_minimize_float` to expect `(List Float)` instead of the bare unparametrized `List`, so it unifies with stdlib's parametric `List a`.
- Adds `@multi_minimize_int` for fitness functions returning `(List Int)`.

## Why
The previous `@multi_minimize_float` hard-coded its expected return as `STypeConstructor(Name("List", 0))`, which forced examples to declare a local monomorphic `type List` and prevented them from using the stdlib parametric `List`. With this change, stubs can `open List` and refine inputs as `(List Int)` or `(List Float)` directly.

The hole annotation `(?hole: {r:T | P})` carries the output refinement — that's the point at which the synthesizer's grammar reads it and biases candidate generation. Refining only the function's return type isn't enough; verification needs the refinement on the hole itself.

## Refinement strategy in the new stubs
| Stub | Input refinements | Output refinement | Decorator |
|---|---|---|---|
| `gcd.ae` | `n, z : {Int \| 1 <= · <= 1_000_000}` | `{r:Int \| 1 <= r}` | `@multi_minimize_int` |
| `snow_day.ae` | `n: [0,20]`, `m: [0.0,20.0]`, `t: [0.0,10.0]`, `p: [0.0,1.0]` | `{r:Float \| 0.0 <= r}` | `@multi_minimize_float` |
| `fuel_cost.ae` | `xs: {(List Int) \| 1 <= size xs <= 20}` | `{r:Int \| 0 <= r}` | `@multi_minimize_int` |

## Known follow-up
The 24 files under `examples/PSB2/annotations/multi_objective/*.ae` declare a local monomorphic `type List` and still use the old bare-`List` shape for `@multi_minimize_float`. They no longer elaborate after this change. They are **not** run by `run_examples.sh` (only `PSB2/solved` is), so this is not a CI regression, but they should be migrated to stdlib `(List Float)` / `(List Int)` in a follow-up pass.

## Test plan
- [x] `uv run pytest tests/` — 415 passed, 9 skipped
- [x] `uv run python -m aeon --no-main --budget 2 examples/PSB2/gcd.ae` — runs synthesis, generates refinement-respecting candidates
- [x] `uv run python -m aeon --no-main --budget 2 examples/PSB2/snow_day.ae` — same
- [x] `uv run python -m aeon --no-main --budget 2 examples/PSB2/fuel_cost.ae` — same
- [ ] Migrate `examples/PSB2/annotations/multi_objective/*.ae` to the new convention (separate PR)
- [ ] Port next-tier PSB2 stubs: `basement`, `vector_distance`, `spin_words` (separate PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)