### PR TITLE
Handle ExistentialType bindings in lower_context

### DIFF
--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -10,6 +10,7 @@ from aeon.core.liquid import LiquidTerm
 from aeon.core.liquid import LiquidVar
 from aeon.core.types import (
     AbstractionType,
+    ExistentialType,
     LiquidHornApplication,
     RefinedType,
     RefinementPolymorphism,
@@ -101,34 +102,42 @@ def lower_context(ctx: TypingContext) -> LiquidTypeCheckingContext:
     variables: dict[Name, TypeConstructor | TypeVar] = {}
     functions = {}
 
+    def add_variable(name: Name, ty: Type) -> None:
+        """Record a variable binding for liquid lookup. ``ExistentialType``
+        wrappers are peeled — each ``(bn, bt)`` binder inside is registered
+        recursively as if it were its own ``VariableBinder``, then the bare
+        body is handled. This mirrors what ``wellformed`` does and lets
+        refinements over Form B existentials reach the SMT context."""
+        match ty:
+            case ExistentialType(binders, body):
+                for bn, bt in binders:
+                    add_variable(bn, bt)
+                add_variable(name, body)
+            case TypeConstructor(_) | TypeConstructor(_, _):
+                variables[name] = ty
+            case TypeVar(tvname):
+                known_types.append(tvname)
+                variables[name] = ty
+            case RefinedType(_, TypeConstructor(_) as bt, _) | RefinedType(_, TypeConstructor(_, _) as bt, _):
+                variables[name] = bt
+            case RefinedType(_, TypeVar(tvname) as bt, _):
+                known_types.append(tvname)
+                variables[name] = bt
+            case TypePolymorphism(_, _, _) | RefinementPolymorphism(_, _, _) | AbstractionType(_, _, _):
+                functions[name] = lower_abstraction_type(ty)
+            case _:
+                assert False, f"Unsupported variable binder type {ty} ({type(ty)})"
+
     for entry in ctx.entries[::-1]:
         match entry:
-            case VariableBinder(name, TypeConstructor(_) as bt):
-                variables[name] = bt
-            case VariableBinder(name, TypeConstructor(_, _) as bt):
-                variables[name] = bt
-            case VariableBinder(name, TypeVar(tvname)):
-                known_types.append(tvname)
-                variables[name] = TypeVar(tvname)
-            case VariableBinder(name, TypePolymorphism(_, _, _) as ty):
-                functions[name] = lower_abstraction_type(ty)
-            case VariableBinder(name, RefinementPolymorphism(_, _, _) as ty):
-                functions[name] = lower_abstraction_type(ty)
+            case VariableBinder(name, ty):
+                add_variable(name, ty)
             case TypeBinder(name, _):
                 known_types.append(name)
-            case UninterpretedBinder(name, AbstractionType(_, _, _) as ty) | VariableBinder(
-                name, AbstractionType(_, _, _) as ty
-            ):
+            case UninterpretedBinder(name, AbstractionType(_, _, _) as ty):
                 functions[name] = lower_abstraction_type(ty)
             case UninterpretedBinder(name, TypePolymorphism(_, _, AbstractionType(_, _, _)) as ty):
                 functions[name] = lower_abstraction_type(ty)
-            case VariableBinder(name, RefinedType(_, TypeConstructor(_) as bt, _)):
-                variables[name] = bt
-            case VariableBinder(name, RefinedType(_, TypeConstructor(_, _) as bt, _)):
-                variables[name] = bt
-            case VariableBinder(name, RefinedType(_, TypeVar(tvname) as bt, _)):
-                known_types.append(tvname)
-                variables[name] = bt
             case TypeConstructorBinder(_, _):
                 pass
             case _:

--- a/tests/liquid_typechecking_test.py
+++ b/tests/liquid_typechecking_test.py
@@ -14,6 +14,7 @@ from aeon.core.liquid import (
 )
 from aeon.core.types import (
     AbstractionType,
+    ExistentialType,
     LiquidHornApplication,
     RefinedType,
     TypeConstructor,
@@ -285,6 +286,27 @@ def test_lower_context_refined_var():
     lctx = lower_context(ctx)
     assert x in lctx.variables
     assert lctx.variables[x] == t_int
+
+
+def test_lower_context_existential_var():
+    """Form B ``ExistentialType`` bindings should be peeled — the binders
+    inside become independent variables and the body provides the outer
+    variable's bare type. Previously ``lower_context`` raised
+    ``AssertionError("Unknown context type …")`` whenever the typing
+    context held an existential binding (introduced when ANF was replaced
+    with Form B in #226), which propagated as a ``CoreWellformnessError``
+    during synthesis whenever a refinement type was checked."""
+    ctx = TypingContext()
+    inner_binder = Name("inner")
+    inner_refined = RefinedType(Name("v"), t_int, LiquidLiteralBool(True))
+    body = TypeConstructor(Name("String", 0))
+    ty = ExistentialType(((inner_binder, inner_refined),), body)
+    ctx = ctx.with_var(x, ty)
+    lctx = lower_context(ctx)
+    assert x in lctx.variables
+    assert lctx.variables[x] == body
+    assert inner_binder in lctx.variables
+    assert lctx.variables[inner_binder] == t_int
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`lower_context` in [aeon/typechecking/liquid.py](aeon/typechecking/liquid.py) didn't have a case for `VariableBinder(name, ExistentialType(binders, body))`. After ANF was replaced with Form B existential binders in #226, any synthesis flow whose typing context carried such a binding tripped `assert False, "Unknown context type …"` whenever a downstream refinement (e.g. `{v:Int | v != 0}` on `Math.floor_division`'s second argument) needed to be checked.

This surfaces during synthesis on `examples/PSB2/square_digit.ae` once #269 + #271 let it elaborate, but is independent of those PRs — any context carrying a Form B binding into refinement-checking territory hits it.

## Fix

Peel each `ExistentialType` and register its `(binder_name, binder_type)` pairs recursively as if they were independent variable bindings, then handle the bare body. Mirrors what `wellformed` (`aeon/typechecking/well_formed.py`) already does for `ExistentialType`.

The body and binder types can themselves carry refinements, polymorphism, or further existentials; the same recursive helper (`add_variable`) covers all of those uniformly and lets the outer loop stay flat.

## Test plan

- [x] New unit test: `tests/liquid_typechecking_test.py::test_lower_context_existential_var` — verifies an `ExistentialType` binder in the context is peeled, with each inner binder registered alongside the outer variable. (Fails on master with `Unknown context type …`.)
- [x] `uv run pytest tests/` — 973 passed, 9 skipped (was 972; +1 for the new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)