### PR TITLE
refactor(synthesis): mark elaboration-introduced holes with a typed flag

### DIFF
--- a/aeon/core/terms.py
+++ b/aeon/core/terms.py
@@ -78,6 +78,11 @@ class Annotation(Term):
 class Hole(Term):
     name: Name
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    # Marks placeholders inserted by elaboration when instantiating an
+    # ``RefinementPolymorphism``: they stand in for an implicit refinement
+    # predicate and are solved by Horn inference, not by GP synthesis. User
+    # holes leave this ``False``.
+    is_implicit_refinement: bool = False
 
     def __str__(self):
         return f"?{self.name}"

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -363,7 +363,7 @@ def elaborate_synth(ctx: ElaborationTypingContext, t: STerm) -> tuple[STerm, STy
                 nfun = STypeApplication(nfun, u)
                 nfun_type = type_substitution(nfun_type.body, nfun_type.name, u)
             while isinstance(nfun_type, SRefinementPolymorphism):
-                h = SHole(Name("_pred", fresh_counter.fresh()))
+                h = SHole(Name("_pred", fresh_counter.fresh()), is_implicit_refinement=True)
                 nfun = SRefinementApplication(nfun, h)
                 nfun_type = substitution_sterm_in_stype(nfun_type.body, h, nfun_type.name)
 
@@ -450,7 +450,7 @@ def get_rid_of_polymorphism(ctx: ElaborationTypingContext, c: STerm, s: SType, t
         c = STypeApplication(c, u)
         s = type_substitution(s.body, s.name, u)
     while isinstance(s, SRefinementPolymorphism) and not isinstance(ty, SRefinementPolymorphism):
-        h = SHole(Name("_pred", fresh_counter.fresh()))
+        h = SHole(Name("_pred", fresh_counter.fresh()), is_implicit_refinement=True)
         c = SRefinementApplication(c, h)
         s = substitution_sterm_in_stype(s.body, h, s.name)
     return (c, s)

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -147,7 +147,7 @@ def bind_sterm(t: STerm, subs: RenamingSubstitions) -> STerm:
             return SVar(apply_subs_name(subs, name), loc=loc)
         case SHole(name, loc=loc):
             name, _ = check_name(name, subs)
-            return SHole(name, loc=loc)
+            return SHole(name, loc=loc, is_implicit_refinement=t.is_implicit_refinement)
         case SBy(steps, loc=loc):
             return SBy(steps, loc=loc)
         case SAnnotation(e, ty, loc=loc):

--- a/aeon/sugar/lifting.py
+++ b/aeon/sugar/lifting.py
@@ -118,7 +118,7 @@ def lift(t: Term) -> STerm:
         case Annotation(expr, typ, loc):
             return SAnnotation(lift(expr), lift_type(typ), loc=loc)
         case Hole(name, loc):
-            return SHole(name, loc=loc)
+            return SHole(name, loc=loc, is_implicit_refinement=t.is_implicit_refinement)
         case Application(fun, arg, loc):
             return SApplication(lift(fun), lift(arg), loc=loc)
         case Abstraction(var_name, body, loc):

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -245,7 +245,7 @@ def lower_to_core(t: STerm) -> Term:
     """Converts Surface terms into Core terms."""
     match t:
         case SHole(name, loc):
-            return Hole(name, loc=loc)
+            return Hole(name, loc=loc, is_implicit_refinement=t.is_implicit_refinement)
         case SLiteral(val, ty, loc):
             return Literal(val, type_to_core(ty), loc=loc)
         case SVar(name, loc):

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -86,6 +86,11 @@ class SAnnotation(STerm):
 class SHole(STerm):
     name: Name
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+    # Marks placeholders inserted by elaboration when instantiating an
+    # ``SRefinementPolymorphism``: they stand in for an implicit refinement
+    # predicate and are solved by Horn inference, not by GP synthesis. User
+    # holes leave this ``False``.
+    is_implicit_refinement: bool = False
 
     def __str__(self):
         return f"?{self.name}"

--- a/aeon/synthesis/identification.py
+++ b/aeon/synthesis/identification.py
@@ -167,9 +167,11 @@ def get_holes(term: Term) -> list[Name]:
         case RefinementAbstraction(name=_, body=body):
             return get_holes(body)
         case RefinementApplication(body=body, refinement=refinement):
-            # TODO better solution
-            # Implicit refinement placeholders (elaboration) are solved by Horn inference, not GP synthesis.
-            if isinstance(refinement, Hole) and refinement.name.name.startswith("_pred"):
+            # Implicit refinement placeholders (inserted by elaboration when
+            # instantiating an ``RefinementPolymorphism``) are solved by Horn
+            # inference, not by GP synthesis. They carry the
+            # ``is_implicit_refinement`` flag set in ``aeon/elaboration``.
+            if isinstance(refinement, Hole) and refinement.is_implicit_refinement:
                 return get_holes(body)
             return get_holes(body) + get_holes(refinement)
         case _:

--- a/aeon/utils/pprint.py
+++ b/aeon/utils/pprint.py
@@ -621,7 +621,7 @@ def normalize_term(term: STerm, context: dict[Name, STerm] = None, seen: set[Nam
             new_seen.add(name)
             return normalize_term(simplified_term, context, new_seen)
         case SHole(name=name):
-            return SHole(name=name)
+            return SHole(name=name, is_implicit_refinement=term.is_implicit_refinement)
         case SBy(steps=steps, loc=loc):
             return SBy(steps=steps, loc=loc)
         case SAnnotation(expr=expr, type=type):

--- a/tests/hole_test.py
+++ b/tests/hole_test.py
@@ -1,4 +1,5 @@
-from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.core.terms import Hole, RefinementApplication, Var
+from aeon.synthesis.identification import get_holes, incomplete_functions_and_holes
 from aeon.utils.name import Name
 from tests.driver import check_and_return_core
 
@@ -61,3 +62,32 @@ def test_hole3():
             pass
         case _:
             assert False, "Wrong hole identification"
+
+
+def test_get_holes_skips_implicit_refinement_placeholders():
+    """``get_holes`` must skip ``RefinementApplication`` refinement positions
+    when the inner ``Hole`` carries the ``is_implicit_refinement`` flag.
+
+    These placeholders are inserted by elaboration when instantiating an
+    ``RefinementPolymorphism`` and are solved by Horn inference, not GP.
+    Regression for #295: previously the filter relied on the hole's name
+    starting with the ``_pred`` prefix, which is brittle to renames.
+    """
+    body = Var(Name("f", 0))
+    implicit = Hole(Name("_pred", 1), is_implicit_refinement=True)
+    user = Hole(Name("user_hole", 2))
+
+    # Implicit refinement placeholder is filtered out — only the body is walked.
+    assert get_holes(RefinementApplication(body, implicit)) == []
+    # A user hole in the same position is still reported.
+    assert get_holes(RefinementApplication(body, user)) == [Name("user_hole", 2)]
+
+
+def test_get_holes_ignores_name_prefix_for_user_holes():
+    """A user-written hole that happens to be named ``_pred*`` must still be
+    reported. The old prefix-based check would have silently dropped it;
+    after #295 only the typed marker matters.
+    """
+    body = Var(Name("f", 0))
+    misnamed = Hole(Name("_pred_user", 7), is_implicit_refinement=False)
+    assert get_holes(RefinementApplication(body, misnamed)) == [Name("_pred_user", 7)]


### PR DESCRIPTION
## Summary
- Replaces the brittle ``refinement.name.name.startswith(\"_pred\")`` check in ``aeon/synthesis/identification.py:get_holes`` with a typed marker on ``Hole``/``SHole``.
- Adds ``is_implicit_refinement: bool = False`` to ``SHole`` (``aeon/sugar/program.py``) and ``Hole`` (``aeon/core/terms.py``); set ``True`` at the two elaboration sites in ``aeon/elaboration/__init__.py`` that synthesize implicit refinement-application placeholders for ``SRefinementPolymorphism``.
- Propagates the flag through ``lower_to_core`` (sugar→core), ``lift`` (core→sugar), ``bind``, and ``pprint``'s ``normalize_term``.

Closes #295.

## Why
Today, ``get_holes`` filters out elaboration-introduced placeholders by checking whether the hole name starts with ``_pred``. Renaming the placeholder anywhere else silently breaks the filter — GP synthesis would start trying to fill predicate slots that Horn inference is supposed to solve. A boolean flag at the point of construction makes the intent explicit and refactor-safe.

## Test plan
- [x] ``uv run pytest tests/hole_test.py`` — 6/6 pass, including two new regression tests:
  - ``test_get_holes_skips_implicit_refinement_placeholders`` — flagged hole inside ``RefinementApplication`` is filtered out; unflagged hole in the same slot is reported.
  - ``test_get_holes_ignores_name_prefix_for_user_holes`` — a user hole named ``_pred_user`` (which the old prefix check would have silently dropped) is now correctly returned.
- [x] ``uv run pytest tests/parametric_refinements_test.py tests/elaboration_test.py tests/tactic_synth_test.py tests/end_to_end_test.py`` — 56/56 pass.
- [x] Full ``uv run pytest tests/`` — 1020 passed / 9 skipped / 2 xfailed (the one pre-existing ``test_measure_energy_returns_finite_nonnegative`` RAPL/permissions failure also fails on ``master`` and is unrelated to this change).
- [x] ``uvx pre-commit run`` on all touched files — mypy, ruff, ruff format all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)