### PR TITLE
Elaboration cleanup: resolve TODO cluster around elaborate_remove_unification (closes #290)

### DIFF
--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -252,7 +252,15 @@ def _resolve_uvars(ty: SType) -> SType:
             return ty
 
 
-def unify_single(vname: str, xs: list[SType]) -> SType:
+def unify_single(origin: str, xs: list[SType]) -> SType:
+    """Collapse a union/intersection of inferred types into a single type.
+
+    All members must already agree (up to unification-variable resolution); if
+    two members resolve to incompatible types the collapse is impossible, so we
+    raise a ``UnificationFailedError`` naming where the conflict came from (the
+    ``origin`` describes the union/intersection being collapsed) and the two
+    concrete types that clashed.
+    """
     match [x for x in xs if x != st_top]:
         case []:
             return st_unit
@@ -262,17 +270,16 @@ def unify_single(vname: str, xs: list[SType]) -> SType:
             fst_original = other[0]
             for snd, snd_r in zip(other[1:], resolved[1:]):
                 if snd_r != fst_r:
-                    raise UnificationFailedError(vname, fst_original, snd)
+                    raise UnificationFailedError(origin, fst_original, snd)
             return fst_r
 
 
 def remove_unions_and_intersections(ctx: ElaborationTypingContext, ty: SType) -> SType:
     match ty:
         case Union(united):
-            # TODO: raise better errors
-            return unify_single("?", united)
+            return unify_single(f"the union type {ty}", united)
         case Intersection(intersected):
-            return unify_single("?", intersected)
+            return unify_single(f"the intersection type {ty}", intersected)
         case SAbstractionType(name, vtype, rtype, loc):
             return SAbstractionType(
                 var_name=name,
@@ -585,6 +592,36 @@ def remove_from_union_and_intersection(
         union.united = list(filter(rem, union.united))
 
 
+def _base_subtype(sub: SType, sup: SType) -> bool:
+    """Conservative, purely structural subtyping between *base* surface types.
+
+    Used by the unification-flattening step to decide when a variable sandwich
+    ``sub <: u <: sup`` can collapse. It is intentionally syntactic — it never
+    invokes the SMT solver — and treats refinements transparently (only the
+    underlying base type matters). It is a superset of structural equality, so
+    it preserves the previous equality-based behaviour while additionally
+    relating any type with ``Top``, equal type variables, and covariant
+    constructor arguments.
+    """
+    # Refinements are transparent: relate the underlying base types.
+    if isinstance(sub, SRefinedType):
+        return _base_subtype(sub.type, sup)
+    if isinstance(sup, SRefinedType):
+        return _base_subtype(sub, sup.type)
+    match (sub, sup):
+        case (_, STypeConstructor(Name("Top", _), _)):
+            return True
+        case (STypeVar(n1), STypeVar(n2)):
+            return n1 == n2
+        case (STypeConstructor(n1, args1), STypeConstructor(n2, args2)):
+            return n1 == n2 and len(args1) == len(args2) and all(_base_subtype(a1, a2) for a1, a2 in zip(args1, args2))
+        case (SAbstractionType(_, v1, r1), SAbstractionType(_, v2, r2)):
+            # Functions: contravariant in the argument, covariant in the result.
+            return _base_subtype(v2, v1) and _base_subtype(r1, r2)
+        case _:
+            return sub == sup
+
+
 def handle_unification_in_type(ctx: ElaborationTypingContext, ty: SType) -> SType:
     # Source: https://dl.acm.org/doi/pdf/10.1145/3409006
     nt, unions, intersections = replace_unification_variables(ctx, ty)
@@ -618,9 +655,11 @@ def handle_unification_in_type(ctx: ElaborationTypingContext, ty: SType) -> STyp
         base_types_together_with_u_neg = [
             b for i in intersections if u in i.intersected for b in i.intersected if not isinstance(b, UnificationVar)
         ]
-        # TODO: I think we need subtyping here.
-
-        if any(bp in base_types_together_with_u_neg for bp in base_types_together_with_u_pos):
+        # The sandwich ``bp <: u <: bn`` collapses whenever some lower bound is a
+        # subtype of some upper bound. Using subtyping (rather than equality)
+        # also flattens variables squeezed between distinct-but-compatible types,
+        # e.g. ``T`` sandwiched against ``Top``.
+        if any(_base_subtype(bp, bn) for bp in base_types_together_with_u_pos for bn in base_types_together_with_u_neg):
             to_be_removed.append(u.name)
 
     remove_from_union_and_intersection(
@@ -636,15 +675,33 @@ def elaborate_remove_unification(ctx: ElaborationTypingContext, t: STerm) -> STe
         case SLiteral() | SVar() | SHole() | SImplicitRefinementHole() | SAnonConstructor():
             return t
         case SAnnotation(expr, ty, loc=loc):
-            return SAnnotation(elaborate_remove_unification(ctx, expr), ty, loc=loc)
-            # TODO NOW: what about ty?
+            # The annotation type is elaborated as well, mirroring ``SRec``: any
+            # unification variables/unions/intersections introduced while
+            # checking the annotation are resolved here instead of leaking into
+            # lowering. For a fully concrete user annotation this is a no-op.
+            nty = handle_unification_in_type(ctx, ty)
+            return SAnnotation(elaborate_remove_unification(ctx, expr), nty, loc=loc)
         case SAbstraction(name, body, loc=loc):
             return SAbstraction(name, elaborate_remove_unification(ctx, body), loc=loc)
         case SLet(name, val, body, loc=loc):
-            nctx = ctx.with_var(t.var_name, st_unit)  # TODO poly: Unit??
+            nval = elaborate_remove_unification(ctx, val)
+            # Bind the let variable to its actual (resolved) type in the body's
+            # context instead of a ``Unit`` placeholder. The type is recovered by
+            # re-synthesising the bound value and resolving its unification
+            # variables. This is best-effort — the value may contain holes or
+            # reference locally-bound names this pass does not track — so on
+            # failure we fall back to ``Top``: an honest "unknown" type, unlike
+            # ``Unit``, which previously claimed a concrete type and could mask
+            # type errors when the binding was polymorphic.
+            try:
+                _, vty = elaborate_synth(ctx, val)
+                vty = handle_unification_in_type(ctx, vty)
+            except (AeonError, AssertionError):
+                vty = st_top
+            nctx = ctx.with_var(t.var_name, vty)
             return SLet(
                 name,
-                elaborate_remove_unification(ctx, val),
+                nval,
                 elaborate_remove_unification(nctx, body),
                 loc=loc,
                 multiplicity=t.multiplicity,
@@ -716,17 +773,23 @@ def elaborate_remove_unification(ctx: ElaborationTypingContext, t: STerm) -> STe
                             if should_be_refined:
                                 nv = Name("self", fresh_counter.fresh())
                                 nh = Name("k", fresh_counter.fresh())
-                                # TODO NOW: liquidhornapp
-                                # ref = LiquidHornApplication("k", [(LiquidVar(new_var), str(nt))])
-                                new_type = SRefinedType(nv, nt, SHole(nh))
+                                # The refinement is a Liquid horn application
+                                # ``k(self)``: an unknown predicate over the
+                                # refined variable, to be solved by the Horn
+                                # solver. At the sugar level it is encoded as the
+                                # hole applied to ``self``; ``liquefy_app`` lowers
+                                # this to ``LiquidHornApplication(k, ...)``.
+                                ref = SApplication(SHole(nh), SVar(nv), loc=loc)
+                                new_type = SRefinedType(nv, nt, ref)
                             else:
                                 new_type = nt
                             return STypeApplication(body, new_type, loc=loc)
-                        case SRefinedType(name, ity, ref):
-                            # TODO NOW: liquidhornapp
-                            # ref = LiquidHornApplication("k", [(LiquidVar(nt.name), str(nt.type))])
+                        case SRefinedType(name, ity, _ref):
+                            # Replace the existing refinement with a fresh horn
+                            # application ``k(name)`` over the already-bound
+                            # variable, lowered to a ``LiquidHornApplication``.
                             nh = Name("k", fresh_counter.fresh())
-                            ref = SHole(nh)
+                            ref = SApplication(SHole(nh), SVar(name), loc=loc)
                             new_type = SRefinedType(name, ity, ref)
                             return STypeApplication(body, new_type, loc=loc)
                         case SAbstractionType(_, _, _):

--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -55,7 +55,10 @@ class UnificationFailedError(AeonError):
     conflict2: SType
 
     def __str__(self) -> str:
-        return f"Unification variable {self.name} needs to be {self.conflict1} and {self.conflict2} simultaneously, but the two types are not compatible."
+        return (
+            f"Could not infer a single type for {self.name}: it would need to be both "
+            f"{self.conflict1} and {self.conflict2} simultaneously, but those two types are not compatible."
+        )
 
     def position(self) -> Location:
         return self.conflict1.loc


### PR DESCRIPTION
Closes #290.

Resolves the cluster of six TODOs in and around `elaborate_remove_unification` and its helpers (`aeon/elaboration/__init__.py`), plus the associated error message in `aeon/facade/api.py`. None of these had been addressed previously; all six sites were still present (line numbers had shifted as the file grew).

## Changes (per issue site)

| Issue site | Change |
|---|---|
| `remove_unions_and_intersections` — *raise better errors* | `unify_single` now receives a descriptive **origin** (the union/intersection being collapsed) instead of a literal `"?"`, and `UnificationFailedError`'s message is reworded to be actionable. |
| `SAnnotation` — *what about ty?* | The annotation type is now elaborated via `handle_unification_in_type`, mirroring `SRec`, so unification variables/unions/intersections don't leak into lowering. No-op for fully concrete annotations. |
| `STypeApplication` — *liquidhornapp* (×2) | The refinement is now built as an explicit Liquid **horn application** `k(self)` and the dead `SHole`-only path is removed. |
| `SLet` — *Unit??* | The let variable is bound to its **actual resolved type** (best-effort re-synthesis + `handle_unification_in_type`), falling back to `Top` instead of the misleading `Unit` placeholder. |
| `handle_unification_in_type` — *I think we need subtyping here* | Variable-sandwich flattening now uses a conservative, SMT-free structural **subtyping** relation (`_base_subtype`) instead of equality. |

## Implementation notes

- **LiquidHornApplication (#3):** `SRefinedType.refinement` is an `STerm`, but `LiquidHornApplication` is a *core* `LiquidTerm` and cannot live there directly (lowering's `liquefy` would `assert False`). The faithful sugar-level encoding of the horn predicate `k(self)` is `SApplication(SHole(k), SVar(self))`, which `liquefy_app` lowers to exactly a `LiquidHornApplication`. This switches the representation to the intended horn-application form while staying type-correct; the lowered result is a `LiquidHornApplication` as the commented-out code intended.
- **Subtyping (#5):** `_base_subtype` is purely structural (never invokes the SMT solver), treats refinements transparently, and is a strict superset of the previous equality check — so it preserves all prior behaviour while additionally collapsing sandwiches like `T <: u <: Top` and covariant-constructor cases. The condition `bp <: bn` is the textbook generalisation of `bp == bn` for the `bp <: u <: bn` sandwich.
- **SLet (#4):** Re-synthesis is best-effort and guarded; on failure (holes, locally-bound names this pass doesn't track) it falls back to `Top` — an honest "unknown" — rather than `Unit`, which previously claimed a concrete type and could mask polymorphism-related mismatches.

## Verification

- `uv run pytest` — **1263 passed, 9 skipped**
- `bash run_examples.sh` — all **122** examples succeed
- pre-commit (ruff, ruff-format, **mypy**, etc.) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)