### PR TITLE
Skip untranslatable z3 constraints instead of crashing the typechecker

### DIFF
--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -486,6 +486,12 @@ def smt_valid(constraint: Constraint) -> bool:
             smt_c = translate(c)
         except ZeroDivisionError:
             continue
+        except TypeError:
+            # Untranslatable to z3 (e.g. arithmetic over uninterpreted-sort
+            # constructor vars whose measure functions aren't in scope).
+            # Skip this clause rather than crashing the typechecker. Same
+            # soundness caveat as the ZeroDivisionError branch above.
+            continue
         if smt_c is False:
             continue
         s.add(smt_c)


### PR DESCRIPTION
## Summary

\`smt_valid\` already swallowed \`ZeroDivisionError\` from \`translate\`. Extend that pattern to \`TypeError\`, which surfaces when a refinement mixes arithmetic operators with uninterpreted-sort constructor variables whose measure functions aren't in scope — z3 raises \`TypeError: unsupported operand type(s) for +: 'ExprRef' and 'ExprRef'\` (or \`-\`, \`/\`, etc.).

Concretely, \`examples/synthesis/supermario.ae\` crashes the synthesizer hard on master: validation of \`len bs\` over \`Chunk_boxes_chunk\` hits this path and the unhandled \`TypeError\` kills the whole search. With this fix the clause is treated as "unknown" and the run continues. Same soundness caveat as the existing \`ZeroDivisionError\` branch.

## Test plan

- [x] \`uv run pytest tests/ --ignore=tests/end_to_end_test.py\` → 963 passed, 9 skipped
- [x] \`uv run python -m aeon --budget 30 -s gp examples/synthesis/supermario.ae\` no longer crashes with \`TypeError\` from \`smt.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)