### PR TITLE
feat(elaboration): collect and display multiple errors (#283)

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -6,7 +6,18 @@ import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
-from aeon.facade.api import AeonError
+from aeon.facade.api import (
+    AeonError,
+    CoreTypeCheckingError,
+    ImportError as AeonImportError,
+    InstanceResolutionError,
+    LinearityError,
+    NonOrderableComparisonError,
+    UnificationFailedError,
+    UnificationKindError,
+    UnificationSubtypingError,
+    UnificationUnknownTypeError,
+)
 from aeon.facade.driver import AeonConfig, AeonDriver
 from aeon.synthesis.api import SynthesisNotSuccessful
 from aeon.logger.logger import export_log
@@ -131,12 +142,51 @@ def select_synthesis_ui() -> SynthesisUI:
     return TerminalUI()
 
 
-def handle_error(err: AeonError):
-    # TODO: handle each error with proper printing
+def format_location(err: AeonError) -> str:
+    """Render an error's source span as ``file:line:col`` when positional
+    information is available, otherwise fall back to ``str(location)``."""
+    loc = err.position()
+    file = getattr(loc, "file", "")
+    start = getattr(loc, "start", None)
+    if start is not None:
+        line, col = start[0], start[1]
+        prefix = f"{file}:" if file else ""
+        return f"{prefix}{line}:{col}"
+    return str(loc)
+
+
+def _error_kind_and_hint(err: AeonError) -> tuple[str, str | None]:
+    """Map each error variant to a short human-readable kind label and an
+    optional hint suggesting how to fix it."""
     match err:
+        case AeonImportError():
+            return "Import error", "Check the module name and your AEONPATH / libraries folder."
+        case UnificationSubtypingError():
+            return "Type mismatch", "The expression's type is incompatible with the expected type."
+        case UnificationFailedError():
+            return "Unification error", "The same value is being constrained to two incompatible types."
+        case UnificationKindError():
+            return "Kind mismatch", "A type was used at the wrong kind."
+        case UnificationUnknownTypeError():
+            return "Unknown variable", "This name is not defined in the current context."
+        case InstanceResolutionError():
+            return "Missing instance", "Define a typeclass instance for this type, or add it as a constraint."
+        case NonOrderableComparisonError():
+            return "Non-orderable comparison", "Use Int, Float or String, or define an Ord instance for this type."
+        case LinearityError():
+            return "Linearity error", "A binding's usage does not match its declared multiplicity."
+        case CoreTypeCheckingError():
+            return "Type error", None
         case _:
-            print(f">>> Error at {err.position()}:")
-            print(err)
+            return "Error", None
+
+
+def handle_error(err: AeonError):
+    kind, hint = _error_kind_and_hint(err)
+    print(f">>> {kind} at {format_location(err)}:")
+    print(f"    {err}")
+    if hint is not None:
+        print(f"    hint: {hint}")
 
 
 def main() -> None:

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -4,6 +4,7 @@ from aeon.core.types import Kind
 from aeon.elaboration.context import ElaborationTypingContext
 from aeon.elaboration.instantiation import type_substitution
 from aeon.facade.api import (
+    AeonError,
     InstanceResolutionError,
     NonOrderableComparisonError,
     UnificationFailedError,
@@ -878,3 +879,81 @@ def elaborate(ctx: ElaborationTypingContext, e: STerm, expected_type: SType = st
     e3 = elaborate_check(ctx, e2, expected_type)
     e4 = elaborate_remove_unification(ctx, e3)
     return e4
+
+
+def _elaborate_check_spine(ctx: ElaborationTypingContext, t: STerm, ty: SType, errors: list[AeonError]) -> STerm:
+    """Walk the chain of top-level ``SRec`` definitions, elaborating each
+    definition's value in isolation so that a failure in one is recorded and the
+    remaining definitions are still elaborated.
+
+    Mirrors the ``SRec`` arm of ``elaborate_check``: the body is checked under a
+    context that binds the definition's name to its declared type, so it stays
+    in scope even when the value failed to elaborate.
+    """
+    match t:
+        case SRec(name, vty, val, body, decreasing_by, loc=loc):
+            nctx = ctx.with_var(name, vty)
+            try:
+                nval = elaborate_check(nctx, val, vty)
+            except AeonError as e:
+                errors.append(e)
+                nval = val
+            nbody = _elaborate_check_spine(nctx, body, ty, errors)
+            return SRec(name, vty, nval, nbody, decreasing_by=decreasing_by, loc=loc, multiplicity=t.multiplicity)
+        case _:
+            try:
+                return elaborate_check(ctx, t, ty)
+            except AeonError as e:
+                errors.append(e)
+                return t
+
+
+def _remove_unification_spine(ctx: ElaborationTypingContext, t: STerm, errors: list[AeonError]) -> STerm:
+    """Walk the top-level ``SRec`` spine running ``elaborate_remove_unification``
+    per definition, so errors raised in this phase (e.g. instance resolution and
+    non-orderable comparison checks) are collected per definition rather than
+    aborting the whole program.
+
+    Mirrors the ``SRec`` arm of ``elaborate_remove_unification``.
+    """
+    match t:
+        case SRec(name, ty, val, body, decreasing_by, loc=loc):
+            nctx = ctx.with_var(t.var_name, t.var_type)
+            try:
+                nty = handle_unification_in_type(ctx, ty)
+                val_ctx = nctx
+                for inst_name, inst_class in _collect_given_instances(t.var_type, val):
+                    val_ctx = val_ctx.with_instance(inst_name, inst_class)
+                nval = elaborate_remove_unification(val_ctx, val)
+            except AeonError as e:
+                errors.append(e)
+                nty = ty
+                nval = val
+            nbody = _remove_unification_spine(nctx, body, errors)
+            return SRec(name, nty, nval, nbody, decreasing_by=decreasing_by, loc=loc, multiplicity=t.multiplicity)
+        case _:
+            try:
+                return elaborate_remove_unification(ctx, t)
+            except AeonError as e:
+                errors.append(e)
+                return t
+
+
+def elaborate_collecting_errors(
+    ctx: ElaborationTypingContext, e: STerm, expected_type: SType = st_top
+) -> tuple[STerm | None, list[AeonError]]:
+    """Like :func:`elaborate`, but accumulates one error per top-level
+    definition that fails instead of bailing on the first.
+
+    Returns ``(term, [])`` on success, or ``(None, errors)`` when at least one
+    definition failed to elaborate.
+    """
+    e2 = elaborate_foralls(e)
+    errors: list[AeonError] = []
+    e3 = _elaborate_check_spine(ctx, e2, expected_type, errors)
+    if errors:
+        return None, errors
+    e4 = _remove_unification_spine(ctx, e3, errors)
+    if errors:
+        return None, errors
+    return e4, []

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -9,7 +9,7 @@ from aeon.core.substitutions import substitution
 from aeon.core.terms import Term
 from aeon.core.types import top
 from aeon.decorators import Metadata, apply_core_decorators_phase
-from aeon.elaboration import elaborate
+from aeon.elaboration import elaborate_collecting_errors
 from aeon.facade.api import AeonError
 from aeon.prelude.prelude import evaluation_vars
 from aeon.sugar.ast_helpers import st_top
@@ -72,11 +72,11 @@ class AeonDriver:
             )
             metadata: Metadata = desugared.metadata
 
-        try:
-            with RecordTime("Elaboration"):
-                sterm: STerm = elaborate(desugared.elabcontext, desugared.program, st_top)
-        except AeonError as e:
-            return [e]  # TODO: Support multiple errors
+        with RecordTime("Elaboration"):
+            sterm, elab_errors = elaborate_collecting_errors(desugared.elabcontext, desugared.program, st_top)
+        if elab_errors:
+            return elab_errors
+        assert sterm is not None
 
         with RecordTime("Core generation"):
             typing_ctx = lower_to_core_context(desugared.elabcontext)

--- a/tests/multiple_errors_test.py
+++ b/tests/multiple_errors_test.py
@@ -1,0 +1,51 @@
+from aeon.facade.api import AeonError, NonOrderableComparisonError
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SynthesisUI
+
+setup_logger()
+
+
+def _errors(source: str) -> list[AeonError]:
+    cfg = AeonConfig(synthesizer="none", synthesis_ui=SynthesisUI(), synthesis_budget=0)
+    driver = AeonDriver(cfg)
+    return list(driver.parse(aeon_code=source))
+
+
+def test_single_error_still_reported():
+    source = "def main (args : Int) : Int = unknown_name;"
+    errors = _errors(source)
+    assert len(errors) == 1, errors
+
+
+def test_multiple_unknown_variables_all_reported():
+    """Two distinct top-level definitions each reference an undefined name; the
+    elaborator should report both rather than bailing on the first."""
+    source = r"""
+    def foo (x : Int) : Int = does_not_exist_a;
+    def bar (y : Int) : Int = does_not_exist_b;
+    def main (args : Int) : Int = 0;
+    """
+    errors = _errors(source)
+    assert len(errors) >= 2, errors
+
+
+def test_multiple_phase3_errors_all_reported():
+    """Errors raised during the unification-removal phase (non-orderable
+    comparisons, issue #292) are also collected across definitions."""
+    source = r"""
+    def foo (x : Int) : Int = if true < false then 0 else 1;
+    def bar (y : Int) : Int = if false > true then 0 else 1;
+    def main (args : Int) : Int = 0;
+    """
+    errors = _errors(source)
+    assert len(errors) >= 2, errors
+    assert all(isinstance(e, NonOrderableComparisonError) for e in errors), errors
+
+
+def test_valid_program_has_no_errors():
+    source = r"""
+    def foo (x : Int) : Int = x;
+    def main (args : Int) : Int = foo 1;
+    """
+    assert _errors(source) == []


### PR DESCRIPTION
## Summary

Closes #283.

Elaboration previously caught the first `AeonError` and returned a singleton list, so a file with several mistakes only ever surfaced one error per run. The CLI's `handle_error` likewise had only a default arm with no per-variant formatting.

This change:

- **Collects multiple errors.** Adds `elaborate_collecting_errors` in `aeon/elaboration/__init__.py`, which walks the top-level `SRec` spine and elaborates each definition in isolation. Failures are recorded per definition (the name stays bound so later definitions still elaborate), and collection wraps **both** elaboration phases — `elaborate_check` *and* `elaborate_remove_unification`. The latter matters because non-orderable comparison (#292) and instance-resolution errors are raised in phase 3.
- **Wires it into the driver.** `aeon/facade/driver.py` now returns the accumulated error list instead of bailing on the first.
- **Formats each error per variant.** `aeon/__main__.py`'s `handle_error` now prints a short kind label, a `file:line:col` source span (`format_location`), and a fix hint where applicable (`_error_kind_and_hint`).

## Why

A user fixing a file with multiple errors should see all of them in one pass rather than re-running after each fix.

## Notes for reviewers

- The spine-walking helpers `_elaborate_check_spine` and `_remove_unification_spine` mirror the existing `SRec` arms of `elaborate_check` / `elaborate_remove_unification` exactly (including bringing `given` instance constraints into scope), differing only by wrapping each definition's value in a `try/except` that appends to an error list.
- `elaborate()` is left untouched (still raises) to avoid disturbing other callers.

## Test plan

- [x] New `tests/multiple_errors_test.py`: single error, multiple phase-2 (unknown-variable) errors, multiple phase-3 (non-orderable comparison) errors, and the no-error case.
- [x] Full suite green: 1236 passed, 9 skipped.
- [x] pre-commit (mypy, ruff, ruff format) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)