### PR TITLE
fix(core): inline multi-argument refinement predicates

### DIFF
--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -117,23 +117,44 @@ def substitute_vartype_in_term(t: Term, rep: Type, name: Name) -> Term:
             assert False
 
 
+def _peel_abstractions(term: Term, n: int) -> tuple[list[Name], Term] | None:
+    """Peel ``n`` nested ``Abstraction`` binders off a curried lambda.
+
+    Returns the bound parameter names (outermost first) and the remaining body,
+    or ``None`` if ``term`` has fewer than ``n`` leading abstractions.
+    """
+    params: list[Name] = []
+    body = term
+    for _ in range(n):
+        if not isinstance(body, Abstraction):
+            return None
+        params.append(body.var_name)
+        body = body.body
+    return params, body
+
+
 def instantiate_refinement_in_liquid(
     t: LiquidTerm,
     pred_name: Name,
     refinement: Abstraction,
 ) -> LiquidTerm:
-    """Replaces LiquidApp(pred_name, [arg]) with the inlined refinement body.
-    Implements tutorial fig 8.6: κ(x)[ρ := φ] = p[y := x] if ρ = κ:·, φ = λy.p"""
+    """Replaces LiquidApp(pred_name, [args...]) with the inlined refinement body.
+    Implements tutorial fig 8.6 generalized to multiple arguments:
+    κ(x1, ..., xn)[ρ := φ] = p[y1 := x1, ..., yn := xn] if ρ = κ:·, φ = λy1...yn. p"""
     match t:
         case LiquidApp(aname, args, loc):
-            # TODO: support multi-arg predicates
-            if aname == pred_name and len(args) == 1 and isinstance(args[0], LiquidVar):
-                arg = args[0]
-                body_subst = substitution(refinement.body, Var(arg.name, loc=arg.loc), refinement.var_name)
-                body_subst = inline_lets(body_subst)
-                liq = liquefy(body_subst)
-                if liq is not None:
-                    return liq
+            if aname == pred_name and len(args) >= 1 and all(isinstance(a, LiquidVar) for a in args):
+                peeled = _peel_abstractions(refinement, len(args))
+                if peeled is not None:
+                    params, body = peeled
+                    body_subst = body
+                    for param, arg in zip(params, args):
+                        assert isinstance(arg, LiquidVar)
+                        body_subst = substitution(body_subst, Var(arg.name, loc=arg.loc), param)
+                    body_subst = inline_lets(body_subst)
+                    liq = liquefy(body_subst)
+                    if liq is not None:
+                        return liq
             return LiquidApp(
                 aname,
                 [instantiate_refinement_in_liquid(a, pred_name, refinement) for a in args],

--- a/tests/instantiate_refinement_multiarg_test.py
+++ b/tests/instantiate_refinement_multiarg_test.py
@@ -1,0 +1,76 @@
+"""Tests for multi-argument predicate inlining in `instantiate_refinement_in_liquid`.
+
+See issue #297: `κ(x1, ..., xn)[ρ := φ]` should inline a curried refinement
+`φ = λy1...yn. p` to `p[y1 := x1, ..., yn := xn]`, not just the single-arg case.
+"""
+
+from aeon.core.liquid import LiquidApp, LiquidVar
+from aeon.core.substitutions import instantiate_refinement_in_liquid
+from aeon.core.terms import Abstraction, Application, Var
+from aeon.utils.name import Name
+
+
+def _lt(a: Name, b: Name) -> Application:
+    """The core term `a < b`, curried: ((< a) b)."""
+    return Application(Application(Var(Name("<", 0)), Var(a)), Var(b))
+
+
+def test_single_arg_predicate_still_inlines():
+    """Regression: the original single-argument path keeps working."""
+    pred = Name("k", 1)
+    y = Name("y", 2)
+    x = Name("x", 3)
+    # φ = λy. (y < y)  ; instantiate k(x)
+    refinement = Abstraction(y, _lt(y, y))
+    term = LiquidApp(pred, [LiquidVar(x)])
+
+    result = instantiate_refinement_in_liquid(term, pred, refinement)
+
+    assert result == LiquidApp(Name("<", 0), [LiquidVar(x), LiquidVar(x)])
+
+
+def test_two_arg_predicate_inlines():
+    """φ = λa. λb. (a < b) ; k(x, z) should become (x < z)."""
+    pred = Name("k", 1)
+    a = Name("a", 2)
+    b = Name("b", 3)
+    x = Name("x", 4)
+    z = Name("z", 5)
+    refinement = Abstraction(a, Abstraction(b, _lt(a, b)))
+    term = LiquidApp(pred, [LiquidVar(x), LiquidVar(z)])
+
+    result = instantiate_refinement_in_liquid(term, pred, refinement)
+
+    assert result == LiquidApp(Name("<", 0), [LiquidVar(x), LiquidVar(z)])
+
+
+def test_arity_mismatch_falls_through():
+    """If the curried refinement has fewer binders than the application has
+    arguments, the predicate is left untouched (recursing into its args)."""
+    pred = Name("k", 1)
+    a = Name("a", 2)
+    x = Name("x", 4)
+    z = Name("z", 5)
+    # Only one binder, but two arguments supplied.
+    refinement = Abstraction(a, _lt(a, a))
+    term = LiquidApp(pred, [LiquidVar(x), LiquidVar(z)])
+
+    result = instantiate_refinement_in_liquid(term, pred, refinement)
+
+    assert result == LiquidApp(pred, [LiquidVar(x), LiquidVar(z)])
+
+
+def test_nested_predicate_application_is_inlined():
+    """A multi-arg predicate nested as an argument of another app is inlined."""
+    pred = Name("k", 1)
+    a = Name("a", 2)
+    b = Name("b", 3)
+    x = Name("x", 4)
+    z = Name("z", 5)
+    refinement = Abstraction(a, Abstraction(b, _lt(a, b)))
+    inner = LiquidApp(pred, [LiquidVar(x), LiquidVar(z)])
+    term = LiquidApp(Name("&&", 0), [inner])
+
+    result = instantiate_refinement_in_liquid(term, pred, refinement)
+
+    assert result == LiquidApp(Name("&&", 0), [LiquidApp(Name("<", 0), [LiquidVar(x), LiquidVar(z)])])


### PR DESCRIPTION
## Summary

Fixes #297. `instantiate_refinement_in_liquid` (`aeon/core/substitutions.py`) only inlined **single-argument** refinement predicates:

```
κ(x)[ρ := φ]  =  p[y := x]   if φ = λy. p
```

Multi-argument predicate applications `κ(x1, …, xn)` against a curried `λy1…yn. p` were silently skipped (left as opaque `LiquidApp`), limiting the expressiveness of inferred refinements.

## Fix

Generalize the inlining to any arity: peel `n` curried `Abstraction` binders off the refinement (new `_peel_abstractions` helper) and substitute each parameter with the corresponding argument:

```
κ(x1, …, xn)[ρ := φ]  =  p[y1 := x1, …, yn := xn]   if φ = λy1…yn. p
```

- The single-argument path is preserved **exactly** (n == 1 reduces to the previous behavior).
- When the curried refinement's arity doesn't match the application's argument count, the predicate falls through unchanged (recursing into its arguments), as before.

## Tests

New `tests/instantiate_refinement_multiarg_test.py`:
- single-arg regression (unchanged behavior),
- two-arg predicate inlines correctly,
- arity mismatch falls through untouched,
- multi-arg predicate nested inside another application is inlined.

## Verification

- New tests pass; liquid / substitution / refinement / typecheck suites pass.
- Full suite green (1024 passed, 9 skipped, 2 xfailed). One unrelated test (`polymorphic_uninterpreted_test::test_unrelated_pair_projections_not_equated`) flaked once due to per-process `PYTHONHASHSEED` reordering the SMT encoding; it passes in isolation and on a clean re-run of the full suite, and this change cannot affect it (it exercises no multi-arg predicate inlining). The pre-existing `optimization_decorators_test::test_measure_energy_returns_finite_nonnegative` failure is environmental (`PermissionError` reading RAPL counters) and deselected.
- `mypy` clean on the changed module.

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)