### PR TITLE
Bump version to 4.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AeonLang"
-version = "4.0.8"
+version = "4.1.0"
 description = "Language with Refinement Types"
 authors = [
     { name = "Alcides Fonseca", email = "me@alcidesfonseca.com" }


### PR DESCRIPTION
Version bump to **4.1.0** in preparation for the release tag.

Merging this to `master` lets the `v4.1.0` tag point at a commit whose `pyproject.toml` version is `4.1.0`, which the `python-publish` workflow needs to publish the correct version to PyPI.

The release notes below will be used for the GitHub release once tagged.

---

## Aeon 4.1.0

This release lands ~144 commits since 4.0.8, with major additions across the type system, surface language, synthesis backends, and tooling.

### Type system & verification
- **Typeclasses** (Lean-style) with dictionary passing and refinement laws (#319), plus `Num`/`Ord` typeclasses in the stdlib and cross-module class imports (#320)
- **Linearity / QTT enforcement** (Phases 2a–4), `n` polymorphism, native FFI bottom, per-use diagnostics, and a linear `Socket` library (#231)
- Polymorphic uninterpreted functions now reach the SMT layer (#280)
- Covariant subtyping for type-constructor arguments (#315)
- SMT `Set` support for refinement types (#199) and probabilistic refinements + Float SMT sort fix (#234)
- Ordered comparisons constrained to orderable types (#326); capture-avoiding type substitution (#307)
- Collect and display multiple elaboration errors at once (#330); simplified verification conditions in error messages (#274)

### Surface language
- **Lean-style module system** with import caching (#200) and module-qualified names (#205)
- Lean-style surface syntax: `by` tactics, optional `;`, `def =`, and a tactics stack (#189)
- Lean-style dot syntax for inductive constructors (#204)
- Inductive abstract refinements and inferred `rforall`s (#180)
- `decreasing_by` termination metrics (LH-style) (#178)
- Opt-in reflection of function bodies into return types via the `_` marker (#317, #323)
- Imports from out-of-tree files (#275)

### Synthesis
- **Liquid Tree Automata** synthesizer backend (#247)
- Tactics-based random synthesizer with `apply?`/`constructor` and `by_cases` (#182, #185)
- `tdsyn` synthesizer exposed in LSP and CLI defaults (#176)
- Synquid engine with Q-guards, modular VCs, and enumerator extensions (#175, #179)
- Knee-point selection on the Pareto front (#302) and multi-objective fitness via native refined Array (#310)
- PLE reflection for non-native functions (#191)
- `@minimize_cputime` / `@minimize_energy` objectives via a cross-platform resource_meters module (#217, #251)

### Standard library
- Refined Learning library + boolean precedence fix + if-cond refinement propagation (#279)
- PIL-like `Image` library with synthesis benchmarks and a synthesis terminal UI (#220)
- `Sys`, `Args`, `Json`, `Path` libraries + string-literal type inference fix (#223)
- Unified `List`/`Array` stdlib: inductive `List` + opaque `Array`, both with `forall <p>` (#268)

### Tooling & docs
- **AeonDoc** — HTML documentation generator for Aeon (#276)
- README/intro rewrite around liquid types + synthesis, documenting all synthesizers (#273, #281)
- Guide on writing Python FFI bindings (#282); `AGENTS.md` onboarding (#213); expanded Contributing.md (#198)

### Benchmarks
- Vericoding harness (Dafny→Aeon translator) (#245), MBPP scaffolding (#242), 39 Ninety-Nine-Problems (#243), Z3-derived (#241), image-edit (#240), SMT-style from hakank.org/z3 (#238), PSB2 stubs (#261)

### Performance
- Run examples in parallel across all cores (#325); ~1.9x nqueens synthesis speedup (#236); memoized `smt_valid` (#196); cached Lark parser instances (#195)

### Internals
- Replaced ANF with Form B existential binders and removed the converter (#226, #255)