### PR TITLE
docs: rewrite intro around liquid types + synthesis, document all synthesizers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,11 @@
-# Aeon Programming language
+# Aeon Programming Language
 
-Aeon is a programming that with a focus on Liquid Types. Liquid types allow developers to be more specific and annotate their types with a predicate.
+**Aeon** is a statically-typed functional language built around two ideas that usually live in separate research papers:
+
+1. **Liquid (refinement) types** — types that carry a logical predicate, so the compiler can rule out whole classes of bugs (negative balances, off-by-one errors, division by zero, ...) before the program ever runs. The proof obligations are discharged by an SMT solver (z3).
+2. **Program synthesis** — anywhere you would write a value, you can write `?hole` instead. Aeon then searches for an expression that satisfies the surrounding type, optionally minimising or maximising a cost function. Several synthesizers are available (genetic programming, enumerative, SMT-guided, LLM-based, ...).
+
+The two features feed each other: stronger types make synthesis precise (the synthesizer only proposes solutions the type system accepts), and synthesis lets you write *specifications* and let the machine fill in the *implementation*.
 
 ```
 let age : Int = 25;
@@ -8,9 +13,57 @@ let age : {age:Int | age > 0} = 25;
 let age : {age:Int | age >= 18 && age < 130} = 25;
 ```
 
-In Aeon, all three declarations are valid, and each more specific than the previous. Liquid Types restrict the domain of values and functions, support assertions in the source code, and can statically catch violations at compile time.
+All three declarations are valid, and each is more specific than the previous. Liquid types restrict the domain of values and functions, support assertions in the source code, and statically catch violations at compile time.
 
-There are other languages with Liquid Types, such as [LiquidHaskell](https://ucsd-progsys.github.io/liquidhaskell/), [LiquidJava](https://catarinagamboa.github.io/liquidjava.html), or Rust with [Flux](https://flux-rs.github.io/flux/). But while these languages add liquid types to an existing language, aeon is built with support from liquid types from the start.
+Other languages with liquid types — [LiquidHaskell](https://ucsd-progsys.github.io/liquidhaskell/), [LiquidJava](https://catarinagamboa.github.io/liquidjava.html), or Rust with [Flux](https://flux-rs.github.io/flux/) — bolt liquid types onto an existing language. Aeon was designed around them from the start, which is what allows synthesis to be deeply integrated as well.
+
+## A complete example: types prove safety, synthesis fills the gap
+
+The function below carries its full specification in its type:
+
+* The **preconditions** say `price` is non-negative and `pct` is a real percentage (0–100).
+* The **postcondition** says the discounted price is non-negative and never exceeds the original.
+
+```
+def apply_discount (price : Int | price >= 0)
+                   (pct   : Int | pct >= 0 && pct <= 100)
+                 : {r : Int | r >= 0 && r <= price} =
+    price - (price * pct / 100);
+```
+
+If the body ever violated those constraints (say, we accidentally wrote `price + pct`), Aeon rejects the program at compile time — no test required, no runtime check inserted.
+
+Now suppose we don't know *the answer*, but we do know *what makes an answer valid*. How small can the yearly deposit be if we want to reach \$10,000 in 20 years at ~1% interest (compound factor ≈ 21.9)? We write the specification and leave a hole:
+
+```
+@minimize_int(deposit)
+def deposit : {d : Int | d > 0 && d * 21900 >= 10000000} = ?hole;
+```
+
+Running this with `uv run python -m aeon --budget 10 -s gp file.ae`, Aeon searches for an integer that satisfies the predicate and is as small as possible — landing on `457` (since `457 * 21900 = 10_008_300`).
+
+The same machinery scales up: holes can appear inside functions, take arguments, and be guided by training data (`@csv_file`), runtime energy use (`@minimize_energy`), or natural-language prompts (`@prompt`, used by the `llm` backend).
+
+## Important concepts when learning Aeon
+
+The list below covers the ideas you'll meet first, with just enough context to get oriented.
+
+| Concept | What it means in Aeon |
+|---|---|
+| **Refinement types** | Types can carry a logical predicate: `{x:Int \| x > 0}` is the type of positive integers. Preconditions and postconditions live in the type itself and are checked statically by an SMT solver. |
+| **Specifications as types** | A function's contract is its type. Once `withdraw : (balance:Int \| balance >= 0) -> (amount:Int \| amount <= balance) -> {r:Int \| r >= 0}` type-checks, the contract is proved — no runtime assertion, no test required. |
+| **Immutability** | There is no assignment. `let x = 5` introduces a fresh binding for `x` in the scope that follows; the binding cannot be updated in place. |
+| **Currying and space application** | Multi-argument functions are nested single-argument functions. You apply them with whitespace: `add 2 3` is `(add 2) 3`. Partial application is automatic. |
+| **Expression-oriented** | Every construct is an expression and returns a value, including `if ... then ... else`. The last expression of a block is the block's value, so there is no separate `return` statement. |
+| **No exceptions, no `null`** | Errors are not raised. Failure is modelled with inductive types (`Maybe a`, `Either a b`) or, when possible, ruled out by refinement types so the failure case becomes unrepresentable. |
+| **Inductive types and pattern matching** | Data is defined with `inductive` (a sum of named constructors, each carrying typed fields), and destructured with `match ... with`. All constructors must be covered. |
+| **Functional, not object-oriented** | There are no classes, methods, or inheritance — only functions and inductive types. Behaviour is composed by passing functions, not by overriding. |
+| **Explicit polymorphism** | Generics are introduced with `forall t : B, ...` and applied at the call site, e.g. `id[Int]`. Type abstractions in the body use `Λ` (capital lambda). |
+| **Parametric refinements** | A function can be polymorphic over a refinement *predicate*, not just over a type. This lets one definition preserve whatever invariant the caller's arguments happen to satisfy. |
+| **Synthesis is a language feature** | `?hole` is a legal expression. The compiler can search for an expression of the surrounding type, optionally guided by `@minimize` / `@maximize` decorators, training data, or natural-language prompts. |
+| **Surface syntax** | Top-level definitions use `def`; local bindings use `let`. Function types use `->`. Comments begin with `#`. |
+| **Entry point** | A function `main` returning `Unit` is the program's entry point. Side effects come from primitives like `print` or through the FFI. |
+| **Python FFI** | Aeon is implemented as a Python interpreter, so it ships with a direct bridge to Python: `native "expr"` evaluates a Python expression, and `native_import "module"` pulls in a Python module (numpy, sklearn, etc.). The bridge is not statically type-checked, so an incorrect annotation surfaces at runtime. |
 
 ## The Aeon interpreter
 

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -89,6 +89,49 @@ Requires Ollama to be running locally. Use the `@prompt` decorator to provide a 
 
 ---
 
+### `tdsyn` / `tdsyn_enumerative` — Type-Directed Synthesis (BFS)
+
+Top-down, type-directed synthesizer that grows a partial AST by applying **backward** and **forward** actions to each open hole. Subtyping queries are discharged by an SMT solver, and when every remaining hole is a base-type leaf the synthesizer asks z3 to solve them all in one shot.
+
+Search is breadth-first over partial ASTs (capped by a depth bound). When the worklist is exhausted, the search restarts with a shuffled expansion order so that subsequent iterations explore different term shapes until the budget runs out. If no optimization goals are present, the first valid term is returned; otherwise the best-scoring term across iterations wins.
+
+---
+
+### `tdsyn_random` — Type-Directed Synthesis (Random Walks)
+
+Same expansion rules as `tdsyn`, but instead of a BFS worklist it performs independent random walks from the initial hole. Each walk repeatedly picks a random open hole and a random candidate expansion, falling back to SMT completion when only base-type leaves remain. Lighter than the BFS mode, useful when the term space is wide and shallow.
+
+---
+
+### `tactics` — Random Tactic Search
+
+A Lean-style tactic synthesizer. The proof obligation (the hole's goal type in its typing context) is reduced step by step by repeatedly choosing a random open hole and a random tactic from:
+
+- `apply?` — apply a function from context, leaving holes for its arguments
+- `assumption` — close the hole with a matching binding from context
+- `constructor` — apply an inductive-type constructor
+- `inst` — instantiate a type or refinement parameter
+- `choose_literal` — pick a base-type literal
+- `by_cases` — split on a boolean
+- `split` — split a conjunction in the goal
+
+Each iteration starts a fresh walk (up to 20 tactic steps); walks that fail to close all holes are abandoned. When optimization goals are present, the best-scoring closed walk across the budget is returned.
+
+---
+
+### `lta` — Liquid Tree Automata
+
+Component-based synthesis via Liquid Tree Automata (Algorithm 1 of the LTA paper). An automaton is seeded from the library functions in scope, the parameters of the goal type, and a minimal set of constants. It is then iteratively expanded by an explore-reduce-check loop:
+
+1. **Transition** — one round of E-app expansion pairs every function state with every argument state.
+2. **Prune** — drops states whose refinements are unsatisfiable.
+3. **Similarity / Minimize** — collapses observationally equivalent states.
+4. **Goal check** — Q-goal transitions try to connect candidate states to the goal type; a non-empty final state yields a candidate term.
+
+Polymorphic library functions are kept as cyclic *template* states and finitely unrolled into monomorphic instantiations against a small type universe. The expansion is depth-bounded (default `max_depth = 4`).
+
+---
+
 ## Choosing a Synthesizer
 
 | Synthesizer     | Strategy         | Best for |
@@ -102,3 +145,7 @@ Requires Ollama to be running locally. Use the `@prompt` decorator to provide a 
 | `smt`           | SMT solving      | Arithmetic / boolean constraints on base types |
 | `decision_tree` | Data-driven      | Regression from input–output examples |
 | `llm`           | LLM generation   | Problems that are easy to describe in natural language |
+| `tdsyn` / `tdsyn_enumerative` | Type-directed BFS with SMT leaves | Tightly-typed holes where leaves reduce to arithmetic |
+| `tdsyn_random` | Type-directed random walks with SMT leaves | Wider, shallower term spaces than `tdsyn` |
+| `tactics`       | Random tactic walks (Lean-style) | Goals whose proof decomposes into tactic steps |
+| `lta`           | Component-based via Liquid Tree Automata | Reusing a library of refined functions to assemble a term |


### PR DESCRIPTION
## Summary
- Reframe `docs/index.md` around Aeon's two pillars (refinement types + synthesis): new intro, a worked end-to-end example (`apply_discount` precondition/postcondition + a minimized `?hole` for a deposit problem), and a standalone "important concepts" table for newcomers (FFI is the only point that references Python explicitly).
- Document the four synthesizers that were registered in `aeon/synthesis/modules/synthesizerfactory.py` but missing from `docs/synthesizers.md`: `tdsyn` (BFS with backward/forward actions and SMT leaf-solving), `tdsyn_random` (random-walk variant), `tactics` (Lean-style random tactic search), and `lta` (Liquid Tree Automata).
- Extend the "Choosing a Synthesizer" table so all 13 registered modes are listed side by side.

## Test plan
- [ ] Render `docs/index.md` and `docs/synthesizers.md` via Jekyll / GitHub Pages preview and sanity-check the new sections and tables.
- [ ] Verify the synthesizer names in the new tables match `aeon/synthesis/modules/synthesizerfactory.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)