### PR TITLE
fix(verification): resolve stale monomorphic-uncurried-function TODO (#299)

### DIFF
--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -552,7 +552,14 @@ def smt_valid(constraint: Constraint) -> bool:
         n += 1
         s.push()
 
-        # TODO now: Add monomorphic, uncurried functions here
+        # Monomorphic, uncurried function declarations need no separate
+        # emission step here: each CanonicConstraint carries its own
+        # `functions` (including the monomorphised twins minted by
+        # `_specialize_liquid_term`), and `translate` -> `mk_funs` uncurries
+        # them into Z3 `Function`s while building this constraint's formula.
+        # Z3 declares a function symbol implicitly wherever it appears in the
+        # asserted formula, and the push/pop here scopes each constraint, so
+        # the declarations are re-emitted per constraint by construction.
         try:
             smt_c = translate(c)
         except ZeroDivisionError:

--- a/tests/polymorphic_uninterpreted_test.py
+++ b/tests/polymorphic_uninterpreted_test.py
@@ -25,6 +25,41 @@ def use_int (n: Int) : {r: Int | r == my_id n} =
     assert check_compile(source, st_top)
 
 
+def test_monomorphic_uncurried_uf_congruence():
+    """A multi-argument *monomorphic* uninterpreted function reaches the SMT
+    layer and the solver applies function congruence through it.
+
+    ``add2`` is already monomorphic, so no specialisation twin is minted;
+    it flows straight through ``flatten`` into each ``CanonicConstraint``'s
+    ``functions`` and is uncurried into a 2-ary Z3 ``Function`` by
+    ``mk_funs``. With premise ``c == a`` the solver must discharge
+    ``add2 c b == add2 a b`` purely by congruence (issue #299).
+    """
+    source = """
+def add2 : (x: Int) -> (y: Int) -> Int = uninterpreted
+
+def go (a: Int) (b: Int) (c: {z: Int | z == a}) : {n: Int | n == add2 a b} =
+    let r : {y: Int | y == add2 c b} = native "0" in
+    r ;
+"""
+    assert check_compile(source, st_top)
+
+
+def test_monomorphic_uncurried_uf_no_spurious_congruence():
+    """Without a premise linking the arguments, the solver must *not* assume
+    ``add2 a b == add2 c b``. Locks in that the uncurried monomorphic
+    declaration is interpreted soundly, not collapsed to a constant.
+    """
+    source = """
+def add2 : (x: Int) -> (y: Int) -> Int = uninterpreted
+
+def go (a: Int) (b: Int) (c: Int) : {n: Int | n == add2 a b} =
+    let r : {y: Int | y == add2 c b} = native "0" in
+    r ;
+"""
+    assert not check_compile(source, st_top)
+
+
 def test_polymorphic_uf_at_user_type():
     """The same polymorphic UF specialises to a user-declared opaque sort."""
     source = """


### PR DESCRIPTION
## Summary

Resolves #299. The issue flagged a stale `# TODO now: Add monomorphic, uncurried functions here` inside the per-constraint solve loop in `aeon/verification/smt.py`, asking whether monomorphic uncurried function declarations need to be re-emitted per constraint.

**Finding:** they need no separate emission step there — they're already handled per constraint:

- `flatten`'s `LiquidConstraint` case mints monomorphic twins of polymorphic functions via `_specialize_liquid_term` and stores them in each `CanonicConstraint.functions`.
- `translate(c)` → `mk_funs` uncurries every entry into a Z3 `Function` while building that constraint's formula. Z3 declares a function symbol implicitly wherever it appears, and the `push()`/`pop()` scopes each constraint — so declarations are re-emitted per constraint by construction.

## Changes

- `aeon/verification/smt.py`: replaced the TODO with a comment documenting where/why monomorphic uncurried functions are emitted per constraint.
- `tests/polymorphic_uninterpreted_test.py`: two regression tests pinning that a multi-arg monomorphic uncurried uninterpreted function reaches the SMT layer and is interpreted soundly — congruence holds given a linking premise (`c == a` ⊢ `add2 c b == add2 a b`), and is *not* spuriously assumed without one.

## Notes for reviewers

- Verified empirically that a 2-arg monomorphic uncurried UF reaches the solver and discharges congruence; the negative test confirms soundness.
- Out of scope: while investigating I found that UF results in **function-argument position** (e.g. `consume (f a) (f a)`) get hoisted into fresh existential binders that lose the defining equation `binder == f(args)`, so even reflexive congruence fails there. That's an orthogonal pre-existing argument-hoisting bug, not #299, and is left untouched.

## Test plan

- [x] `uv run pytest tests/polymorphic_uninterpreted_test.py` (10 passed)
- [x] `uv run pytest tests/smt_test.py tests/horn_test.py tests/smt_sets_test.py tests/reflect_underscore_test.py tests/synth_gaps_test.py tests/end_to_end_test.py`
- [x] pre-commit hooks (mypy, ruff, ruff format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)