### PR TITLE
feat: Num/Ord typeclasses in stdlib + cross-module class imports

### DIFF
--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -46,6 +46,7 @@ from aeon.sugar.program import ImportAe
 from aeon.sugar.program import Program
 from aeon.sugar.program import TypeDecl, InductiveDecl
 from aeon.sugar.program import ClassMethod, InstanceMethod
+from aeon.sugar.program import ClassDecl, InstanceDecl
 from aeon.sugar.stypes import (
     SAbstractionType,
     SRefinedType,
@@ -510,6 +511,24 @@ def resolve_qualified_names_in_definition(
 def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType] | None = None) -> DesugaredProgram:
     vs: dict[Name, SType] = {} if extra_vars is None else extra_vars
     vs.update(typing_vars)
+
+    # Pull class/instance declarations from imported modules into the main
+    # program so they are expanded by the single ``expand_typeclasses`` pass
+    # below. Typeclass methods resolve by type through the global instance
+    # registry rather than by qualified name, so — unlike ordinary library
+    # definitions, which ``handle_imports`` module-prefixes — they live
+    # directly in the main namespace.
+    inductive_names_top = {d.name.name for d in p.inductive_decls}
+    imported_classes, imported_instances = collect_imported_typeclasses(p.imports, inductive_names_top)
+    if imported_classes or imported_instances:
+        p = Program(
+            p.imports,
+            p.type_decls,
+            p.inductive_decls,
+            p.definitions,
+            imported_classes + p.class_decls,
+            imported_instances + p.instance_decls,
+        )
 
     # Lower class/instance declarations into inductives + plain definitions
     # before any inductive processing so the generated dictionary types flow
@@ -1550,6 +1569,47 @@ def _bare_name(module_name: str, def_name: str) -> str:
 ModuleScope = dict[str, Name]  # bare_name -> original Name
 QualifiedScope = dict[tuple[str, str], Name]  # (qualifier, bare_name) -> original Name
 UnqualifiedScope = dict[str, Name]  # bare_name -> original Name
+
+
+def collect_imported_typeclasses(
+    imports: list[ImportAe],
+    inductive_names: set[str],
+    _seen: set[str] | None = None,
+) -> tuple[list[ClassDecl], list[InstanceDecl]]:
+    """Gather ``class``/``instance`` declarations from (transitively) imported
+    modules.
+
+    Typeclass declarations are resolved by type via the global instance
+    registry rather than by qualified name, so they must be expanded in the
+    *main* program's namespace alongside its own typeclasses — they cannot be
+    module-prefixed like ordinary library definitions. This walks the import
+    graph (deduplicating by module path, mirroring ``handle_imports``) and
+    returns the collected declarations for the caller to merge before
+    ``expand_typeclasses`` runs."""
+    seen: set[str] = set() if _seen is None else _seen
+    classes: list[ClassDecl] = []
+    instances: list[InstanceDecl] = []
+    for imp in imports:
+        # ``open SomeLocalInductive`` is not a file import — skip it (there is
+        # no ``SomeLocalInductive.ae`` to resolve).
+        if imp.is_open and imp.module_path in inductive_names:
+            continue
+        if imp.module_path in seen:
+            continue
+        seen.add(imp.module_path)
+        try:
+            import_p = _resolve_import(imp)
+        except Exception:
+            # A genuinely missing/erroneous import is reported authoritatively
+            # by ``handle_imports`` later; don't double-report here.
+            continue
+        sub_inductive_names = {d.name.name for d in import_p.inductive_decls}
+        sub_classes, sub_instances = collect_imported_typeclasses(import_p.imports, sub_inductive_names, seen)
+        classes.extend(sub_classes)
+        instances.extend(sub_instances)
+        classes.extend(import_p.class_decls)
+        instances.extend(import_p.instance_decls)
+    return classes, instances
 
 
 def handle_imports(

--- a/examples/syntax/num_typeclass.ae
+++ b/examples/syntax/num_typeclass.ae
@@ -1,0 +1,20 @@
+# Importing typeclasses from the standard library.
+#
+# `Num` and `Ord` (in libraries/Num.ae) give named, type-directed access to
+# arithmetic (`add`/`sub`/`mul`) and ordering (`lt`/`leq`/`gt`/`geq`) for the
+# primitive numeric types. `open Num` pulls the classes *and* their instances
+# into this program, so method calls resolve automatically by argument type:
+# `add 3 4` selects `Num Int`, `add 1.5 2.5` selects `Num Float`.
+#
+# `gt`/`geq` are class defaults derived from `lt`/`leq`, so the Int/Float
+# instances only provide `lt`/`leq` yet all four comparisons are available.
+
+open Num
+
+def main (args : Int) : Int =
+    let s   : Int   = add 3 4 in          # 7        (Num Int)
+    let d   : Int   = sub s 2 in          # 5
+    let p   : Int   = mul d 2 in          # 10
+    let f   : Float = add 1.5 2.5 in      # 4.0      (Num Float)
+    # `gt`/`geq` reach the Ord defaults; `lt` dispatches to Ord Float.
+    if gt p 5 then (if lt 3.0 f then p else 0) else 0;

--- a/libraries/Num.ae
+++ b/libraries/Num.ae
@@ -1,0 +1,50 @@
+# Numeric and ordering typeclasses (Lean-style, dictionary-passing).
+#
+# These classes give *named, type-directed* access to arithmetic and
+# comparison for the primitive numeric types. Method calls such as
+# ``add x y`` resolve automatically to the instance selected by the
+# argument types — ``Num Int`` for integers, ``Num Float`` for floats.
+#
+# The instance bodies delegate to the built-in operators (``+``, ``-``,
+# ``*``, ``<``, ``<=``). Those builtins remain the primitive, SMT-
+# interpreted operations; ``Num``/``Ord`` only add a typeclass surface on
+# top of them. Because the methods are dictionary projections (opaque to
+# the SMT backend) the classes are best used in ordinary computation
+# rather than inside refinements that must reason about exact arithmetic —
+# for that, keep using ``+``/``-`` directly.
+
+# ── Classes ────────────────────────────────────────────────────────────
+
+# Num: addition, subtraction, multiplication.
+class Num (a : B) where
+    add : (x : a) -> (y : a) -> a;
+    sub : (x : a) -> (y : a) -> a;
+    mul : (x : a) -> (y : a) -> a;
+
+# Ord: ordering comparisons. ``gt``/``geq`` have default bodies derived
+# from ``lt``/``leq``, so instances only need to provide the latter two.
+class Ord (a : B) where
+    lt : (x : a) -> (y : a) -> Bool;
+    leq : (x : a) -> (y : a) -> Bool;
+    gt : (x : a) -> (y : a) -> Bool := \x -> \y -> lt y x;
+    geq : (x : a) -> (y : a) -> Bool := \x -> \y -> leq y x;
+
+# ── Instances ──────────────────────────────────────────────────────────
+
+instance : Num Int where
+    add x y := x + y;
+    sub x y := x - y;
+    mul x y := x * y;
+
+instance : Num Float where
+    add x y := x + y;
+    sub x y := x - y;
+    mul x y := x * y;
+
+instance : Ord Int where
+    lt x y := x < y;
+    leq x y := x <= y;
+
+instance : Ord Float where
+    lt x y := x < y;
+    leq x y := x <= y;

--- a/tests/stdlib_num_test.py
+++ b/tests/stdlib_num_test.py
@@ -1,0 +1,79 @@
+"""Tests for the ``Num``/``Ord`` typeclasses shipped in ``libraries/Num.ae``.
+
+These exercise typeclasses *across a module import*: the class and instance
+declarations live in the standard library and are pulled into the main
+program by ``collect_imported_typeclasses`` so the single ``expand_typeclasses``
+pass generates the method projections and registers the instances.
+"""
+
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SynthesisUI
+
+setup_logger()
+
+
+def _run(source: str):
+    cfg = AeonConfig(synthesizer="none", synthesis_ui=SynthesisUI(), synthesis_budget=0)
+    driver = AeonDriver(cfg)
+    errors = list(driver.parse(aeon_code=source))
+    assert not errors, errors
+    return driver.run()
+
+
+def test_num_int_add_sub_mul():
+    source = r"""
+    open Num
+
+    def main (args : Int) : Int =
+        let s : Int = add 3 4 in      # 7
+        let d : Int = sub s 2 in      # 5
+        mul d 2;                      # 10
+    """
+    assert _run(source) == 10
+
+
+def test_num_float_instance_dispatch():
+    # Float arithmetic dispatches to ``Num Float``; convert back to Int only
+    # via a comparison so the test asserts on an Int result.
+    source = r"""
+    open Num
+
+    def main (args : Int) : Int =
+        let f : Float = add 1.5 2.5 in   # 4.0 via Num Float
+        if lt 3.0 f then 0 else 1;       # 3.0 < 4.0 via Ord Float
+    """
+    assert _run(source) == 0
+
+
+def test_ord_int_lt_leq():
+    source = r"""
+    open Num
+
+    def main (args : Int) : Int =
+        if lt 1 2 then (if leq 5 5 then 0 else 1) else 2;
+    """
+    assert _run(source) == 0
+
+
+def test_ord_default_methods():
+    # ``gt`` and ``geq`` are class defaults derived from ``lt``/``leq``; the
+    # Int instance provides only ``lt``/``leq``, so this exercises default
+    # methods reached through an imported class.
+    source = r"""
+    open Num
+
+    def main (args : Int) : Int =
+        if gt 5 2 then (if geq 5 5 then 0 else 1) else 2;
+    """
+    assert _run(source) == 0
+
+
+def test_ord_default_false_branch():
+    source = r"""
+    open Num
+
+    def main (args : Int) : Int =
+        if gt 2 5 then 100 else 200;   # default gt: lt 5 2 == false
+    """
+    assert _run(source) == 200


### PR DESCRIPTION
## Summary
Follow-on to the typeclasses feature (#319). Adds the first standard-library
module that uses `class`/`instance`, and the cross-module plumbing needed to
import typeclasses.

- **`libraries/Num.ae`** — `Num` (`add`/`sub`/`mul`) and `Ord` (`lt`/`leq`,
  with `gt`/`geq` as class defaults) plus `Int`/`Float` instances. Method
  bodies delegate to the SMT-interpreted builtins (`+`/`-`/`*`/`<`/`<=`); the
  classes only add a named, type-directed surface on top. Header comment notes
  the projections are opaque to SMT, so the classes are for ordinary
  computation rather than refinement arithmetic (keep using `+`/`-` there).
- **`aeon/sugar/desugar.py`** — `collect_imported_typeclasses` resolves imports
  transitively and merges imported `class`/`instance` decls into the program
  *before* `expand_typeclasses`. Previously imported classes were never
  expanded (expansion ran before `handle_imports`), so `open Num; add 3 4`
  failed with "add does not exist". Now methods resolve by argument type across
  a module boundary (`add 3 4` → `Num Int`, `add 1.5 2.5` → `Num Float`).
- **`examples/syntax/num_typeclass.ae`** — demonstrates `open Num` with both
  classes and default methods.
- **`tests/stdlib_num_test.py`** — 5 tests covering Int/Float dispatch,
  ordering, and the `gt`/`geq` default methods reached through an imported
  class.

## Test plan
- [x] `uv run pytest tests/stdlib_num_test.py` — 5 passed
- [x] `uv run pytest` — 1232 passed, 9 skipped
- [x] `uvx pre-commit run --files ...` — mypy + ruff clean
- [x] `uv run python -m aeon examples/syntax/num_typeclass.ae` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)