### PR TITLE
Raise InvalidFitnessException on evaluator failure (closes #120)

### DIFF
--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -30,6 +30,14 @@ class ErrorInSynthesis(SynthesisError):
         self.msg = msg
 
 
+class InvalidFitness(SynthesisError):
+    """Raised by an evaluator when a candidate has no well-defined fitness
+    (e.g. its evaluation throws). Backend-neutral: synthesizer adapters are
+    responsible for translating this into whatever notion of "invalid
+    candidate" their search framework uses.
+    """
+
+
 class Synthesizer(ABC):
     def synthesize(
         self,

--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -30,7 +30,7 @@ class ErrorInSynthesis(SynthesisError):
         self.msg = msg
 
 
-class InvalidFitness(SynthesisError):
+class InvalidIndividualException(SynthesisError):
     """Raised by an evaluator when a candidate has no well-defined fitness
     (e.g. its evaluation throws). Backend-neutral: synthesizer adapters are
     responsible for translating this into whatever notion of "invalid

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -23,7 +23,7 @@ from aeon.typechecking.context import TypingContext
 from aeon.typechecking.typeinfer import check_type
 from aeon.utils.name import Name
 
-from aeon.synthesis.api import ErrorInSynthesis, InvalidFitness, Synthesizer, TimeoutInEvaluationException
+from aeon.synthesis.api import ErrorInSynthesis, InvalidIndividualException, Synthesizer, TimeoutInEvaluationException
 from aeon.synthesis.tactics.explicit_synth import ExplicitTacticSynthesizer
 
 from aeon.synthesis.decorators import Goal
@@ -65,10 +65,11 @@ def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float
             # for ``@maximize_*`` and "infinitely bad" for ``@minimize_*``
             # at the same time — a hybrid the Pareto front cannot dominate,
             # so a single crash would lock in as "Best" forever (issue
-            # #120). Raise the backend-neutral ``InvalidFitness`` instead;
-            # synthesizer adapters translate it into their search
-            # framework's notion of "drop this candidate".
-            raise InvalidFitness()
+            # #120). Raise the backend-neutral
+            # ``InvalidIndividualException`` instead; synthesizer adapters
+            # translate it into their search framework's notion of "drop
+            # this candidate".
+            raise InvalidIndividualException()
 
     return fitness
 
@@ -97,7 +98,7 @@ def make_evaluator(
                 results = [ev(program) for ev in evaluators]
                 assert isinstance(results, list)
                 result_queue.put(("ok", results))
-            except InvalidFitness:
+            except InvalidIndividualException:
                 result_queue.put(("invalid", None))
         except Exception as e:
             logger.log("SYNTHESIZER", f"Failed in the fitness function: {e}, {type(e)}")
@@ -126,7 +127,7 @@ def make_evaluator(
         if kind == "ok":
             return payload
         if kind == "invalid":
-            raise InvalidFitness()
+            raise InvalidIndividualException()
         raise ErrorInSynthesis(Exception(payload), msg=str(payload))
 
     return evaluate

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -6,7 +6,6 @@ from typing import Callable
 from typing import TypeAlias
 
 import multiprocess as mp
-from geneticengine.problems import InvalidFitnessException
 from loguru import logger
 
 import aeon.logger.logger  # noqa: F401  — registers custom levels (SYNTHESIZER etc.) at import.
@@ -24,7 +23,7 @@ from aeon.typechecking.context import TypingContext
 from aeon.typechecking.typeinfer import check_type
 from aeon.utils.name import Name
 
-from aeon.synthesis.api import ErrorInSynthesis, Synthesizer, TimeoutInEvaluationException
+from aeon.synthesis.api import ErrorInSynthesis, InvalidFitness, Synthesizer, TimeoutInEvaluationException
 from aeon.synthesis.tactics.explicit_synth import ExplicitTacticSynthesizer
 
 from aeon.synthesis.decorators import Goal
@@ -66,9 +65,10 @@ def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float
             # for ``@maximize_*`` and "infinitely bad" for ``@minimize_*``
             # at the same time — a hybrid the Pareto front cannot dominate,
             # so a single crash would lock in as "Best" forever (issue
-            # #120). Raise ``InvalidFitnessException`` instead so the
-            # search drops the candidate cleanly.
-            raise InvalidFitnessException()
+            # #120). Raise the backend-neutral ``InvalidFitness`` instead;
+            # synthesizer adapters translate it into their search
+            # framework's notion of "drop this candidate".
+            raise InvalidFitness()
 
     return fitness
 
@@ -97,7 +97,7 @@ def make_evaluator(
                 results = [ev(program) for ev in evaluators]
                 assert isinstance(results, list)
                 result_queue.put(("ok", results))
-            except InvalidFitnessException:
+            except InvalidFitness:
                 result_queue.put(("invalid", None))
         except Exception as e:
             logger.log("SYNTHESIZER", f"Failed in the fitness function: {e}, {type(e)}")
@@ -126,7 +126,7 @@ def make_evaluator(
         if kind == "ok":
             return payload
         if kind == "invalid":
-            raise InvalidFitnessException()
+            raise InvalidFitness()
         raise ErrorInSynthesis(Exception(payload), msg=str(payload))
 
     return evaluate

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import sys
 import time
 from typing import Any, Optional
 from typing import Callable
 from typing import TypeAlias
 
 import multiprocess as mp
+from geneticengine.problems import InvalidFitnessException
 from loguru import logger
 
 import aeon.logger.logger  # noqa: F401  — registers custom levels (SYNTHESIZER etc.) at import.
@@ -61,7 +61,14 @@ def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float
                 return measure_energy(lambda: eval(program_for_fitness, ectx))
             return eval(program_for_fitness, ectx)
         except Exception:
-            return sys.maxsize
+            # A candidate that crashes mid-evaluation has no well-defined
+            # fitness. Returning ``sys.maxsize`` made it "infinitely good"
+            # for ``@maximize_*`` and "infinitely bad" for ``@minimize_*``
+            # at the same time — a hybrid the Pareto front cannot dominate,
+            # so a single crash would lock in as "Best" forever (issue
+            # #120). Raise ``InvalidFitnessException`` instead so the
+            # search drops the candidate cleanly.
+            raise InvalidFitnessException()
 
     return fitness
 
@@ -86,11 +93,18 @@ def make_evaluator(
         """Function to run in a separate process and places the result in a Queue."""
         start = time.time()
         try:
-            results = [ev(program) for ev in evaluators]
-            assert isinstance(results, list)
-            result_queue.put(results)
+            try:
+                results = [ev(program) for ev in evaluators]
+                assert isinstance(results, list)
+                result_queue.put(("ok", results))
+            except InvalidFitnessException:
+                result_queue.put(("invalid", None))
         except Exception as e:
             logger.log("SYNTHESIZER", f"Failed in the fitness function: {e}, {type(e)}")
+            # Make sure the parent isn't left blocked on ``result_queue.get()``
+            # if an unexpected exception escapes — propagate it as a typed
+            # message so the parent re-raises ``ErrorInSynthesis``.
+            result_queue.put(("error", f"{type(e).__name__}: {e}"))
             raise ErrorInSynthesis(e, msg=f"Failed in the fitness function: {e}, {type(e)}")
         finally:
             end = time.time()
@@ -108,9 +122,12 @@ def make_evaluator(
             eval_process.terminate()
             eval_process.join()
             raise TimeoutInEvaluationException()
-        else:
-            fitness_values = result_queue.get()
-            return fitness_values
+        kind, payload = result_queue.get()
+        if kind == "ok":
+            return payload
+        if kind == "invalid":
+            raise InvalidFitnessException()
+        raise ErrorInSynthesis(Exception(payload), msg=str(payload))
 
     return evaluate
 

--- a/aeon/synthesis/grammar/ge_synthesis.py
+++ b/aeon/synthesis/grammar/ge_synthesis.py
@@ -8,7 +8,7 @@ from aeon.utils.name import Name
 
 
 from aeon.synthesis.uis.api import SynthesisUI
-from aeon.synthesis.api import InvalidFitness, Synthesizer
+from aeon.synthesis.api import InvalidIndividualException, Synthesizer
 
 from aeon.decorators.api import Metadata
 
@@ -50,7 +50,7 @@ def create_problem(
                 raise InvalidFitnessException()
             try:
                 return evaluate(p)
-            except InvalidFitness:
+            except InvalidIndividualException:
                 # Translate the backend-neutral exception raised by the
                 # Aeon evaluator into geneticengine's own "drop this
                 # candidate" sentinel.

--- a/aeon/synthesis/grammar/ge_synthesis.py
+++ b/aeon/synthesis/grammar/ge_synthesis.py
@@ -8,7 +8,7 @@ from aeon.utils.name import Name
 
 
 from aeon.synthesis.uis.api import SynthesisUI
-from aeon.synthesis.api import Synthesizer
+from aeon.synthesis.api import InvalidFitness, Synthesizer
 
 from aeon.decorators.api import Metadata
 
@@ -48,7 +48,13 @@ def create_problem(
             assert isinstance(p, Term)
             if not validate(p):
                 raise InvalidFitnessException()
-            return evaluate(p)
+            try:
+                return evaluate(p)
+            except InvalidFitness:
+                # Translate the backend-neutral exception raised by the
+                # Aeon evaluator into geneticengine's own "drop this
+                # candidate" sentinel.
+                raise InvalidFitnessException()
 
         return MultiObjectiveProblem(fitness_function=fitness_fun, minimize=minimize_list)
     else:


### PR DESCRIPTION
## Summary

When a candidate's fitness evaluation throws, \`_make_fitness\` returned \`sys.maxsize\` for every objective. \`MultiObjectiveProblem\` then treats that as *infinitely good* for \`@maximize_*\` and *infinitely bad* for \`@minimize_*\` at the same time — a hybrid the Pareto front cannot dominate, so a single crashing candidate locks in as "Best" forever with \`[INT64_MAX, INT64_MAX]\`.

That's exactly the symptom in #120: in \`examples/synthesis/supermario.ae\` the trivial empty \`Level_mk_level nil nil\` would win because anything more ambitious crashed during fitness eval and got the sentinel score.

Replace the sentinel with \`InvalidFitnessException\` so the search drops the candidate cleanly. The subprocess wrapper in \`make_evaluator\` is updated to ship typed messages through \`result_queue\` (\`("ok", values)\` / \`("invalid", None)\` / \`("error", repr)\`) so the exception propagates back to the parent process.

**Side benefit**: this also fixes a latent deadlock. Previously, any exception escaping \`evaluate_individual\` (the worker subprocess) left the parent blocked forever on \`result_queue.get()\` because nothing was ever put on the queue.

## Test plan

- [x] \`uv run pytest tests/ --ignore=tests/end_to_end_test.py\` → 963 passed, 9 skipped

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)