### PR TITLE
Fix multi-objective synthesis: closure, sentinel, recursor, refinements

### DIFF
--- a/aeon/backend/evaluator.py
+++ b/aeon/backend/evaluator.py
@@ -17,6 +17,24 @@ from aeon.decorators.api import Metadata
 from aeon.llvm.core import LLVMPipeline
 
 real_eval = eval
+real_exec = exec
+
+
+def _native_eval(source: str, env: dict[str, Any]) -> Any:
+    """Run a Python snippet from a `native` FFI call and return its result.
+
+    Most snippets are expressions (e.g. `len(xs) + 1`). The inductive-type
+    recursor desugars to a `match` statement with `return` arms, which
+    `eval` can't run — wrap it in a generated function and call it.
+    """
+    try:
+        return real_eval(source, env)
+    except SyntaxError:
+        indented = "\n".join("    " + line for line in source.splitlines())
+        wrapped = f"def __aeon_native__():\n{indented}\n"
+        locals_ns: dict[str, Any] = {}
+        real_exec(wrapped, env, locals_ns)
+        return locals_ns["__aeon_native__"]()
 
 
 class EvaluationContext:
@@ -78,7 +96,7 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
 
                 python_ctx = {str(name): v for name, v in globals().items()}
                 python_ctx.update({str(name.name): v for name, v in ctx.variables.items()})
-                e = real_eval(argv, python_ctx)
+                e = _native_eval(argv, python_ctx)
             else:
                 e = f(argv)
             if is_native_import(fun):

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import sys
 import time
 from typing import Any, Optional
 from typing import Callable
 from typing import TypeAlias
 
 import multiprocess as mp
+from geneticengine.problems import InvalidFitnessException
 from loguru import logger
 
 from aeon.backend.evaluator import EvaluationContext
@@ -57,15 +57,25 @@ def make_evaluators(ectx: EvaluationContext, fun_name: Name, metadata: Metadata)
     for goal in goals:
         assert goal.length == 1, "Currently, we only support 1 fitness value per function"
 
-        def fitness(v: Term) -> float:
-            program_for_fitness = substitution(v, Var(goal.function), Name("main", 0))
-            try:
-                result = eval(program_for_fitness, ectx)
-            except Exception:
-                result = sys.maxsize
-            return result
+        # Bind `goal` per-iteration via a factory; otherwise every closure
+        # would share the loop variable and end up referring to the last
+        # goal — which silently collapses multi-objective fitness to a
+        # single objective evaluated N times.
+        def make_fitness(goal: Goal) -> Callable[[Term], float]:
+            def fitness(v: Term) -> float:
+                program_for_fitness = substitution(v, Var(goal.function), Name("main", 0))
+                try:
+                    return eval(program_for_fitness, ectx)
+                except Exception:
+                    # A candidate that crashes mid-evaluation has no
+                    # well-defined fitness; surface it as invalid so the
+                    # search drops it rather than letting a sentinel value
+                    # dominate one objective and tank another (issue #120).
+                    raise InvalidFitnessException()
 
-        fitnesses.append(fitness)
+            return fitness
+
+        fitnesses.append(make_fitness(goal))
     return fitnesses
 
 
@@ -78,11 +88,15 @@ def make_evaluator(
         """Function to run in a separate process and places the result in a Queue."""
         start = time.time()
         try:
-            results = [ev(program) for ev in evaluators]
-            assert isinstance(results, list)
-            result_queue.put(results)
+            try:
+                results = [ev(program) for ev in evaluators]
+                assert isinstance(results, list)
+                result_queue.put(("ok", results))
+            except InvalidFitnessException:
+                result_queue.put(("invalid", None))
         except Exception as e:
             logger.log("SYNTHESIZER", f"Failed in the fitness function: {e}, {type(e)}")
+            result_queue.put(("error", f"{type(e).__name__}: {e}"))
             raise ErrorInSynthesis(e, msg=f"Failed in the fitness function: {e}, {type(e)}")
         finally:
             end = time.time()
@@ -100,9 +114,13 @@ def make_evaluator(
             eval_process.terminate()
             eval_process.join()
             raise TimeoutInEvaluationException()
-        else:
-            fitness_values = result_queue.get()
-            return fitness_values
+        msg = result_queue.get()
+        kind, payload = msg
+        if kind == "ok":
+            return payload
+        if kind == "invalid":
+            raise InvalidFitnessException()
+        raise ErrorInSynthesis(Exception(payload), msg=str(payload))
 
     return evaluate
 

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -57,6 +57,28 @@ APP_WEIGHT = 1000
 ABS_WEIGHT = 100
 
 
+def strip_refinements_keep_arg_refinements(ty: Type) -> Type:
+    """Like ``refined_to_unrefined_type`` but preserves refinements on the
+    argument positions of an abstraction chain.
+
+    Refinements on inductive-constructor argument positions (e.g.
+    ``Chunk_hill_chunk : {x:Int | x >= 5 && x <= 95} -> ... -> Chunk``)
+    are the only signal the grammar generator has for sampling ints within
+    the constructor's required range. Stripping them away makes the search
+    plug random ints from the global ``[-1, 256]`` default into refined
+    slots, which almost never type-checks.
+    """
+    if isinstance(ty, RefinedType):
+        return ty.type
+    if isinstance(ty, AbstractionType):
+        return AbstractionType(
+            ty.var_name,
+            ty.var_type,
+            strip_refinements_keep_arg_refinements(ty.type),
+        )
+    return ty
+
+
 def extract_class_name(class_name: str) -> str:
     prefixes = [
         "var_",
@@ -193,8 +215,11 @@ def create_literal_ref_nodes(type_info: dict[Type, TypingType] = None) -> list[T
     Each node:
     - Uses a metahandler (e.g. IntRange(1, 99)) so the enumerative search only
       iterates values that satisfy the refinement.
-    - Inherits from the BASE type's grammar class (e.g. æInt) so it is a direct
-      alternative for that class in the grammar — no refined abstract class needed.
+    - Inherits from the refined type's grammar class, which itself inherits
+      from the base type's class. The literal thus fills both refined-typed
+      slots (e.g. ``Chunk_hill_chunk``'s ``{x:Int|5..95}`` arg) AND base-typed
+      slots (plain ``Int`` holes) — geneticengine considers any transitive
+      subclass a valid alternative.
     - Returns a Literal with the base (unrefined) type from get_core() so the
       type checker can handle it correctly.
     """
@@ -202,8 +227,12 @@ def create_literal_ref_nodes(type_info: dict[Type, TypingType] = None) -> list[T
     result = []
     for aeon_ty in ref_types:
         base_type = aeon_ty.type
-        # Parent is the BASE type's class (e.g. æInt), not the refined abstract class.
-        parent_class = type_info[base_type]
+        # Parent is the refined type's own abstract class so this literal can
+        # fill positions typed exactly as the refined type (constructor args,
+        # function params with refinements). The refined abstract class in
+        # turn inherits from the base, so this also remains an alternative
+        # for plain base-typed slots.
+        parent_class = type_info[aeon_ty]
         metahandler = refined_type_to_metahandler(aeon_ty)
         if metahandler is None:
             continue
@@ -626,8 +655,12 @@ def gen_grammar_nodes(
     poly_ctx_vars = [(vn, vt) for (vn, vt) in ctx_vars if isinstance(vt, TypePolymorphism)]
     mono_ctx_vars = [(vn, vt) for (vn, vt) in ctx_vars if not isinstance(vt, TypePolymorphism)]
 
-    # Strip refinements from monomorphic variable types
-    ctx_vars_unrefined = [(var_name, refined_to_unrefined_type(var_ty)) for (var_name, var_ty) in mono_ctx_vars]
+    # Strip refinements from the return positions of monomorphic variable
+    # types but keep them on argument positions so the grammar can sample
+    # values within each argument's refinement bounds.
+    ctx_vars_unrefined = [
+        (var_name, strip_refinements_keep_arg_refinements(var_ty)) for (var_name, var_ty) in mono_ctx_vars
+    ]
 
     # Collect types that are used as type arguments to parameterized constructors.
     # These are the only types we need to instantiate forall-bound variables with.
@@ -641,7 +674,7 @@ def gen_grammar_nodes(
     monomorphized: list[tuple[Name, Type, list[Type]]] = []
     for vn, vt in poly_ctx_vars:
         for mono_body, type_apps in monomorphize_poly_type(vt, instantiation_types):
-            mono_body_unrefined = refined_to_unrefined_type(mono_body)
+            mono_body_unrefined = strip_refinements_keep_arg_refinements(mono_body)
             monomorphized.append((vn, mono_body_unrefined, type_apps))
 
     # Collect types from monomorphized vars

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -485,6 +485,12 @@ def smt_valid(constraint: Constraint) -> bool:
             smt_c = translate(c)
         except ZeroDivisionError:
             continue
+        except TypeError:
+            # Untranslatable to z3 (e.g. arithmetic over uninterpreted-sort
+            # constructor vars whose measure functions aren't in scope).
+            # Skip this clause rather than crashing the typechecker. Same
+            # soundness caveat as the ZeroDivisionError branch above.
+            continue
         if smt_c is False:
             continue
         s.add(smt_c)


### PR DESCRIPTION
## Summary

Five independent bugs in the synthesis pipeline that together caused `examples/synthesis/supermario.ae` (and any multi-objective synthesis over refined inductive constructors) to silently lock onto degenerate candidates. Fixing them — most importantly a Python closure bug in `make_evaluators` — lets the search produce real Levels with refinement-bounded chunk coordinates instead of empty placeholders.

## What changed

### 1. `make_evaluators` closure bug — the headline fix
`aeon/synthesis/entrypoint.py`. The per-goal fitness closure captured `goal` by reference inside `for goal in goals:`, so every fitness function ended up pointing at the last goal. For two-objective setups like `@maximize_int(coverage)` + `@minimize_int(conflicts)`, both slots actually computed `conflicts`, collapsing the search to a single objective evaluated twice and reporting `[0, 0]` for almost every candidate. Fixed by extracting `make_fitness(goal)` so each closure binds its own goal.

### 2. Invalid-fitness sentinel (closes #120)
On evaluator exceptions, `fitness` returned `sys.maxsize` for every objective. A `MultiObjectiveProblem` treats that as *infinitely good* for maximize and *infinitely bad* for minimize — a hybrid the Pareto front cannot dominate, so a crashing candidate locked in as "Best" forever with `[INT64_MAX, INT64_MAX]`. Now raise `InvalidFitnessException` instead. The subprocess queue is updated to ship typed messages (`("ok", values)` / `("invalid", None)` / `("error", repr)`) so the exception propagates back. Side benefit: also fixes a latent deadlock where a worker that raised any exception left the parent blocked on `result_queue.get()` indefinitely.

### 3. `match this:` recursor crash
`aeon/backend/evaluator.py`. The inductive-type desugar at `sugar/desugar.py:709` builds the recursor body as a Python `match` *statement* with `return` arms, but the backend evaluator fed it to Python's `eval()`, which only handles expressions. Added `_native_eval` that falls back to wrapping the snippet in `def __aeon_native__():` and running via `exec()` whenever `eval()` raises `SyntaxError`.

### 4. Refinements stripped from inductive-constructor arguments
`aeon/synthesis/grammar/grammar_generation.py`. The grammar generator called `refined_to_unrefined_type` on every context variable, turning e.g.
```
Chunk_hill_chunk : {x:Int|5..95} -> {y:Int|3..5} -> {w:Int|3..15} -> Chunk
```
into `Int -> Int -> Int -> Chunk`. The synthesizer then plugged random ints from the default `[-1, 256]` range into all three slots, the per-argument refinements almost never type-checked, and the search collapsed onto the trivial empty constructor. Replaced with `strip_refinements_keep_arg_refinements`, which preserves argument refinements while stripping only return-position ones. Refined-type literal classes now inherit from the refined abstract class (not the base class) so they can fill refined-typed slots; the refined class in turn inherits from the base, so they remain alternatives for plain base-typed slots too.

### 5. Defensive SMT translation
`aeon/verification/smt.py`. `smt_valid` already swallowed `ZeroDivisionError`; extended to also catch `TypeError` so a single untranslatable clause (e.g. arithmetic over uninterpreted-sort constructor vars whose measure functions aren't in scope) doesn't abort the whole synthesizer run. Same soundness caveat as the existing branch.

## Before / after on supermario.ae

**Before** (15 s budget): Best stuck at empty `Level_mk_level nil nil` with bogus `[INT64_MAX, INT64_MAX]` fitness.

**After** (60 s budget): Best `Level_mk_level (cons (gap_chunk 17 5 4 6 7) nil) nil` → `[17, 0]` (coverage maximized in range, zero conflicts). Args within all refinement bounds: 17∈[5,95], 5∈[3,5], 4∈[2,5], 6∈[2,7], 7∈[2,7]. Search produces diverse fitnesses `[4,0]..[17,0]` and exercises every chunk constructor.

## Test plan

- [x] `uv run pytest tests/` → 415 passed, 9 skipped, 0 failures
- [x] Minimal recursor repro (`match l with | nil => 0 | cons hd tl => 1 + size tl`) returns the expected size
- [x] Single-objective minimal repro (`@maximize_int(coord_x new_coord)` over a refined `mk_coord`) finds the upper-bound value
- [x] Multi-objective minimal repro finds `Chunk_coin_chunk 50 4 15` with fitness `[15, 0]`
- [x] `examples/synthesis/supermario.ae` produces non-degenerate Levels with valid refinement bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)