### PR TITLE
feat(synthesis): knee-point selection on the Pareto front (closes #284)

### DIFF
--- a/aeon/synthesis/grammar/ge_synthesis.py
+++ b/aeon/synthesis/grammar/ge_synthesis.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from aeon.typechecking.context import TypingContext
 
@@ -31,6 +31,47 @@ from geneticengine.solutions import Individual
 from geneticengine.evaluation.recorder import SearchRecorder
 
 from aeon.synthesis.decorators import Goal
+
+
+def _knee_point_individual(
+    individuals: Sequence[Individual | None],
+    problem: Problem,
+) -> Individual | None:
+    """Pick a single individual from a Pareto front by knee-point (compromise) selection.
+
+    All objectives are oriented toward minimization (maximize objectives are negated)
+    and normalized to ``[0, 1]``. The chosen individual is the one whose normalized
+    fitness vector has the smallest Euclidean distance to the utopia origin — the
+    "elbow" where further gains in one objective require disproportionate sacrifice
+    in another. Falls back to the lone valid candidate when only one exists, or to
+    ``None`` when none are valid.
+    """
+    valid = [ind for ind in individuals if ind is not None and ind.get_fitness(problem).valid]
+    if not valid:
+        return None
+    if len(valid) == 1:
+        return valid[0]
+
+    fits = [ind.get_fitness(problem).fitness_components for ind in valid]
+    minimize = problem.minimize
+    n_obj = len(minimize)
+    # Orient each objective so smaller = better.
+    oriented = [[(f[d] if minimize[d] else -f[d]) for d in range(n_obj)] for f in fits]
+    # Per-dimension normalization to [0, 1]; dimensions with zero spread contribute 0.
+    mins = [min(o[d] for o in oriented) for d in range(n_obj)]
+    maxs = [max(o[d] for o in oriented) for d in range(n_obj)]
+    spreads = [maxs[d] - mins[d] for d in range(n_obj)]
+
+    def squared_distance_to_utopia(o: list[float]) -> float:
+        total = 0.0
+        for d in range(n_obj):
+            if spreads[d] > 0:
+                normalized = (o[d] - mins[d]) / spreads[d]
+                total += normalized * normalized
+        return total
+
+    best_idx = min(range(len(valid)), key=lambda i: squared_distance_to_utopia(oriented[i]))
+    return valid[best_idx]
 
 
 def create_problem(
@@ -128,13 +169,9 @@ class GESynthesizer(Synthesizer):
             case _:
                 assert False, f"Method {self.method} not available for synthesis."
         individuals = alg.search()
-        match individuals:
-            case None | [None]:
-                return None
-            case [ind, *_]:
-                # TODO: handle multiple answers
-                if not ind.get_fitness(problem).valid:
-                    return None
-                return ind.get_phenotype().get_core()
-            case _:
-                return None
+        if not individuals:
+            return None
+        chosen = _knee_point_individual(individuals, problem)
+        if chosen is None:
+            return None
+        return chosen.get_phenotype().get_core()

--- a/tests/knee_point_selection_test.py
+++ b/tests/knee_point_selection_test.py
@@ -1,0 +1,128 @@
+"""Unit tests for the knee-point Pareto-front selector used by `GESynthesizer`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from geneticengine.problems import Fitness, MultiObjectiveProblem
+
+from aeon.synthesis.grammar.ge_synthesis import _knee_point_individual
+
+
+@dataclass
+class _StubIndividual:
+    """Minimal Individual stand-in: holds a `Fitness` and returns it from `get_fitness`."""
+
+    fitness: Fitness
+
+    def get_fitness(self, problem: Any) -> Fitness:
+        return self.fitness
+
+
+def _make_problem(minimize: list[bool]) -> MultiObjectiveProblem:
+    return MultiObjectiveProblem(
+        fitness_function=lambda _phenotype: [0.0] * len(minimize),
+        minimize=minimize,
+    )
+
+
+def _ind(*components: float) -> _StubIndividual:
+    return _StubIndividual(Fitness(list(components), valid=True))
+
+
+def _invalid() -> _StubIndividual:
+    return _StubIndividual(Fitness([0.0], valid=False))
+
+
+# ---------------------------------------------------------------------------
+# Empty / invalid inputs
+# ---------------------------------------------------------------------------
+
+
+def test_empty_returns_none():
+    assert _knee_point_individual([], _make_problem([True])) is None
+
+
+def test_all_invalid_returns_none():
+    problem = _make_problem([True, True])
+    assert _knee_point_individual([_invalid(), _invalid()], problem) is None
+
+
+def test_none_entries_are_skipped():
+    problem = _make_problem([True, True])
+    only_valid = _ind(1.0, 1.0)
+    chosen = _knee_point_individual([None, only_valid, None], problem)
+    assert chosen is only_valid
+
+
+# ---------------------------------------------------------------------------
+# Trivial cases
+# ---------------------------------------------------------------------------
+
+
+def test_single_valid_returned_directly():
+    problem = _make_problem([True, True])
+    only = _ind(5.0, 7.0)
+    assert _knee_point_individual([only], problem) is only
+
+
+def test_single_objective_minimize_picks_smallest():
+    problem = _make_problem([True])
+    pop = [_ind(10.0), _ind(3.0), _ind(7.0)]
+    assert _knee_point_individual(pop, problem).fitness.fitness_components == [3.0]
+
+
+def test_single_objective_maximize_picks_largest():
+    problem = _make_problem([False])
+    pop = [_ind(10.0), _ind(3.0), _ind(7.0)]
+    assert _knee_point_individual(pop, problem).fitness.fitness_components == [10.0]
+
+
+# ---------------------------------------------------------------------------
+# Multi-objective knee selection
+# ---------------------------------------------------------------------------
+
+
+def test_balanced_point_beats_extremes_two_objective():
+    """Front: (0, 10), (5, 5), (10, 0). Knee is the middle, closest to utopia (0, 0)."""
+    problem = _make_problem([True, True])
+    extremes_and_knee = [_ind(0.0, 10.0), _ind(5.0, 5.0), _ind(10.0, 0.0)]
+    chosen = _knee_point_individual(extremes_and_knee, problem)
+    assert chosen.fitness.fitness_components == [5.0, 5.0]
+
+
+def test_maximize_objectives_are_oriented_correctly():
+    """Mixed direction: minimize obj0, maximize obj1.
+    Front: (0, 0)  -- worst on obj1
+           (5, 5)  -- balanced
+           (10, 10)-- worst on obj0
+    Best obj0 = 0, best obj1 = 10. Utopia point (oriented to min) is (0, -10).
+    Distances (normalized):
+      (0, 0)   -> (0.0, 1.0)  -> 1.0
+      (5, 5)   -> (0.5, 0.5)  -> 0.5
+      (10, 10) -> (1.0, 0.0)  -> 1.0
+    Knee is (5, 5).
+    """
+    problem = _make_problem([True, False])
+    pop = [_ind(0.0, 0.0), _ind(5.0, 5.0), _ind(10.0, 10.0)]
+    chosen = _knee_point_individual(pop, problem)
+    assert chosen.fitness.fitness_components == [5.0, 5.0]
+
+
+def test_zero_spread_dimension_is_ignored():
+    """One dim flat across the front: contributes zero to distance; selection
+    reduces to the active dimension."""
+    problem = _make_problem([True, True])
+    pop = [_ind(1.0, 5.0), _ind(3.0, 5.0), _ind(8.0, 5.0)]
+    chosen = _knee_point_individual(pop, problem)
+    # All have obj1 == 5 (flat); knee == smallest obj0.
+    assert chosen.fitness.fitness_components == [1.0, 5.0]
+
+
+def test_invalid_individuals_filtered_out():
+    """Invalid candidates must not skew the normalization range."""
+    problem = _make_problem([True, True])
+    pop = [_invalid(), _ind(0.0, 10.0), _ind(5.0, 5.0), _ind(10.0, 0.0), _invalid()]
+    chosen = _knee_point_individual(pop, problem)
+    assert chosen.fitness.fitness_components == [5.0, 5.0]


### PR DESCRIPTION
## Summary

Closes #284. When multi-objective synthesis returned a Pareto front, `GESynthesizer` kept only the first individual and dropped the rest — an arbitrary choice that users couldn't influence. This PR adds a deterministic knee-point (compromise) selector.

### How it works

All objectives are oriented toward minimization (maximize objectives are negated) and per-dimension normalized to `[0, 1]`. The chosen individual is the one whose normalized fitness vector has the smallest Euclidean distance to the utopia origin — the "elbow" where further gains in one objective require disproportionate sacrifice in another. Zero-spread dimensions contribute 0 (no preference along that axis).

### Edge-case behaviour

- empty input or all-invalid → `None` (preserves prior contract)
- single valid candidate → returned directly (no normalization needed)
- single-objective problems → degenerates to "smallest after orientation", which is the correct extremum

### Tests

`tests/knee_point_selection_test.py` (10 unit tests, no synthesis run needed) covers:

- empty / all-invalid / mixed `None`-and-valid input
- single-objective minimize and maximize
- balanced trade-off (front with extremes + knee)
- mixed-direction objectives (minimize + maximize)
- zero-spread dimensions

## Test plan

- [x] `uv run pytest tests/knee_point_selection_test.py -v` — 10 passed
- [x] `uv run pytest -q --ignore=tests/optimization_decorators_test.py` — **1007 passed, 9 skipped, 2 xfailed** (vs. 997 before — the 10 new tests)
- [x] `uvx pre-commit run --all-files` — all hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
