### PR TITLE
Resolve first three Vericoding Known Limitations (--> in prelude, ! precedence, pprint order)

### DIFF
--- a/aeon/prelude/prelude.py
+++ b/aeon/prelude/prelude.py
@@ -115,6 +115,7 @@ prelude = [
     ("%", "(n x:Int) -> (n y:Int) -> Int", lambda x: lambda y: x % y),
     ("&&", "(n x:Bool) -> (n y:Bool) -> Bool", lambda x: lambda y: x and y),
     ("||", "(n x:Bool) -> (n y:Bool) -> Bool", lambda x: lambda y: x or y),
+    ("-->", "(n x:Bool) -> (n y:Bool) -> Bool", lambda x: lambda y: (not x) or y),
     ("!", "(n x:Bool) -> Bool", lambda x: not x),
     # SMT Set operations (logical only, used in refinements)
     ("Set_empty", "Set", set()),

--- a/benchmarks/vericoding/README.md
+++ b/benchmarks/vericoding/README.md
@@ -20,7 +20,7 @@ The translator rejects tasks outside the subset with a printed reason (so a task
 | `int` / `bool` | `Int` / `Bool` |
 | `predicate P(args) { body }` | `def P args : Bool = body;` |
 | `method M(args) returns (r:T) requires R ensures E` | `def M args (last:Tlast \| R) : {r:T \| E} = ?hole;` |
-| `==>` (implication) | `(!(a)) \|\| (b)` — aeon's `-->` is in the grammar but [not registered as a function](../../aeon/prelude/prelude.py), so we desugar |
+| `==>` (implication) | `(a) --> (b)` — aeon's `-->` is parsed by the grammar and [registered in the prelude](../../aeon/prelude/prelude.py) |
 | `<==>` (iff) | `a == b` (Bool equivalence) |
 | `a <= b <= c` (chained) | `(a <= b) && (b <= c)` |
 | `f(a, b, c)` (Dafny call) | `(f a b c)` (curried aeon call) |
@@ -46,11 +46,14 @@ Dafny sources are fetched on demand from `raw.githubusercontent.com` and cached 
 
 These are tracked separately from this issue:
 
-* **`-->` not in prelude.** Aeon's grammar parses logical implication `-->` but [`aeon/prelude/prelude.py`](../../aeon/prelude/prelude.py) doesn't register it as a function, so the typechecker rejects refinements that use it. The translator desugars to `(!a) || b` as a workaround.
-* **`!` is right-greedy.** `!a || b` parses as `!(a || b)` because aeon's grammar makes the `!` rule consume an entire `expression_un`. The translator emits explicit parens around the negated operand.
-* **Pretty-printer flips operands.** `y >= 100` displays as `100 >= y` (and similar) — synthesis is correct; the printout is misleading. Cosmetic.
 * **SMT accepts undefined arithmetic.** `1 % 0`, `5 / 0` are sometimes "synthesized" as solutions because aeon's verifier doesn't constrain divisor-non-zero. Affects pass rates upward.
 * **Synthesizer can't handle `if` in specs.** Tasks whose predicates use Dafny's `if-then-else` expression form (e.g. DA0522) trip `AssertionError: Unhandled term If in synth`.
+
+### Resolved
+
+* **`-->` now in prelude.** Logical implication `-->` is registered in [`aeon/prelude/prelude.py`](../../aeon/prelude/prelude.py) (with an `Implies` SMT translation), so refinements may use it directly. The translator emits `(a) --> (b)` instead of desugaring to `(!a) || b`.
+* **`!` precedence fixed.** `!a || b` now parses as `(!a) || b` — the grammar gives `!` its own precedence level tighter than the boolean connectives, so no explicit parens around the negated operand are needed.
+* **Pretty-printer operand order fixed.** Comparisons such as `y >= 100` now print in source order rather than flipped (`100 >= y`).
 
 ## Extending the subset
 

--- a/benchmarks/vericoding/translate.py
+++ b/benchmarks/vericoding/translate.py
@@ -11,7 +11,7 @@ V1 subset (intentionally narrow):
 Tasks outside this subset are returned with a rejection reason; nothing is
 emitted for them in v1.
 
-Implication `a ==> b` is rewritten as `(!(a)) || (b)`.
+Implication `a ==> b` is rewritten as aeon's `(a) --> (b)`.
 Iff `a <==> b` is rewritten as `a == b` (valid for Bool operands).
 Chained comparisons `a <= b <= c` are split into `(a <= b) && (b <= c)`.
 """
@@ -235,7 +235,7 @@ def _validate_references(spec: TaskSpec) -> None:
 # Steps, in order, on a string:
 #   1. Strip trailing `;` and surrounding whitespace.
 #   2. Rewrite `<==>` -> `==` (Bool iff).
-#   3. Rewrite `==>` -> a special marker, then later expand to `(!(a)) || (b)`.
+#   3. Rewrite `==>` -> aeon's `-->` (right-associative).
 #   4. Expand chained comparisons `a OP b OP c` -> `(a OP b) && (b OP c)`.
 #   5. Pass through everything else.
 #
@@ -303,9 +303,11 @@ def _recurse_into_parens(s: str, fn) -> str:
 
 
 def _expand_implication(s: str) -> str:
-    """Rewrite `==>` (right-associative) into `(!(a)) || (b)`, at every depth.
+    """Rewrite Dafny `==>` into aeon's `-->`, at every depth.
 
-    Implication is right-assoc in Dafny: `a ==> b ==> c` == `a ==> (b ==> c)`.
+    Implication is right-assoc in Dafny: `a ==> b ==> c` == `a ==> (b ==> c)`,
+    and aeon's `-->` is right-assoc too, so we keep that grouping. `-->` is now
+    registered in aeon's prelude, so no desugaring to `(!(a)) || (b)` is needed.
     """
     # First recurse into parens.
     s = _recurse_into_parens(s, _expand_implication)
@@ -313,9 +315,9 @@ def _expand_implication(s: str) -> str:
     if len(parts) == 1:
         return s
     parts = [p.strip() for p in parts]
-    out = parts[-1]
+    out = f"({parts[-1]})"
     for p in reversed(parts[:-1]):
-        out = f"((!({p})) || ({out}))"
+        out = f"(({p}) --> {out})"
     return out
 
 
@@ -355,6 +357,9 @@ def _find_top_ops(text: str, ops: tuple[str, ...]) -> list[tuple[int, str]]:
                     if op == "<" and text[i : i + 2] == "<=":
                         continue
                     if op == ">" and text[i : i + 2] == ">=":
+                        continue
+                    # The `>` tail of an implication `-->` is not a comparison.
+                    if op == ">" and i >= 2 and text[i - 2 : i + 1] == "-->":
                         continue
                     spans.append((i, op))
                     i += len(op)

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -8,7 +8,7 @@ from aeon.sugar.ast_helpers import st_top
 from aeon.sugar.bind import bind, bind_program
 from aeon.sugar.desugar import DesugaredProgram, desugar
 from aeon.sugar.lowering import lower_to_core, lower_to_core_context
-from aeon.sugar.parser import parse_main_program, parse_type
+from aeon.sugar.parser import parse_expression, parse_main_program, parse_type
 from aeon.typechecking.typeinfer import check_type_errors
 from aeon.utils.location import FileLocation
 from tests.driver import check_compile_expr
@@ -114,3 +114,24 @@ def k : Int = g (2 + 40);
     _check_refinement_error_location(
         source, "test_refinement.ae", expected_line=3, expected_col_min=14, expected_col_max=24
     )
+
+
+def test_implication_in_refinement_typechecks():
+    """`-->` is registered in the prelude, so refinements may use logical
+    implication directly instead of desugaring to `(!a) || b`."""
+    source = r"""let f : (x:Int) -> {r:Int | (x > 0) --> (r > 0)} = \x -> (if x > 0 then x else 0) in f 5"""
+    assert check_compile_expr(source, parse_type("Int"), 5)
+
+
+def test_implication_in_refinement_rejects_violation():
+    """The implication is genuinely enforced by the verifier: an implementation
+    that breaks `(x > 0) --> (r > 0)` must be rejected."""
+    source = r"""let f : (x:Int) -> {r:Int | (x > 0) --> (r > 0)} = \x -> (0 - x) in f 5"""
+    assert not check_compile_expr(source, parse_type("Int"))
+
+
+def test_negation_binds_tighter_than_or():
+    """`!a || b` parses as `(!a) || b`, not `!(a || b)` — the `!` operator is no
+    longer right-greedy."""
+    parsed = str(parse_expression("!a || b"))
+    assert parsed == "((|| (! a?)) b?)"

--- a/tests/vericoding_translator_test.py
+++ b/tests/vericoding_translator_test.py
@@ -28,7 +28,8 @@ from translate import (  # noqa: E402
 
 
 def test_implication_at_top_level():
-    assert _expand_implication("a ==> b") == "((!(a)) || (b))"
+    # `==>` maps to aeon's `-->`, now registered in the prelude.
+    assert _expand_implication("a ==> b") == "((a) --> (b))"
 
 
 def test_implication_inside_parens():
@@ -36,7 +37,7 @@ def test_implication_inside_parens():
     # implications survive into the aeon output where `==>` is a parse error.
     out = _expand_implication("(x ==> y)")
     assert "==>" not in out
-    assert "||" in out
+    assert "-->" in out
 
 
 def test_iff_becomes_equality():
@@ -56,10 +57,11 @@ def test_chained_comparison_with_and_split():
 
 
 def test_chained_comparison_does_not_split_implication():
-    # The `>` in `==>` must not be treated as a comparison operator.
+    # The `>` in `==>` (and in the emitted `-->`) must not be treated as a
+    # comparison operator.
     out = translate_expression("k == 1 ==> b >= a")
     assert "==>" not in out
-    assert "(!(k == 1)) || (b >= a)" in out
+    assert "(k == 1) --> (b >= a)" in out
 
 
 def test_var_bindings_become_let_with_scope_parens():


### PR DESCRIPTION
## Summary

Addresses the first three items in the [Vericoding benchmark Known Limitations](benchmarks/vericoding/README.md) list.

- **`-->` not in prelude** → **fixed.** Logical implication `-->` is now registered as a `Bool -> Bool -> Bool` function in [`aeon/prelude/prelude.py`](aeon/prelude/prelude.py). The SMT layer already translated `-->` to z3 `Implies`, but the typechecker rejected refinements using it because the operator had no typing-context entry. Refinements can now use `-->` directly and the verifier enforces it (a violating implementation is correctly rejected). The Vericoding translator emits `(a) --> (b)` instead of desugaring `==>` to `(!a) || b`.
- **`!` is right-greedy** → **already fixed** by the boolean-precedence refactor in #279; `!a || b` now parses as `(!a) || b`. Added a regression test.
- **Pretty-printer flips operands** → **already fixed**; `y >= 100` prints in source order. Guarded by the existing `test_refinement_comparison_operand_order` regression test.

The README Known Limitations section is updated to move these three into a "Resolved" subsection.

## Changes

- `aeon/prelude/prelude.py`: register `-->`.
- `benchmarks/vericoding/translate.py`: emit `-->`; teach `_find_top_ops` to ignore the `>` tail of `-->`; docstring updates.
- `benchmarks/vericoding/README.md`: mark the three limitations resolved; update the `==>` translation row.
- `tests/end_to_end_test.py`: new tests for `-->` in refinements (accept + reject) and `!` precedence.
- `tests/vericoding_translator_test.py`: update implication-expansion expectations to the `-->` output.

## Test plan

- [x] `uv run pytest` — 992 passed, 9 skipped
- [x] pre-commit (ruff, mypy, format) clean
- [x] Verified `-->` refinement typechecks, evaluates, and rejects a violating impl
- [x] Verified `!a || b` parses as `(!a) || b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)