### PR TITLE
refactor: drop FPSort TODO from Float SMT encoding

### DIFF
--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from z3 import Function
 from z3 import Int
+from z3 import Real
 from z3 import Solver
 from z3 import StringVal
 from z3 import sat
@@ -629,13 +630,7 @@ def make_variable(name: str, base: TypeConstructor | AbstractionType | Top) -> A
         case TypeConstructor(Name("Bool", _)):
             return Bool(name)
         case TypeConstructor(Name("Float", _), _):
-            import z3
-
-            v = z3.Real(name)
-            return v
-            # TODO: see problem with version below
-            # fpsort = FPSort(8, 24)
-            # return FP(name, fpsort)
+            return Real(name)
         case TypeConstructor(Name("String", _)):
             return String(name)
         case TypeConstructor(Name("Set", _)):


### PR DESCRIPTION
## Summary
- Remove the commented-out `FPSort(8, 24)` attempt and stale `TODO` from `make_variable`'s `Float` case in `aeon/verification/smt.py`.
- Simplify the case to `return Real(name)` (adding a top-level `from z3 import Real` instead of the inline `import z3`).

The Real-vs-FP trade-off and a concrete future plan for an FP-sort encoding are now captured in #300, so the dead code in the source is no longer needed.

## Why
`Float` is encoded as z3 `Real`, which is the only numeric sort that lets the generic, sort-agnostic operator translation in `base_functions` serve both `Int` and `Float`. A `RealSort` -> `FPSort` swap is a much larger design change (see #300), not a one-line substitution, so the inline TODO was misleading.

## Test plan
- [x] `uv run pytest tests/smt_test.py tests/liquid_typechecking_test.py` -- 44 passed
- [x] `uv run pytest tests/ -k "float or smt or Float"` -- 30 passed
- [x] Float refinement examples still verify: `{y:Float | y * 2.0 == x}` (`half 10.0` -> `5.0`), `{y:Float | y == y}`, `{y:Float | y + 1.0 > y}`
- [x] pre-commit (mypy, ruff, ruff format) green

Relates to #300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)