### PR TITLE
Require well-founded termination for recursive-refinement typing (#291)

### DIFF
--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -602,7 +602,12 @@ def liquefy_app(app: Application) -> LiquidApp | None:
 
 
 def liquefy_rec(t: Rec) -> LiquidTerm | None:
-    value = liquefy(t.var_value)  # TODO: induction?
+    # Best-effort inline by substitution; no inductive unrolling. A genuinely
+    # recursive value is an abstraction and liquefies to None, dropping the
+    # whole term. Sound reasoning about recursive functions flows through
+    # termination-gated reflection instead. Full induction over recursive
+    # refinements remains open (issue #291).
+    value = liquefy(t.var_value)
     body = liquefy(t.body)
     if value and body:
         return substitution_in_liquid(body, value, t.var_name)

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -48,7 +48,10 @@ class TypeVar(Type):
         return hash(self.name)
 
 
+@dataclass
 class Top(Type):
+    loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+
     def __repr__(self):
         return "⊤"
 

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -79,7 +79,7 @@ def _sugar_contains_recursive_call(t: STerm, fname: Name) -> bool:
         cur = node
         while isinstance(cur, SApplication):
             cur = cur.fun
-        return isinstance(cur, SVar) and cur == fname
+        return isinstance(cur, SVar) and cur.name == fname
 
     def walk(node: STerm) -> bool:
         if isinstance(node, SApplication) and is_call_tree(node):
@@ -140,6 +140,12 @@ def _expand_reflection_marker(t: STerm, binder: Name, body: STerm) -> tuple[STer
 
 
 def _mentions_function(body: STerm, fname: Name) -> bool:
+    """Whether ``fname`` appears free in ``body`` (used to detect self-recursion).
+
+    Must traverse every construct a reflectable body can take; otherwise a
+    recursive call hidden inside an ``if``/``let``/``match`` slips past the
+    self-reference check and reaches the solver as an unprovable constraint.
+    """
     match body:
         case SVar(name, _):
             return name.name == fname.name
@@ -147,6 +153,20 @@ def _mentions_function(body: STerm, fname: Name) -> bool:
             return _mentions_function(fun, fname) or _mentions_function(arg, fname)
         case SAnnotation(expr, _, _):
             return _mentions_function(expr, fname)
+        case SIf(cond, then, otherwise, _):
+            return (
+                _mentions_function(cond, fname)
+                or _mentions_function(then, fname)
+                or _mentions_function(otherwise, fname)
+            )
+        case SLet(_, val, inner, _) | SRec(_, _, val, inner, _, _):
+            return _mentions_function(val, fname) or _mentions_function(inner, fname)
+        case STypeApplication(expr, _, _) | SRefinementApplication(expr, _, _):
+            return _mentions_function(expr, fname)
+        case SAbstraction(_, inner, _):
+            return _mentions_function(inner, fname)
+        case SMatch(scrutinee, branches, _):
+            return _mentions_function(scrutinee, fname) or any(_mentions_function(b.body, fname) for b in branches)
         case _:
             return False
 
@@ -214,8 +234,11 @@ def reflect_underscore_in_definitions(defs: list[Definition]) -> list[Definition
             )
         if _mentions_function(d.body, d.name):
             raise TypeError(
-                f"Cannot reflect the recursive body of '{d.name.name}' with `_` yet: "
-                "self-referential reflection is not supported."
+                f"Cannot reflect the recursive body of '{d.name.name}' with `_`: "
+                "self-referential reflection would require inductive reasoning (see issue #291). "
+                "Instead, state the recurrence explicitly in the return refinement "
+                "(e.g. `: {r:Int | r == n + n} decreasing_by [n]`), which the recursive "
+                "call's declared type discharges soundly."
             )
         bad = _unreflectable_construct(d.body)
         if bad is not None:

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -92,7 +92,9 @@ class LiquefactionException(LoweringException):
     pass
 
 
-# TODO: NOW! detect built-in SMT functions
+# Built-in SMT operators (Set ops, comparisons, etc.) need no special handling
+# here: every applied SVar liquefies to a LiquidApp, and dispatch between SMT
+# built-ins and uninterpreted functions is resolved later in translate_liq.
 def liquefy_app(
     app: SApplication,
     available_vars: list[tuple[Name, TypeConstructor | TypeVar]] | None = None,
@@ -171,7 +173,14 @@ def liquefy(t: STerm, available_vars: list[tuple[Name, TypeConstructor | TypeVar
                 return substitution_in_liquid(lbody, lval, name)
             return None
         case SRec(name, _, val, body, _, _):
-            lval = liquefy(val, available_vars)  # TODO: induction?
+            # Best-effort: inline the binding by substitution. No inductive
+            # unrolling happens here — a genuinely recursive `val` is an
+            # abstraction, which liquefies to None, so the whole term drops to
+            # None. Sound reasoning about recursive functions instead flows
+            # through termination-gated reflection (see `_reflected_impl_for`
+            # in typeinfer and `ReflectedFunctionDeclaration`). Full induction
+            # over recursive refinements remains open (issue #291).
+            lval = liquefy(val, available_vars)
             lbody = liquefy(body, available_vars)
             if lval and lbody:
                 return substitution_in_liquid(lbody, lval, name)
@@ -202,8 +211,8 @@ def type_to_core(ty: SType, available_vars: list[tuple[Name, TypeConstructor | T
         available_vars = []
 
     match normalize(ty):
-        case STypeConstructor(Name("Top", 0), loc):
-            return Top()  # TODO: loc?
+        case STypeConstructor(Name("Top", 0), _, loc):
+            return Top(loc=loc)
         case STypeVar(name, loc):
             return TypeVar(name, loc=loc)
         case SAbstractionType(name, vty, rty, loc):

--- a/aeon/typechecking/termination.py
+++ b/aeon/typechecking/termination.py
@@ -241,9 +241,15 @@ def _termination_obligation(
     entry_refs: list[LiquidTerm],
     nested_refs: tuple[LiquidTerm, ...],
 ) -> Constraint:
-    r"""``(entry /\ nested /\ branch) => (lex and metric(call) >= 0)`` when guarded; else ``lex`` only."""
-    needs_call_nonneg = bool(path) or bool(entry_refs) or bool(nested_refs)
-    oblig = mk_liquid_and(lex, _metric_call_non_negative(call_ms)) if needs_call_nonneg else lex
+    r"""``(entry /\ nested /\ branch) => (lex and metric(call) >= 0)``.
+
+    Non-negativity is **always** required: a well-founded measure must strictly
+    decrease *and* be bounded below. An unbounded integer metric descends
+    forever (``f (n - 1)`` never terminates) yet would satisfy a decrease-only
+    obligation, making the inductive hypothesis used for the recursive call
+    unsound. See ``tests/recursion_soundness_test.py``.
+    """
+    oblig = mk_liquid_and(lex, _metric_call_non_negative(call_ms))
     full = _full_path_guard_liquid(entry_refs, nested_refs, path, formals, type_formals)
     if full is None:
         return LiquidConstraint(LiquidLiteralBool(False))

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import replace
 from typing import Iterable
 
 from loguru import logger
@@ -107,6 +108,33 @@ def _strip_type_level_wrappers(t: Term) -> Term:
         else:
             t = t.expr
     return t
+
+
+def _erase_return_refinement(ty: Type) -> Type:
+    """Weaken ``ty``'s final codomain to its bare carrier type.
+
+    Walks the function-type spine (type/refinement polymorphism and arrow
+    binders) down to the return type; if that return type is a ``RefinedType``,
+    drop the refinement, keeping only the underlying ``TypeConstructor``/
+    ``TypeVar``.
+
+    Used to weaken the *inductive hypothesis* of a recursive binding that has no
+    well-founded termination metric. Typing a recursive call at the declared
+    refined return type is only sound when the function provably terminates;
+    without a metric, a non-terminating definition could otherwise "prove" an
+    absurd codomain such as ``{r:Int | r > r}`` and poison downstream proofs.
+    Argument refinements are left intact — they constrain how the function is
+    *called*, not what it may *assume* about its own result.
+    """
+    if isinstance(ty, TypePolymorphism):
+        return replace(ty, body=_erase_return_refinement(ty.body))
+    if isinstance(ty, RefinementPolymorphism):
+        return replace(ty, body=_erase_return_refinement(ty.body))
+    if isinstance(ty, AbstractionType):
+        return replace(ty, type=_erase_return_refinement(ty.type))
+    if isinstance(ty, RefinedType):
+        return ty.type
+    return ty
 
 
 def _reflected_impl_for(
@@ -479,14 +507,25 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             r = (Conjunction(c1, inner), t2)
             return r
         case Rec(var_name, var_type, var_value, body):
+            has_metric = bool(t.decreasing_by)
+            # The recursive occurrence may assume the declared (refined) return
+            # type as an inductive hypothesis only when a well-founded
+            # termination metric justifies the induction. Without one, weaken
+            # the hypothesis to the bare codomain so a non-terminating
+            # definition cannot "prove" an absurd refinement (see
+            # recursion_soundness_test.py). Non-recursive bindings are
+            # unaffected: their body never references var_name, so the weaker
+            # context binding is never consulted.
+            rec_var_type = var_type if has_metric else _erase_return_refinement(var_type)
+            rec_ctx: TypingContext = ctx.with_var(var_name, rec_var_type)
+            c1 = check(rec_ctx, var_value, var_type)
             nrctx: TypingContext = ctx.with_var(var_name, var_type)
-            c1 = check(nrctx, var_value, var_type)
             (c2, t2) = synth(nrctx, body)
             reflected_impl = _reflected_impl_for(
                 var_name,
                 var_type,
                 var_value,
-                has_termination_metric=bool(t.decreasing_by),
+                has_termination_metric=has_metric,
             )
             c1 = implication_constraint(var_name, var_type, c1, var_value.loc, reflected_impl=reflected_impl)
             c2 = implication_constraint(var_name, var_type, c2, body.loc, reflected_impl=reflected_impl)
@@ -657,15 +696,25 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
                 inner = implication_constraint(bn, bt, inner, body.loc)
             return Conjunction(c1, inner)
         case Rec(var_name, var_type, var_value, body), _:
+            has_metric = bool(t.decreasing_by)
             t1 = fresh(ctx, var_type)
+            # The recursive occurrence may assume the declared (refined) return
+            # type as an inductive hypothesis only when a well-founded
+            # termination metric justifies the induction. Without one, weaken
+            # the hypothesis to the bare codomain so a non-terminating
+            # definition cannot "prove" an absurd refinement (see
+            # recursion_soundness_test.py). Non-recursive bindings are
+            # unaffected: their body never references var_name.
+            rec_t1 = t1 if has_metric else _erase_return_refinement(t1)
+            rec_ctx: TypingContext = ctx.with_var(var_name, rec_t1)
+            c1 = check(rec_ctx, var_value, var_type)
             nrctx: TypingContext = ctx.with_var(var_name, t1)
-            c1 = check(nrctx, var_value, var_type)
             c2 = check(nrctx, body, ty)
             reflected_impl = _reflected_impl_for(
                 var_name,
                 t1,
                 var_value,
-                has_termination_metric=bool(t.decreasing_by),
+                has_termination_metric=has_metric,
             )
             c1 = implication_constraint(var_name, t1, c1, var_value.loc, reflected_impl=reflected_impl)
             c2 = implication_constraint(var_name, t1, c2, body.loc, reflected_impl=reflected_impl)

--- a/tests/infer_test.py
+++ b/tests/infer_test.py
@@ -178,32 +178,29 @@ def test_sumToSimple5():
 
 
 def test_sumToSimple6():
-    assert tt(
+    # `k` recurses with no base case (`k 5 -> k 1 -> k 0 -> k 0 -> …`), so it
+    # never terminates, yet claims the refined codomain `{y | y > 0}`. A core
+    # `let rec` carries no termination metric, so the recursive occurrence may
+    # NOT assume that refinement as an inductive hypothesis; this must be
+    # rejected. (Accepting it was the pre-fix soundness bug.)
+    assert not tt(
         "let k : (x:Int) -> {y:Int | y > 0} = \\x -> if x == 5 then k 1 else k 0 in k 5",
         "{k:Int| k > 0}",
     )
 
 
 def test_sumTo():
-    sumTo_def = """
-        let sum : ((x: Int) -> {y: Int | (y >= 0) && (x <= y) }) =
-        \\n ->
-            let b : {k:Bool | k == (n <= 0)} = n <= 0 in
-            if b then 0 else (
-                let n_minus_1 : {nm1:Int | nm1 == (n - 1) } = (n - 1) in
-                let sum_n_minus_1 : {s:Int| (s >= 0) && (n_minus_1 <= s)} = sum n_minus_1 in
-                n + sum_n_minus_1
-            ) in 1
-    """
-    sumTo_def = sumTo_def = (
+    # `sum` is total, but a core `let rec` cannot carry a termination metric, so
+    # its refined recurrence `{y | y >= 0 && x <= y}` cannot be assumed at the
+    # recursive call without a well-foundedness proof — the core checker
+    # conservatively rejects it. The same recurrence IS accepted in the surface
+    # language, where metric inference / `decreasing_by` supply well-foundedness
+    # (see tests/recursion_soundness_test.py).
+    sumTo_def = (
         "let sum : ((x: Int) -> {y: Int | (y >= 0) && (x <= y) }) = \\n -> if n <= 0 then 0 else n + sum (n-1) in sum 4"
     )
     sumTo_type = "Int"
-    assert tt(sumTo_def, sumTo_type)
-    """
-    sumTo_def = "let sum : ((x: Int) -> {y: Int | (y >= 0) && (x <= y) }) = \\n -> if n <= 0 then 0 else n + sum (n-1) in sum"
-    sumTo_type = "(x: Int) -> {y: Int | (y >= 0) && (x <= y) } "
-    """
+    assert not tt(sumTo_def, sumTo_type)
 
 
 def test_simplerec():

--- a/tests/liquefy_builtins_test.py
+++ b/tests/liquefy_builtins_test.py
@@ -1,0 +1,65 @@
+"""Regression tests: built-in SMT operators liquefy to LiquidApp.
+
+Built-in SMT functions (Set operations, comparisons) need no special casing
+in ``liquefy_app``; every applied ``SVar`` becomes a ``LiquidApp`` and the
+built-in vs. uninterpreted distinction is resolved later in the SMT layer.
+These tests pin that behaviour (issue #291, item 1).
+"""
+
+from __future__ import annotations
+
+from aeon.core.liquid import LiquidApp
+from aeon.core.types import LiquidHornApplication
+from aeon.sugar.ast_helpers import mk_binop
+from aeon.sugar.lowering import liquefy
+from aeon.sugar.program import SApplication, SVar
+from aeon.utils.name import Name
+
+
+def test_comparison_liquefies_to_liquid_app():
+    term = mk_binop(Name("<=", 0), SVar(Name("x", 0)), SVar(Name("y", 0)))
+    result = liquefy(term)
+    assert isinstance(result, LiquidApp)
+    assert result.fun == Name("<=", 0)
+    assert not isinstance(result, LiquidHornApplication)
+
+
+def test_set_op_liquefies_to_liquid_app():
+    # Set_mem x s
+    inner = SApplication(SVar(Name("Set_mem", 0)), SVar(Name("x", 0)))
+    term = SApplication(inner, SVar(Name("s", 0)))
+    result = liquefy(term)
+    assert isinstance(result, LiquidApp)
+    assert result.fun == Name("Set_mem", 0)
+    assert len(result.args) == 2
+
+
+def test_user_function_also_liquefies_to_liquid_app():
+    # A non-built-in name is treated identically; SMT dispatch happens later.
+    term = SApplication(SVar(Name("myMeasure", 0)), SVar(Name("xs", 0)))
+    result = liquefy(term)
+    assert isinstance(result, LiquidApp)
+    assert result.fun == Name("myMeasure", 0)
+
+
+def test_set_op_through_smt():
+    """End-to-end: a refinement using a Set op + comparison verifies via SMT."""
+    from aeon.sugar.ast_helpers import st_top
+    from tests.driver import check_compile
+
+    code = """
+type IntList
+
+def elts : (l:IntList) -> Set = uninterpreted
+def size : (l:IntList) -> Int = uninterpreted
+
+def empty : {l:IntList | elts l == Set_empty} = native "[]"
+
+def cons (x:Int) (xs:IntList) : {l:IntList | Set_mem x (elts l)} =
+    native "[x] + xs"
+
+def main (_:Int) : Unit =
+    a = cons 1 empty;
+    print(a)
+"""
+    assert check_compile(code, st_top)

--- a/tests/recursion_soundness_test.py
+++ b/tests/recursion_soundness_test.py
@@ -1,0 +1,155 @@
+"""Soundness tests for well-founded recursion.
+
+A recursive definition is typed with its declared return refinement available
+for the recursive call (the inductive hypothesis). That is only sound if the
+function terminates, so the termination metric must be a *well-founded* measure
+— it must strictly decrease AND stay non-negative at every reachable recursive
+call.
+
+These tests pin that requirement. The NEGATIVE cases exercise recursion whose
+metric decreases without a lower bound (an unbounded integer descends forever),
+which must be rejected; otherwise an absurd return refinement like
+``{r:Int | r > r}`` becomes inhabited and poisons downstream proofs.
+"""
+
+from __future__ import annotations
+
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import DesugaredProgram, desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_main_program
+from aeon.typechecking.typeinfer import check_type_errors
+
+
+def _typechecks(src: str) -> bool:
+    """Run the full front-to-typecheck pipeline; True iff no type errors.
+
+    Mirrors the reflection-aware harness used in ``decreasing_by_test.py`` so
+    reflected recursive functions get their formals bound for the SMT layer.
+    """
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(
+        progt, ctx, desugared.metadata, desugared.constructor_to_type, desugared.constructor_defs
+    )
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    errors = list(check_type_errors(typing_ctx, core_ast, top))
+    return errors == []
+
+
+# ---------------------------------------------------------------------------
+# Positive: genuinely well-founded recursion must stay accepted.
+# ---------------------------------------------------------------------------
+
+
+def test_factorial_nat_is_accepted():
+    src = """
+        def fact (n:Int | n >= 0) : Int decreasing_by [n] =
+          if n == 0 then 1 else n * fact (n - 1);
+        def main (_:Int) : Int = fact 5
+    """
+    assert _typechecks(src)
+
+
+def test_explicit_recurrence_refinement_is_accepted():
+    src = """
+        def double (n:Int | n >= 0) : {r:Int | r == n + n} decreasing_by [n] =
+          if n == 0 then 0 else double (n - 1) + 2;
+        def main (_:Int) : Int = double 5
+    """
+    assert _typechecks(src)
+
+
+def test_inferred_metric_guarded_nat_is_accepted():
+    # No explicit decreasing_by: unary Int recursion infers [n]; guarded + n>=0
+    # gives a well-founded obligation.
+    src = """
+        def countdown (n:Int | n >= 0) : Int =
+          if n == 0 then 0 else countdown (n - 1);
+        def main (_:Int) : Int = countdown 5
+    """
+    assert _typechecks(src)
+
+
+# ---------------------------------------------------------------------------
+# Negative: non-well-founded recursion must be rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_unbounded_decrement_with_metric_is_rejected():
+    # f (n-1) with metric [n] but no lower bound on n: decreases forever.
+    src = """
+        def f (n:Int) : Int decreasing_by [n] = f (n - 1);
+        def main (_:Int) : Int = 0
+    """
+    assert not _typechecks(src)
+
+
+def test_unbounded_decrement_inferred_metric_is_rejected():
+    # Same shape, relying on the inferred [n] metric (no decreasing_by written).
+    src = """
+        def f (n:Int) : Int = f (n - 1);
+        def main (_:Int) : Int = 0
+    """
+    assert not _typechecks(src)
+
+
+def test_absurd_refinement_on_nonterminating_fn_is_rejected():
+    # The non-terminating function claims an uninhabited codomain.
+    src = """
+        def f (n:Int) : {r:Int | r > r} decreasing_by [n] = f (n - 1);
+        def main (_:Int) : Int = 0
+    """
+    assert not _typechecks(src)
+
+
+def test_nonterminating_fn_cannot_poison_downstream_proof():
+    # If f were accepted, binding its absurd result would let us prove `false`.
+    src = """
+        def f (n:Int) : {r:Int | r > r} decreasing_by [n] = f (n - 1);
+        def exploit (n:Int) : {b:Bool | b} = (let x = f n in false);
+        def main (_:Int) : Int = 0
+    """
+    assert not _typechecks(src)
+
+
+def test_multiarg_no_metric_absurd_refinement_is_rejected():
+    # Multi-arg recursion has no inferred metric (inference only covers the
+    # unary-Int case). Without a metric, the recursive occurrence must NOT be
+    # allowed to assume the declared absurd return refinement.
+    src = """
+        def f (n:Int) (m:Int) : {r:Int | r > r} = f n m;
+        def main (_:Int) : Int = 0
+    """
+    assert not _typechecks(src)
+
+
+def test_nonint_arg_no_metric_absurd_refinement_is_rejected():
+    # A single non-Int parameter is likewise outside the inference's reach;
+    # self-recursion may not assume an absurd codomain without a metric.
+    src = """
+        def f (b:Bool) : {r:Int | r > r} = f b;
+        def main (_:Int) : Int = 0
+    """
+    assert not _typechecks(src)
+
+
+def test_multiarg_recurrence_with_explicit_metric_is_accepted():
+    # The sound escape hatch: state a well-founded metric explicitly. A
+    # two-argument recursion with a guarded, decreasing first metric is total,
+    # so its declared recurrence refinement may be assumed at the recursive call.
+    src = """
+        def add (n:Int | n >= 0) (m:Int) : {r:Int | r == n + m} decreasing_by [n] =
+          if n == 0 then m else add (n - 1) (m + 1);
+        def main (_:Int) : Int = add 3 4
+    """
+    assert _typechecks(src)

--- a/tests/reflect_underscore_test.py
+++ b/tests/reflect_underscore_test.py
@@ -116,3 +116,29 @@ def test_recursive_body_rejected_with_clear_error():
 def main (_:Int) : Int = 0"""
     with pytest.raises(TypeError, match="recursive"):
         reflect_underscore_in_definitions(parse_program(src).definitions)
+
+
+def test_recursive_body_under_if_rejected():
+    # Regression (issue #291): the self-reference guard must see through `if`;
+    # otherwise this slips past and reaches the solver as an unprovable goal.
+    src = """def f (n:Int) : {r:Int | _} = if n == 0 then 0 else f (n - 1) + 2;
+def main (_:Int) : Int = 0"""
+    with pytest.raises(TypeError, match="recursive"):
+        reflect_underscore_in_definitions(parse_program(src).definitions)
+
+
+def test_recursive_body_under_let_rejected():
+    # Regression (issue #291): the guard must also see through `let`.
+    src = """def g (n:Int) : {r:Int | _} = (let m = g (n - 1) in m + 1);
+def main (_:Int) : Int = 0"""
+    with pytest.raises(TypeError, match="recursive"):
+        reflect_underscore_in_definitions(parse_program(src).definitions)
+
+
+def test_explicit_recurrence_with_metric_verifies():
+    # The supported, sound alternative to recursive `_`: state the recurrence
+    # explicitly so the recursive call's declared return type discharges it.
+    src = """def double (n:Int | n >= 0) : {r:Int | r == n + n} decreasing_by [n] =
+    if n == 0 then 0 else double (n - 1) + 2;
+def main (_:Int) : Int = 0"""
+    assert _verify(src) == []


### PR DESCRIPTION
## Summary

Typing a recursive call at its declared **refined** return type (the inductive hypothesis) is only sound if the function terminates. This PR closes a pre-existing soundness gap where non-terminating recursion could "prove" an absurd codomain such as `{r:Int | r > r}` and poison downstream proofs (e.g. binding such a result lets you derive `false`).

It also resolves the four TODOs grouped under #291.

### Soundness fixes
- **`termination.py`** — non-negativity is now *always* required (dropped the `needs_call_nonneg` gate). A well-founded measure must strictly decrease **and** stay bounded below, so an unbounded integer descent (`f (n-1)` with no lower bound) is rejected.
- **`desugar.py`** — fixed `_sugar_contains_recursive_call` (it compared `SVar == Name`, always `False`, so unary-`Int` metric inference never fired) and broadened `_mentions_function` to traverse every reflectable construct.
- **`typeinfer.py`** — new `_erase_return_refinement`; both `Rec` cases grant the refined return type as an inductive hypothesis **only** when a well-founded metric is present, otherwise the recursive occurrence is weakened to its bare codomain. This closes the multi-arg / non-`Int` gap that metric inference doesn't reach.

### Issue #291 TODOs
- Preserve source `loc` on `Top()` in `type_to_core`.
- `liquefy_app`: documented that built-in SMT vs. uninterpreted dispatch is resolved later in `translate_liq` (no special handling needed here).
- `liquefy` / `liquefy_rec`: documented the no-induction behavior for recursive bindings; sound reasoning flows through termination-gated reflection (full induction remains open, #291).

## Notable consequence

Core `let rec` carries no termination metric (there is no core syntax for one), so **core-level refined-return recursion is now rejected**. Refined recursion works through the surface language, where metric inference / `decreasing_by` lower a metric into `Rec.decreasing_by`. Two core-syntax tests in `infer_test.py` were updated to assert this sound behavior: `test_sumToSimple6` (genuinely non-terminating — no base case) and `test_sumTo` (total, but unprovable without a metric).

## Test plan

- [x] `tests/recursion_soundness_test.py` (new, 10 cases): positives (factorial, explicit recurrence, inferred-metric countdown, multi-arg with explicit metric) + negatives (unbounded decrement w/ & w/o explicit metric, absurd refinement on non-terminating fn, downstream-poison exploit, multi-arg & non-`Int` no-metric absurd refinements)
- [x] `tests/liquefy_builtins_test.py` (new): built-in SMT ops and user functions all liquefy to `LiquidApp`
- [x] Full unit suite: **1221 passed, 9 skipped**
- [x] CI example suite (`run_examples.sh`): **136 examples, 0 failures (exit 0)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)