### PR TITLE
refactor: Remove minimize_cpu_time decorator alias

### DIFF
--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -58,8 +58,6 @@ sugar_decorators_environment: dict[str, DecoratorType] = {
     "minimize": minimize,
     "maximize": maximize,
     "minimize_cputime": minimize_cputime,
-    # Spelled-out alias (same implementation as minimize_cputime).
-    "minimize_cpu_time": minimize_cputime,
     "minimize_energy": minimize_energy,
 }
 

--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -460,8 +460,7 @@ def minimize_cputime(
 ) -> tuple[Definition, list[Definition], Metadata]:
     """Adds CPU time of the given expression as a synthesis objective.
 
-    Usage: ``@minimize_cputime(fun 42)`` — equivalent registry name:
-    ``@minimize_cpu_time(fun 42)``.
+    Usage: ``@minimize_cputime(fun 42)``.
 
     The expression is typically a call to the decorated function. During
     synthesis, the synthesizer evaluates the candidate program against this

--- a/docs/index.md
+++ b/docs/index.md
@@ -434,7 +434,6 @@ def approx (x:Int | x > 0) : Float =
 These add extra minimization objectives alongside numeric ones (for example `@minimize_int`). The synthesizer measures how expensive it is to **evaluate** the given expression for each candidate; the expression’s *value* is ignored, so its static type is unconstrained.
 
 - `@minimize_cputime(expr)` — fitness is CPU time in seconds for evaluating `expr` (`time.process_time()` around the evaluation).
-- `@minimize_cpu_time(expr)` — same as `@minimize_cputime` (alternate spelling).
 - `@minimize_energy(expr)` — fitness is energy in joules for evaluating `expr`. Uses Intel RAPL via the optional `pyRAPL` package when available; otherwise a CPU-time proxy (`cpu_time ×` a fixed watt estimate) so cheaper candidates still score better.
 
 See `examples/synthesis/cputime_energy.ae` for a program that combines correctness and resource objectives.

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -14,7 +14,7 @@ The `--budget` flag sets the time limit in seconds (default: 60).
 
 ### `gp` — Genetic Programming *(default)*
 
-Evolves a population of candidate programs using genetic programming, implemented via [GeneticEngine](https://github.com/alcides/GeneticEngine). Candidate programs are represented as syntax trees drawn from a grammar derived from the typing context. Selection, crossover, and mutation operators drive the search towards better fitness scores as defined by the synthesis decorators (`@minimize`, `@maximize`, `@minimize_cputime` / `@minimize_cpu_time`, `@minimize_energy`, etc.).
+Evolves a population of candidate programs using genetic programming, implemented via [GeneticEngine](https://github.com/alcides/GeneticEngine). Candidate programs are represented as syntax trees drawn from a grammar derived from the typing context. Selection, crossover, and mutation operators drive the search towards better fitness scores as defined by the synthesis decorators (`@minimize`, `@maximize`, `@minimize_cputime`, `@minimize_energy`, etc.).
 
 Best suited for problems with a rich fitness landscape and sufficient budget.
 

--- a/tests/optimization_decorators_test.py
+++ b/tests/optimization_decorators_test.py
@@ -59,9 +59,9 @@ def test_minimize_cputime_registers_goal():
     assert goals[0].kind == "cputime"
 
 
-def test_minimize_cpu_time_alias_registers_goal():
+def test_minimize_cputime_alias_registers_goal():
     source = """
-        @minimize_cpu_time(synth 7)
+        @minimize_cputime(synth 7)
         def synth (i:Int) : Int = i * (?hole: Int)
     """
     _, _, _, metadata = check_and_return_core(source)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove the duplicate `@minimize_cpu_time` decorator alias, keeping only the canonical `@minimize_cputime` decorator to simplify the API.

Changes:
- Removed `minimize_cpu_time` from decorator registry
- Updated test to use `@minimize_cputime` instead
- Updated documentation to remove mention of the alias
- Cleaned up docstring

All tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4af9512b-1452-4d70-ada4-4b9f8547b41a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4af9512b-1452-4d70-ada4-4b9f8547b41a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

