### PR TITLE
feat: reflect function bodies into return types via `_` marker (#192)

### DIFF
--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -104,6 +104,128 @@ def _sugar_contains_recursive_call(t: STerm, fname: Name) -> bool:
     return walk(t)
 
 
+def _is_reflection_marker(t: STerm) -> bool:
+    return isinstance(t, SVar) and t.name.name == "_"
+
+
+def _expand_reflection_marker(t: STerm, binder: Name, body: STerm) -> tuple[STerm, int]:
+    """Replace each ``_`` marker inside a refinement with ``binder == body``.
+
+    Returns the rewritten term and the number of markers expanded.
+    """
+    if _is_reflection_marker(t):
+        loc = t.loc
+        eq = SApplication(
+            SApplication(SVar(Name("==", 0), loc=loc), SVar(binder, loc=loc), loc=loc),
+            body,
+            loc=loc,
+        )
+        return eq, 1
+    match t:
+        case SApplication(fun, arg, loc):
+            nf, c1 = _expand_reflection_marker(fun, binder, body)
+            na, c2 = _expand_reflection_marker(arg, binder, body)
+            return SApplication(nf, na, loc=loc), c1 + c2
+        case SIf(cond, then, otherwise, loc):
+            nc, c1 = _expand_reflection_marker(cond, binder, body)
+            nt, c2 = _expand_reflection_marker(then, binder, body)
+            no, c3 = _expand_reflection_marker(otherwise, binder, body)
+            return SIf(nc, nt, no, loc=loc), c1 + c2 + c3
+        case SAnnotation(expr, ty, loc):
+            ne, c1 = _expand_reflection_marker(expr, binder, body)
+            return SAnnotation(ne, ty, loc=loc), c1
+        case _:
+            return t, 0
+
+
+def _mentions_function(body: STerm, fname: Name) -> bool:
+    match body:
+        case SVar(name, _):
+            return name.name == fname.name
+        case SApplication(fun, arg, _):
+            return _mentions_function(fun, fname) or _mentions_function(arg, fname)
+        case SAnnotation(expr, _, _):
+            return _mentions_function(expr, fname)
+        case _:
+            return False
+
+
+def _is_native_or_uninterpreted_body(body: STerm) -> bool:
+    match body:
+        case SVar(Name("uninterpreted", _)):
+            return True
+        case SApplication(SVar(Name("native", _)), _):
+            return True
+        case SApplication(SVar(Name("native_import", _)), _):
+            return True
+    return False
+
+
+def _unreflectable_construct(body: STerm) -> str | None:
+    """Name the first body construct that cannot appear in a liquid refinement, or None.
+
+    Reflection via `_` strengthens the return type with ``binder == body``, so the
+    body has to be a liquid term (variables, literals, applications, and
+    ``if``/``then``/``else`` which lowers to ``ite``). ``match`` and binders
+    (``let``/``\\``) are not yet supported.
+    """
+    match body:
+        case SVar() | SLiteral() | SQualifiedVar() | SHole():
+            return None
+        case SAnnotation(expr, _, _):
+            return _unreflectable_construct(expr)
+        case SApplication(fun, arg, _):
+            return _unreflectable_construct(fun) or _unreflectable_construct(arg)
+        case SIf(cond, then, otherwise, _):
+            return (
+                _unreflectable_construct(cond) or _unreflectable_construct(then) or _unreflectable_construct(otherwise)
+            )
+        case SMatch():
+            return "match"
+        case SLet() | SRec():
+            return "let"
+        case SAbstraction():
+            return "lambda"
+        case _:
+            return type(body).__name__
+
+
+def reflect_underscore_in_definitions(defs: list[Definition]) -> list[Definition]:
+    """Expand the ``_`` reflection marker in each definition's return-type refinement.
+
+    ``def f (x:Int) : {y:Int | _} = x + x`` strengthens the return type to
+    ``{y:Int | y == x + x}``, reflecting the body into the predicate.
+    """
+    out: list[Definition] = []
+    for d in defs:
+        rtype = d.type
+        if not isinstance(rtype, SRefinedType) or any(n.name == "_" for n, _ in d.args):
+            out.append(d)
+            continue
+        new_ref, count = _expand_reflection_marker(rtype.refinement, rtype.name, d.body)
+        if count == 0:
+            out.append(d)
+            continue
+        if _is_native_import_def(d) or _is_native_or_uninterpreted_body(d.body):
+            raise TypeError(
+                f"Cannot reflect the body of '{d.name.name}' with `_`: native and uninterpreted "
+                "functions have no encodable implementation."
+            )
+        if _mentions_function(d.body, d.name):
+            raise TypeError(
+                f"Cannot reflect the recursive body of '{d.name.name}' with `_` yet: "
+                "self-referential reflection is not supported."
+            )
+        bad = _unreflectable_construct(d.body)
+        if bad is not None:
+            raise TypeError(
+                f"Cannot reflect the body of '{d.name.name}' with `_`: "
+                f"'{bad}' is not expressible in a refinement predicate."
+            )
+        out.append(replace(d, type=SRefinedType(rtype.name, rtype.type, new_ref, loc=rtype.loc)))
+    return out
+
+
 def definition_with_inferred_decreasing(d: Definition) -> Definition:
     """If omitted, use the sole ``Int`` parameter as the metric for unary self-recursion."""
     if d.decreasing_by or len(d.args) != 1:
@@ -440,6 +562,8 @@ def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType]
     ]
     prog = resolve_qualified_names_in_sterm(prog, qualified_scope, unqualified_scope, constructor_defs)
 
+    # Expand the `_` reflection marker in return-type refinements into `binder == body`.
+    defs = reflect_underscore_in_definitions(defs)
     defs, metadata = apply_decorators_in_definitions(defs)
     defs, metadata = lower_by_blocks_in_definitions(defs, metadata)
 

--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -172,6 +172,15 @@ def type_infer_liquid(
                     return ty
                 case _:
                     raise LiquidTypeCheckException("Could not find type for {liq} ({ctx.variables[name]})")
+        case LiquidApp(Name("ite", _), [cond, then, otherwise]):
+            kc = type_infer_liquid(ctx, cond)
+            if not (isinstance(kc, TypeConstructor) and kc.name.name == "Bool"):
+                raise LiquidTypeCheckException(f"Condition {cond} of {liq} must be Bool, but {kc} was found.")
+            kt = type_infer_liquid(ctx, then)
+            ke = type_infer_liquid(ctx, otherwise)
+            if kt != ke and not isinstance(kt, TypeVar) and not isinstance(ke, TypeVar):
+                raise LiquidTypeCheckException(f"Branches of {liq} have different types: {kt} and {ke}.")
+            return kt if not isinstance(kt, TypeVar) else ke
         case LiquidApp(fun, args):
             if fun not in ctx.functions:
                 raise LiquidTypeCheckException(f"Function {fun} not in context in {liq} ({ctx.functions}).")

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -18,6 +18,7 @@ from z3.z3 import BoolRef
 from z3.z3 import BoolSort
 from z3.z3 import Const
 from z3.z3 import DeclareSort
+from z3.z3 import If
 from z3.z3 import Implies
 from z3.z3 import IntSort
 from z3.z3 import RealSort
@@ -128,6 +129,7 @@ base_functions: dict[str, Any] = {
     "/": lambda x, y: x / y,
     "%": lambda x, y: x % y,
     "-->": lambda x, y: Implies(x, y),
+    "ite": lambda c, t, e: If(c, t, e),
     # SMT Set operations
     "Set_empty": EmptySet(IntSort()),
     "Set_sng": lambda x: SetAdd(EmptySet(IntSort()), x),

--- a/examples/syntax/reflect_underscore.ae
+++ b/examples/syntax/reflect_underscore.ae
@@ -1,0 +1,30 @@
+# Reflecting a function body into its return type with `_`.
+#
+# Writing `_` as the refinement of a return type asks the compiler to
+# reflect the function's body into the predicate: the binder is made equal
+# to the body. So `{y:Int | _}` on `double` below becomes `{y:Int | y == x + x}`,
+# and that equation is visible to the SMT solver at every call site.
+
+# `_` expands to `y == x + x`.
+def double (x:Int) : {y:Int | _} = x + x;
+
+# `_` expands to `y == x + 1`.
+def inc (x:Int) : {y:Int | _} = x + 1;
+
+# if-then-else bodies are reflected too, lowering to `ite` in the predicate:
+# `_` expands to `y == ite(x < 0, 0 - x, x)`.
+def abs (x:Int) : {y:Int | _} = if x < 0 then (0 - x) else x;
+
+# `_` can be combined with manual conjuncts. With a non-negative input,
+# the reflected `y == x + x` plus `y >= 0` both hold.
+def double_nat (x:{v:Int | v >= 0}) : {y:Int | _ && y >= 0} = x + x;
+
+# Because the bodies are reflected, these post-conditions are proven
+# automatically — no manual lemmas, no annotations at the call site.
+def c1 : {b:Bool | b} = double 5 == 10;
+def c2 : {b:Bool | b} = inc (double 3) == 7;
+def c3 : {b:Bool | b} = abs (0 - 8) == 8;
+def c4 : {b:Bool | b} = abs 8 == 8;
+def c5 : {b:Bool | b} = double_nat 4 == 8;
+
+def main (_:Int) : Unit = print "reflected post-conditions verified";

--- a/tests/reflect_underscore_test.py
+++ b/tests/reflect_underscore_test.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pytest
+
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import (
+    DesugaredProgram,
+    desugar,
+    reflect_underscore_in_definitions,
+)
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_main_program, parse_program
+from aeon.sugar.program import SApplication, SVar
+from aeon.sugar.stypes import SRefinedType
+from aeon.typechecking.typeinfer import check_type_errors
+
+
+def _verify(src: str) -> list:
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(
+        progt, ctx, desugared.metadata, desugared.constructor_to_type, desugared.constructor_defs
+    )
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    return list(check_type_errors(typing_ctx, core_ast, top))
+
+
+def test_marker_expands_to_body_equation():
+    src = """def double (x:Int) : {y:Int | _} = x + x;
+def main (_:Int) : Int = 0"""
+    defs = reflect_underscore_in_definitions(parse_program(src).definitions)
+    rtype = defs[0].type
+    assert isinstance(rtype, SRefinedType)
+    # refinement is `y == (x + x)`
+    assert isinstance(rtype.refinement, SApplication)
+    assert isinstance(rtype.refinement.fun, SApplication)
+    assert isinstance(rtype.refinement.fun.fun, SVar)
+    assert rtype.refinement.fun.fun.name.name == "=="
+
+
+def test_reflected_body_is_visible_at_call_site():
+    src = """def double (x:Int) : {y:Int | _} = x + x;
+def inc (x:Int) : {y:Int | _} = x + 1;
+def check : {b:Bool | b} = double 5 == 10;
+def check2 : {b:Bool | b} = inc (double 3) == 7;
+def main (_:Int) : Int = 0"""
+    assert _verify(src) == []
+
+
+def test_marker_composes_with_manual_refinement():
+    # The body must satisfy the manual conjunct too: with a non-negative input,
+    # `x + x >= 0` holds, so `_ && y >= 0` is provable.
+    src = """def double (x:{v:Int | v >= 0}) : {y:Int | _ && y >= 0} = x + x;
+def check : {b:Bool | b} = double 5 == 10;
+def main (_:Int) : Int = 0"""
+    assert _verify(src) == []
+
+
+def test_wrong_postcondition_fails_to_verify():
+    src = """def double (x:Int) : {y:Int | _} = x + x;
+def check : {b:Bool | b} = double 5 == 11;
+def main (_:Int) : Int = 0"""
+    assert _verify(src) != []
+
+
+def test_no_marker_is_left_unchanged():
+    src = """def double (x:Int) : {y:Int | y > 0} = x + x;
+def main (_:Int) : Int = 0"""
+    defs = parse_program(src).definitions
+    out = reflect_underscore_in_definitions(defs)
+    assert out[0] is defs[0]
+
+
+def test_underscore_parameter_name_is_not_a_marker():
+    src = """def const (_:Unit) : {y:Int | y == 3} = 3;
+def main (_:Int) : Int = 0"""
+    defs = parse_program(src).definitions
+    out = reflect_underscore_in_definitions(defs)
+    assert out[0] is defs[0]
+
+
+def test_if_body_reflects_and_verifies():
+    # An if-then-else body lowers to `ite` in the refinement and verifies.
+    src = """def absv (x:Int) : {y:Int | _} = if x < 0 then (0 - x) else x;
+def check : {b:Bool | b} = absv (0 - 5) == 5;
+def check2 : {b:Bool | b} = absv 3 == 3;
+def main (_:Int) : Int = 0"""
+    assert _verify(src) == []
+
+
+def test_if_body_wrong_claim_fails():
+    src = """def absv (x:Int) : {y:Int | _} = if x < 0 then (0 - x) else x;
+def check : {b:Bool | b} = absv (0 - 5) == 4;
+def main (_:Int) : Int = 0"""
+    assert _verify(src) != []
+
+
+def test_native_body_rejected_with_clear_error():
+    src = """def foo (x:Int) : {y:Int | _} = native "x";
+def main (_:Int) : Int = 0"""
+    with pytest.raises(TypeError, match="native and uninterpreted"):
+        reflect_underscore_in_definitions(parse_program(src).definitions)
+
+
+def test_recursive_body_rejected_with_clear_error():
+    src = """def fact (n:Int) : {r:Int | _} = n * fact (n - 1);
+def main (_:Int) : Int = 0"""
+    with pytest.raises(TypeError, match="recursive"):
+        reflect_underscore_in_definitions(parse_program(src).definitions)


### PR DESCRIPTION
## Summary

Implements the "hole in the type" approach to PLE reflection from #192. Instead of `@reflect`/`@opaque` decorators, a function can reflect its own body into its return-type refinement by writing `_` as the predicate:

```aeon
def double (x:Int) : {y:Int | _} = x + x;   -- becomes {y:Int | y == x + x}
def abs    (x:Int) : {y:Int | _} = if x < 0 then (0 - x) else x;
```

The reflected equation is visible to the SMT solver at every call site, so post-conditions like `double 5 == 10` and `abs (0 - 8) == 8` are proven automatically — no manual lemmas, no call-site annotations.

- **`reflect_underscore_in_definitions`** desugar pass expands the `_` marker in return-type refinements into `binder == body`. It composes with manual conjuncts (`{y:Int | _ && y >= 0}`) and raises clear `TypeError`s for bodies that cannot be reflected: native/uninterpreted functions, recursive (self-referential) bodies, and `match`/`let`/`lambda`.
- **if-then-else support in refinements:** `if`/`then`/`else` bodies lower to `ite`, now understood by the liquid type checker (`aeon/typechecking/liquid.py`) and translated to z3's `If` (`aeon/verification/smt.py`).
- An `_` used as a *parameter name* is not treated as a marker.

Closes #192

## Test plan

- [x] `tests/reflect_underscore_test.py` — 10 tests: marker expansion, call-site visibility, conjunct composition, if-then-else reflects + wrong-claim rejection, and the native/recursive/non-marker guards.
- [x] `examples/syntax/reflect_underscore.ae` — runnable demonstration, exercised by `run_examples.sh` CI.
- [x] Full suite: 999 passed, 9 skipped.
- [x] mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)