### PR TITLE
feat(verification): covariant subtyping for type-constructor arguments

### DIFF
--- a/aeon/verification/sub.py
+++ b/aeon/verification/sub.py
@@ -141,6 +141,43 @@ def implication_constraint(
             assert False
 
 
+def base_subtype_constraint(
+    ctx: TypingContext,
+    ty1: Type,
+    ty2: Type,
+    loc: Location | None = None,
+) -> Constraint | None:
+    """Subtyping between the *unrefined cores* of two types (``TypeConstructor``
+    or ``TypeVar``), accounting for the variance of constructor arguments.
+
+    Returns the constraint witnessing ``ty1 <: ty2`` ignoring any surrounding
+    refinement, or ``None`` when the heads are incompatible (different
+    constructor name, arity, or type variable).
+
+    Type constructors in aeon are immutable inductive datatypes (``List``,
+    ``Maybe``, ``Pair``, ``Tree`` …), so their arguments are **covariant**:
+    ``C a`` <: ``C b`` whenever ``a`` <: ``b``. This mirrors Liquid Haskell,
+    where element refinements flow covariantly through containers
+    (``List {v:Int | v > 0}`` is a subtype of ``List Int``).
+
+    Covariance is sound here because every parameter of an inductive type occurs
+    only in positive (constructor-result / field) positions. A parameter used in
+    a negative position (e.g. a function-typed field ``k : a -> Int``) would be
+    contravariant/invariant and needs declared-or-inferred per-parameter
+    variance — see issue #298.
+    """
+    match ty1, ty2:
+        case TypeConstructor(name1, args1), TypeConstructor(name2, args2):
+            if name1 != name2 or len(args1) != len(args2):
+                return None
+            c: Constraint = ctrue
+            for a1, a2 in zip(args1, args2):
+                c = Conjunction(c, sub(ctx, a1, a2, loc))
+            return c
+        case _:
+            return ctrue if ty1 == ty2 else None
+
+
 def sub(ctx: TypingContext, t1: Type, t2: Type, loc: Location | None = None) -> Constraint:
     if t2 == Top():
         return ctrue
@@ -161,7 +198,15 @@ def sub(ctx: TypingContext, t1: Type, t2: Type, loc: Location | None = None) -> 
         case RefinedType(n1, ty1, r1), RefinedType(n2, ty2, r2):
             if ty2 == Top():
                 return ctrue
-            if ty1 != ty2:
+            # Subtype the unrefined cores first. This is where constructor-arg
+            # variance lives: ``ensure_refined`` wraps every bare
+            # ``TypeConstructor``/``TypeVar`` into a ``RefinedType``, so two
+            # ``List …`` always reach this arm rather than the TypeConstructor
+            # arm below — comparing args with ``!=`` here used to force
+            # invariance. ``base_subtype_constraint`` instead recurses
+            # covariantly into the arguments (see issue #298).
+            args_c = base_subtype_constraint(ctx, ty1, ty2, loc)
+            if args_c is None:
                 return cfalse
 
             new_name: Name = Name(n1.name + n2.name, fresh_counter.fresh())
@@ -173,7 +218,7 @@ def sub(ctx: TypingContext, t1: Type, t2: Type, loc: Location | None = None) -> 
             assert isinstance(lowert, TypeConstructor)
             rconstraint = Implication(new_name, lowert, r1_, LiquidConstraint(r2_, loc=loc), loc=loc)
 
-            return rconstraint
+            return Conjunction(args_c, rconstraint) if args_c is not ctrue else rconstraint
         case TypePolymorphism(_, _, _), _:
             return ctrue
         case RefinementPolymorphism(_, _, _), _:
@@ -186,15 +231,13 @@ def sub(ctx: TypingContext, t1: Type, t2: Type, loc: Location | None = None) -> 
             rt2_ = substitution_in_type(rt2, Var(new_name_a), a2)
             c1 = sub(ctx, rt1_, rt2_, loc)
             return Conjunction(c0, implication_constraint(new_name_a, t2, c1, loc))
-        case TypeConstructor(name1, args1), TypeConstructor(name2, args2):
-            if name1 != name2:
-                return cfalse
-            if len(args1) != len(args2):
-                return cfalse
-            for it1, it2 in zip(args1, args2):
-                if it1 != it2:  # TODO polytypes: subtyping here?
-                    return cfalse
-            return ctrue
+        case TypeConstructor(_, _) as tc1, TypeConstructor(_, _) as tc2:
+            # Defensive: ``ensure_refined`` normally wraps bare type
+            # constructors into ``RefinedType`` (handled above), so this arm is
+            # only reached if a non-refined constructor ever flows in. Use the
+            # same covariant rule as the refined path.
+            args_c = base_subtype_constraint(ctx, tc1, tc2, loc)
+            return cfalse if args_c is None else args_c
         case _:
             logger.error(f"Failed subtyping by exhaustion: {t1} <: {t2}")
             return cfalse


### PR DESCRIPTION
## Summary

Closes #298. Subtyping between two type constructors previously compared argument lists by structural equality, i.e. **invariant** subtyping for every argument position.

This makes type-constructor arguments **covariant**: `C a <: C b` whenever `a <: b`. Type constructors in aeon are immutable inductive datatypes (`List`, `Maybe`, `Pair`, `Tree` …) whose parameters occur only in positive positions, so covariance is the right (and sound) rule. This mirrors Liquid Haskell, where element refinements flow covariantly through containers — e.g. `List {v:Int | v > 0} <: List Int`.

## Where the fix actually goes

The `it1 != it2` loop the issue points at (the `TypeConstructor` arm of `sub`) is **dead code**: `ensure_refined` wraps every bare `TypeConstructor`/`TypeVar` into a `RefinedType` before the `match`, so two `List …` types always land in the `RefinedType` arm. The invariance came from `if ty1 != ty2: return cfalse` there.

A new `base_subtype_constraint` helper compares the unrefined cores with covariant arguments (returning `None` for incompatible heads). The `RefinedType` arm now conjoins the per-argument VC with the existing refinement implication; the dead `TypeConstructor` arm is routed through the same helper defensively. Element refinements are stripped by `lower_constraint_type`, so both heads still lower to the same SMT sort and the refinement implication stays well-sorted.

## Soundness & caveat

Covariance holds because inductive-type parameters appear only in positive (constructor-result/field) positions. A parameter in a **negative** position (e.g. a function-typed field `mk (k : a -> Int)`) would be contravariant/invariant; no stdlib/example type does this today. Per-parameter declared/inferred variance (the Scala/OCaml/LH route) is a follow-up — `base_subtype_constraint` is the single place to thread it. Abstract-refinement parameters (`forall <p>`) remain a separate axis and are unchanged.

This also unblocks the refinement-parametricity follow-up noted at `aeon/sugar/desugar.py:767`.

## Test plan

Directional checks (empty context, SMT-discharged):

- [x] `List {v>0} <: List Int` holds
- [x] `List Int <: List {v>0}` rejected
- [x] `List Int <: List Bool` rejected
- [x] `List Int <: List Int` holds
- [x] `Pair {v>0} Int <: Pair Int Int` holds; reverse rejected
- [x] `List (List {v>0}) <: List (List Int)` holds (nested)

Regression suite (170 passed, 0 failed): `sub`, `polytypes`, `typevars`, `intlist_match_*`, `liquid_typechecking`, `substitutions`, `type_substitution_capture`, `parametric_refinements`, `match_inductive`, `instantiate_refinement_multiarg`, `elaboration`, `infer`, `instantiation`, `polymorphism`, `polymorphic_uninterpreted`, `end_to_end`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)