### PR TITLE
Make TypingContext the source of truth for builtin type constructors and typevar kinds (#293)

### DIFF
--- a/aeon/typechecking/context.py
+++ b/aeon/typechecking/context.py
@@ -129,9 +129,14 @@ class TypingContext:
             case Top() | RefinedType(_, TypeConstructor(_), _) | RefinedType(_, TypeConstructor(_, _), _):
                 return Kind.BASE
             case TypeVar(name):
-                assert (name, Kind.BASE) in self.typevars()
-                # TODO Polytypes: What it * is in context?
-                return Kind.BASE
+                # Look up the kind the variable was bound with rather than
+                # assuming ``BASE``. Polytypes introduce type variables of
+                # higher kind (e.g. ``* -> *``), so the binder is the source
+                # of truth here.
+                for tv_name, tv_kind in self.typevars():
+                    if tv_name == name:
+                        return tv_kind
+                assert False, f"TypeVar {name} not found in context type variables {self.typevars()}"
             case RefinedType(_, TypeVar(name), _):
                 assert (name, Kind.BASE) in self.typevars(), f"{name} not in {self.typevars()}"
                 return Kind.BASE
@@ -161,14 +166,15 @@ class TypingContext:
         return name in [e.name for e in self.entries if isinstance(e, UninterpretedBinder)]
 
     def get_type_constructor(self, name: Name) -> list[Name] | None:
+        # Built-in type constructors (``Unit``, ``Int``, ``Bool``, ``Float``,
+        # ``String``, ``Set``, ...) are entered as ``TypeConstructorBinder``
+        # entries in ``__post_init__``, so there is no need for a hardcoded
+        # escape hatch here — the context is the single source of truth.
         for entry in self.entries[::-1]:
             match entry:
                 case TypeConstructorBinder(ename, eargs):
                     if ename == name:
                         return eargs
-        # TODO: enter in context.
-        if name.name in ["Unit", "Int", "Bool", "Float", "String"]:
-            return []
         return None
 
     def __hash__(self):


### PR DESCRIPTION
## Summary

Resolves the two TODOs in `aeon/typechecking/context.py` flagged in #293, making `TypingContext` the single source of truth for built-in and polymorphic type information.

- **`kind_of(TypeVar)`**: previously asserted the variable was in `typevars()` and returned `Kind.BASE` *unconditionally*. It now looks up the kind the variable was actually bound with. This is sound for higher-kinded type variables (e.g. `* -> *`) that polytypes will introduce; the assert-and-return-BASE shortcut would have been unsound for those.
- **`get_type_constructor`**: drops the hardcoded `["Unit", "Int", "Bool", "Float", "String"]` escape hatch. Built-in type constructors are already entered as `TypeConstructorBinder` entries in `__post_init__` (with `id 0`), and lowered built-in constructors carry `id 0` too, so the context lookup alone resolves them — no fallback needed.

## Why

Both TODOs were about removing special-casing so the typing context, not hardcoded lists or kind assumptions, carries the truth about built-in and polymorphic types.

## Notes for reviewers

- Behaviour is unchanged for all existing programs: every current type variable is `BASE`-kinded, so `kind_of` returns the same result; and the dropped fallback only ever matched names the `__post_init__` binders already cover (verified lowered `Int`/`Bool`/... constructors use `Name(..., 0)`, matching the binder entries — note `Set`/`Tensor`/`GpuConfig` already relied solely on those binders, not the fallback).

## Test plan

- [x] `uv run pytest` — 1235 passed, 9 skipped
- [x] `uvx pre-commit run` (mypy + ruff + format) on the changed file — all green

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)