### PR TITLE
PSB2 String→String stubs with Levenshtein fitness (spin_words, camel_case, middle_char)

### DIFF
--- a/examples/PSB2/annotations/multi_objective/basement.ae
+++ b/examples/PSB2/annotations/multi_objective/basement.ae
@@ -1,21 +1,17 @@
-import PSB2 (extract_train_data, load_dataset, calculate_basement_errors)
+# Basement: Given a vector of integers (each -1 or 1), starting from 0,
+# return the first index where the running sum becomes negative.
+# If never negative, return -1.
+# input  : vector of integers (length [1, 20]) in {-1, 1}
+# output : integer
 
-type List
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def List_size: (l:List) -> Int = uninterpreted
-def List_len (l:List) : Int  = native "len(l)"
-def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
-def List_get (l:List) (i: Int) : Int = native "l[i]"
+def train : TrainData = extract_train_data (load_dataset "basement" 200 200)
 
-#PSB2 functions
+def calculate_basement_errors : (train: TrainData) -> (f: (a: {l:(List Int) | 1 <= List.size l && List.size l <= 20}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
 
-def train: TrainData = extract_train_data (load_dataset "basement" 200 200)
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_basement_errors)
-@allow_recursion
-@multi_minimize_float(calculate_basement_errors train synth, 1)
-def synth (nums: List) : Int = (?hole : Int)
+@hide(extract_train_data, load_dataset, train, calculate_basement_errors)
+@multi_minimize_int(calculate_basement_errors train synth, 1)
+def synth (nums : {l:(List Int) | 1 <= List.size l && List.size l <= 20}) : Int = (?hole: Int);

--- a/examples/PSB2/annotations/multi_objective/bouncing_balls.ae
+++ b/examples/PSB2/annotations/multi_objective/bouncing_balls.ae
@@ -1,19 +1,21 @@
-open Math
+# Bouncing Balls: Given a starting height, a height after the first bounce,
+# and a number of bounces, return the total distance the ball travels.
+# input  : float in [1.0, 100.0], float in [1.0, 100.0], int in [1, 20]
+# output : float
 
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-type List
+def train : TrainData = extract_train_data (load_dataset "bouncing-balls" 200 200)
 
-def calculate_bouncing_balls_errors : (train : TrainData) -> (f:(a: Float) ->( b:Float ) -> (c:Int) -> Float)  -> List  =  \data -> \func -> native "[abs(func(x[0][0])(x[0][1])(x[0][2]) - x[1][0]) for x in data]"
+def calculate_bouncing_balls_errors : (train: TrainData) -> (f: (a: {x:Float | 1.0 <= x && x <= 100.0})
+                                                              -> (b: {y:Float | 1.0 <= y && y <= 100.0})
+                                                              -> (c: {z:Int   | 1   <= z && z <= 20})
+                                                              -> Float) -> (List Float) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1])(x[0][2]) - x[1][0]) for x in data]"
 
-def isZero : (n: Int) -> Bool = \n -> n == 0;
-
-def train: TrainData = extract_train_data (load_dataset "bouncing-balls" 200 200)
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_bouncing_balls_errors)
+@hide(extract_train_data, load_dataset, train, calculate_bouncing_balls_errors)
 @multi_minimize_float(calculate_bouncing_balls_errors train synth, 1)
-def synth (a:Float) (b:Float) (c:Int) : Float
-    = (?hole: Float);
+def synth (a : {x:Float | 1.0 <= x && x <= 100.0})
+          (b : {y:Float | 1.0 <= y && y <= 100.0})
+          (c : {z:Int   | 1   <= z && z <= 20}) : {r:Float | 0.0 <= r} = (?hole: {r:Float | 0.0 <= r});

--- a/examples/PSB2/annotations/multi_objective/bowling.ae
+++ b/examples/PSB2/annotations/multi_objective/bowling.ae
@@ -1,37 +1,19 @@
-import PSB2 (extract_train_data, get_input_list, get_output_list, calculate_list_errors, get_bowling_synth_values, unpack_train_data, calculate_bowling_errors, load_dataset)
+# Bowling: Given a string representing a complete bowling game
+# (X = strike, / = spare, digits 0-9 = pins, -- between frames),
+# return the integer score.
+# input  : string of length [12, 20]
+# output : integer
 
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-type List
+def String_len (s: String) : Int = native "len(s)"
 
-#def calculate_bowling_errors : (train : TrainData) -> (f:(a: String) -> Int)  -> List  =  \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
+def train : TrainData = extract_train_data (load_dataset "bowling" 200 200)
 
-def List_sum : (l:List) -> Int = \x -> native "sum(x)"
+def calculate_bowling_errors : (train: TrainData) -> (f: (a: {x:String | 12 <= String_len x && String_len x <= 20}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
 
-def List_map: (function: (a: Int) -> Int) ->
-                               (l: List) ->
-                               List =
-    \f -> \xs -> native "list(map(f, xs))";
-
-
-def String_replace : (s:String) -> (t:String) -> (rep:String) -> String = \x -> \y -> \z -> native "x.replace(y, z)"
-def String_length: (l:String) -> Int = \list -> native "len(list)"
-def String_get : (l:String) -> (i:Int) -> String = \l -> \i -> native "l[i]"
-def String_to_int : (s:String) -> Int = \s -> native "int(s)"
-def String_eq : (s:String) -> (s2:String) -> Bool = \s -> \s2 -> native "s == s2";
-
-def List_range_step : (start:Int) -> (end:Int) -> (step:Int) -> List = \s -> \e -> \st -> native "list(range(s, e, st))"
-
-def const1 : String = "X"
-def const2 : String = "/"
-
-def train: TrainData = extract_train_data (load_dataset "bowling" 200 200)
-
-
-@hide(extract_train_data,
-            unpack_train_data,
-            load_dataset,
-            train,
-            calculate_bowling_errors)
-@hide_types(TrainData)
-@multi_minimize_float(calculate_bowling_errors train synth, 1)
-def synth (scores: String) : Int = (?hole: Int)
+@hide(extract_train_data, load_dataset, train, calculate_bowling_errors, String_len)
+@multi_minimize_int(calculate_bowling_errors train synth, 1)
+def synth (scores : {x:String | 12 <= String_len x && String_len x <= 20}) : {r:Int | 0 <= r} = (?hole: {r:Int | 0 <= r});

--- a/examples/PSB2/annotations/multi_objective/camel_case.ae
+++ b/examples/PSB2/annotations/multi_objective/camel_case.ae
@@ -1,29 +1,19 @@
-import PSB2 (psb2_aeon, extract_train_data, load_dataset)
-type List
+# Camel Case: Given a string of words delimited by spaces and hyphens,
+# convert it to a camelCase string (no delimiters, second-and-later words
+# capitalized).
+# input  : string of length [1, 50] in [A-Za-z\-\s]*
+# output : camelCase string
 
-def calculate_camel_case_errors : (train : TrainData) -> (f:(a: String) -> String)  -> List  =  \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def String_split : (s:String) -> (sep:String) -> List = \s -> \sep -> native "s.split(sep)"
-def String_concat : (i:String) -> (j:String) -> String = \i -> \j -> native "i + j"
+def String_len (s: String) : Int = native "len(s)"
 
-def Map_string_string : (f: (s:String) -> String) -> (l:String) -> List = \f -> \xs -> native "list(map(f, xs))"
-def Map_string_list : (f: (s:String) -> String) -> (l:List) -> List = \f -> \xs -> native "list(map(f, xs))"
-def Map_list_list : (f: (s:String) -> List) -> (l:List) -> List = \f -> \xs -> native "list(map(f, xs))"
+def train : TrainData = extract_train_data (load_dataset "camel-case" 200 200)
 
-def String_join : (l:List) -> (s:String) -> String = \l -> \s -> native "str(s.join(l))"
-def String_tail:(l:String) -> String = \xs -> native "xs[1:]"
-def String_capitalize : (s:String) -> String = \s -> native "s.capitalize()"
-def String_get : (s:String) -> (i:Int) -> String = \s -> \i -> native "s[i]"
-def String_tail:(l:String) -> String = \xs -> native "xs[1:]"
+def calculate_camel_case_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 50}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
 
-def const1 : String = "-"
-def const1 : String = " "
-
-def train: TrainData = extract_train_data (load_dataset "camel-case" 200 200)
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_camel_case_errors)
-@multi_minimize_float(calculate_camel_case_errors train synth, 1)
-def synth (s:String) : String = (?hole:String)
+@hide(extract_train_data, load_dataset, train, calculate_camel_case_errors, String_len)
+@multi_minimize_int(calculate_camel_case_errors train synth, 1)
+def synth (s : {x:String | 1 <= String_len x && String_len x <= 50}) : String = (?hole: String);

--- a/examples/PSB2/annotations/multi_objective/coin_sum.ae
+++ b/examples/PSB2/annotations/multi_objective/coin_sum.ae
@@ -1,21 +1,17 @@
-import PSB2 (extract_train_data, load_dataset, calculate_coin_sum_errors)
+# Coin Sums: Given an integer total cents, return four integers giving the
+# number of quarters, dimes, nickels, pennies (in order) that sum to that
+# many cents using the minimum number of coins.
+# input  : integer in [1, 10000]
+# output : list of 4 integers (quarters, dimes, nickels, pennies)
 
-type List
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def Math_floor_division : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "i // j"
+def train : TrainData = extract_train_data (load_dataset "coin-sums" 200 200)
 
-def List_size : (l:List) -> Int = uninterpreted
+def calculate_coin_sum_errors : (train: TrainData) -> (f: (a: {x:Int | 1 <= x && x <= 10000}) -> (List Int)) -> (List Int) =
+    \data -> \func -> native "[(lambda output, correct: (abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(x[0][0]), x[1]) for x in data]"
 
-def List_new : {x:List | List_size x == 0} = native "[]" ;
-
-def List_append (l:List) (i:Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
-
-def train: TrainData = extract_train_data (load_dataset "coin-sums" 200 200)
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_coin_sum_errors
-            )
-@multi_minimize_float(calculate_coin_sum_errors train synth, 4)
-def synth (cents: Int) : List = (?hole:List)
+@hide(extract_train_data, load_dataset, train, calculate_coin_sum_errors)
+@multi_minimize_int(calculate_coin_sum_errors train synth, 1)
+def synth (cents : {x:Int | 1 <= x && x <= 10000}) : (List Int) = (?hole: (List Int));

--- a/examples/PSB2/annotations/multi_objective/cut_vector.ae
+++ b/examples/PSB2/annotations/multi_objective/cut_vector.ae
@@ -1,43 +1,17 @@
+# Cut Vector: Given a list of positive integers, return a 2-element list
+# of lists that partitions the input contiguously so that the absolute
+# difference between the sums of the two parts is minimized.
+# input  : list of integers (length [1, 20]) in [1, 10000]
+# output : list (we score by length plus per-element abs diff)
+
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-type List
+def train : TrainData = extract_train_data (load_dataset "cut-vector" 200 200)
 
-def itertools : Unit = native_import "itertools"
+def calculate_cut_vector_errors : (train: TrainData) -> (f: (a: {l:(List Int) | 1 <= List.size l && List.size l <= 20}) -> (List Int)) -> (List Int) =
+    \data -> \func -> native "[(lambda output, correct: (abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(x[0][0]), x[1][0]) for x in data]"
 
-def Range: (start : Int) -> (end : Int) -> (step : Int) -> List = \start -> \end -> \step -> native "list(range(start, end, step ))"
-
-def List_slice : (i:List) -> (j:Int) -> (l:Int)-> List = \i -> \j -> \l -> native "i[j:l]"
-def List_remove_last : (i:List) -> List = \i -> native "i[:-1]"
-def List_remove_first : (i:List) -> List = \i -> native "i[1:]"
-def List_reversed: (l: List)-> List = \xs -> native "xs[::-1]"
-
-def List_length: (l:List) -> Int = \list -> native "len(list)"
-def List_new : List = native "[]"
-def List_append: (l:List) -> (i: Int) -> List = \xs -> \x -> native "xs + [x]"
-
-def Accumulate : (xs:List) -> List = \xs -> native "list(itertools.accumulate(xs))"
-def Zip : (xs:List) -> (ys:List) -> List = \xs -> \ys -> native "list(zip(xs, ys))"
-def Enumerate : (xs:List) -> List = \xs -> native "list(enumerate(xs))"
-def Map : (f: (s:List) -> List) -> (l:List) -> List = \f -> \xs -> native "list(map(f, xs))"
-def Math_abs : (i:Int) -> Int = \i -> native "abs(i)"
-def Tuple : (i:Int) -> (j:Int) -> List = \i -> \j -> native "(i, j)"
-def Tuple_list : (i:List) -> (j:List) -> List = \i -> \j -> native "[i, j]"
-def min_list : (i:List) -> (key: (xs:List) -> Int) -> List = \i -> \f -> native "min(i,key=f)";
-
-def get_fst : (i:List) -> Int = \i -> native "i[0]"
-def get_snd : (i:List) -> Int = \i -> native "i[1] if len(i) > 1 else i[0]"
-def get_zip : (i:List) -> List = \i -> native "i[1]"
-
-#PSB2 functions
-
-def train: TrainData = extract_train_data (load_dataset "cut-vector" 200 200)
-
-def calculate_cut_vector_errors : (train : TrainData) -> (f:(a: List) -> List ) -> List  =  \data -> \func -> native "[(lambda output, correct:(abs(len(output) - len(correct)) * 1000) + sum(abs(sum(a) - sum(b)) for a, b in zip(output, correct)) )(func(input_value[0]), correct_output) for input_value, correct_output in data ]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_cut_vector_errors)
-@multi_minimize_float(calculate_cut_vector_errors train cut_vector, 2)
-def cut_vector ( ls : List ) : List = (?hole:List)
+@hide(extract_train_data, load_dataset, train, calculate_cut_vector_errors)
+@multi_minimize_int(calculate_cut_vector_errors train cut_vector, 1)
+def cut_vector (ls : {l:(List Int) | 1 <= List.size l && List.size l <= 20}) : (List Int) = (?hole: (List Int));

--- a/examples/PSB2/annotations/multi_objective/dice_game.ae
+++ b/examples/PSB2/annotations/multi_objective/dice_game.ae
@@ -1,20 +1,18 @@
+# Dice Game (PE): Given an n-sided die and an m-sided die, return
+# the probability that the n-sided die rolls strictly higher than the
+# m-sided die.
+# input  : 2 integers in [1, 1000]
+# output : float in [0.0, 1.0]
+
 import PSB2 (extract_train_data, load_dataset)
-type List
+open List
 
-def math : Unit = native_import "math"
-def Math_toFloat : (i:Int) -> Float = \i -> native "float(i)"
-def Math_max : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "max(i,j)"
-def Math_round : (f:Float) -> (i:Int) -> Float = \f -> \i -> native "round(f, i)"
+def train : TrainData = extract_train_data (load_dataset "dice-game" 200 200)
 
-# PSB2  functions
+def calculate_dice_game_errors : (train: TrainData) -> (f: (a: {x:Int | 1 <= x && x <= 1000}) -> (b: {y:Int | 1 <= y && y <= 1000}) -> Float) -> (List Float) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1]) - x[1][0]) for x in data]"
 
-def train: TrainData = extract_train_data (load_dataset "dice-game" 200 200)
-
-def calculate_dice_game_errors : (train : TrainData) -> (f:(a: Int) -> (b:Int) -> Float)  -> List  =  \data -> \func -> native "[abs(func(x[0][0])(x[0][1]) - x[1][0]) for x in data]"
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_dice_game_errors)
+@hide(extract_train_data, load_dataset, train, calculate_dice_game_errors)
 @multi_minimize_float(calculate_dice_game_errors train synth, 1)
-def synth (n:Int) (m: Int) : Float = (?hole: Float)
+def synth (n : {x:Int | 1 <= x && x <= 1000})
+          (m : {y:Int | 1 <= y && y <= 1000}) : {r:Float | 0.0 <= r && r <= 1.0} = (?hole: {r:Float | 0.0 <= r && r <= 1.0});

--- a/examples/PSB2/annotations/multi_objective/find_pair.ae
+++ b/examples/PSB2/annotations/multi_objective/find_pair.ae
@@ -1,37 +1,17 @@
-import PSB2 (extract_train_data, load_dataset, get_input_list, get_output_list, unpack_train_data)
+# Find Pair: Given a list of integers and a target integer, return a pair
+# (as a 2-element list) of integers from the input list that sum to the
+# target. If multiple solutions exist, any is acceptable.
+# input  : list of integers, integer target
+# output : list of 2 integers
 
-type List
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def itertools : Unit = native_import "itertools"
-def combinations : (n:List) -> (m:Int) -> List = \n -> \m -> native "list(itertools.combinations(n, m))"
+def train : TrainData = extract_train_data (load_dataset "find-pair" 200 200)
 
-def Math_toFloat : (i:Int) -> Float = \i -> native "float(i)"
-def Math_max : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "max(i,j)"
+def calculate_find_pair_errors : (train: TrainData) -> (f: (a: (List Int)) -> (b: Int) -> (List Int)) -> (List Int) =
+    \data -> \func -> native "[(lambda output, correct: (abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(x[0][0])(x[0][1]), x[1]) for x in data]"
 
-def List_filter :  (f: (s:List) -> Bool) -> (l:List) -> List = \f -> \xs -> native "[x for x in xs if f(x)]"
-
-def List_sum : (l:List) -> Int = \xs -> native "sum(xs)"
-def List_head : (l: List) -> List = \xs -> native "xs[0]"
-def List_size : (l:List) -> Int = uninterpreted
-def List_length : (l:List) -> Int = \list -> native "len(list)"
-def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
-
-#PSB2 functions
-
-def train: TrainData = extract_train_data (load_dataset "find-pair" 200 200)
-
-def input_list : List = get_input_list (unpack_train_data train)
-
-def expected_values : List = get_output_list (unpack_train_data train)
-def flatten_list : (t:List) -> List = \l -> native "__import__('functools').reduce(lambda x, y: x + y, l)"
-
-def calculate_find_pair_errors : (train : TrainData) -> (f:(a: List) -> (b:Int) -> List ) -> List  =  \data -> \func -> native "[(lambda output, correct:(abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)) )(func(input_value[0])(input_value[1]), correct_output) for input_value, correct_output in data ]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_find_pair_errors,
-            train)
-@multi_minimize_float(calculate_find_pair_errors train synth, 1)
-def synth (numbers: List) (target: Int) : List = (?hole:List)
+@hide(extract_train_data, load_dataset, train, calculate_find_pair_errors)
+@multi_minimize_int(calculate_find_pair_errors train synth, 1)
+def synth (numbers : (List Int)) (target : Int) : (List Int) = (?hole: (List Int));

--- a/examples/PSB2/annotations/multi_objective/fizzbuzz.ae
+++ b/examples/PSB2/annotations/multi_objective/fizzbuzz.ae
@@ -1,24 +1,17 @@
+# Fizz Buzz: Given an integer n, return "Fizz" if n is divisible by 3,
+# "Buzz" if divisible by 5, "FizzBuzz" if divisible by both, otherwise
+# return the integer as a string.
+# input  : integer in [1, 1000000]
+# output : string
+
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-type List
+def train : TrainData = extract_train_data (load_dataset "fizz-buzz" 200 200)
 
-def div3 (n:Int) : Bool = if ((n % 3) == 0) then true else false;
-def div5 (n:Int) : Bool = if ((n % 5) == 0) then true else false;
-def div15 (n:Int) : Bool = if ((n % 15) == 0) then true else false;
+def calculate_fizzbuzz_errors : (train: TrainData) -> (f: (a: {x:Int | 1 <= x && x <= 1000000}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
 
-def toString : (n:Int) -> String = \n -> native "str(n)"
-
-def const1 : String = "Fizz"
-def const2 : String = "Buzz"
-def const3 : String = "FizzBuzz"
-
-def train: TrainData = extract_train_data (load_dataset "fizz-buzz" 200 200)
-
-def calculate_fizzbuzz_errors : (train : TrainData) -> (f:(a: Int) -> String)  -> List  =  \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_fizzbuzz_errors,
-            train )
-@multi_minimize_float(calculate_fizzbuzz_errors train synth, 1)
-def synth (n:Int) : String = (?hole:String)
+@hide(extract_train_data, load_dataset, train, calculate_fizzbuzz_errors)
+@multi_minimize_int(calculate_fizzbuzz_errors train synth, 1)
+def synth (n : {x:Int | 1 <= x && x <= 1000000}) : String = (?hole: String);

--- a/examples/PSB2/annotations/multi_objective/fuel_cost.ae
+++ b/examples/PSB2/annotations/multi_objective/fuel_cost.ae
@@ -1,33 +1,16 @@
-import PSB2 (extract_train_data, psb2_aeon, get_input_list, get_output_list, calculate_list_errors, get_fc_synth_values, unpack_train_data, load_dataset)
+# Fuel Cost: Given a vector of positive integers, divide each by 3,
+# round down, and subtract 2. Return the sum of all values >= 0.
+# input  : vector of integers (length [1, 20]) in [6, 100000]
+# output : integer
 
-type List
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def List_size: (l:List) -> Int = uninterpreted
-def List_length: (l:List) -> Int = \list -> native "len(list)"
-def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
+def train : TrainData = extract_train_data (load_dataset "fuel-cost" 200 200)
 
-def sum: (l:List) -> Int = \xs -> native "sum(xs)"
-def Math_max : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "max(i,j)"
-def Math_floor_division : (i:Int) -> (j:Int)-> Int = \i -> \j -> native "i // j"
+def calculate_fuel_cost_errors : (train: TrainData) -> (f: (a: {l:(List Int) | 1 <= List.size l && List.size l <= 20}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
 
-def List_map_Int_Int: (function:(a: Int) -> Int) -> (l: List) -> List = \f -> \xs -> native "map(f, xs)"
-
-def train: TrainData = extract_train_data (load_dataset "fuel-cost" 200 200)
-
-def input_list : List = get_input_list (unpack_train_data train)
-
-def expected_values : List = get_output_list (unpack_train_data train)
-def flatten_list : (t:List) -> List = \l -> native "__import__('functools').reduce(lambda x, y: x + y, l)"
-
-
-def calculate_fuel_cost_errors : (train : TrainData) -> (f:(a: List) -> Int)  -> List  =  \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
-
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_fuel_cost_errors,
-            train)
-@multi_minimize_float(calculate_fuel_cost_errors train synth, 1)
-def synth  (xs: List) : Int = (?hole: Int)
+@hide(extract_train_data, load_dataset, train, calculate_fuel_cost_errors)
+@multi_minimize_int(calculate_fuel_cost_errors train synth, 1)
+def synth (xs : {l:(List Int) | 1 <= List.size l && List.size l <= 20}) : {r:Int | 0 <= r} = (?hole: {r:Int | 0 <= r});

--- a/examples/PSB2/annotations/multi_objective/gcd.ae
+++ b/examples/PSB2/annotations/multi_objective/gcd.ae
@@ -1,13 +1,16 @@
+# GCD: Given two positive integers, return their greatest common divisor.
+# input  : 2 integers in [1, 1000000]
+# output : integer in [1, 1000000]
+
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-def train: TrainData = extract_train_data (load_dataset "gcd" 200 200)
+def train : TrainData = extract_train_data (load_dataset "gcd" 200 200)
 
-def calculate_gcd_errors : (train : TrainData) -> (f:(a: Int) -> (b: Int) -> Int)  -> List  =  \data -> \func -> native "[abs(func(x[0])(x[1]) - y[0]) for x, y  in data]"
+def calculate_gcd_errors : (train: TrainData) -> (f: (a: {x:Int | 1 <= x && x <= 1000000}) -> (b: {y:Int | 1 <= y && y <= 1000000}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1]) - x[1][0]) for x in data]"
 
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_fuel_cost_errors)
-#@allow_recursion
-@multi_minimize_float(calculate_gcd_errors train synth, 1)
-def synth (n:Int) (z:Int) : Int = (?hole: Int)
+@hide(extract_train_data, load_dataset, train, calculate_gcd_errors)
+@multi_minimize_int(calculate_gcd_errors train synth, 1)
+def synth (n : {x:Int | 1 <= x && x <= 1000000})
+          (z : {y:Int | 1 <= y && y <= 1000000}) : {r:Int | 1 <= r} = (?hole: {r:Int | 1 <= r});

--- a/examples/PSB2/annotations/multi_objective/indices_of_substring.ae
+++ b/examples/PSB2/annotations/multi_objective/indices_of_substring.ae
@@ -1,27 +1,21 @@
+# Indices of Substring: Given a text string and a target string, return a
+# list of all starting indices of occurrences of target inside text.
+# input  : text string of length [1, 25], target string of length [1, 5]
+# output : list of integers
+
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-type List
+def String_len (s: String) : Int = native "len(s)"
 
-def String_len : (i:String) -> Int = \i -> native "len(i)"
+def train : TrainData = extract_train_data (load_dataset "indices-of-substring" 200 200)
 
-def Range: (start : Int) -> (end : Int) -> (step : Int) -> List = \start -> \end -> \step -> native "list(range(start, end, step ))"
+def calculate_indices_of_substring_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 25})
+                                                                   -> (b: {y:String | 1 <= String_len y && String_len y <= 5})
+                                                                   -> (List Int)) -> (List Int) =
+    \data -> \func -> native "[(lambda output, correct: (abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(str(x[0][0]))(str(x[0][1])), x[1][0]) for x in data]"
 
-def Filter :  (f: (s:Int) -> Bool) -> (l:List) -> List = \f -> \xs -> native "[x for x in xs if f(x)]"
-
-def String_equal : (i:String) -> (j:String) -> Bool = \i -> \j -> native "i == j";
-
-def String_slice : (i:String) -> (j:Int) -> (l:Int)-> String = \i -> \j -> \l -> native "i[j:l]"
-
-
-def train: TrainData = extract_train_data (load_dataset "indices-of-substring" 200 200)
-
-
-def calculate_indices_of_substring_errors : (train : TrainData) -> (f:(a: String) -> (b: String) -> List ) -> List  =  \data -> \func -> native "[(lambda output, correct:(abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(str(x[0]))(str(x[1])), y[0]) for x, y in data ]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_indices_of_substring_errors,
-            train )
-@multi_minimize_float(calculate_indices_of_substring_errors train synth, 1)
-def synth ( text :String) (target: String) : List = (?hole:List)
+@hide(extract_train_data, load_dataset, train, calculate_indices_of_substring_errors, String_len)
+@multi_minimize_int(calculate_indices_of_substring_errors train synth, 1)
+def synth (text   : {x:String | 1 <= String_len x && String_len x <= 25})
+          (target : {y:String | 1 <= String_len y && String_len y <= 5}) : (List Int) = (?hole: (List Int));

--- a/examples/PSB2/annotations/multi_objective/leaders.ae
+++ b/examples/PSB2/annotations/multi_objective/leaders.ae
@@ -1,28 +1,17 @@
+# Leaders: Given a vector of integers, return all the "leaders" — elements
+# greater than every element to their right. The rightmost element is always
+# a leader. Return the leaders in their original order.
+# input  : vector of integers
+# output : vector of integers
+
 import PSB2 (extract_train_data, load_dataset)
-type List
+open List
 
-def itertools : Unit = native_import "itertools"
+def train : TrainData = extract_train_data (load_dataset "leaders" 50 50)
 
-def List_reversed: (l: List)-> List = \xs -> native "xs[::-1]"
-def List_new : List = native "[]"
-def List_append: (l:List) -> (i: Int) -> List = \xs -> \x -> native "xs + [x]"
-def List_get: (l:List) -> (i:Int) -> Int = \xs -> \i -> native "xs[i]"
+def calculate_leaders_errors : (train: TrainData) -> (f: (a: (List Int)) -> (List Int)) -> (List Int) =
+    \data -> \func -> native "[(lambda output, correct: (abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(x[0][0]), x[1][0]) for x in data]"
 
-def Scanl_max : (xs:List) -> List = \xs -> native "list(itertools.accumulate(xs, max))"
-def Filter :  (f: (s:List) -> Bool) -> (l:List) -> List = \f -> \xs -> native "[x for x in xs if f(x)]"
-def Zip : (xs:List) -> (ys:List) -> List = \xs -> \ys -> native "list(zip(xs, ys))"
-def Map : (f: (s:List) -> Int) -> (l:List) -> List = \f -> \xs -> native "list(map(f, xs))"
-
-#PSB2 functions
-def train: TrainData = extract_train_data (load_dataset "leaders" 50 50)
-
-
-def calculate_leaders_errors : (train : TrainData) -> (f:(a: List) -> List ) -> List  =  \data -> \func -> native "[(lambda output, correct:(abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(x[0]), y[0]) for x, y in data ]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_leaders_errors,
-            train )
-@multi_minimize_float(calculate_leaders_errors train synth, 1)
-def synth ( vector : List ) : List = (?hole:List)
+@hide(extract_train_data, load_dataset, train, calculate_leaders_errors)
+@multi_minimize_int(calculate_leaders_errors train synth, 1)
+def synth (vector : (List Int)) : (List Int) = (?hole: (List Int));

--- a/examples/PSB2/annotations/multi_objective/luhn.ae
+++ b/examples/PSB2/annotations/multi_objective/luhn.ae
@@ -1,44 +1,17 @@
+# Luhn: Given a vector of 16 single-digit integers, return the Luhn checksum.
+# Double every second digit from the right; if the doubled value is >9,
+# subtract 9. Sum all digits and return the total.
+# input  : vector of 16 integers in [1, 9]
+# output : integer
+
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-type List
-type Range
-type Map
+def train : TrainData = extract_train_data (load_dataset "luhn" 200 200)
 
-def List_size: (l:List) -> Int = uninterpreted
-def List_length: (l:List) -> Int = \list -> native "len(list)"
-def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
+def calculate_luhn_errors : (train: TrainData) -> (f: (a: {l:(List Int) | List.size l == 16}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
 
-
-def sum : (l:List) -> Int = \xs -> native "sum(xs)"
-
-def List_map_List_Range : (function:(a: Int) -> (b:Int) -> Int)
-                        -> (l:List)
-                        -> (r:Range)
-                        -> List = \f -> \xs -> \r -> native "list(map(lambda x, y:f(x)(y), xs, r))";
-
-def List_map_List : (function:(a: Int) -> Int)
-                        -> (l:List)
-                        -> List = \f -> \xs -> native "list(map(lambda x: f(x), xs))";
-
-
-def Range_new : (a:Int) -> (b:Int) -> Range = \a -> \b -> native "range(a,b)"
-
-def even : (n:Int) -> Bool = \n -> n % 2 == 0;
-
-def map_digit (x:Int) (i:Int) : Int = if (i % 2) == 0 then ( if (x * 2) > 9 then ((x * 2) - 9) else ( x * 2 ) : Int) else x;
-
-
-#PSB2
-def train: TrainData = extract_train_data (load_dataset "luhn" 200 200)
-
-def calculate_luhn_errors : (train : TrainData) -> (f:(a: List) -> Int)  -> List  =  \data -> \func -> native "[abs(func(x[0]) - y[0]) for x , y  in data]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_luhn_errors,
-            train )
-@multi_minimize_float(calculate_luhn_errors train synth, 1)
-@disable_control_flow
-def synth (digits: List) : Int = (?hole: Int)
+@hide(extract_train_data, load_dataset, train, calculate_luhn_errors)
+@multi_minimize_int(calculate_luhn_errors train synth, 1)
+def synth (digits : {l:(List Int) | List.size l == 16}) : {r:Int | 0 <= r} = (?hole: {r:Int | 0 <= r});

--- a/examples/PSB2/annotations/multi_objective/mastermind.ae
+++ b/examples/PSB2/annotations/multi_objective/mastermind.ae
@@ -1,36 +1,23 @@
-import PSB2 (extract_train_data, psb2_aeon, get_input_list, get_output_list, calculate_list_errors, get_mm_synth_values, unpack_train_data, load_dataset)
+# Mastermind: Given two strings of length 4 (the secret code and the guess),
+# return a 2-element list of integers: [black, white] where black is the
+# number of exactly-correct positions, and white is the number of correct
+# colors in wrong positions.
+# input  : two strings of length 4
+# output : list of 2 integers
 
-type List
-type Counter
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def itertools : Unit = native_import "itertools"
-def collections : Unit = native_import "collections"
+def String_len (s: String) : Int = native "len(s)"
 
-def Zip : (xs:List) -> (ys:List) -> List = \xs -> \ys -> native "list(zip(xs, ys))"
-def Map : (f: (s:List) -> String) -> (l:List) -> List = \f -> \xs -> native "list(map(f, xs))"
-def Map_bool : (f: (s:List) -> Int) -> (l:List) -> List = \f -> \xs -> native "list(map(f, xs))"
+def train : TrainData = extract_train_data (load_dataset "mastermind" 200 200)
 
-def String_eq : (i:String) -> (j:String) -> Bool = \i -> \j -> native "i == j";
-def List_sum : (l:List) -> Int = \xs -> native "sum(xs)"
-def String_toList : (s:String) -> List = \s -> native "list(s)"
-def String_Zip : (xs:String) -> (ys:String) -> List = \xs -> \ys -> native "(zip(xs, ys))"
-def List_get_fst : (s: List) -> String = \s -> native "s[0]"
-def List_get_snd : (s: List) -> String = \s -> native "s[1]"
-def String_neq : (i:String) -> (j:String) -> Bool = \i -> \j -> native "i != j";
-def Filter :  (f: (s:List) -> Bool) -> (l:List) -> List = \f -> \xs -> native "[x for x in xs if f(x)]"
-def Counter : (l:List) -> Counter = \xs -> native "collections.Counter(xs)"
-def Counter_intersection : (c1:Counter) -> (c2:Counter) -> Counter = \c1 -> \c2 -> native "c1 & c2"
-def Counter_values : (c:Counter) -> List = \c -> native "list(c.values())"
-def Tuple : (a:Int) -> (b:Int) -> List = \a -> \b -> native "[a,b]"
+def calculate_mastermind_errors : (train: TrainData) -> (f: (a: {x:String | String_len x == 4})
+                                                          -> (b: {y:String | String_len y == 4})
+                                                          -> (List Int)) -> (List Int) =
+    \data -> \func -> native "[(lambda output, correct: (abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(x[0][0])(x[0][1]), x[1]) for x in data]"
 
-def train: TrainData = extract_train_data (load_dataset "mastermind" 200 200)
-
-def calculate_mastermind_errors : (train : TrainData) -> (f:(a: String) -> (b:String) -> List ) -> List  =  \data -> \func -> native "[(lambda output, correct:(abs(len(output) - len(correct)) * 1000) + sum(abs(a - b) for a, b in zip(output, correct)))(func(x[0])(x[1]), y) for x, y in data ]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_mastermind_errors,
-            train)
-@multi_minimize_float(calculate_mastermind_errors train synth, 2)
-def synth ( code : String) (guess: String ) : List = (?hole:List)
+@hide(extract_train_data, load_dataset, train, calculate_mastermind_errors, String_len)
+@multi_minimize_int(calculate_mastermind_errors train synth, 1)
+def synth (code  : {x:String | String_len x == 4})
+          (guess : {y:String | String_len y == 4}) : (List Int) = (?hole: (List Int));

--- a/examples/PSB2/annotations/multi_objective/middle_char.ae
+++ b/examples/PSB2/annotations/multi_objective/middle_char.ae
@@ -1,27 +1,18 @@
+# Middle Character: Given a string, return the middle character. If the
+# length is odd, return one character; if even, return the two middle ones.
+# input  : string of length [1, 100] (printable ASCII)
+# output : string of length 1 or 2
+
 import PSB2 (extract_train_data, load_dataset)
-type List
+open List
 
-def math : Unit = native_import "math"
-def Math_floor : (i:Float) -> Int = \i -> native "math.floor(i)"
-def Math_toFloat : (i:Int) -> Float = \i -> native "float(i)"
-def Math_toInt : (i:Float) -> Int = \i -> native "int(i)"
+def String_len (s: String) : Int = native "len(s)"
 
-def String_len : (i:String) -> Int = \i -> native "len(i)"
-def String_slice : (i:String) -> (j:Int) -> (l:Int)-> String = \i -> \j -> \l -> native "i[j:l]"
+def train : TrainData = extract_train_data (load_dataset "middle-character" 200 200)
 
+def calculate_middle_char_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 100}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
 
-def equal_int : (a: Int) -> (b: Int) -> Bool = \x -> \y -> native "x == y";
-
-
-def train: TrainData = extract_train_data (load_dataset "middle-character" 200 200)
-
-
-def calculate_middle_char_errors : (train : TrainData) -> (f:(a: String) -> String)  -> List  =  \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0]), y[0]) for x , y in data]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_middle_char_errors,
-            train )
-@multi_minimize_float(calculate_middle_char_errors train synth, 1)
-def synth(s: String) : String = (?hole:String)
+@hide(extract_train_data, load_dataset, train, calculate_middle_char_errors, String_len)
+@multi_minimize_int(calculate_middle_char_errors train synth, 1)
+def synth (s : {x:String | 1 <= String_len x && String_len x <= 100}) : String = (?hole: String);

--- a/examples/PSB2/annotations/multi_objective/paired_digits.ae
+++ b/examples/PSB2/annotations/multi_objective/paired_digits.ae
@@ -1,31 +1,18 @@
+# Paired Digits: Given a string of digits, return the sum of all pairs of
+# adjacent equal digits' values.
+# input  : string of length [2, 20] of digits
+# output : integer
+
 import PSB2 (extract_train_data, load_dataset)
-type List
+open List
 
-def get_fst: (l:String) -> String = \xs -> native "xs[0]"
-def get_snd: (l:String) -> String = \xs -> native "xs[1]"
+def String_len (s: String) : Int = native "len(s)"
 
-def String_len : (i:String) -> Int = \i -> native "len(i)"
-def String_slice : (i:String) -> (j:Int) -> (l:Int)-> String = \i -> \j -> \l -> native "i[j:l]"
-def String_zip : (i:String) -> (j:String) -> String = \i -> \j -> native "zip(i,j)"
-def String_to_List : (i:String) -> List = \i -> native "list(i)"
-def String_to_Int : (i:String) -> Int = \i -> native "int(i)"
+def train : TrainData = extract_train_data (load_dataset "paired-digits" 200 200)
 
-def filter :  (f: (s:String) -> Bool) -> (l:List) -> List = \f -> \xs -> native "[x for x in xs if f(x)]"
-# def filter2 :  (f: (s:String) -> Bool) -> (l:List) -> List = \f -> \xs -> native "filter(f, xs)"
+def calculate_paired_digits_errors : (train: TrainData) -> (f: (a: {x:String | 2 <= String_len x && String_len x <= 20}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
 
-def List_sum: (l:List) -> Int = \xs -> native "sum(xs)"
-def List_map_String_Int: (function:(a: String) -> Int) -> (l: List) -> List = \f -> \xs -> native "map(f, xs)"
-
-
-def train: TrainData = extract_train_data (load_dataset "paired-digits" 200 200)
-
-
-def calculate_paired_digits_errors : (train : TrainData) -> (f:(a: String) -> Int)  -> List  =  \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_paired_digits_errors,
-            train )
-@multi_minimize_float(calculate_paired_digits_errors train synth, 1)
-def synth (nums: String) : Int = (?hole:Int)
+@hide(extract_train_data, load_dataset, train, calculate_paired_digits_errors, String_len)
+@multi_minimize_int(calculate_paired_digits_errors train synth, 1)
+def synth (nums : {x:String | 2 <= String_len x && String_len x <= 20}) : {r:Int | 0 <= r} = (?hole: {r:Int | 0 <= r});

--- a/examples/PSB2/annotations/multi_objective/shopping.ae
+++ b/examples/PSB2/annotations/multi_objective/shopping.ae
@@ -1,33 +1,16 @@
-import PSB2 (extract_train_data, psb2_aeon, get_input_list, get_output_list, calculate_list_errors, get_shop_synth_values, unpack_train_data, load_dataset)
-type List
-type Map
+# Shopping List: Given a list of prices and a list of discounts (one per item),
+# return the total cost after discounts are applied (rounded to nearest integer).
+# input  : list of floats (prices), list of floats (discounts)
+# output : integer
 
-def List_size: (l:List) -> Int = uninterpreted
-def List_length: (l:List) -> Int = \list -> native "len(list)"
-def List_new : {x:List | List_size x == 0} = native "[]" ;
-def List_append (l:List) (i: Int) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def List_sum: (l:List) -> Int = \xs -> native "sum(xs)"
-def Math_max : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "max(i,j)"
-def Math_floor_division : (i:Int) -> (j:Int)-> Int = \i -> \j -> native "i // j"
+def train : TrainData = extract_train_data (load_dataset "shopping-list" 200 200)
 
-def List_map_Int_Int_Int_List: (function: (a: Int) -> (b: Int) -> Int) ->
-                               (l: List) ->
-                               (l2: List) ->
-                               List =
-    \f -> \xs -> \ys -> native "list(map(lambda x, y: f(x)(y), xs, ys))";
+def calculate_shopping_errors : (train: TrainData) -> (f: (a: (List Float)) -> (b: (List Float)) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1]) - x[1][0]) for x in data]"
 
-
-
-def train: TrainData = extract_train_data (load_dataset "shopping-list" 200 200)
-
-
-def calculate_shopping_errors : (train : TrainData) -> (f:(a: List) -> (b: List) -> Int)  -> List  =  \data -> \func -> native "[abs(func(x[0])(x[1]) - y[0]) for x , y in data]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_shopping_errors,
-            train)
-@multi_minimize_float(calculate_shopping_errors train synth, 1)
-def synth  (prices: List) (discounts: List) : Int = (?hole:Int)
+@hide(extract_train_data, load_dataset, train, calculate_shopping_errors)
+@multi_minimize_int(calculate_shopping_errors train synth, 1)
+def synth (prices : (List Float)) (discounts : (List Float)) : {r:Int | 0 <= r} = (?hole: {r:Int | 0 <= r});

--- a/examples/PSB2/annotations/multi_objective/snow_day.ae
+++ b/examples/PSB2/annotations/multi_objective/snow_day.ae
@@ -1,15 +1,28 @@
-open Math
+# Snow Day (HW): Given an integer number of hours and 3 floats
+# representing the snow currently on the ground, the rate of
+# snowfall, and the proportion of snow melting per hour, return
+# the amount of snow on the ground after the given number of hours.
+# input  : integer in [0, 20],
+#          float   in [0.0, 20.0],
+#          float   in [0.0, 10.0],
+#          float   in [0.0, 1.0]
+# output : float
+
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-def isZero : (n: Int) -> Bool = \n -> n == 0;
+def train : TrainData = extract_train_data (load_dataset "snow-day" 200 200)
 
-def train: TrainData = extract_train_data (load_dataset "snow-day" 200 200)
-def calculate_snow_day_errors : (train : TrainData) -> (f:(a: Int) -> (b: Float) -> (c: Float) -> (d: Float) -> Float)  -> List  =  \data -> \func -> native "[abs(func(x[0])(x[1])(x[2])(x[3]) - y[0]) for x , y in data]"
+def calculate_snow_day_errors : (train: TrainData) -> (f: (a: {x:Int   |  0   <= x && x <= 20})
+                                                       -> (b: {y:Float |  0.0 <= y && y <= 20.0})
+                                                       -> (c: {z:Float |  0.0 <= z && z <= 10.0})
+                                                       -> (d: {w:Float |  0.0 <= w && w <= 1.0})
+                                                       -> Float) -> (List Float) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1])(x[0][2])(x[0][3]) - x[1][0]) for x in data]"
 
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_snow_day_errors)
+@hide(extract_train_data, load_dataset, train, calculate_snow_day_errors)
 @multi_minimize_float(calculate_snow_day_errors train synth, 1)
-def synth ( n :Int) (m :Float) (t :Float) (p :Float) : Float = (?hole:Float)
+def synth (n : {x:Int   |  0   <= x && x <= 20})
+          (m : {a:Float |  0.0 <= a && a <= 20.0})
+          (t : {b:Float |  0.0 <= b && b <= 10.0})
+          (p : {c:Float |  0.0 <= c && c <= 1.0}) : {r:Float | 0.0 <= r} = (?hole: {r:Float | 0.0 <= r});

--- a/examples/PSB2/annotations/multi_objective/solve_boolean.ae
+++ b/examples/PSB2/annotations/multi_objective/solve_boolean.ae
@@ -1,28 +1,19 @@
+# Solve Boolean: Given a string representing a boolean expression with
+# 't', 'f', '|', and '&' (no operator precedence: left-to-right), evaluate
+# the expression and return the result as a Bool.
+# input  : string of length [1, 30]
+# output : Bool
+
 import PSB2 (extract_train_data, load_dataset)
-type List
+open List
 
-def String_split : (s:String) -> (sep:String) -> List = \s -> \sep -> native "s.split(sep, 1)"
-def String_concat : (i:String) -> (j:String) -> String = \i -> \j -> native "i + j"
+def String_len (s: String) : Int = native "len(s)"
 
-def Map_string : (f: (s:String) -> String) -> (l:String) -> String = \f -> \xs -> native "str(map(f, xs))"
-def String_join : (l:List) -> (s:String) -> String = \l -> \s -> native "s.join(l)"
-def String_tail:(l:String) -> String = \xs -> native "xs[1:]"
-def String_contains:(s:String) -> (c:String) -> Bool = \s -> \c -> native "c in s"
-def String_equal : (i:String) -> (j:String) -> Bool = \i -> \j -> native "i == j";
-def String_get: (l:String) -> (i:Int) -> String = \xs -> \i -> native "xs[i]"
-def String_slice: (s:String) -> (start:Int) -> (end:Int) -> String = \s -> \start -> \end -> native "s[start:end]"
-def String_length: (s:String) -> Int = \s -> native "len(s)"
-def List_get: (l:List) -> (i:Int) -> String = \xs -> \i -> native "xs[i]"
+def train : TrainData = extract_train_data (load_dataset "solve-boolean" 200 200)
 
+def calculate_solve_boolean_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 30}) -> Bool) -> (List Int) =
+    \data -> \func -> native "[0 if func(x[0][0]) == x[1][0] else 1 for x in data]"
 
-def train: TrainData = extract_train_data (load_dataset "solve-boolean" 200 200)
-
-
-def calculate_solve_boolean_errors : (train : TrainData) -> (f:(a: String) -> Bool)  -> List  =  \data -> \func -> native "[0 if func(x[0]) == y[0] else 1 for x ,y  in data]";
-
-@hide(extract_train_data,
-            load_dataset,
-            train,
-            calculate_solve_boolean_errors)
-@multi_minimize_float(calculate_solve_boolean_errors train synth, 1)
-def synth ( s : String ) : Bool = (?hole:Bool)
+@hide(extract_train_data, load_dataset, train, calculate_solve_boolean_errors, String_len)
+@multi_minimize_int(calculate_solve_boolean_errors train synth, 1)
+def synth (s : {x:String | 1 <= String_len x && String_len x <= 30}) : Bool = (?hole: Bool);

--- a/examples/PSB2/annotations/multi_objective/spin_words.ae
+++ b/examples/PSB2/annotations/multi_objective/spin_words.ae
@@ -1,20 +1,18 @@
-import PSB2 (extract_train_data, psb2_aeon, get_input_list, get_output_list, calculate_str_list_errors, get_sw_synth_values, unpack_train_data, load_dataset)
-type List
+# Spin Words: Given a string of one or more words (separated by single spaces),
+# return the string with each word of 5 or more letters reversed.
+# input  : string of length [1, 100], words 1-15 chars from [A-Za-z]
+# output : string of the same length
 
-def String_len : (i:String) -> Int = \i -> native "len(i)"
-def String_list_to_String : (l:List) -> String = \l -> native "' '.join(l)"
-def map_String_String_List : (function:(a: String) -> String) -> (l: List) -> List = \f -> \xs -> native "map(f, xs)"
-def String_split : (i:String) -> (j:String) -> List = \i -> \j -> native "i.split(j)"
-def String_reverse : (i:String) -> String = \i -> native "i[::-1]"
+import PSB2 (extract_train_data, load_dataset)
+open List
 
-def train: TrainData = extract_train_data (load_dataset "spin-words" 200 200)
+def String_len (s: String) : Int = native "len(s)"
 
-def calculate_spin_words_errors : (train : TrainData) -> (f:(a: String) -> String)  -> List  =  \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0]), y[0]) for x , y in data]"
+def train : TrainData = extract_train_data (load_dataset "spin-words" 200 200)
 
-@hide(extract_train_data,
-            unpack_train_data,
-            load_dataset,
-            calculate_spin_words_errors,
-            train )
-@multi_minimize_float(calculate_spin_words_errors train synth, 1)
-def synth (phrase: String) : String = (?hole:String)
+def calculate_spin_words_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 100}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_spin_words_errors, String_len)
+@multi_minimize_int(calculate_spin_words_errors train synth, 1)
+def synth (phrase : {x:String | 1 <= String_len x && String_len x <= 100}) : String = (?hole: String);

--- a/examples/PSB2/annotations/multi_objective/square_digits.ae
+++ b/examples/PSB2/annotations/multi_objective/square_digits.ae
@@ -1,20 +1,16 @@
+# Square Digits: Given a non-negative integer n, square each digit and
+# concatenate the squared digits' decimal representations to form the result.
+# input  : integer in [0, 1000000]
+# output : string
+
 import PSB2 (extract_train_data, load_dataset)
-type List
+open List
 
+def train : TrainData = extract_train_data (load_dataset "square-digits" 200 200)
 
-def Math_floor_division : (i:Int) -> (j:Int)-> Int = \i -> \j -> native "i // j"
+def calculate_square_digits_errors : (train: TrainData) -> (f: (a: {x:Int | 0 <= x && x <= 1000000}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
 
-def String_concat : (i:String) -> (j:String) -> String = \i -> \j -> native "i + j"
-def String_intToString : (i:Int) -> String = \i -> native "str(i)"
-
-
-def train: TrainData = extract_train_data (load_dataset "square-digits" 200 200)
-def calculate_square_digits_errors : (train : TrainData) -> (f:(a: Int) -> String)  -> List  =  \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0]), y[0]) for x , y in data]"
-
-
-@hide(extract_train_data,
-            calculate_square_digits_errors,
-            load_dataset,
-            train)
-@multi_minimize_float(calculate_square_digits_errors train synth, 1)
-def synth ( n : Int) : String = (?hole:String)
+@hide(extract_train_data, load_dataset, train, calculate_square_digits_errors)
+@multi_minimize_int(calculate_square_digits_errors train synth, 1)
+def synth (n : {x:Int | 0 <= x && x <= 1000000}) : String = (?hole: String);

--- a/examples/PSB2/annotations/multi_objective/substitution_cipher.ae
+++ b/examples/PSB2/annotations/multi_objective/substitution_cipher.ae
@@ -1,26 +1,24 @@
+# Substitution Cipher: Given two strings of the same length specifying a
+# character substitution alphabet (a -> b), and a third string (the message),
+# return the message with characters substituted according to the mapping.
+# input  : three strings of length [0, 26], len(b) == len(a)
+# output : string
+
 import PSB2 (extract_train_data, load_dataset)
-type List
-type Zip
-type Dict
+open List
 
-def Zip_String_String : (l1: String) -> (l2: String) -> Zip = \xs -> \ys -> native "zip(xs, ys)"
-def Dict_zip : (l: Zip) -> Dict = \xs -> native "dict(xs)"
-def String_list_to_String : (l:List) -> String = \l -> native "''.join(l)"
-def Dict_get : (d: Dict) -> (k: String) -> (default: String) -> String = \d -> \k -> \y -> native "d.get(k, y)"
+def String_len (s: String) : Int = native "len(s)"
 
+def train : TrainData = extract_train_data (load_dataset "substitution-cipher" 200 200)
 
-def Map_String_String: (function: (a:String) -> String) -> (l: String) -> List = \f -> \xs -> native "map(f, xs)"
+def calculate_cipher_errors : (train: TrainData) -> (f: (a: {x:String | 0 <= String_len x && String_len x <= 26})
+                                                      -> (b: {y:String | String_len y == String_len a})
+                                                      -> (c: {z:String | 0 <= String_len z && String_len z <= 26})
+                                                      -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0])(x[0][1])(x[0][2]), x[1][0]) for x in data]"
 
-
-def train: TrainData = extract_train_data (load_dataset "substitution-cipher" 200 200)
-
-def calculate_cipher_errors : (train : TrainData) -> (f:(a: String) ->(a: String) ->(a: String) -> String)  -> List  =  \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0])(x[1])(x[2]), y[0]) for x , y in data]"
-
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_square_digits_errors,
-            train)
-@multi_minimize_float(calculate_cipher_errors train synth, 1)
-def synth (cipher_from: String) (cypher_to: String) (msg: String) : String = (?hole:String)
+@hide(extract_train_data, load_dataset, train, calculate_cipher_errors, String_len)
+@multi_minimize_int(calculate_cipher_errors train synth, 1)
+def synth (cipher_from : {x:String | 0 <= String_len x && String_len x <= 26})
+          (cypher_to   : {y:String | String_len y == String_len cipher_from})
+          (msg         : {z:String | 0 <= String_len z && String_len z <= 26}) : String = (?hole: String);

--- a/examples/PSB2/annotations/multi_objective/twitter.ae
+++ b/examples/PSB2/annotations/multi_objective/twitter.ae
@@ -1,25 +1,20 @@
+# Twitter: Given a string representing a tweet, return:
+#   - "You didn't type anything" if the string is empty
+#   - "Too many characters" if length > 140
+#   - "Your tweet has N characters" otherwise (N = length)
+# input  : string of length [0, 200]
+# output : string
+
 import PSB2 (extract_train_data, load_dataset)
+open List
 
-def String_len : (i:String) -> Int = \i -> native "len(i)"
-def String_intToString : (i:Int) -> String = \i -> native "str(i)"
+def String_len (s: String) : Int = native "len(s)"
 
-def String_concat : (i:String) -> (j:String) -> String = \i -> \j -> native "i + j"
+def train : TrainData = extract_train_data (load_dataset "twitter" 200 200)
 
-def const1 : String = "You didn't type anything"
-def const2 : String = "Too many characters"
-def const3 : String = "Your tweet has "
-def const4 : String = " characters"
+def calculate_twitter_errors : (train: TrainData) -> (f: (a: {x:String | 0 <= String_len x && String_len x <= 200}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
 
-
-def train: TrainData = extract_train_data (load_dataset "twitter" 200 200)
-
-
-def calculate_twitter_errors : (train : TrainData) -> (f:(a: String) -> String)  -> List  =  \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0]), y[0]) for x , y in data]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_twitter_errors,
-            train )
-@multi_minimize_float(calculate_twitter_errors train synth, 1)
-def synth (tweet: String) : String = (?hole:String)
+@hide(extract_train_data, load_dataset, train, calculate_twitter_errors, String_len)
+@multi_minimize_int(calculate_twitter_errors train synth, 1)
+def synth (tweet : {x:String | 0 <= String_len x && String_len x <= 200}) : String = (?hole: String);

--- a/examples/PSB2/annotations/multi_objective/vector_distance.ae
+++ b/examples/PSB2/annotations/multi_objective/vector_distance.ae
@@ -1,39 +1,16 @@
+# Vector Distance: Given two equal-length vectors of floats, return the
+# Euclidean distance between them.
+# input  : two float vectors of the same length
+# output : float
+
 import PSB2 (extract_train_data, load_dataset)
-type List
+open List
 
-def math : Unit = native_import "math"
-def Math_sqrt_Float : (i:Float) -> Float = \i -> native "math.sqrt(i)"
-def Math_pow : (i:Int) -> (j:Int) -> Int = \i -> \j -> native "i ** j"
-def Math_pow_Float : (i:Float) -> (j:Float) -> Float = \i -> \j -> native "i ** j"
+def train : TrainData = extract_train_data (load_dataset "vector-distance" 200 200)
 
-def Map_Float_Float_Float_List_List: (function: (a: Float) -> (b: Float) -> Float) ->
-                               (l: List) ->
-                               (l2: List) ->
-                               List =
-    \f -> \xs -> \ys -> native "list(map(lambda x, y: f(x)(y), xs, ys))";
+def calculate_vector_distance_errors : (train: TrainData) -> (f: (a: (List Float)) -> (b: (List Float)) -> Float) -> (List Float) =
+    \data -> \func -> native "[abs(func(x[0][0])(x[0][1]) - x[1][0]) for x in data]"
 
-def List_sum_Float : (l:List) -> Float = \xs -> native "sum(xs)"
-
-def List_size: (l:List) -> Int = uninterpreted
-
-def List_new : {x:List | List_size x == 0} = native "[]" ;
-
-def List_append_float (l:List) (i: Float) : {l2:List | List_size l2 == List_size l + 1} = native "l + [i]";
-
-
-def train: TrainData = extract_train_data (load_dataset "vector-distance" 200 200)
-
-def input_list : List = get_input_list (unpack_train_data train)
-
-def expected_values : List = get_output_list (unpack_train_data train)
-def flatten_list : (t:List) -> List = \l -> native "__import__('functools').reduce(lambda x, y: x + y, l)"
-
-def calculate_vector_distance_errors : (train : TrainData) -> (f:(a: List) -> (b: List) -> Float)  -> List  =  \data -> \func -> native "[abs(func(x[0])(x[1]) - y[0]) for x , y in data]"
-
-
-@hide(extract_train_data,
-            load_dataset,
-            calculate_vector_distance_errors,
-            train)
+@hide(extract_train_data, load_dataset, train, calculate_vector_distance_errors)
 @multi_minimize_float(calculate_vector_distance_errors train synth, 1)
-def synth  (vector1: List) (vector2: List) : Float = (?hole:Float)
+def synth (xs : (List Float)) (ys : (List Float)) : {r:Float | 0.0 <= r} = (?hole: {r:Float | 0.0 <= r});

--- a/examples/PSB2/camel_case.ae
+++ b/examples/PSB2/camel_case.ae
@@ -1,0 +1,19 @@
+# Camel Case: Given a string of words delimited by spaces and hyphens,
+# convert it to a camelCase string (no delimiters, second-and-later words
+# capitalized).
+# input  : string of length [1, 50] in [A-Za-z\-\s]*
+# output : camelCase string
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "camel-case" 200 200)
+
+def calculate_camel_case_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 50}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_camel_case_errors, String_len)
+@multi_minimize_int(calculate_camel_case_errors train synth, 1)
+def synth (s : {x:String | 1 <= String_len x && String_len x <= 50}) : String = (?hole: String);

--- a/examples/PSB2/indices_of_substring.ae
+++ b/examples/PSB2/indices_of_substring.ae
@@ -1,0 +1,23 @@
+# Indices of Substring: Given two strings (text and target), return a list
+# of all starting indices where the target appears in the text.
+# input  : text length [1, 25], target length [1, 5]
+# output : list of integer indices
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "indices-of-substring" 200 200)
+
+# Structural list error: penalize length mismatches heavily, then sum
+# absolute differences between aligned elements.
+def calculate_indices_of_substring_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 25})
+                                                                  -> (b: {y:String | 1 <= String_len y && String_len y <= 5})
+                                                                  -> (List Int)) -> (List Int) =
+    \data -> \func -> native "[(lambda out, correct: abs(len(out) - len(correct)) * 1000 + sum(abs(a - b) for a, b in zip(out, correct)))(func(x[0][0])(x[0][1]), x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_indices_of_substring_errors, String_len)
+@multi_minimize_int(calculate_indices_of_substring_errors train synth, 1)
+def synth (text   : {x:String | 1 <= String_len x && String_len x <= 25})
+          (target : {y:String | 1 <= String_len y && String_len y <= 5}) : (List Int) = (?hole: (List Int));

--- a/examples/PSB2/middle_char.ae
+++ b/examples/PSB2/middle_char.ae
@@ -1,0 +1,18 @@
+# Middle Character: Given a string, return the middle character. If the
+# length is odd, return one character; if even, return the two middle ones.
+# input  : string of length [1, 100] (printable ASCII)
+# output : string of length 1 or 2
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "middle-character" 200 200)
+
+def calculate_middle_char_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 100}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_middle_char_errors, String_len)
+@multi_minimize_int(calculate_middle_char_errors train synth, 1)
+def synth (s : {x:String | 1 <= String_len x && String_len x <= 100}) : String = (?hole: String);

--- a/examples/PSB2/paired_digits.ae
+++ b/examples/PSB2/paired_digits.ae
@@ -1,0 +1,18 @@
+# Paired Digits: Given a string of digits, sum each digit that equals the
+# digit immediately following it.
+# input  : string of length [2, 20] of digits 0-9
+# output : integer in [0, 180]
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "paired-digits" 200 200)
+
+def calculate_paired_digits_errors : (train: TrainData) -> (f: (a: {x:String | 2 <= String_len x && String_len x <= 20}) -> Int) -> (List Int) =
+    \data -> \func -> native "[abs(func(x[0][0]) - x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_paired_digits_errors, String_len)
+@multi_minimize_int(calculate_paired_digits_errors train synth, 1)
+def synth (s : {x:String | 2 <= String_len x && String_len x <= 20}) : {r:Int | 0 <= r && r <= 180} = (?hole: {r:Int | 0 <= r && r <= 180});

--- a/examples/PSB2/solve_boolean.ae
+++ b/examples/PSB2/solve_boolean.ae
@@ -1,0 +1,19 @@
+# Solve Boolean: Given a string representing a boolean expression with
+# characters 't', 'f', '&' (AND), '|' (OR), evaluate left-to-right
+# (no precedence, no parentheses) and return the resulting boolean.
+# input  : string of length [1, 30] in {'t','f','&','|'}
+# output : boolean
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "solve-boolean" 200 200)
+
+def calculate_solve_boolean_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 30}) -> Bool) -> (List Int) =
+    \data -> \func -> native "[0 if func(x[0][0]) == x[1][0] else 1 for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_solve_boolean_errors, String_len)
+@multi_minimize_int(calculate_solve_boolean_errors train synth, 1)
+def synth (s : {x:String | 1 <= String_len x && String_len x <= 30}) : Bool = (?hole: Bool);

--- a/examples/PSB2/spin_words.ae
+++ b/examples/PSB2/spin_words.ae
@@ -1,0 +1,18 @@
+# Spin Words: Given a string of one or more words (separated by single spaces),
+# return the string with each word of 5 or more letters reversed.
+# input  : string of length [1, 100], words 1-15 chars from [A-Za-z]
+# output : string of the same length
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "spin-words" 200 200)
+
+def calculate_spin_words_errors : (train: TrainData) -> (f: (a: {x:String | 1 <= String_len x && String_len x <= 100}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_spin_words_errors, String_len)
+@multi_minimize_int(calculate_spin_words_errors train synth, 1)
+def synth (s : {x:String | 1 <= String_len x && String_len x <= 100}) : String = (?hole: String);

--- a/examples/PSB2/substitution_cipher.ae
+++ b/examples/PSB2/substitution_cipher.ae
@@ -1,0 +1,24 @@
+# Substitution Cipher: Given three strings, the first two of equal length,
+# return the third string mapped through the substitution defined by the
+# first->second character correspondence (unmapped characters pass through).
+# input  : 3 strings, lengths [0, 26], [0, 26], [0, 26]
+# output : string
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "substitution-cipher" 200 200)
+
+def calculate_substitution_cipher_errors : (train: TrainData) -> (f: (a: {x:String | 0 <= String_len x && String_len x <= 26})
+                                                                -> (b: {y:String | 0 <= String_len y && String_len y <= 26 && String_len y == String_len a})
+                                                                -> (c: {z:String | 0 <= String_len z && String_len z <= 26})
+                                                                -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0])(x[0][1])(x[0][2]), x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_substitution_cipher_errors, String_len)
+@multi_minimize_int(calculate_substitution_cipher_errors train synth, 1)
+def synth (a : {x:String | 0 <= String_len x && String_len x <= 26})
+          (b : {y:String | 0 <= String_len y && String_len y <= 26 && String_len y == String_len a})
+          (c : {z:String | 0 <= String_len z && String_len z <= 26}) : String = (?hole: String)

--- a/examples/PSB2/twitter.ae
+++ b/examples/PSB2/twitter.ae
@@ -1,0 +1,20 @@
+# Twitter: Given a tweet string, return:
+#   "You didn't type anything"  if the tweet is empty,
+#   "Too many characters"       if length > 140,
+#   "Your tweet has N characters" otherwise.
+# input  : string of length [0, 200]
+# output : string
+
+import PSB2 (extract_train_data, load_dataset)
+open List
+
+def String_len (s: String) : Int = native "len(s)"
+
+def train : TrainData = extract_train_data (load_dataset "twitter" 200 200)
+
+def calculate_twitter_errors : (train: TrainData) -> (f: (a: {x:String | 0 <= String_len x && String_len x <= 200}) -> String) -> (List Int) =
+    \data -> \func -> native "[__import__('textdistance').levenshtein(func(x[0][0]), x[1][0]) for x in data]"
+
+@hide(extract_train_data, load_dataset, train, calculate_twitter_errors, String_len)
+@multi_minimize_int(calculate_twitter_errors train synth, 1)
+def synth (s : {x:String | 0 <= String_len x && String_len x <= 200}) : String = (?hole: String);


### PR DESCRIPTION
## Summary
Three new top-level synthesis stubs for PSB2 problems whose fitness is Levenshtein distance over the synth output:

- spin_words — reverse every word of length ≥ 5
- camel_case — convert space/hyphen-delimited words to camelCase
- middle_char — return the middle 1 or 2 characters

Stacked on top of #261 (uses the new `@multi_minimize_int` introduced there).

## Pattern (Option A from the design conversation)
All three stubs share:
- `import PSB2 (extract_train_data, load_dataset)` + `open List`
- A local `calculate_X_errors` returning `(List Int)` of Levenshtein distances (via `textdistance.levenshtein` in the native body)
- `@multi_minimize_int(calculate_X_errors train synth, 1)` for fitness
- `@hide(...)` to keep loaders and helpers out of the synthesizer grammar
- Input refinements encoding the PSB2 spec's length bounds (e.g. `1 <= len s <= 100` for spin_words)

## Pre-existing bug: `open String` breaks String-typed holes
All three stubs work around a pre-existing elaboration bug: `open String` causes `String`-annotated holes to fail with `type String vs String¹²¹ ()`. This also affects `examples/PSB2/square_digit.ae` on main — try `uv run python -m aeon --no-main --budget 1 examples/PSB2/square_digit.ae`.

Workaround in each new stub: a local `def String_len (s: String) : Int = native "len(s)"` shim instead of `open String`. The shims can be removed once the bug is fixed.

## What's missing
- Output refinements on the hole — useful relationships (spin_words preserves length, camel_case shrinks) would require length-aware refinements on stdlib String operations.
- Synthesizer's grammar is small until `open String` is fixed; once that lands, the grammar will pick up split/concat/upper/lower/etc.

## Test plan
- [x] `uv run python -m aeon --no-main --budget 2 examples/PSB2/spin_words.ae` — runs synthesis, Levenshtein fitness computes
- [x] `uv run python -m aeon --no-main --budget 2 examples/PSB2/camel_case.ae` — same
- [x] `uv run python -m aeon --no-main --budget 2 examples/PSB2/middle_char.ae` — same
- [ ] Fix `open String` elaboration bug; drop the `String_len` shims (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)