### PR TITLE
refactor(core): split implicit refinement holes into a distinct Term type

### DIFF
--- a/aeon/core/bind.py
+++ b/aeon/core/bind.py
@@ -14,6 +14,7 @@ from aeon.core.terms import (
     Application,
     Hole,
     If,
+    ImplicitRefinementHole,
     Let,
     Rec,
     RefinementAbstraction,
@@ -159,6 +160,9 @@ def bind_term(t: Term, subs: RenamingSubstitions) -> Term:
         case Hole(name, loc):
             name, _ = check_name(name, subs)
             return Hole(name, loc=loc)
+        case ImplicitRefinementHole(name, loc):
+            name, _ = check_name(name, subs)
+            return ImplicitRefinementHole(name, loc=loc)
         case Annotation(e, ty, loc):
             return Annotation(bind_term(e, subs), bind_type(ty, subs), loc=loc)
         case Application(e1, e2, loc):

--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -18,6 +18,7 @@ from aeon.core.terms import (
 from aeon.core.terms import Annotation
 from aeon.core.terms import Application
 from aeon.core.terms import Hole
+from aeon.core.terms import ImplicitRefinementHole
 from aeon.core.terms import If
 from aeon.core.terms import Let
 from aeon.core.terms import Literal
@@ -75,6 +76,8 @@ def substitute_vartype_in_term(t: Term, rep: Type, name: Name) -> Term:
         case Var():
             return t
         case Hole():
+            return t
+        case ImplicitRefinementHole():
             return t
         case Application(fun, arg, loc):
             return Application(fun=rec(fun), arg=rec(arg), loc=loc)
@@ -367,6 +370,8 @@ def substitution_liquid_in_term(t: Term, rep: LiquidTerm, name: Name) -> Term:
             return t
         case Hole():
             return t
+        case ImplicitRefinementHole():
+            return t
         case Application(fun, arg, loc):
             return Application(fun=rec(fun), arg=rec(arg), loc=loc)
         case Abstraction(var_name, body, loc):
@@ -454,6 +459,10 @@ def substitution(t: Term, rep: Term, name: Name) -> Term:
                 return rep
             else:
                 return t
+        case ImplicitRefinementHole():
+            # Implicit refinement placeholders are solved by Horn inference,
+            # never by term-level substitution. Treat as a leaf.
+            return t
         case Application(fun, arg, loc):
             return Application(fun=rec(fun), arg=rec(arg), loc=loc)
         case Abstraction(vname, body, loc):

--- a/aeon/core/terms.py
+++ b/aeon/core/terms.py
@@ -90,6 +90,31 @@ class Hole(Term):
 
 
 @dataclass(frozen=True)
+class ImplicitRefinementHole(Term):
+    """Placeholder inserted by elaboration when instantiating an
+    ``RefinementPolymorphism``.
+
+    Always appears as the ``refinement`` field of ``RefinementApplication``.
+    Solved by Horn inference, never by GP synthesis — ``get_holes`` skips it
+    by virtue of being a distinct ``Term`` subclass (not a subclass of
+    ``Hole``), so ``case Hole(...)`` patterns at synthesis sites do not
+    match it.
+    """
+
+    name: Name
+    loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+
+    def __str__(self):
+        return f"?ρ{self.name}"
+
+    def __repr__(self):
+        return f"ImplicitRefinementHole({self.name})"
+
+    def __eq__(self, other):
+        return isinstance(other, ImplicitRefinementHole) and self.name == other.name
+
+
+@dataclass(frozen=True)
 class Application(Term):
     fun: Term
     arg: Term

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -16,6 +16,7 @@ from aeon.sugar.program import (
     SApplication,
     SHole,
     SIf,
+    SImplicitRefinementHole,
     SLet,
     SLiteral,
     SRec,
@@ -363,7 +364,7 @@ def elaborate_synth(ctx: ElaborationTypingContext, t: STerm) -> tuple[STerm, STy
                 nfun = STypeApplication(nfun, u)
                 nfun_type = type_substitution(nfun_type.body, nfun_type.name, u)
             while isinstance(nfun_type, SRefinementPolymorphism):
-                h = SHole(Name("_pred", fresh_counter.fresh()))
+                h = SImplicitRefinementHole(Name("_pred", fresh_counter.fresh()))
                 nfun = SRefinementApplication(nfun, h)
                 nfun_type = substitution_sterm_in_stype(nfun_type.body, h, nfun_type.name)
 
@@ -450,7 +451,7 @@ def get_rid_of_polymorphism(ctx: ElaborationTypingContext, c: STerm, s: SType, t
         c = STypeApplication(c, u)
         s = type_substitution(s.body, s.name, u)
     while isinstance(s, SRefinementPolymorphism) and not isinstance(ty, SRefinementPolymorphism):
-        h = SHole(Name("_pred", fresh_counter.fresh()))
+        h = SImplicitRefinementHole(Name("_pred", fresh_counter.fresh()))
         c = SRefinementApplication(c, h)
         s = substitution_sterm_in_stype(s.body, h, s.name)
     return (c, s)
@@ -592,7 +593,7 @@ def handle_unification_in_type(ctx: ElaborationTypingContext, ty: SType) -> STyp
 
 def elaborate_remove_unification(ctx: ElaborationTypingContext, t: STerm) -> STerm:
     match t:
-        case SLiteral() | SVar() | SHole() | SAnonConstructor():
+        case SLiteral() | SVar() | SHole() | SImplicitRefinementHole() | SAnonConstructor():
             return t
         case SAnnotation(expr, ty, loc=loc):
             return SAnnotation(elaborate_remove_unification(ctx, expr), ty, loc=loc)

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -17,6 +17,7 @@ from aeon.sugar.program import (
     SAnnotation,
     SApplication,
     SHole,
+    SImplicitRefinementHole,
     SBy,
     SIf,
     SMatch,
@@ -148,6 +149,9 @@ def bind_sterm(t: STerm, subs: RenamingSubstitions) -> STerm:
         case SHole(name, loc=loc):
             name, _ = check_name(name, subs)
             return SHole(name, loc=loc)
+        case SImplicitRefinementHole(name, loc=loc):
+            name, _ = check_name(name, subs)
+            return SImplicitRefinementHole(name, loc=loc)
         case SBy(steps, loc=loc):
             return SBy(steps, loc=loc)
         case SAnnotation(e, ty, loc=loc):

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -26,6 +26,7 @@ from aeon.sugar.program import (
     SApplication,
     SAnnotation,
     SHole,
+    SImplicitRefinementHole,
     SBy,
     SLiteral,
     SIf,
@@ -139,7 +140,7 @@ def lower_by_blocks_in_sterm(t: STerm) -> tuple[STerm, dict[Name, tuple[str, ...
         case SBy(steps, loc=loc):
             h = Name("_by", fresh_counter.fresh())
             return SHole(h, loc=loc), {h: tuple(steps)}
-        case SLiteral() | SVar() | SHole() | SQualifiedVar() | SAnonConstructor():
+        case SLiteral() | SVar() | SHole() | SImplicitRefinementHole() | SQualifiedVar() | SAnonConstructor():
             return t, {}
         case SAnnotation(expr, ty, loc=loc):
             ne, s1 = lower_by_blocks_in_sterm(expr)

--- a/aeon/sugar/equality.py
+++ b/aeon/sugar/equality.py
@@ -13,6 +13,7 @@ from aeon.sugar.program import (
     SAnnotation,
     SApplication,
     SHole,
+    SImplicitRefinementHole,
     SBy,
     SIf,
     SLet,
@@ -62,6 +63,8 @@ def term_equality(a: STerm, b: STerm, rename_left: dict[Name, Name] | None = Non
         case SVar(an), SVar(bn):
             return rename_left.get(an, an) == bn
         case SHole(an), SHole(bn):
+            return rename_left.get(an, an) == bn
+        case SImplicitRefinementHole(an), SImplicitRefinementHole(bn):
             return rename_left.get(an, an) == bn
         case SBy(asteps), SBy(bsteps):
             return asteps == bsteps

--- a/aeon/sugar/lifting.py
+++ b/aeon/sugar/lifting.py
@@ -13,6 +13,7 @@ from aeon.core.terms import (
     Var,
     Annotation,
     Hole,
+    ImplicitRefinementHole,
     Application,
     Abstraction,
     Let,
@@ -39,6 +40,7 @@ from aeon.sugar.program import (
     SVar,
     SAnnotation,
     SHole,
+    SImplicitRefinementHole,
     SApplication,
     SAbstraction,
     SLet,
@@ -119,6 +121,8 @@ def lift(t: Term) -> STerm:
             return SAnnotation(lift(expr), lift_type(typ), loc=loc)
         case Hole(name, loc):
             return SHole(name, loc=loc)
+        case ImplicitRefinementHole(name, loc):
+            return SImplicitRefinementHole(name, loc=loc)
         case Application(fun, arg, loc):
             return SApplication(lift(fun), lift(arg), loc=loc)
         case Abstraction(var_name, body, loc):

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -15,6 +15,7 @@ from aeon.core.terms import (
     Annotation,
     Application,
     If,
+    ImplicitRefinementHole,
     Let,
     Literal,
     Rec,
@@ -49,6 +50,7 @@ from aeon.sugar.program import (
     SAnnotation,
     SApplication,
     SIf,
+    SImplicitRefinementHole,
     SLet,
     SLiteral,
     SRec,
@@ -246,6 +248,8 @@ def lower_to_core(t: STerm) -> Term:
     match t:
         case SHole(name, loc):
             return Hole(name, loc=loc)
+        case SImplicitRefinementHole(name, loc):
+            return ImplicitRefinementHole(name, loc=loc)
         case SLiteral(val, ty, loc):
             return Literal(val, type_to_core(ty), loc=loc)
         case SVar(name, loc):

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -98,6 +98,32 @@ class SHole(STerm):
 
 
 @dataclass(frozen=True)
+class SImplicitRefinementHole(STerm):
+    """Placeholder inserted by elaboration when instantiating an
+    ``SRefinementPolymorphism``.
+
+    Always appears as the ``refinement`` field of ``SRefinementApplication``
+    (and its core counterpart, ``RefinementApplication``). Solved by Horn
+    inference downstream of elaboration, never by GP synthesis. Kept as a
+    distinct ``STerm`` subclass — rather than a flag on ``SHole`` — so the
+    two roles can't be confused at pattern-match sites: ``case SHole(...)``
+    only fires for user-written or tactic-introduced holes.
+    """
+
+    name: Name
+    loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+
+    def __str__(self):
+        return f"?ρ{self.name}"
+
+    def __repr__(self):
+        return f"ImplicitRefinementHole({self.name})"
+
+    def __eq__(self, other):
+        return isinstance(other, SImplicitRefinementHole) and self.name == other.name
+
+
+@dataclass(frozen=True)
 class SBy(STerm):
     """Lean-style ``by`` tactic script (no ``end``).
 

--- a/aeon/sugar/substitutions.py
+++ b/aeon/sugar/substitutions.py
@@ -15,6 +15,7 @@ from aeon.sugar.program import (
     SAnnotation,
     SApplication,
     SHole,
+    SImplicitRefinementHole,
     SBy,
     SIf,
     SMatch,
@@ -113,7 +114,7 @@ def substitution_sterm_in_sterm(t: STerm, beta: STerm, alpha: Name) -> STerm:
         return substitution_sterm_in_stype(x, beta, alpha)
 
     match t:
-        case SLiteral(_, _) | SHole(_) | SBy() | SQualifiedVar() | SAnonConstructor():
+        case SLiteral(_, _) | SHole(_) | SImplicitRefinementHole(_) | SBy() | SQualifiedVar() | SAnonConstructor():
             return t
         case SVar(name):
             if name == alpha:
@@ -215,7 +216,7 @@ def substitution_svartype_in_sterm(t: STerm, rep: SType, name: Name) -> STerm:
         return substitution_svartype_in_sterm(x, rep, name)
 
     match t:
-        case SVar(_) | SHole(_) | SBy() | SQualifiedVar() | SAnonConstructor():
+        case SVar(_) | SHole(_) | SImplicitRefinementHole(_) | SBy() | SQualifiedVar() | SAnonConstructor():
             return t
         case SLiteral(v, ty, loc):
             return SLiteral(v, substitute_svartype_in_stype(ty, rep, name), loc=loc)

--- a/aeon/synthesis/identification.py
+++ b/aeon/synthesis/identification.py
@@ -5,6 +5,7 @@ from aeon.core.terms import (
     Application,
     Hole,
     If,
+    ImplicitRefinementHole,
     Let,
     Literal,
     Rec,
@@ -137,12 +138,20 @@ def get_holes_info(
 
 
 def get_holes(term: Term) -> list[Name]:
-    """Returns the names of holes in a particular term."""
+    """Returns the names of holes in a particular term.
+
+    ``ImplicitRefinementHole`` (inserted by elaboration when instantiating an
+    ``RefinementPolymorphism``) is *not* a synthesis hole: it is solved by
+    Horn inference, so this function returns ``[]`` for it. Since it is a
+    distinct ``Term`` subclass — not a subclass of ``Hole`` — the
+    ``case Hole(...)`` arm cannot match it, and the recursion through
+    ``RefinementApplication`` lands on the dedicated leaf case below.
+    """
     match term:
         case Hole(name=name):
             return [name]
-        case Hole(name=name):
-            return [name]
+        case ImplicitRefinementHole(_):
+            return []
         case Literal(_):
             return []
         case Var(_):
@@ -167,10 +176,6 @@ def get_holes(term: Term) -> list[Name]:
         case RefinementAbstraction(name=_, body=body):
             return get_holes(body)
         case RefinementApplication(body=body, refinement=refinement):
-            # TODO better solution
-            # Implicit refinement placeholders (elaboration) are solved by Horn inference, not GP synthesis.
-            if isinstance(refinement, Hole) and refinement.name.name.startswith("_pred"):
-                return get_holes(body)
             return get_holes(body) + get_holes(refinement)
         case _:
             assert False

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -28,6 +28,7 @@ from aeon.core.terms import Abstraction, RefinementAbstraction, RefinementApplic
 from aeon.core.terms import Annotation
 from aeon.core.terms import Application
 from aeon.core.terms import Hole
+from aeon.core.terms import ImplicitRefinementHole
 from aeon.core.terms import If
 from aeon.core.terms import Let
 from aeon.core.terms import Literal
@@ -508,7 +509,7 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             (c, rp) = synth(ctx, body)
             if not isinstance(rp, RefinementPolymorphism):
                 raise CoreInvalidApplicationError(t, rp)
-            if isinstance(refinement, Hole):
+            if isinstance(refinement, ImplicitRefinementHole):
                 horn_name = Name("kappa", fresh_counter.fresh())
                 nty = instantiate_refinement_with_horn_in_type(rp.body, rp.name, rp.sort, horn_name)
                 return (c, nty)

--- a/aeon/utils/pprint.py
+++ b/aeon/utils/pprint.py
@@ -18,6 +18,7 @@ from aeon.sugar.program import (
     SLiteral,
     SVar,
     SHole,
+    SImplicitRefinementHole,
     SBy,
     STerm,
     Node,
@@ -166,7 +167,7 @@ def get_sterm_operation(sterm: STerm) -> Operation:
             return Operation.POLYMORPHISM
         case STypeApplication():
             return Operation.TYPE_APPLICATION
-        case SLiteral() | SVar() | SHole() | SBy():
+        case SLiteral() | SVar() | SHole() | SImplicitRefinementHole() | SBy():
             return Operation.LITERAL
         case _:
             return Operation.LITERAL
@@ -430,6 +431,9 @@ def sterm_pretty(sterm: STerm, context: ParenthesisContext = None, depth: int = 
         case SHole(name=name):
             return text("?" + name.pretty())
 
+        case SImplicitRefinementHole(name=name):
+            return text("?ρ" + name.pretty())
+
         case SBy(steps=steps):
             inner = text("; ".join(steps))
             return group(concat([text("by "), inner]))
@@ -622,6 +626,8 @@ def normalize_term(term: STerm, context: dict[Name, STerm] = None, seen: set[Nam
             return normalize_term(simplified_term, context, new_seen)
         case SHole(name=name):
             return SHole(name=name)
+        case SImplicitRefinementHole(name=name):
+            return SImplicitRefinementHole(name=name)
         case SBy(steps=steps, loc=loc):
             return SBy(steps=steps, loc=loc)
         case SAnnotation(expr=expr, type=type):

--- a/tests/hole_test.py
+++ b/tests/hole_test.py
@@ -1,4 +1,5 @@
-from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.core.terms import Hole, ImplicitRefinementHole, RefinementApplication, Var
+from aeon.synthesis.identification import get_holes, incomplete_functions_and_holes
 from aeon.utils.name import Name
 from tests.driver import check_and_return_core
 
@@ -61,3 +62,46 @@ def test_hole3():
             pass
         case _:
             assert False, "Wrong hole identification"
+
+
+def test_get_holes_skips_implicit_refinement_placeholders():
+    """``get_holes`` must not return ``ImplicitRefinementHole`` placeholders.
+
+    Elaboration inserts these as the ``refinement`` field of
+    ``RefinementApplication`` when instantiating an
+    ``RefinementPolymorphism``. They are solved by Horn inference, not GP
+    synthesis. Regression for #295: previously the filter relied on the
+    hole's name starting with ``_pred``, which silently broke if anyone
+    renamed elaboration-generated holes.
+    """
+    body = Var(Name("f", 0))
+    implicit = ImplicitRefinementHole(Name("_pred", 1))
+    user = Hole(Name("user_hole", 2))
+
+    # Implicit placeholder is structurally distinct — recursion lands on the
+    # dedicated leaf case and yields no hole names.
+    assert get_holes(RefinementApplication(body, implicit)) == []
+    # A user hole in the same field position is still reported.
+    assert get_holes(RefinementApplication(body, user)) == [Name("user_hole", 2)]
+
+
+def test_get_holes_ignores_name_prefix_for_user_holes():
+    """A user hole that happens to be named ``_pred...`` must still be
+    reported. The old prefix-based filter would have silently dropped it.
+    """
+    body = Var(Name("f", 0))
+    misnamed = Hole(Name("_pred_user", 7))
+    assert get_holes(RefinementApplication(body, misnamed)) == [Name("_pred_user", 7)]
+
+
+def test_implicit_refinement_hole_not_a_hole_subclass():
+    """``ImplicitRefinementHole`` must be a sibling, not a subclass, of
+    ``Hole``. The whole point of #295's structural split is that
+    ``isinstance(x, Hole)`` patterns at synthesis sites never match an
+    implicit-refinement placeholder. If someone ever makes the new class
+    inherit from ``Hole``, this test fires before any other consumer
+    silently regresses to the old, brittle behavior.
+    """
+    irh = ImplicitRefinementHole(Name("_pred", 0))
+    assert not isinstance(irh, Hole)
+    assert not issubclass(ImplicitRefinementHole, Hole)


### PR DESCRIPTION
## Summary
- Introduces ``ImplicitRefinementHole`` (``aeon/core/terms.py``) and ``SImplicitRefinementHole`` (``aeon/sugar/program.py``) as sibling ``Term`` subclasses — **not** subclasses of ``Hole``/``SHole``.
- Elaboration's two construction sites in ``aeon/elaboration/__init__.py`` (handling ``SRefinementPolymorphism`` instantiation) emit the new sugar type instead of ``SHole(Name(\"_pred\", ...))``. ``lower_to_core`` (``aeon/sugar/lowering.py``) and ``lift`` (``aeon/sugar/lifting.py``) carry the distinction across the sugar↔core boundary.
- Structural passes that treat holes as leaves get parallel arms for the new type: ``aeon/sugar/substitutions.py``, ``aeon/sugar/bind.py``, ``aeon/sugar/equality.py``, ``aeon/sugar/desugar.py``, ``aeon/utils/pprint.py``, ``aeon/core/substitutions.py``, ``aeon/core/bind.py``, and ``elaborate_remove_unification`` in ``aeon/elaboration/__init__.py``.
- ``aeon/typechecking/typeinfer.py``'s ``RefinementApplication`` branch now dispatches Horn-inference instantiation on ``isinstance(refinement, ImplicitRefinementHole)`` instead of ``isinstance(refinement, Hole)``.
- ``get_holes`` in ``aeon/synthesis/identification.py`` drops the brittle ``\"_pred\"`` name-prefix check. ``case Hole(...)`` can no longer match the implicit type; a dedicated ``case ImplicitRefinementHole(_): return []`` arm makes the intent explicit. (Also collapses a duplicated ``case Hole(name=name)`` arm that was dead code.)

Closes #295.

## Why this shape (vs. a flag on ``Hole``)
A boolean flag on ``Hole`` would have left the runtime distinction up to "did somebody remember to set the field?" — and every ``case Hole(...)`` in synthesis would still match. The structural split makes the discrimination unforgeable: synthesis-side pattern matches simply cannot fire on an implicit-refinement placeholder. The cost is the parallel arms in structural passes (substitutions, bind, equality, etc.), which are mechanical and now sit at the leaf positions where the original ``SHole``/``Hole`` arms already were.

A test (``test_implicit_refinement_hole_not_a_hole_subclass``) pins the invariant so a future edit can't accidentally re-inherit and silently regress the filter.

## Test plan
- [x] ``uv run pytest tests/hole_test.py`` — 7/7 pass, including three new tests:
  - ``test_get_holes_skips_implicit_refinement_placeholders`` — flagged hole inside ``RefinementApplication`` is filtered out; user hole in the same slot is reported.
  - ``test_get_holes_ignores_name_prefix_for_user_holes`` — a user hole named ``_pred_user`` (which the old prefix check would have dropped) is now reported.
  - ``test_implicit_refinement_hole_not_a_hole_subclass`` — pins the structural-split invariant.
- [x] ``uv run pytest tests/parametric_refinements_test.py tests/elaboration_test.py`` — 23/23 pass (covers the elaboration paths that introduce these placeholders).
- [x] Full ``uv run pytest tests/`` — 1023 passed / 9 skipped / 2 xfailed / 1 deselected. The deselected ``test_measure_energy_returns_finite_nonnegative`` is a pre-existing RAPL/permissions failure on ``master``, unrelated to this change.
- [x] ``uvx pre-commit run`` on all touched files — mypy, ruff, ruff format all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)