### PR TITLE
feat(horn): plumb typing context measures into candidate generation (closes #289)

### DIFF
--- a/aeon/verification/horn.py
+++ b/aeon/verification/horn.py
@@ -26,7 +26,15 @@ from aeon.core.types import RefinementPolymorphism
 from aeon.core.types import TypeVar
 from aeon.core.liquid_ops import liquid_prelude
 from aeon.typechecking.context import TypingContext
-from aeon.typechecking.liquid import LiquidTypeCheckingContext, check_liquid, lower_context
+from aeon.typechecking.context import UninterpretedBinder
+from aeon.typechecking.liquid import (
+    LiquidTypeCheckException,
+    LiquidTypeCheckingContext,
+    check_liquid,
+    lower_abstraction_type,
+    lower_context,
+    type_infer_liquid,
+)
 from aeon.typechecking.qualifiers import extract_qualifier_atoms
 from aeon.verification.helpers import constraint_builder
 from aeon.verification.helpers import end
@@ -265,32 +273,104 @@ def build_qualifier_candidates(
     return out
 
 
-def get_possible_args(vars: list[tuple[LiquidTerm, TypeConstructor | TypeVar]], arity: int):
+def get_possible_args(
+    vars: list[tuple[LiquidTerm, TypeConstructor | TypeVar]],
+    arity: int,
+    extra_atoms: list[LiquidTerm] | None = None,
+):
+    extra = extra_atoms or []
     if arity == 0:
         yield []
     else:
-        for base in get_possible_args(vars, arity - 1):
+        for base in get_possible_args(vars, arity - 1, extra):
             for i, (_, _) in enumerate(vars):
                 yield [LiquidVar(mk_arg(i))] + base
                 yield [LiquidLiteralBool(True)] + base
                 yield [LiquidLiteralBool(False)] + base
                 yield [LiquidLiteralInt(0)] + base
                 yield [LiquidLiteralInt(1)] + base
+            for atom in extra:
+                yield [atom] + base
 
 
-def build_possible_assignment(hole: LiquidHornApplication) -> Generator[LiquidApp]:
-    ctx = LiquidTypeCheckingContext(
-        known_types=[TypeConstructor(Name(bn.name.name, 0)) for bn in builtin_core_types],
-        functions=liquid_prelude,
-        variables={mk_arg(i): t for i, (_, t) in enumerate(hole.argtypes)},
-    )
+def context_measures(typing_ctx: TypingContext | None) -> dict[Name, list[TypeConstructor | TypeVar]]:
+    """Custom measures available for Horn predicate generation.
 
-    for fname in liquid_prelude:
-        ftype = liquid_prelude[fname]
+    These are the user-declared uninterpreted functions associated with
+    constructors (``def feats : (ds:Dataset) -> Int = uninterpreted``, the
+    auto-generated inductive projections ``Pair_mk_fst``, …). They are
+    lowered to the liquid signature shape so they can be applied to a hole's
+    argument slots. Only ``UninterpretedBinder`` entries are taken — plain
+    first-order program functions are deliberately excluded to keep the
+    candidate space bounded.
+    """
+    if typing_ctx is None:
+        return {}
+    measures: dict[Name, list[TypeConstructor | TypeVar]] = {}
+    for entry in typing_ctx.entries:
+        if isinstance(entry, UninterpretedBinder):
+            lowered = lower_abstraction_type(entry.type)
+            if len(lowered) >= 2:
+                measures[entry.name] = lowered
+    return measures
+
+
+def build_measure_atoms(
+    ctx: LiquidTypeCheckingContext,
+    hole: LiquidHornApplication,
+    measures: dict[Name, list[TypeConstructor | TypeVar]],
+) -> list[LiquidTerm]:
+    """Applications of custom measures to the hole's variable slots.
+
+    A measure such as ``feats : Dataset -> Int`` is not itself a boolean
+    predicate, so it can only appear in a refinement nested inside a prelude
+    operator (e.g. ``feats(arg_0) <= 0``). These applications become extra
+    atoms that ``get_possible_args`` can place in operator argument
+    positions. Only single applications over the hole variables are produced;
+    deeper nesting is intentionally out of scope.
+    """
+    atoms: list[LiquidTerm] = []
+    seen: set[LiquidTerm] = set()
+    for fname, ftype in measures.items():
         arity = len(ftype) - 1
+        if arity == 0:
+            continue
         for args in get_possible_args(hole.argtypes, arity):
-            # At least one LiquidVar must be used.
             if not any(isinstance(a, LiquidVar) for a in args):
+                continue
+            app = LiquidApp(fname, list(args))
+            if app in seen:
+                continue
+            try:
+                type_infer_liquid(ctx, app)
+            except LiquidTypeCheckException:
+                continue
+            seen.add(app)
+            atoms.append(app)
+    return atoms
+
+
+def build_possible_assignment(
+    hole: LiquidHornApplication,
+    typing_ctx: TypingContext | None = None,
+) -> Generator[LiquidApp]:
+    ctx = liquid_typechecking_ctx_for_hole(typing_ctx, hole)
+    measures = context_measures(typing_ctx)
+    measure_atoms = build_measure_atoms(ctx, hole, measures)
+    measure_atom_set = set(measure_atoms)
+
+    # Boolean-returning measures may serve as predicates directly; the prelude
+    # supplies the relational operators that consume the non-boolean ones.
+    gen_functions: dict[Name, list[TypeConstructor | TypeVar]] = dict(liquid_prelude)
+    for fname, ftype in measures.items():
+        gen_functions.setdefault(fname, ftype)
+
+    for fname in gen_functions:
+        ftype = gen_functions[fname]
+        arity = len(ftype) - 1
+        for args in get_possible_args(hole.argtypes, arity, measure_atoms):
+            # At least one hole variable (directly or via a measure application) must be used.
+            if not any(isinstance(a, LiquidVar) or a in measure_atom_set for a in args):
                 continue
             arg_list = list(args)
             app = LiquidApp(fname, arg_list)
@@ -308,7 +388,7 @@ def build_initial_assignment(
     assign: dict[Name, list[LiquidTerm]] = {}
     for h in holes:
         if h.name not in assign:
-            prelude = list(build_possible_assignment(h))
+            prelude = list(build_possible_assignment(h, typing_ctx))
             extra = build_qualifier_candidates(typing_ctx, h, atoms)
             prelude_set = set(prelude)
             assign[h.name] = prelude + [c for c in extra if c not in prelude_set]
@@ -484,9 +564,6 @@ def fixpoint(cs: list[Constraint], assign) -> Assignment:
     else:
         weakened_assignment = weaken(assign, ncs[0])
         return fixpoint(cs, weakened_assignment)
-
-
-# TODO uninterpreted: We need to pass the context here, to use custom measures in the horn clause.
 
 
 def solve(

--- a/tests/horn_test.py
+++ b/tests/horn_test.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidVar
+from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidTerm, LiquidVar
+from aeon.core.types import AbstractionType
 from aeon.core.types import LiquidHornApplication
 from aeon.core.types import RefinedType
+from aeon.core.types import TypeConstructor
 from aeon.core.types import t_int
+from aeon.typechecking.context import TypingContext, UninterpretedBinder
+from aeon.typechecking.entailment import entailment
 from aeon.utils.ctx_helpers import build_context
 from aeon.verification.helpers import conj, constraint_builder, end, imp, parse_liquid
 from aeon.verification.helpers import simplify_constraint_fixpoint
@@ -130,6 +134,93 @@ def test_solve():
     ex = get_abs_example()
     b = solve(ex)
     assert b is True
+
+
+def _liquid_function_names(t: LiquidTerm) -> set[Name]:
+    """All function names applied anywhere inside a liquid term."""
+    match t:
+        case LiquidApp(fun, args):
+            names = {fun}
+            for a in args:
+                names |= _liquid_function_names(a)
+            return names
+        case _:
+            return set()
+
+
+def _measure_context() -> tuple[TypingContext, Name]:
+    """A context with a user type ``Dataset`` and a custom measure
+    ``feats : (ds: Dataset) -> Int`` declared uninterpreted."""
+    dataset = TypeConstructor(Name("Dataset", 0))
+    feats = Name("feats", 0)
+    ctx = TypingContext()
+    ctx.entries.append(UninterpretedBinder(feats, AbstractionType(Name("ds", 0), dataset, t_int)))
+    return ctx, feats
+
+
+def test_initial_assignment_without_context_ignores_measures():
+    """Without a typing context, candidate generation is unchanged (prelude only)."""
+    k = Name("k")
+    hole = LiquidHornApplication(k, [(parse_liquid("x"), t_int)])
+    assign = build_initial_assignment(LiquidConstraint(hole))
+    assert k in assign
+    assert len(assign[k]) == 30
+
+
+def test_initial_assignment_uses_custom_measures():
+    """A custom measure in the typing context is woven into candidate predicates
+    for a hole over that measure's domain (e.g. ``feats(arg_0) <= 0``)."""
+    ctx, feats = _measure_context()
+    dataset = TypeConstructor(Name("Dataset", 0))
+    k = Name("k")
+    hole = LiquidHornApplication(k, [(parse_liquid("d"), dataset)])
+
+    base = build_initial_assignment(LiquidConstraint(hole))
+    with_ctx = build_initial_assignment(LiquidConstraint(hole), typing_ctx=ctx)
+
+    # The measure introduces strictly more candidates than the prelude alone.
+    assert len(with_ctx[k]) > len(base[k])
+
+    # At least one candidate actually mentions the custom measure.
+    assert any(feats in _liquid_function_names(c) for c in with_ctx[k])
+
+
+def _eq(a: LiquidTerm, b: LiquidTerm) -> LiquidApp:
+    return LiquidApp(Name("==", 0), [a, b])
+
+
+def test_solve_discharges_goal_requiring_a_measure():
+    """The hole's only viable refinement mentions a custom measure, so the
+    solver must *synthesise* a measure-based predicate to discharge the goal.
+
+    Two occurrences of the same hole ``?k(_, _)`` over ``(Dataset, Int)``:
+
+        forall d, n | n == feats(d)  =>  ?k(d, n)        (k as head)
+        forall p, m | ?k(p, m)       =>  feats(p) == m   (k as premise)
+
+    The second implication only holds if ``?k`` is strong enough to carry
+    ``feats(arg_0) == arg_1`` — a predicate that can only be generated once
+    the custom measure ``feats`` is plumbed into candidate generation.
+    """
+    ctx, feats = _measure_context()
+    dataset = TypeConstructor(Name("Dataset", 0))
+    k = Name("k")
+
+    d, n = Name("d", 0), Name("n", 0)
+    head_hole = LiquidHornApplication(k, [(LiquidVar(d), dataset), (LiquidVar(n), t_int)])
+    ap = constraint_builder(
+        vs=[(d, dataset), (n, t_int)],
+        exp=imp(_eq(LiquidVar(n), LiquidApp(feats, [LiquidVar(d)])), end(head_hole)),
+    )
+
+    p, m = Name("p", 0), Name("m", 0)
+    prem_hole = LiquidHornApplication(k, [(LiquidVar(p), dataset), (LiquidVar(m), t_int)])
+    cp = constraint_builder(
+        vs=[(p, dataset), (m, t_int)],
+        exp=imp(prem_hole, end(_eq(LiquidApp(feats, [LiquidVar(p)]), LiquidVar(m)))),
+    )
+
+    assert entailment(ctx, conj(ap, cp)) is True
 
 
 def test_simplify_constraint_fixpoint_reduces_trivial_boolean_structure():


### PR DESCRIPTION
## Summary

Closes #289.

`solve()` in `aeon/verification/horn.py` already received the `typing_ctx`, but the predicate **candidates** for refinement holes were generated solely from `liquid_prelude`. As a result, user-declared **measures** (uninterpreted functions associated with constructors, e.g. `def feats : (ds:Dataset) -> Int = uninterpreted` or the auto-generated inductive projections `Pair_mk_fst`) could only appear in refinements the user wrote *explicitly* — never in a refinement the Horn solver *synthesised* for a hole.

The SMT-solving side already worked: `entailment_context` injects an `UninterpretedFunctionDeclaration` for every measure, so they are declared to z3. The missing half was **generation**, which is what this PR adds.

## Changes

- Thread `typing_ctx` from `build_initial_assignment` into `build_possible_assignment`.
- New `context_measures()` collects the lowered signatures of `UninterpretedBinder` entries from the context. (Only uninterpreted binders — not arbitrary first-order program functions — to keep the candidate space bounded.)
- New `build_measure_atoms()` builds single applications of those measures to the hole's argument slots (`feats(arg_0)`); these are offered as nested atoms.
- `get_possible_args()` gains an `extra_atoms` parameter so measure applications can sit in prelude operator argument positions (`feats(arg_0) == arg_1`, `feats(arg_0) <= 0`, …).
- Boolean-returning measures additionally serve as top-level predicate candidates.
- Removed the stale `# TODO uninterpreted` comment above `solve()`.

With **no** typing context the generated candidate set is unchanged (the existing `len(assign[k]) == 30` / `== 120` invariants in `horn_test.py` still hold).

## Tests

Added to `tests/horn_test.py`:
- `test_initial_assignment_without_context_ignores_measures` — pins the prelude-only baseline.
- `test_initial_assignment_uses_custom_measures` — a custom measure produces strictly more candidates, and at least one mentions the measure.
- `test_solve_discharges_goal_requiring_a_measure` — a two-occurrence hole whose only viable refinement is `feats(arg_0) == arg_1`; the solver now synthesises it and discharges the implication.

The latter two were verified to **fail** before the threading change and pass after.

`uv run pytest tests/` is green (except `test_measure_energy_returns_finite_nonnegative`, a pre-existing environmental `PermissionError` on RAPL energy counters, which also fails on clean `master`). `pre-commit` (mypy + ruff) passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)