### PR TITLE
Refined Learning library + boolean precedence fix + if-cond refinement propagation

### DIFF
--- a/aeon/bindings/learning.py
+++ b/aeon/bindings/learning.py
@@ -1,183 +1,504 @@
-import sklearn.model_selection
-from sklearn.ensemble import RandomForestClassifier
-from collections import Counter
-from imblearn.over_sampling import SMOTE
-from sklearn.metrics import confusion_matrix
-from sklearn.preprocessing import StandardScaler, MinMaxScaler
+"""Python bindings for the Aeon ``Learning`` library.
+
+Each function exposed to Aeon is named ``Learning_<name>`` and curried so
+that the native string ``Learning_<name>(a, b)`` can be partially or fully
+applied. Aeon's ``Dataset`` is a plain ``(X, y)`` Python tuple — the
+splitting of features and target is hidden from the surface language so
+users never have to think about ``X``/``y`` directly. ``DataFrame`` is a
+pandas ``DataFrame`` retained when the source still has all columns
+together.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
 import pandas as pd
+from sklearn.ensemble import (
+    GradientBoostingClassifier,
+    GradientBoostingRegressor,
+    RandomForestClassifier,
+    RandomForestRegressor,
+)
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import (
+    ElasticNet,
+    Lasso,
+    LinearRegression,
+    LogisticRegression,
+    Ridge,
+)
+from sklearn.metrics import (
+    accuracy_score,
+    classification_report,
+    confusion_matrix,
+    explained_variance_score,
+    f1_score,
+    mean_absolute_error,
+    mean_squared_error,
+    precision_score,
+    r2_score,
+    recall_score,
+    roc_auc_score,
+)
+from sklearn.model_selection import train_test_split
+from sklearn.naive_bayes import ComplementNB, GaussianNB, MultinomialNB
+from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+from sklearn.neural_network import MLPClassifier, MLPRegressor
+from sklearn.preprocessing import MinMaxScaler, RobustScaler, StandardScaler
+from sklearn.svm import SVC, SVR
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
+
+from aeon.bindings.binding_utils import curried
 
 
-def train_test_split_pairs(X, y, test_size):
-    """
-    Splits features X and labels y into training and test sets, then zips them into (x, y) pairs.
-
-    Parameters:
-        X (list): List of feature vectors.
-        y (list): List of labels.
-        test_size (float): Fraction of the dataset to use as the test set.
-
-    Returns:
-        tuple: (train, test), where train and test are lists of (x, y) pairs.
-    """
-    X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y, test_size=test_size)
-    train = list(zip(X_train, y_train))
-    test = list(zip(X_test, y_test))
-    return train, test
+# ─── helpers (not exposed to Aeon) ───────────────────────────────────────
 
 
-def balanced(ds):
-    """
-    Checks if a dataset is balanced (all classes have the same number of samples).
-
-    Parameters:
-        ds (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
-
-    Returns:
-        bool: True if all classes have the same count, False otherwise.
-    """
-    _, y = ds
-    counts = Counter(y)  # count occurrences of each class label
-    return len(set(counts.values())) == 1  # ensure all classes have the same count
+def _as_xy(ds: Any) -> tuple[Any, Any]:
+    X, y = ds
+    return X, y
 
 
-def load_dataset(filename):
-    """
-    Loads a dataset from a CSV file, assuming the last column is the label.
-
-    Parameters:
-        filename (str): Path to the CSV file.
-
-    Returns:
-        tuple: (X, y), where X is a list of feature vectors and y is a list of labels.
-    """
-    df = pd.read_csv(filename)
-    X = df.iloc[:, :-1].values.tolist()
-    y = df.iloc[:, -1].tolist()
+def _xy(X: Any, y: Any) -> tuple[Any, Any]:
     return (X, y)
 
 
-def split_dataset(ds, fraction):
-    """
-    Splits a dataset into training and test sets according to the given fraction.
-
-    Parameters:
-        ds (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
-        fraction (float): Fraction of the dataset to use as the training set.
-
-    Returns:
-        tuple: ((X_train, y_train), (X_test, y_test))
-    """
-    X, y = ds
-    X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(X, y, test_size=1 - fraction)
-    return ((X_train, y_train), (X_test, y_test))
+def _counts(y: Any) -> dict[Any, int]:
+    s = pd.Series(y)
+    return s.value_counts().to_dict()
 
 
-def train_random_forest(dataset):
-    """
-    Trains a RandomForestClassifier on the given dataset.
+def _smote_lazy() -> Any:
+    from imblearn.over_sampling import SMOTE
 
-    Parameters:
-        dataset (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
-
-    Returns:
-        RandomForestClassifier: The trained classifier.
-    """
-    X, y = dataset
-    clf = RandomForestClassifier()
-    clf.fit(X, y)
-    return clf
+    return SMOTE
 
 
-def smote_oversample(ds):
-    """
-    Applies SMOTE oversampling to balance the classes in the dataset.
+def _random_oversampler_lazy() -> Any:
+    from imblearn.over_sampling import RandomOverSampler
 
-    Parameters:
-        ds (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
-
-    Returns:
-        tuple: (X_res, y_res), the oversampled features and labels as lists.
-    """
-    X, y = ds
-    X_res, y_res = SMOTE().fit_resample(X, y)
-    return (X_res.tolist(), y_res.tolist())
+    return RandomOverSampler
 
 
-def predict(model, ds):
-    """
-    Uses the given model to predict labels for the features in ds.
+def _random_undersampler_lazy() -> Any:
+    from imblearn.under_sampling import RandomUnderSampler
 
-    Parameters:
-        model: Trained classifier with a predict method.
-        ds (tuple): Tuple (X, _), where X is a list of feature vectors.
-
-    Returns:
-        list: Predicted labels.
-    """
-    X, _ = ds
-    y_pred = model.predict(X)
-    return y_pred.tolist()
+    return RandomUnderSampler
 
 
-def score(model, ds):
-    """
-    Computes the accuracy score of the model on the given dataset.
-
-    Parameters:
-        model: Trained classifier with a score method.
-        ds (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
-
-    Returns:
-        float: Accuracy score.
-    """
-    X, y = ds
-    return float(model.score(X, y))
+# ─── Loading / target selection ─────────────────────────────────────────
 
 
-def confusion_matrix_(model, ds):
-    """
-    Computes the confusion matrix for the model's predictions on the dataset.
-
-    Parameters:
-        model: Trained classifier with a predict method.
-        ds (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
-
-    Returns:
-        list: Confusion matrix as a nested list.
-    """
-    X, y = ds
-    y_pred = model.predict(X)
-    cm = confusion_matrix(y, y_pred)
-    return cm.tolist()
+@curried
+def Learning_read_csv(path):
+    """Read a CSV file into a pandas DataFrame (all columns kept)."""
+    return pd.read_csv(path)
 
 
-def standard_scale(ds):
-    """
-    Scales features in the dataset to have zero mean and unit variance.
-
-    Parameters:
-        ds (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
-
-    Returns:
-        tuple: (X_scaled, y), where X_scaled is the scaled features as a list.
-    """
-    X, y = ds
-    scaler = StandardScaler()
-    X_scaled = scaler.fit_transform(X)
-    return (X_scaled.tolist(), y)
+@curried
+def Learning_target(df, column):
+    """Designate ``column`` as the target; return the ``(X, y)`` Dataset."""
+    y = df[column].tolist()
+    X = df.drop(columns=[column]).values.tolist()
+    return _xy(X, y)
 
 
-def minmax_scale(ds):
-    """
-    Scales features in the dataset to the [0, 1] range.
+@curried
+def Learning_target_at(df, index):
+    """Designate the column at ``index`` (0-based) as the target."""
+    column = df.columns[index]
+    return Learning_target(df, column)
 
-    Parameters:
-        ds (tuple): Tuple (X, y), where X is a list of feature vectors and y is a list of labels.
 
-    Returns:
-        tuple: (X_scaled, y), where X_scaled is the scaled features as a list.
-    """
-    X, y = ds
-    scaler = MinMaxScaler()
-    X_scaled = scaler.fit_transform(X)
-    return (X_scaled.tolist(), y)
+@curried
+def Learning_load(path):
+    """Convenience: read a CSV and use the *last* column as the target."""
+    df = pd.read_csv(path)
+    return Learning_target_at(df, len(df.columns) - 1)
+
+
+@curried
+def Learning_columns(df):
+    """Return the list of column names."""
+    return list(df.columns)
+
+
+@curried
+def Learning_has_column(df, column):
+    return column in df.columns
+
+
+# ─── Dataset introspection ──────────────────────────────────────────────
+
+
+@curried
+def Learning_n_rows(ds):
+    X, _ = _as_xy(ds)
+    return len(X)
+
+
+@curried
+def Learning_n_features(ds):
+    X, _ = _as_xy(ds)
+    if len(X) == 0:
+        return 0
+    return len(X[0])
+
+
+@curried
+def Learning_is_balanced(ds):
+    _, y = _as_xy(ds)
+    counts = _counts(y)
+    return len(set(counts.values())) == 1
+
+
+@curried
+def Learning_class_counts(ds):
+    """Return a list of (label, count) tuples sorted by label."""
+    _, y = _as_xy(ds)
+    items = sorted(_counts(y).items(), key=lambda kv: str(kv[0]))
+    return [list(kv) for kv in items]
+
+
+# ─── Splitting ──────────────────────────────────────────────────────────
+
+
+@curried
+def Learning_split(ds, fraction):
+    """Split into (training, testing). ``fraction`` is the training share."""
+    X, y = _as_xy(ds)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=1 - fraction)
+    return (_xy(X_train, y_train), _xy(X_test, y_test))
+
+
+@curried
+def Learning_split_training(ds, fraction):
+    return Learning_split(ds, fraction)[0]
+
+
+@curried
+def Learning_split_testing(ds, fraction):
+    return Learning_split(ds, fraction)[1]
+
+
+# ─── Resampling / balancing ─────────────────────────────────────────────
+
+
+@curried
+def Learning_smote(ds):
+    X, y = _as_xy(ds)
+    smote = _smote_lazy()()
+    X_res, y_res = smote.fit_resample(X, y)
+    return _xy(np.asarray(X_res).tolist(), list(y_res))
+
+
+@curried
+def Learning_random_oversample(ds):
+    X, y = _as_xy(ds)
+    ros = _random_oversampler_lazy()()
+    X_res, y_res = ros.fit_resample(X, y)
+    return _xy(np.asarray(X_res).tolist(), list(y_res))
+
+
+@curried
+def Learning_random_undersample(ds):
+    X, y = _as_xy(ds)
+    rus = _random_undersampler_lazy()()
+    X_res, y_res = rus.fit_resample(X, y)
+    return _xy(np.asarray(X_res).tolist(), list(y_res))
+
+
+# ─── Scaling ────────────────────────────────────────────────────────────
+
+
+def _scale(ds, scaler):
+    X, y = _as_xy(ds)
+    X_scaled = scaler.fit_transform(X).tolist()
+    return _xy(X_scaled, y)
+
+
+@curried
+def Learning_standard_scale(ds):
+    return _scale(ds, StandardScaler())
+
+
+@curried
+def Learning_minmax_scale(ds):
+    return _scale(ds, MinMaxScaler())
+
+
+@curried
+def Learning_robust_scale(ds):
+    return _scale(ds, RobustScaler())
+
+
+# ─── Missing-value imputation ───────────────────────────────────────────
+
+
+def _impute(ds, strategy, fill_value=None):
+    X, y = _as_xy(ds)
+    imp = SimpleImputer(strategy=strategy, fill_value=fill_value)
+    X_imp = imp.fit_transform(X).tolist()
+    return _xy(X_imp, y)
+
+
+@curried
+def Learning_fill_mean(ds):
+    return _impute(ds, "mean")
+
+
+@curried
+def Learning_fill_median(ds):
+    return _impute(ds, "median")
+
+
+@curried
+def Learning_fill_most_frequent(ds):
+    return _impute(ds, "most_frequent")
+
+
+@curried
+def Learning_fill_constant(ds, value):
+    return _impute(ds, "constant", fill_value=value)
+
+
+# ─── Classifier training ────────────────────────────────────────────────
+
+
+def _fit(model, ds):
+    X, y = _as_xy(ds)
+    model.fit(X, y)
+    return model
+
+
+@curried
+def Learning_random_forest_classifier(ds):
+    return _fit(RandomForestClassifier(), ds)
+
+
+@curried
+def Learning_random_forest_classifier_n(n, ds):
+    return _fit(RandomForestClassifier(n_estimators=n), ds)
+
+
+@curried
+def Learning_logistic_regression(ds):
+    return _fit(LogisticRegression(max_iter=1000), ds)
+
+
+@curried
+def Learning_decision_tree_classifier(ds):
+    return _fit(DecisionTreeClassifier(), ds)
+
+
+@curried
+def Learning_gradient_boosting_classifier(ds):
+    return _fit(GradientBoostingClassifier(), ds)
+
+
+@curried
+def Learning_knn_classifier(ds):
+    return _fit(KNeighborsClassifier(), ds)
+
+
+@curried
+def Learning_knn_classifier_k(k, ds):
+    return _fit(KNeighborsClassifier(n_neighbors=k), ds)
+
+
+@curried
+def Learning_svc(ds):
+    return _fit(SVC(probability=True), ds)
+
+
+@curried
+def Learning_gaussian_nb(ds):
+    return _fit(GaussianNB(), ds)
+
+
+@curried
+def Learning_multinomial_nb(ds):
+    return _fit(MultinomialNB(), ds)
+
+
+@curried
+def Learning_complement_nb(ds):
+    return _fit(ComplementNB(), ds)
+
+
+@curried
+def Learning_mlp_classifier(ds):
+    return _fit(MLPClassifier(max_iter=500), ds)
+
+
+# ─── Regressor training ─────────────────────────────────────────────────
+
+
+@curried
+def Learning_linear_regression(ds):
+    return _fit(LinearRegression(), ds)
+
+
+@curried
+def Learning_ridge(ds):
+    return _fit(Ridge(), ds)
+
+
+@curried
+def Learning_ridge_alpha(alpha, ds):
+    return _fit(Ridge(alpha=alpha), ds)
+
+
+@curried
+def Learning_lasso(ds):
+    return _fit(Lasso(), ds)
+
+
+@curried
+def Learning_lasso_alpha(alpha, ds):
+    return _fit(Lasso(alpha=alpha), ds)
+
+
+@curried
+def Learning_elastic_net(ds):
+    return _fit(ElasticNet(), ds)
+
+
+@curried
+def Learning_random_forest_regressor(ds):
+    return _fit(RandomForestRegressor(), ds)
+
+
+@curried
+def Learning_random_forest_regressor_n(n, ds):
+    return _fit(RandomForestRegressor(n_estimators=n), ds)
+
+
+@curried
+def Learning_decision_tree_regressor(ds):
+    return _fit(DecisionTreeRegressor(), ds)
+
+
+@curried
+def Learning_gradient_boosting_regressor(ds):
+    return _fit(GradientBoostingRegressor(), ds)
+
+
+@curried
+def Learning_knn_regressor(ds):
+    return _fit(KNeighborsRegressor(), ds)
+
+
+@curried
+def Learning_svr(ds):
+    return _fit(SVR(), ds)
+
+
+@curried
+def Learning_mlp_regressor(ds):
+    return _fit(MLPRegressor(max_iter=500), ds)
+
+
+# ─── Prediction ─────────────────────────────────────────────────────────
+
+
+@curried
+def Learning_predict(model, ds):
+    X, _ = _as_xy(ds)
+    return list(model.predict(X))
+
+
+@curried
+def Learning_predict_proba(model, ds):
+    X, _ = _as_xy(ds)
+    return model.predict_proba(X).tolist()
+
+
+# ─── Classification metrics ─────────────────────────────────────────────
+
+
+def _predicted_pair(model, ds):
+    X, y = _as_xy(ds)
+    return list(y), list(model.predict(X))
+
+
+@curried
+def Learning_accuracy(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(accuracy_score(y_true, y_pred))
+
+
+@curried
+def Learning_precision(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(precision_score(y_true, y_pred, average="weighted", zero_division=0))
+
+
+@curried
+def Learning_recall(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(recall_score(y_true, y_pred, average="weighted", zero_division=0))
+
+
+@curried
+def Learning_f1(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(f1_score(y_true, y_pred, average="weighted", zero_division=0))
+
+
+@curried
+def Learning_roc_auc(model, ds):
+    X, y = _as_xy(ds)
+    proba = model.predict_proba(X)
+    classes = list(getattr(model, "classes_", []))
+    if len(classes) == 2:
+        return float(roc_auc_score(y, proba[:, 1]))
+    return float(roc_auc_score(y, proba, multi_class="ovr", average="weighted"))
+
+
+@curried
+def Learning_confusion_matrix(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return confusion_matrix(y_true, y_pred).tolist()
+
+
+@curried
+def Learning_classification_report(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return classification_report(y_true, y_pred, zero_division=0)
+
+
+# ─── Regression metrics ─────────────────────────────────────────────────
+
+
+@curried
+def Learning_mse(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(mean_squared_error(y_true, y_pred))
+
+
+@curried
+def Learning_rmse(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(math.sqrt(mean_squared_error(y_true, y_pred)))
+
+
+@curried
+def Learning_mae(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(mean_absolute_error(y_true, y_pred))
+
+
+@curried
+def Learning_r2(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(r2_score(y_true, y_pred))
+
+
+@curried
+def Learning_explained_variance(model, ds):
+    y_true, y_pred = _predicted_pair(model, ds)
+    return float(explained_variance_score(y_true, y_pred))

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -109,12 +109,31 @@ by_body : TACTIC_CMD                                         -> by_body_atomic
 tactic_steps : TACTIC_CMD (";" TACTIC_CMD)*                -> tactic_steps
 TACTIC_CMD : "apply?" | "assumption" | "constructor" | "choose_literal" | "by_cases" | "split" | "inst"
 
-expression_un : expression_bool                                      -> same
-           | "!" expression_un                                       -> nnot
-           | expression_bool "==" expression_un                      -> binop_eq
-           | expression_bool "!=" expression_un                      -> binop_neq
-           | expression_bool "&&" expression_un                      -> binop_and
-           | expression_bool _DOUBLEPIPE expression_un               -> binop_or
+// Boolean operators, in order of precedence (low → high):
+//   || (logical or)
+//   && (logical and)
+//   ==, != (equality)
+//   !  (negation)
+//   <, <=, >, >=, --> (relational, in `expression_bool`)
+// Each level recurses on the right (right-associative). With this split,
+//   ``a == b && c == d`` parses as ``(a == b) && (c == d)``,
+//   ``!a == b``         as ``(!a) == b``,
+//   ``a || b && c``     as ``a || (b && c)``.
+
+expression_un : expression_or                                       -> same
+
+expression_or : expression_and                                      -> same
+              | expression_and _DOUBLEPIPE expression_or            -> binop_or
+
+expression_and : expression_eq                                      -> same
+               | expression_eq "&&" expression_and                  -> binop_and
+
+expression_eq : expression_not                                      -> same
+              | expression_not "==" expression_eq                   -> binop_eq
+              | expression_not "!=" expression_eq                   -> binop_neq
+
+expression_not : expression_bool                                    -> same
+               | "!" expression_not                                 -> nnot
 
 
 expression_bool : expression_plus                                  -> same

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -202,15 +202,19 @@ def _bind_definition(
     for fname, kind in df.foralls:
         nname, nsubs = check_name(fname, nsubs)
         foralls.append((nname, kind))
+    # Bind refinement-polymorphic predicates *before* args so any
+    # ``a<p>`` reference inside an arg's type resolves to the same ``p``
+    # bound here, rather than picking up a placeholder ID that later
+    # diverges from the rforalls entry.
+    rforalls = []
+    for pname, psort in df.rforalls:
+        nname, nsubs = check_name(pname, nsubs)
+        rforalls.append((nname, bind_stype(psort, nsubs)))
     args = []
     for aname, ty in df.args:
         nname, nsubs = check_name(aname, nsubs)
         ty = bind_stype(ty, nsubs)
         args.append((nname, ty))
-    rforalls = []
-    for pname, psort in df.rforalls:
-        nname, nsubs = check_name(pname, nsubs)
-        rforalls.append((nname, bind_stype(psort, nsubs)))
     ntype = bind_stype(df.type, nsubs)
     decreasing = [bind_sterm(m, nsubs) for m in df.decreasing_by]
     body = bind_sterm(df.body, nsubs)

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -735,6 +735,23 @@ def expand_inductive_decls(p: Program) -> Program:
                             )
                             defs.append(de)
 
+                            # NOTE: auto-generated polymorphic projections were
+                            # explored here but blocked on a deeper limitation —
+                            # polymorphic uninterpreted binders are eagerly
+                            # monomorphised to ``Int`` by ``monomorphic_type``,
+                            # and polymorphic non-uninterpreted variable binders
+                            # are silently dropped by ``implication_constraint``
+                            # for ``TypePolymorphism`` (only reflected or
+                            # uninterpreted polymorphic functions reach SMT).
+                            # Until that pipeline lifts, libraries can declare
+                            # **monomorphic** uninterpreted projections per
+                            # concrete instantiation, e.g.::
+                            #
+                            #   def split_fst : (p: (Pair Dataset Dataset)) -> Dataset = uninterpreted
+                            #
+                            # which the SMT layer treats as a plain uninterpreted
+                            # function on the mangled sort.
+
                 def curry(args: list[tuple[Name, SType]], rty: SType, mults: tuple[Multiplicity, ...] = ()) -> SType:
                     n = len(args)
                     for i, (aname, aty) in enumerate(args[::-1]):

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -57,7 +57,6 @@ from aeon.facade.api import (
     CoreSubtypingError,
     CoreTypeApplicationRequiresBareTypesError,
     CoreTypeCheckingError,
-    CoreTypingRelation,
     CoreVariableNotInContext,
     CoreWellformnessError,
     CoreWrongKindInTypeApplicationError,
@@ -88,6 +87,13 @@ from aeon.verification.helpers import (
 )
 
 ctrue = LiquidConstraint(LiquidLiteralBool(True))
+
+
+def _and(a: LiquidTerm, b: "LiquidTerm | None") -> LiquidTerm:
+    """``a && b`` when ``b`` is present, otherwise just ``a``."""
+    if b is None:
+        return a
+    return LiquidApp(Name("&&", 0), [a, b])
 
 
 def _strip_type_level_wrappers(t: Term) -> Term:
@@ -530,23 +536,40 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             # share an expected type — synth each under its guard and join refinements.
             liq_cond = liquefy(cond)
             assert liq_cond is not None, f"Could not liquefy if-condition {cond}"
-            c_cond = check(ctx, cond, t_bool)
+            # Synth the cond so its return refinement is propagated into
+            # the branches' hypotheses (see check-mode for details).
+            (c_synth_cond, t_cond) = synth(ctx, cond)
+            ex_binders: tuple[tuple[Name, Type], ...] = ()
+            if isinstance(t_cond, ExistentialType):
+                ex_binders = t_cond.binders
+                t_cond = t_cond.body
+            c_sub_cond = sub(ctx, t_cond, t_bool, cond.loc)
+            c_cond = Conjunction(c_synth_cond, c_sub_cond)
+            branch_ctx = ctx
+            for bn, bt in ex_binders:
+                branch_ctx = branch_ctx.with_var(bn, bt)
+            cond_ref: "LiquidTerm | None" = None
+            t_cond_r = ensure_refined(t_cond)
+            if isinstance(t_cond_r, RefinedType) and not (
+                isinstance(t_cond_r.refinement, LiquidLiteralBool) and t_cond_r.refinement.value is True
+            ):
+                cond_ref = substitution_in_liquid(t_cond_r.refinement, liq_cond, t_cond_r.name)
 
             y = Name("_cond", fresh_counter.fresh())
-            (c1_inner, t1) = synth(ctx, then)
+            (c1_inner, t1) = synth(branch_ctx, then)
             c1 = implication_constraint(
                 y,
-                RefinedType(Name("branch_pos", fresh_counter.fresh()), t_int, liq_cond),
+                RefinedType(Name("branch_pos", fresh_counter.fresh()), t_int, _and(liq_cond, cond_ref)),
                 c1_inner,
                 then.loc,
             )
-            (c2_inner, t2) = synth(ctx, otherwise)
+            (c2_inner, t2) = synth(branch_ctx, otherwise)
             c2 = implication_constraint(
                 y,
                 RefinedType(
                     Name("branch_neg", fresh_counter.fresh()),
                     t_int,
-                    LiquidApp(Name("!", 0), [liq_cond]),
+                    _and(LiquidApp(Name("!", 0), [liq_cond]), cond_ref),
                 ),
                 c2_inner,
                 otherwise.loc,
@@ -574,7 +597,10 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                 joined = t1
             else:
                 raise CoreSubtypingError(ctx, t, t1, t2)
-            return (Conjunction(c_cond, Conjunction(c1, c2)), joined)
+            if_constraint: Constraint = Conjunction(c_cond, Conjunction(c1, c2))
+            for bn, bt in reversed(ex_binders):
+                if_constraint = implication_constraint(bn, bt, if_constraint, t.loc)
+            return (if_constraint, joined)
 
         case Hole(hole_name):
             name_a = Name(hole_name.name, fresh_counter.fresh())
@@ -633,24 +659,49 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
             y = Name("_cond", fresh_counter.fresh())
             liq_cond = liquefy(cond)
             assert liq_cond is not None
-            if not check_type(ctx, cond, t_bool):
-                raise CoreTypingRelation(ctx, cond, t_bool)
-            c0 = check(ctx, cond, t_bool)
+            # Synth the condition so its refinement can be carried into
+            # the branches: for ``cond : {b: Bool | r(b)}`` we add
+            # ``r(liq_cond)`` to both branches' hypotheses, alongside
+            # the truth/falsity fact. Existential binders are opened
+            # into the branch context (mirroring how ``Let`` does it).
+            (c_synth, t_cond) = synth(ctx, cond)
+            ex_binders: tuple[tuple[Name, Type], ...] = ()
+            if isinstance(t_cond, ExistentialType):
+                ex_binders = t_cond.binders
+                t_cond = t_cond.body
+            c_sub = sub(ctx, t_cond, t_bool, cond.loc)
+            c0 = Conjunction(c_synth, c_sub)
+            branch_ctx = ctx
+            for bn, bt in ex_binders:
+                branch_ctx = branch_ctx.with_var(bn, bt)
+            cond_ref: "LiquidTerm | None" = None
+            t_cond_r = ensure_refined(t_cond)
+            if isinstance(t_cond_r, RefinedType) and not (
+                isinstance(t_cond_r.refinement, LiquidLiteralBool) and t_cond_r.refinement.value is True
+            ):
+                cond_ref = substitution_in_liquid(t_cond_r.refinement, liq_cond, t_cond_r.name)
             name_pos = Name("branch_pos", fresh_counter.fresh())
             c1 = implication_constraint(
                 y,
-                RefinedType(name_pos, t_int, liq_cond),
-                check(ctx, then, ty),
+                RefinedType(name_pos, t_int, _and(liq_cond, cond_ref)),
+                check(branch_ctx, then, ty),
                 then.loc,
             )
             name_neg = Name("branch_neg", fresh_counter.fresh())
             c2 = implication_constraint(
                 y,
-                RefinedType(name_neg, t_int, LiquidApp(Name("!", 0), [liq_cond])),
-                check(ctx, otherwise, ty),
+                RefinedType(
+                    name_neg,
+                    t_int,
+                    _and(LiquidApp(Name("!", 0), [liq_cond]), cond_ref),
+                ),
+                check(branch_ctx, otherwise, ty),
                 otherwise.loc,
             )
-            return Conjunction(c0, Conjunction(c1, c2))
+            if_constraint: Constraint = Conjunction(c0, Conjunction(c1, c2))
+            for bn, bt in reversed(ex_binders):
+                if_constraint = implication_constraint(bn, bt, if_constraint, t.loc)
+            return if_constraint
         case TypeAbstraction(name, kind, body), TypePolymorphism(var_name, var_kind, var_body):
             if var_kind == BaseKind() and kind != var_kind:
                 raise CoreWrongKindInTypeApplicationError(

--- a/aeon/typechecking/well_formed.py
+++ b/aeon/typechecking/well_formed.py
@@ -46,7 +46,11 @@ def wf_inner(ctx: TypingContext, t: Type, k: Kind = StarKind()) -> bool:
                 cargs = ctx.get_type_constructor(name)
                 if not cargs or len(cargs) != len(args):
                     return False
-                return all(wf_inner(ctx, t) for t in args)
+                # Type-constructor arguments are base types (with optional
+                # refinement); use ``wellformed`` so refined type variables
+                # like ``{_r:a | p _r}`` (which need BaseKind) are accepted
+                # in positions like ``List a<p>`` or ``Pair a<p> b<q>``.
+                return all(wellformed(ctx, t) for t in args)
         case RefinedType(name, TypeConstructor(_, args) as ity, refinement):
             return wf_inner(ctx, ity) and typecheck_liquid(ctx.with_var(name, ity), refinement) == t_bool
         case ExistentialType(binders, body):

--- a/examples/demos/3_dataset.ae
+++ b/examples/demos/3_dataset.ae
@@ -1,12 +1,17 @@
+# Multinomial Naive Bayes pipeline.
+# https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf
+
 open Learning
-
-def training_multinomial_nb (filename: String) : Model = let df = Learning.load_dataset filename in
-    let balanced_df = Learning.smote_oversample df in
-    let train_set = Learning.split_dataset_training balanced_df 0.7 in
-    let test_set = Learning.split_dataset_testing balanced_df 0.7 in
-    Learning.train_multinomial_nb train_set;
-
-# https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf
+open Tuple
 
 
-# https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf
+def train_multinomial (path: String) (target_col: String) : Classifier =
+    let 1 df = Learning.read_csv path in
+    let ds = Learning.target df target_col in
+    if Learning.is_multiclass ds then
+        let bds = Learning.smote ds in
+        let parts = Learning.split bds 0.7 in
+        Learning.multinomial_nb (Tuple.fst parts)
+    else
+        let parts = Learning.split ds 0.7 in
+        Learning.multinomial_nb (Tuple.fst parts) ;

--- a/examples/demos/3_dataset.ae
+++ b/examples/demos/3_dataset.ae
@@ -2,7 +2,6 @@
 # https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf
 
 open Learning
-open Tuple
 
 
 def train_multinomial (path: String) (target_col: String) : Classifier =
@@ -11,7 +10,7 @@ def train_multinomial (path: String) (target_col: String) : Classifier =
     if Learning.is_multiclass ds then
         let bds = Learning.smote ds in
         let parts = Learning.split bds 0.7 in
-        Learning.multinomial_nb (Tuple.fst parts)
+        Learning.multinomial_nb (Learning.train_of parts)
     else
         let parts = Learning.split ds 0.7 in
-        Learning.multinomial_nb (Tuple.fst parts) ;
+        Learning.multinomial_nb (Learning.train_of parts) ;

--- a/examples/ml/balanced_dataset.ae
+++ b/examples/ml/balanced_dataset.ae
@@ -1,18 +1,29 @@
-# This file is an example of how to use the Learning libary to generate a statically checked balanced dataset
-# and train a random forest model on it.
+# Train a random-forest classifier on a balanced dataset.
+#
+# The source dataframe is bound linearly so the type checker rules out
+# accidental reuse after the (X, y) split is committed via ``target``.
+# SMOTE's ``ds_classes ds >= 2`` precondition is discharged by an
+# inline ``is_multiclass`` runtime guard.
 
 open Learning
+open Tuple
 
 
-def generate_model_1 (filename: String) : Model =
-    let df = Learning.load_dataset filename in
-    let balanced_df = Learning.smote_oversample df in # Balance the dataset using SMOTE oversampling
-    let train_set = Learning.split_dataset_training balanced_df 0.7 in
-    let test_set = Learning.split_dataset_testing balanced_df 0.7 in
-    Learning.train_random_forest train_set; # Train a random forest model on the training set
+def generate_model_smote (path: String) (target_col: String) : Classifier =
+    let 1 df = Learning.read_csv path in
+    let ds = Learning.target df target_col in
+    if Learning.is_multiclass ds then
+        let bds = Learning.smote ds in
+        let parts = Learning.split bds 0.7 in
+        Learning.random_forest_classifier (Tuple.fst parts)
+    else
+        # Single-class — SMOTE would crash, so skip balancing.
+        let parts = Learning.split ds 0.7 in
+        Learning.random_forest_classifier (Tuple.fst parts) ;
 
-def generate_model_2 (filename: String) : Model =
-    let df = Learning.load_dataset filename in
-    let train_set = Learning.split_dataset_training df 0.7 in
-    let test_set = Learning.split_dataset_testing df 0.7 in
-    Learning.train_random_forest train_set; # Train a random forest model on the training set
+
+def generate_model_plain (path: String) (target_col: String) : Classifier =
+    let 1 df = Learning.read_csv path in
+    let ds = Learning.target df target_col in
+    let parts = Learning.split ds 0.7 in
+    Learning.random_forest_classifier (Tuple.fst parts) ;

--- a/examples/ml/balanced_dataset.ae
+++ b/examples/ml/balanced_dataset.ae
@@ -1,12 +1,11 @@
 # Train a random-forest classifier on a balanced dataset.
 #
-# The source dataframe is bound linearly so the type checker rules out
-# accidental reuse after the (X, y) split is committed via ``target``.
-# SMOTE's ``ds_classes ds >= 2`` precondition is discharged by an
-# inline ``is_multiclass`` runtime guard.
+# The source dataframe is bound linearly, the split returns a refined
+# ``Pair Dataset Dataset`` whose halves preserve the source's feature /
+# class / balance invariants, and the ``train_of`` / ``test_of`` runtime
+# accessors propagate those invariants to the let-bound halves.
 
 open Learning
-open Tuple
 
 
 def generate_model_smote (path: String) (target_col: String) : Classifier =
@@ -15,15 +14,14 @@ def generate_model_smote (path: String) (target_col: String) : Classifier =
     if Learning.is_multiclass ds then
         let bds = Learning.smote ds in
         let parts = Learning.split bds 0.7 in
-        Learning.random_forest_classifier (Tuple.fst parts)
+        Learning.random_forest_classifier (Learning.train_of parts)
     else
-        # Single-class — SMOTE would crash, so skip balancing.
         let parts = Learning.split ds 0.7 in
-        Learning.random_forest_classifier (Tuple.fst parts) ;
+        Learning.random_forest_classifier (Learning.train_of parts) ;
 
 
 def generate_model_plain (path: String) (target_col: String) : Classifier =
     let 1 df = Learning.read_csv path in
     let ds = Learning.target df target_col in
     let parts = Learning.split ds 0.7 in
-    Learning.random_forest_classifier (Tuple.fst parts) ;
+    Learning.random_forest_classifier (Learning.train_of parts) ;

--- a/examples/ml/classification_pipeline.ae
+++ b/examples/ml/classification_pipeline.ae
@@ -1,0 +1,38 @@
+# End-to-end classification pipeline showcasing the Learning library.
+#
+# Runtime witnesses (``is_multiclass``, ``balanced``) can be used inline
+# inside ``if ... then ... else ...`` to discharge precondition
+# refinements — no let-binding workaround needed.
+
+open Learning
+open Tuple
+
+
+def evaluate (train_set: Dataset) (test_set: Dataset) : Float =
+    let model = Learning.random_forest_classifier train_set in
+    Learning.accuracy model test_set ;
+
+
+def pipeline (path: String) (target_col: String) : Classifier =
+    let 1 df = Learning.read_csv path in
+    let ds = Learning.target df target_col in
+    if Learning.is_multiclass ds then
+        let bds = Learning.smote ds in
+        let scaled = Learning.standard_scale bds in
+        let parts = Learning.split scaled 0.8 in
+        Learning.random_forest_classifier (Tuple.fst parts)
+    else
+        let scaled = Learning.standard_scale ds in
+        let parts = Learning.split scaled 0.8 in
+        Learning.random_forest_classifier (Tuple.fst parts) ;
+
+
+# ComplementNB requires imbalanced data. Discharged via an inline
+# ``balanced`` runtime check.
+def cnb_pipeline (path: String) (target_col: String) : Classifier =
+    let 1 df = Learning.read_csv path in
+    let ds = Learning.target df target_col in
+    if Learning.balanced ds then
+        Learning.multinomial_nb ds
+    else
+        Learning.complement_nb ds ;

--- a/examples/ml/classification_pipeline.ae
+++ b/examples/ml/classification_pipeline.ae
@@ -1,33 +1,38 @@
 # End-to-end classification pipeline showcasing the Learning library.
 #
-# Runtime witnesses (``is_multiclass``, ``balanced``) can be used inline
-# inside ``if ... then ... else ...`` to discharge precondition
-# refinements — no let-binding workaround needed.
+# ``Learning.split`` returns a ``Pair Dataset Dataset`` with refinements
+# that link both halves' shape to the source dataset. The ``train_of`` /
+# ``test_of`` accessors propagate that link, so when we
+# ``Learning.accuracy model test_part`` the precondition
+# ``clf_features model == ds_features test_part`` is discharged
+# automatically (the model's ``clf_features`` matches ``ds_features
+# train_part``, which equals ``ds_features ds``, which equals
+# ``ds_features test_part``).
 
 open Learning
-open Tuple
 
 
-def evaluate (train_set: Dataset) (test_set: Dataset) : Float =
-    let model = Learning.random_forest_classifier train_set in
-    Learning.accuracy model test_set ;
-
-
-def pipeline (path: String) (target_col: String) : Classifier =
+def pipeline (path: String) (target_col: String) : Float =
     let 1 df = Learning.read_csv path in
     let ds = Learning.target df target_col in
     if Learning.is_multiclass ds then
         let bds = Learning.smote ds in
         let scaled = Learning.standard_scale bds in
         let parts = Learning.split scaled 0.8 in
-        Learning.random_forest_classifier (Tuple.fst parts)
+        let train_part = Learning.train_of parts in
+        let test_part = Learning.test_of parts in
+        let model = Learning.random_forest_classifier train_part in
+        Learning.accuracy model test_part
     else
         let scaled = Learning.standard_scale ds in
         let parts = Learning.split scaled 0.8 in
-        Learning.random_forest_classifier (Tuple.fst parts) ;
+        let train_part = Learning.train_of parts in
+        let test_part = Learning.test_of parts in
+        let model = Learning.random_forest_classifier train_part in
+        Learning.accuracy model test_part ;
 
 
-# ComplementNB requires imbalanced data. Discharged via an inline
+# ComplementNB requires imbalanced data — discharged via an inline
 # ``balanced`` runtime check.
 def cnb_pipeline (path: String) (target_col: String) : Classifier =
     let 1 df = Learning.read_csv path in

--- a/examples/ml/regression_pipeline.ae
+++ b/examples/ml/regression_pipeline.ae
@@ -1,11 +1,11 @@
 # End-to-end regression pipeline.
 #
-# Showcases the separation between ``Classifier`` and ``Regressor`` at
-# the type level: only regression metrics (``mse``, ``r2``, ...) accept
-# the regressor produced by ``ridge`` / ``random_forest_regressor``.
+# The ``Pair``-based split combined with ``train_of`` / ``test_of`` lets
+# the regressor's ``reg_features`` flow from training through scoring,
+# so ``Learning.r2 model test_part`` discharges its
+# ``reg_features model == ds_features test_part`` precondition.
 
 open Learning
-open Tuple
 
 
 def train_ridge (path: String) (target_col: String) : Regressor =
@@ -14,7 +14,7 @@ def train_ridge (path: String) (target_col: String) : Regressor =
     let imputed = Learning.fill_median ds in
     let scaled = Learning.standard_scale imputed in
     let parts = Learning.split scaled 0.8 in
-    Learning.ridge_alpha 0.5 (Tuple.fst parts) ;
+    Learning.ridge_alpha 0.5 (Learning.train_of parts) ;
 
 
 def score_ridge (path: String) (target_col: String) : Float =
@@ -23,7 +23,7 @@ def score_ridge (path: String) (target_col: String) : Float =
     let imputed = Learning.fill_median ds in
     let scaled = Learning.standard_scale imputed in
     let parts = Learning.split scaled 0.8 in
-    let train_set = Tuple.fst parts in
-    let test_set = Tuple.snd parts in
-    let model = Learning.ridge train_set in
-    Learning.r2 model test_set ;
+    let train_part = Learning.train_of parts in
+    let test_part = Learning.test_of parts in
+    let model = Learning.ridge train_part in
+    Learning.r2 model test_part ;

--- a/examples/ml/regression_pipeline.ae
+++ b/examples/ml/regression_pipeline.ae
@@ -1,0 +1,29 @@
+# End-to-end regression pipeline.
+#
+# Showcases the separation between ``Classifier`` and ``Regressor`` at
+# the type level: only regression metrics (``mse``, ``r2``, ...) accept
+# the regressor produced by ``ridge`` / ``random_forest_regressor``.
+
+open Learning
+open Tuple
+
+
+def train_ridge (path: String) (target_col: String) : Regressor =
+    let 1 df = Learning.read_csv path in
+    let ds = Learning.target df target_col in
+    let imputed = Learning.fill_median ds in
+    let scaled = Learning.standard_scale imputed in
+    let parts = Learning.split scaled 0.8 in
+    Learning.ridge_alpha 0.5 (Tuple.fst parts) ;
+
+
+def score_ridge (path: String) (target_col: String) : Float =
+    let 1 df = Learning.read_csv path in
+    let ds = Learning.target df target_col in
+    let imputed = Learning.fill_median ds in
+    let scaled = Learning.standard_scale imputed in
+    let parts = Learning.split scaled 0.8 in
+    let train_set = Tuple.fst parts in
+    let test_set = Tuple.snd parts in
+    let model = Learning.ridge train_set in
+    Learning.r2 model test_set ;

--- a/libraries/Learning.ae
+++ b/libraries/Learning.ae
@@ -1,68 +1,380 @@
+# Pleasant machine-learning library inspired by ``requests``.
+#
+# Design goals:
+#
+#   * The pandas / sklearn ``X``/``y`` split is hidden. Users work with
+#     two opaque types — ``DataFrame`` (all columns intact) and
+#     ``Dataset`` (features + a designated target column).
+#   * Classification and regression are distinguished at the type level
+#     (``Classifier`` vs ``Regressor``). Metrics are typed against the
+#     right kind of model — ``accuracy`` will not type-check against a
+#     regressor, ``mse`` will not type-check against a classifier.
+#   * A few dataset-consuming operations are linear (``(1 ds: Dataset)``)
+#     so callers who bind their source with ``let 1 df = ...`` get a
+#     type error if they keep using the pre-transformed dataset.
+#   * Refinements carry shape and class invariants. Common ML bugs are
+#     rejected at compile time:
+#
+#       - ``target`` and ``target_at`` link the resulting dataset's
+#         row/feature counts to the source ``DataFrame``.
+#       - Training functions stamp the resulting model with
+#         ``clf_features`` / ``clf_classes`` / ``reg_features``.
+#       - Scaling, imputation and oversampling preserve the feature
+#         count and class count; scaling/imputation preserve balance.
+#       - ``random_undersample`` only ever shrinks the row count;
+#         oversamplers only grow it.
+#       - ``smote`` / ``random_oversample`` / ``random_undersample``
+#         require ``ds_classes ds >= 2``; ``knn_classifier_k`` requires
+#         ``k <= ds_rows ds``; ``complement_nb`` requires an imbalanced
+#         dataset (its actual design intent).
+#       - Probabilities are refined to ``[0, 1]``; error metrics to
+#         ``>= 0.0``.
+#
+#     Runtime witnesses (``is_multiclass``, ``is_splittable``,
+#     ``is_nonempty``, ``balanced``) refine their Bool return type so
+#     they can discharge the corresponding precondition inside an
+#     ``if ... then ... else ...`` guard.
+
+open List
+open Tuple
+
+# ─── Opaque types ───────────────────────────────────────────────────────
+
+type DataFrame
 type Dataset
-type Model
+type Classifier
+type Regressor
+
+# ─── Library-level imports (side-effecting `import` calls) ─────────────
 
 def np : Unit = native_import "numpy"
+def pd : Unit = native_import "pandas"
 def skl : Unit = native_import "sklearn"
-def imblearn : Unit = native_import "imblearn"
 
-# Returns true if the dataset is balanced.
-def is_balanced: (ds: Dataset) -> Bool = uninterpreted
+# ─── Uninterpreted shape / class predicates ────────────────────────────
 
-# Loads a dataset from a file.
-def load_dataset (filename: String) : Dataset = native "learning.load_dataset(filename)"
+def df_rows : (df: DataFrame) -> Int = uninterpreted
+def df_cols : (df: DataFrame) -> Int = uninterpreted
 
-# Splits a dataset into two parts according to the given fraction.
-def split_dataset_training (original: Dataset) (fraction: {f: Float | 0.0 <= f && f <= 1.0}) :
-    {training:Dataset | is_balanced training == is_balanced original } =
-    native "learning.split_dataset(original, fraction)[0]"
+def ds_rows : (ds: Dataset) -> Int = uninterpreted
+def ds_features : (ds: Dataset) -> Int = uninterpreted
+def ds_classes : (ds: Dataset) -> Int = uninterpreted
 
+# Every class label appears the same number of times.
+def is_balanced : (ds: Dataset) -> Bool = uninterpreted
 
-# Splits a dataset into two parts according to the given fraction.
-def split_dataset_testing (original: Dataset) (fraction: {f: Float | 0.0 <= f && f <= 1.0}) :
-    {testing:Dataset | is_balanced testing == is_balanced original } =
-    native "learning.split_dataset(original, fraction)[1]"
+# Shape of a fitted model.
+def clf_features : (m: Classifier) -> Int = uninterpreted
+def clf_classes : (m: Classifier) -> Int = uninterpreted
+def reg_features : (m: Regressor) -> Int = uninterpreted
 
+# ─── Loading & target column selection ─────────────────────────────────
 
-# Trains a random forest model on a balanced dataset.
-def train_random_forest (dataset: {training_dataset: Dataset | is_balanced training_dataset}) : Model =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_train_random_forest(training_dataset)"
+# Read a CSV file into a ``DataFrame`` (all columns kept).
+def read_csv (path: String) : {df: DataFrame | df_cols df >= 1 && df_rows df >= 0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_read_csv(path)"
 
+# Designate ``column`` as the target. Consumes the source DataFrame.
+# Row count is preserved; feature count is one less than the column
+# count of the source.
+def target (1 df: DataFrame) (column: String) :
+    {ds: Dataset | ds_rows ds == df_rows df && ds_features ds == (df_cols df) - 1} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_target(df, column)"
 
-# Trains a random forest model on a balanced dataset.
-def train_multinomial_nb (dataset: {training_dataset: Dataset | is_balanced training_dataset}) : Model =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_train_random_forest(training_dataset)"
- # TODO fix binding
+# Designate the column at position ``index`` (0-based) as the target.
+def target_at (1 df: DataFrame) (index: {n: Int | n >= 0 && n < df_cols df}) :
+    {ds: Dataset | ds_rows ds == df_rows df && ds_features ds == (df_cols df) - 1} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_target_at(df, index)"
 
-# Trains a random forest model on a balanced dataset.
-def train_complement_nb (dataset: {training_dataset: Dataset | is_balanced training_dataset == false}) : Model =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_train_random_forest(training_dataset)"
- # TODO fix binding
+# Convenience: read a CSV and use the *last* column as the target.
+def load (path: String) : {ds: Dataset | ds_features ds >= 0 && ds_rows ds >= 0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_load(path)"
 
-# Applies SMOTE oversampling to balance the dataset.
-def smote_oversample (ds: Dataset) : {ds2: Dataset | is_balanced ds2 } =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_smote_oversample(ds)"
+# ─── DataFrame inspection ──────────────────────────────────────────────
 
+def columns (df: DataFrame) : List =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_columns(df)"
 
-# Predicts labels for the given dataset using the trained model.
-def predict (model: Model) (ds: Dataset) : List =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_predict(model, ds)"
+def has_column (df: DataFrame) (column: String) : Bool =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_has_column(df, column)"
 
+def n_columns (df: DataFrame) : {n: Int | n == df_cols df && n >= 0} =
+    native "len(df.columns)"
 
-# Returns the accuracy score of the model on the given dataset.
-def score (model: Model) (ds: Dataset) : Float =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_score(model, ds)"
+# ─── Dataset inspection — runtime witnesses for the type-level predicates ─
 
+def n_rows (ds: Dataset) : {n: Int | n == ds_rows ds && n >= 0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_n_rows(ds)"
 
-# Returns the confusion matrix for predictions on the dataset.
-def confusion_matrix (model: Model) (ds: Dataset) : List =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_confusion_matrix(model, ds)"
+def n_features (ds: Dataset) : {n: Int | n == ds_features ds && n >= 0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_n_features(ds)"
 
+# Runtime witness for ``is_balanced``.
+def balanced (ds: Dataset) : {b: Bool | b == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_is_balanced(ds)"
 
-# Applies standard scaling (zero mean, unit variance) to the dataset features.
-def standard_scale (ds: Dataset) : Dataset =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_standard_scale(ds)"
+# Runtime witnesses that discharge precondition refinements inside an
+# ``if ... then ... else ...`` branch.
+def is_nonempty (ds: Dataset) : {b: Bool | b == (ds_rows ds > 0)} =
+    native "(__import__('aeon.bindings.learning').bindings.learning.Learning_n_rows(ds) > 0)"
 
+def is_splittable (ds: Dataset) : {b: Bool | b == (ds_rows ds >= 2)} =
+    native "(__import__('aeon.bindings.learning').bindings.learning.Learning_n_rows(ds) >= 2)"
 
-# Applies min-max scaling to the dataset features.
-def minmax_scale (ds: Dataset) : Dataset =
-    native "__import__('aeon.aeon.bindings.learning').aeon.aeon.bindings.learning.Learning_minmax_scale(ds)"
+def is_multiclass (ds: Dataset) : {b: Bool | b == (ds_classes ds >= 2)} =
+    native "(len(set(ds[1])) >= 2)"
+
+# List of ``[label, count]`` pairs sorted by label.
+def class_counts (ds: Dataset) : List =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_class_counts(ds)"
+
+# ─── Splitting ─────────────────────────────────────────────────────────
+
+# Linear split into ``(training, testing)``. Project with ``Tuple.fst`` /
+# ``Tuple.snd``. Consumes the source so training on the un-split dataset
+# becomes a type error.
+def split
+    (1 ds: Dataset)
+    (fraction: {f: Float | 0.0 < f && f < 1.0}) : Tuple =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_split(ds, fraction)"
+
+# ─── Resampling / balancing ────────────────────────────────────────────
+
+# SMOTE oversampling; requires multi-class input (guard with
+# ``is_multiclass``). Output is balanced and preserves the feature
+# count; row count only ever grows.
+def smote (1 ds: {d: Dataset | ds_classes d >= 2}) :
+    {out: Dataset | is_balanced out == true
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && ds_rows out >= ds_rows ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_smote(ds)"
+
+def random_oversample (1 ds: {d: Dataset | ds_classes d >= 2}) :
+    {out: Dataset | is_balanced out == true
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && ds_rows out >= ds_rows ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_oversample(ds)"
+
+def random_undersample (1 ds: {d: Dataset | ds_classes d >= 2}) :
+    {out: Dataset | is_balanced out == true
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && ds_rows out <= ds_rows ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_undersample(ds)"
+
+# ─── Scaling ───────────────────────────────────────────────────────────
+
+def standard_scale (1 ds: Dataset) :
+    {out: Dataset | ds_rows out == ds_rows ds
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && is_balanced out == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_standard_scale(ds)"
+
+def minmax_scale (1 ds: Dataset) :
+    {out: Dataset | ds_rows out == ds_rows ds
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && is_balanced out == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_minmax_scale(ds)"
+
+def robust_scale (1 ds: Dataset) :
+    {out: Dataset | ds_rows out == ds_rows ds
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && is_balanced out == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_robust_scale(ds)"
+
+# ─── Missing-value imputation ──────────────────────────────────────────
+
+def fill_mean (1 ds: Dataset) :
+    {out: Dataset | ds_rows out == ds_rows ds
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && is_balanced out == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_mean(ds)"
+
+def fill_median (1 ds: Dataset) :
+    {out: Dataset | ds_rows out == ds_rows ds
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && is_balanced out == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_median(ds)"
+
+def fill_most_frequent (1 ds: Dataset) :
+    {out: Dataset | ds_rows out == ds_rows ds
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && is_balanced out == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_most_frequent(ds)"
+
+def fill_constant (value: Float) (1 ds: Dataset) :
+    {out: Dataset | ds_rows out == ds_rows ds
+                  && ds_features out == ds_features ds
+                  && ds_classes out == ds_classes ds
+                  && is_balanced out == is_balanced ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_constant(ds, value)"
+
+# ─── Classifier training ───────────────────────────────────────────────
+# Training stamps the model with the dataset's feature/class count.
+
+def random_forest_classifier (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_classifier(ds)"
+
+def random_forest_classifier_n (n: {k: Int | k > 0}) (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_classifier_n(n, ds)"
+
+def logistic_regression (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_logistic_regression(ds)"
+
+def decision_tree_classifier (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_decision_tree_classifier(ds)"
+
+def gradient_boosting_classifier (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_gradient_boosting_classifier(ds)"
+
+def knn_classifier (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_knn_classifier(ds)"
+
+# ``k`` must be positive and not exceed the number of training rows.
+def knn_classifier_k
+    (k: {n: Int | n > 0})
+    (ds: {d: Dataset | ds_rows d >= k}) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_knn_classifier_k(k, ds)"
+
+def svc (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_svc(ds)"
+
+def gaussian_nb (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_gaussian_nb(ds)"
+
+def multinomial_nb (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_multinomial_nb(ds)"
+
+# ComplementNB targets imbalanced data — refining out the balanced case
+# guides callers toward the right tool. Discharge with
+# ``if Learning.balanced ds then ... else Learning.complement_nb ds``.
+def complement_nb (ds: {d: Dataset | is_balanced d == false}) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_complement_nb(ds)"
+
+def mlp_classifier (ds: Dataset) :
+    {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_mlp_classifier(ds)"
+
+# ─── Regressor training ────────────────────────────────────────────────
+
+def linear_regression (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_linear_regression(ds)"
+
+def ridge (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_ridge(ds)"
+
+def ridge_alpha (alpha: {a: Float | a >= 0.0}) (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_ridge_alpha(alpha, ds)"
+
+def lasso (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_lasso(ds)"
+
+def lasso_alpha (alpha: {a: Float | a >= 0.0}) (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_lasso_alpha(alpha, ds)"
+
+def elastic_net (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_elastic_net(ds)"
+
+def random_forest_regressor (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_regressor(ds)"
+
+def random_forest_regressor_n (n: {k: Int | k > 0}) (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_regressor_n(n, ds)"
+
+def decision_tree_regressor (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_decision_tree_regressor(ds)"
+
+def gradient_boosting_regressor (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_gradient_boosting_regressor(ds)"
+
+def knn_regressor (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_knn_regressor(ds)"
+
+def svr (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_svr(ds)"
+
+def mlp_regressor (ds: Dataset) :
+    {m: Regressor | reg_features m == ds_features ds} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_mlp_regressor(ds)"
+
+# ─── Prediction ────────────────────────────────────────────────────────
+
+def predict (model: Classifier) (ds: Dataset) : List =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_predict(model, ds)"
+
+def predict_proba (model: Classifier) (ds: Dataset) : List =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_predict_proba(model, ds)"
+
+def predict_value (model: Regressor) (ds: Dataset) : List =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_predict(model, ds)"
+
+# ─── Classification metrics ────────────────────────────────────────────
+
+def accuracy (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_accuracy(model, ds)"
+
+def precision (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_precision(model, ds)"
+
+def recall (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_recall(model, ds)"
+
+def f1 (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_f1(model, ds)"
+
+def roc_auc (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_roc_auc(model, ds)"
+
+def confusion_matrix (model: Classifier) (ds: Dataset) : List =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_confusion_matrix(model, ds)"
+
+def classification_report (model: Classifier) (ds: Dataset) : String =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_classification_report(model, ds)"
+
+# ─── Regression metrics ────────────────────────────────────────────────
+
+def mse (model: Regressor) (ds: Dataset) : {f: Float | f >= 0.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_mse(model, ds)"
+
+def rmse (model: Regressor) (ds: Dataset) : {f: Float | f >= 0.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_rmse(model, ds)"
+
+def mae (model: Regressor) (ds: Dataset) : {f: Float | f >= 0.0} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_mae(model, ds)"
+
+def r2 (model: Regressor) (ds: Dataset) : Float =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_r2(model, ds)"
+
+def explained_variance (model: Regressor) (ds: Dataset) : Float =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_explained_variance(model, ds)"

--- a/libraries/Learning.ae
+++ b/libraries/Learning.ae
@@ -37,6 +37,7 @@
 
 open List
 open Tuple
+open Pair
 
 # ─── Opaque types ───────────────────────────────────────────────────────
 
@@ -67,6 +68,15 @@ def is_balanced : (ds: Dataset) -> Bool = uninterpreted
 def clf_features : (m: Classifier) -> Int = uninterpreted
 def clf_classes : (m: Classifier) -> Int = uninterpreted
 def reg_features : (m: Regressor) -> Int = uninterpreted
+
+# Uninterpreted projections of the split result. ``Learning.split`` returns
+# a ``Pair Dataset Dataset``; these helpers let the SMT solver reason about
+# the training/testing halves *symbolically* via the split's output refinement
+# without having to commit to a runtime projection in the refinement itself.
+# The runtime accessors ``train_of`` / ``test_of`` are tagged with the same
+# predicates so let-bound halves carry the relationship to the source.
+def split_fst_pred : (p: (Pair Dataset Dataset)) -> Dataset = uninterpreted
+def split_snd_pred : (p: (Pair Dataset Dataset)) -> Dataset = uninterpreted
 
 # ─── Loading & target column selection ─────────────────────────────────
 
@@ -130,13 +140,35 @@ def class_counts (ds: Dataset) : List =
 
 # ─── Splitting ─────────────────────────────────────────────────────────
 
-# Linear split into ``(training, testing)``. Project with ``Tuple.fst`` /
-# ``Tuple.snd``. Consumes the source so training on the un-split dataset
-# becomes a type error.
+# Linear split into ``(training, testing)``. Consumes the source so
+# training on the un-split dataset becomes a type error. The two halves
+# preserve the source's feature count, class count and balance flag —
+# expressed symbolically via the uninterpreted ``split_fst_pred`` and
+# ``split_snd_pred`` projections so the relationship survives through
+# downstream calls.
 def split
     (1 ds: Dataset)
-    (fraction: {f: Float | 0.0 < f && f < 1.0}) : Tuple =
-    native "__import__('aeon.bindings.learning').bindings.learning.Learning_split(ds, fraction)"
+    (fraction: {f: Float | 0.0 < f && f < 1.0}) :
+    {p: (Pair Dataset Dataset)
+        | ds_features (split_fst_pred p) == ds_features ds
+       && ds_features (split_snd_pred p) == ds_features ds
+       && ds_classes (split_fst_pred p) == ds_classes ds
+       && ds_classes (split_snd_pred p) == ds_classes ds
+       && is_balanced (split_fst_pred p) == is_balanced ds
+       && is_balanced (split_snd_pred p) == is_balanced ds} =
+    native "('Pair_mk',) + __import__('aeon.bindings.learning').bindings.learning.Learning_split(ds, fraction)"
+
+# Runtime accessors for the training / testing halves, refined so the
+# returned dataset is linked to the source ``Pair`` via the uninterpreted
+# projection. ``let train = train_of parts`` makes ``train ==
+# split_fst_pred parts`` visible to the SMT solver, so refinements about
+# ``split_fst_pred parts`` (from the split's output type) carry to
+# ``train`` directly.
+def train_of (p: (Pair Dataset Dataset)) : {d: Dataset | d == split_fst_pred p} =
+    native "p[1]"
+
+def test_of (p: (Pair Dataset Dataset)) : {d: Dataset | d == split_snd_pred p} =
+    native "p[2]"
 
 # ─── Resampling / balancing ────────────────────────────────────────────
 
@@ -329,52 +361,95 @@ def mlp_regressor (ds: Dataset) :
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_mlp_regressor(ds)"
 
 # ─── Prediction ────────────────────────────────────────────────────────
+# Each call now carries a feature-count precondition: the model's
+# ``clf_features`` (or ``reg_features``) must match the dataset's
+# ``ds_features``. This is discharged automatically by the typical
+# pipeline because ``split``'s output refinement links both halves'
+# ``ds_features`` to the source's.
 
-def predict (model: Classifier) (ds: Dataset) : List =
+def predict
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) : List =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_predict(model, ds)"
 
-def predict_proba (model: Classifier) (ds: Dataset) : List =
+def predict_proba
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) : List =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_predict_proba(model, ds)"
 
-def predict_value (model: Regressor) (ds: Dataset) : List =
+def predict_value
+    (model: Regressor)
+    (ds: {d: Dataset | reg_features model == ds_features d}) : List =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_predict(model, ds)"
 
 # ─── Classification metrics ────────────────────────────────────────────
 
-def accuracy (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+def accuracy
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_accuracy(model, ds)"
 
-def precision (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+def precision
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_precision(model, ds)"
 
-def recall (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+def recall
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_recall(model, ds)"
 
-def f1 (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+def f1
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_f1(model, ds)"
 
-def roc_auc (model: Classifier) (ds: Dataset) : {f: Float | 0.0 <= f && f <= 1.0} =
+def roc_auc
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_roc_auc(model, ds)"
 
-def confusion_matrix (model: Classifier) (ds: Dataset) : List =
+def confusion_matrix
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) : List =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_confusion_matrix(model, ds)"
 
-def classification_report (model: Classifier) (ds: Dataset) : String =
+def classification_report
+    (model: Classifier)
+    (ds: {d: Dataset | clf_features model == ds_features d}) : String =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_classification_report(model, ds)"
 
 # ─── Regression metrics ────────────────────────────────────────────────
 
-def mse (model: Regressor) (ds: Dataset) : {f: Float | f >= 0.0} =
+def mse
+    (model: Regressor)
+    (ds: {d: Dataset | reg_features model == ds_features d}) :
+    {f: Float | f >= 0.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_mse(model, ds)"
 
-def rmse (model: Regressor) (ds: Dataset) : {f: Float | f >= 0.0} =
+def rmse
+    (model: Regressor)
+    (ds: {d: Dataset | reg_features model == ds_features d}) :
+    {f: Float | f >= 0.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_rmse(model, ds)"
 
-def mae (model: Regressor) (ds: Dataset) : {f: Float | f >= 0.0} =
+def mae
+    (model: Regressor)
+    (ds: {d: Dataset | reg_features model == ds_features d}) :
+    {f: Float | f >= 0.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_mae(model, ds)"
 
-def r2 (model: Regressor) (ds: Dataset) : Float =
+def r2
+    (model: Regressor)
+    (ds: {d: Dataset | reg_features model == ds_features d}) : Float =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_r2(model, ds)"
 
-def explained_variance (model: Regressor) (ds: Dataset) : Float =
+def explained_variance
+    (model: Regressor)
+    (ds: {d: Dataset | reg_features model == ds_features d}) : Float =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_explained_variance(model, ds)"

--- a/libraries/Pair.ae
+++ b/libraries/Pair.ae
@@ -1,0 +1,12 @@
+# Polymorphic product type. Eliminate with ``match`` over the single
+# ``mk`` constructor (the generated recursor ``Pair_rec`` is also
+# available). For SMT-level reasoning about specific projections in
+# refinements, declare monomorphic uninterpreted helpers per concrete
+# instantiation, e.g.
+#
+#     def split_fst : (p: (Pair Dataset Dataset)) -> Dataset = uninterpreted
+#
+# and link them to the runtime values via refined accessors.
+
+inductive Pair a b
+| mk (fst:a) (snd:b) : (Pair a b)


### PR DESCRIPTION
## Summary

Three coordinated changes, all motivated by writing a real refinement-typed ML library.

### 1. Refined Learning library (`libraries/Learning.ae`, `aeon/bindings/learning.py`)

Comprehensive rewrite of the ML library inspired by the [requests](https://requests.readthedocs.io/) ergonomics:

- **Hides the X/y tuple** behind `DataFrame` / `Dataset` opaque types. Picking a target column is a named step (`target df "label"`).
- **Distinguishes Classifier vs Regressor at the type level** — `accuracy` rejects a regressor; `mse` rejects a classifier.
- **12 classifiers, 13 regressors**, classification & regression metrics, scalers, imputers, and balancing operators (sklearn / pandas / imblearn, lazy-imported where needed).
- **Shape & class invariants** encoded with uninterpreted predicates (`ds_rows`, `ds_features`, `ds_classes`, `clf_features`, `clf_classes`, `reg_features`, `df_rows`, `df_cols`, `is_balanced`) tagged on runtime accessors. Transforms carry their guarantees through a pipeline: `target` links `ds_rows`/`ds_features` to the source `DataFrame`; scaling/imputation preserve everything; oversampling grows rows; undersampling shrinks; SMOTE outputs balanced.
- **Linear (QTT) bindings** prevent reuse of pre-transformed datasets — once you've `target`-ed or scaled, the source is consumed.
- **Refinement preconditions** for genuine ML pitfalls: `smote` needs `ds_classes >= 2`; `knn_classifier_k` needs `k <= ds_rows`; `complement_nb` needs imbalanced data (its actual design intent); literal-derived bounds on fractions / alphas / n_estimators / k.
- **Runtime witnesses** (`is_multiclass`, `is_splittable`, `is_nonempty`, `balanced`) return refined `Bool`s that discharge the corresponding precondition inside an `if` guard.

### 2. Boolean operator precedence (`aeon/sugar/aeon_sugar.lark`)

`expression_un` was flat — `&&`, `||`, `==`, `!=`, `!` all at the same precedence and right-associative, so `a == b && c == d` parsed as `a == (b && (c == d))`. Split into proper levels:

```
expression_or  → expression_and       ||
expression_and → expression_eq        &&
expression_eq  → expression_not       ==  !=
expression_not → expression_bool      !
expression_bool ...                   <  <=  >  >=  -->
```

`a == b && c == d` now parses naturally as `(a == b) && (c == d)`. `!a == b` parses as `(!a) == b`.

### 3. If-condition refinement propagation (`aeon/typechecking/typeinfer.py`)

Both synth- and check-mode `If` now:

1. **Synth the condition** (was: `check(cond, t_bool)` only) to obtain its refined type.
2. **Open existential binders** from the inferred type into the branch context, mirroring how `Let` handles `ExistentialType`. The wrapping `implication_constraint` is applied in reverse at the end.
3. **Substitute the condition expression for the refinement's binder** — for `cond : {b: Bool | r(b)}`, derive the predicate `r(liq_cond)` describing the cond expression itself.
4. **Conjoin truth/falsity with that predicate** in the branch hypothesis (`liq_cond && r(liq_cond)` then-branch; `!liq_cond && r(liq_cond)` else-branch).

The result: refined-Bool runtime witnesses discharge precondition refinements **inline**. The Learning library now reads

```aeon
if Learning.is_multiclass ds then
    Learning.smote ds
else ...
```

without the previous `let mc = ... in if mc then ...` workaround.

## Test plan

- [x] `uv run pytest tests/` — **972 passed, 9 skipped** (no regressions; tested twice, once after each change).
- [x] Library and 4 example files type-check.
- [x] Misuse cases rejected with appropriate errors:
  - Unguarded `smote` ⇒ "Failed to prove `ds_classes ds >= 2`".
  - `complement_nb` without imbalance witness ⇒ "Failed to prove `is_balanced d == false`".
  - Negative `alpha` to `ridge_alpha` ⇒ "Failed to prove `a >= 0.0`".
  - Split with `fraction = 1.5` ⇒ "Failed to prove `0.0 < f && f < 1.0`".
  - `accuracy` on a `Regressor` ⇒ "expected `Classifier`, got `Regressor`".
  - Linear leak: `let 1 ds = ... in smote ds; train rfc ds` ⇒ "Linear binding ds is declared with multiplicity 1 but is used 2 times".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
