### PR TITLE
feat(syntax): method-call syntax `receiver.method` (closes #27)

### DIFF
--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -6,6 +6,7 @@ from aeon.elaboration.instantiation import type_substitution
 from aeon.facade.api import (
     AeonError,
     InstanceResolutionError,
+    MethodResolutionError,
     NonOrderableComparisonError,
     UnificationFailedError,
     UnificationKindError,
@@ -23,6 +24,7 @@ from aeon.sugar.program import (
     SInstanceHole,
     SLet,
     SLiteral,
+    SMethodSelector,
     SRec,
     SRefinementAbstraction,
     SRefinementApplication,
@@ -63,6 +65,26 @@ def _extract_base_type_name(ty: SType) -> str | None:
             return _extract_base_type_name(inner)
         case _:
             return None
+
+
+def _resolve_method_selector(ctx: ElaborationTypingContext, receiver: STerm, method: Name, loc) -> STerm:
+    """Rewrite a method call ``receiver.method`` (issue #27) into a plain
+    reference to the resolved ``Type.method`` function applied to the receiver.
+
+    The qualifier is the receiver's inferred base type: we synthesize the
+    receiver's type, take its base type-constructor name (``Int`` for ``1``),
+    and look up the ``Type.method`` definition in scope. The returned term is
+    the *unelaborated* ``SApplication(SVar(resolved), receiver)`` so the caller
+    can route it through normal synth/check (handling polymorphism, instance
+    holes and further applied arguments uniformly)."""
+    (_, recv_ty) = elaborate_synth(ctx, receiver)
+    type_name = _extract_base_type_name(_resolve_uvars(recv_ty))
+    if type_name is None:
+        raise MethodResolutionError(method.name, None, loc)
+    resolved = ctx.resolve_method(method.name, type_name)
+    if resolved is None:
+        raise MethodResolutionError(method.name, type_name, loc)
+    return SApplication(SVar(resolved, loc=loc), receiver, loc=loc)
 
 
 # Ordered comparison operators are restricted to ordered base types (issue
@@ -393,6 +415,12 @@ def elaborate_synth(ctx: ElaborationTypingContext, t: STerm) -> tuple[STerm, STy
             unify(ctx, nthen_type, u)
             unify(ctx, nelse_type, u)
             return SIf(ncond, nthen, nelse), u
+        case SApplication(SMethodSelector(method), receiver, loc=loc):
+            return elaborate_synth(ctx, _resolve_method_selector(ctx, receiver, method, loc))
+        case SMethodSelector(method, loc=loc):
+            # A selector only ever appears applied to its receiver; standalone
+            # is a parser/internal bug.
+            raise MethodResolutionError(method.name, None, loc)
         case SApplication(fun, arg):
             (nfun, nfun_type) = elaborate_synth(ctx, fun)
             while isinstance(nfun_type, STypePolymorphism):
@@ -474,6 +502,8 @@ def elaborate_check(ctx: ElaborationTypingContext, t: STerm, ty: SType) -> STerm
                 return elaborate_check(ctx, resolved, ty)
             # Fallback: raise error
             raise UnificationUnknownTypeError(t)
+        case (SApplication(SMethodSelector(method), receiver, loc=loc), _):
+            return elaborate_check(ctx, _resolve_method_selector(ctx, receiver, method, loc), ty)
         case (SApplication(fun, arg, loc=loc), _):
             u = UnificationVar(ctx.fresh_typevar())
             nfun = elaborate_check(ctx, fun, SAbstractionType(Name("_", fresh_counter.fresh()), u, ty))

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -67,16 +67,67 @@ def _extract_base_type_name(ty: SType) -> str | None:
             return None
 
 
-def _resolve_method_selector(ctx: ElaborationTypingContext, receiver: STerm, method: Name, loc) -> STerm:
-    """Rewrite a method call ``receiver.method`` (issue #27) into a plain
-    reference to the resolved ``Type.method`` function applied to the receiver.
+def _receiver_arg_index(fn_type: SType | None, type_name: str) -> int:
+    """Index (among *explicit* value parameters) of the first parameter whose
+    base type is ``type_name`` — i.e. where a method call's receiver should be
+    inserted, Lean-style. Type/refinement-polymorphism binders are peeled and
+    instance-implicit parameters are skipped (they are auto-filled). Falls back
+    to ``0`` (insert first) when no parameter matches or the type is unknown."""
+    idx = 0
+    ty = fn_type
+    while ty is not None:
+        match ty:
+            case STypePolymorphism(_, _, body) | SRefinementPolymorphism(_, _, body):
+                ty = body
+            case SAbstractionType(_, var_type, rtype):
+                if ty.is_instance:
+                    ty = rtype
+                    continue
+                if _extract_base_type_name(var_type) == type_name:
+                    return idx
+                idx += 1
+                ty = rtype
+            case _:
+                break
+    return 0
 
-    The qualifier is the receiver's inferred base type: we synthesize the
-    receiver's type, take its base type-constructor name (``Int`` for ``1``),
-    and look up the ``Type.method`` definition in scope. The returned term is
-    the *unelaborated* ``SApplication(SVar(resolved), receiver)`` so the caller
-    can route it through normal synth/check (handling polymorphism, instance
-    holes and further applied arguments uniformly)."""
+
+def _method_call_spine(t: STerm) -> tuple[Name, STerm, list[STerm]] | None:
+    """If ``t`` is the application spine of a method call, return
+    ``(method, receiver, call_args)``; otherwise ``None``.
+
+    ``receiver.method a1 ... an`` parses to nested applications whose innermost
+    function is the ``SMethodSelector`` and whose first applied argument is the
+    receiver: ``App(... App(App(SMethodSelector(method), receiver), a1) ..., an)``.
+    We unwind that into the method name, the receiver, and the remaining call
+    arguments ``[a1, ..., an]`` (which may be empty)."""
+    args: list[STerm] = []
+    cur = t
+    while isinstance(cur, SApplication):
+        args.insert(0, cur.arg)
+        cur = cur.fun
+    if isinstance(cur, SMethodSelector) and args:
+        return (cur.method, args[0], args[1:])
+    return None
+
+
+def _build_method_call(
+    ctx: ElaborationTypingContext, method: Name, receiver: STerm, call_args: list[STerm], loc
+) -> STerm:
+    """Rewrite a method call ``receiver.method call_args...`` (issue #27) into a
+    plain application of the resolved method function with the receiver inserted.
+
+    The qualifier is the receiver's inferred base type. Following Lean, the
+    receiver is inserted at the first explicit parameter whose type matches the
+    receiver's type — not blindly first — so ``xs.map f`` becomes ``List.map f
+    xs`` even though ``List.map``'s list is its second argument. Because we have
+    the whole call spine here, the common case is a plain reordered application
+    (no lambda); only a *partial* call that omits arguments before the receiver
+    position needs eta-expansion.
+
+    The returned term is left *unelaborated* so the caller routes it through
+    normal synth/check (handling polymorphism, instance holes and the remaining
+    arguments uniformly)."""
     (_, recv_ty) = elaborate_synth(ctx, receiver)
     type_name = _extract_base_type_name(_resolve_uvars(recv_ty))
     if type_name is None:
@@ -84,7 +135,23 @@ def _resolve_method_selector(ctx: ElaborationTypingContext, receiver: STerm, met
     resolved = ctx.resolve_method(method.name, type_name)
     if resolved is None:
         raise MethodResolutionError(method.name, type_name, loc)
-    return SApplication(SVar(resolved, loc=loc), receiver, loc=loc)
+
+    k = _receiver_arg_index(ctx.type_of(resolved), type_name)
+    term: STerm = SVar(resolved, loc=loc)
+    if k <= len(call_args):
+        final_args = call_args[:k] + [receiver] + call_args[k:]
+        for a in final_args:
+            term = SApplication(term, a, loc=loc)
+        return term
+    # Partial call: the receiver sits past the supplied arguments, so eta-expand
+    # the missing pre-receiver parameters into a lambda.
+    fresh = [Name(f"_self{fresh_counter.fresh()}") for _ in range(k - len(call_args))]
+    final_args = call_args + [SVar(p, loc=loc) for p in fresh] + [receiver]
+    for a in final_args:
+        term = SApplication(term, a, loc=loc)
+    for p in reversed(fresh):
+        term = SAbstraction(p, term, loc=loc)
+    return term
 
 
 # Ordered comparison operators are restricted to ordered base types (issue
@@ -415,8 +482,9 @@ def elaborate_synth(ctx: ElaborationTypingContext, t: STerm) -> tuple[STerm, STy
             unify(ctx, nthen_type, u)
             unify(ctx, nelse_type, u)
             return SIf(ncond, nthen, nelse), u
-        case SApplication(SMethodSelector(method), receiver, loc=loc):
-            return elaborate_synth(ctx, _resolve_method_selector(ctx, receiver, method, loc))
+        case SApplication() if (_spine := _method_call_spine(t)) is not None:
+            method, receiver, call_args = _spine
+            return elaborate_synth(ctx, _build_method_call(ctx, method, receiver, call_args, t.loc))
         case SMethodSelector(method, loc=loc):
             # A selector only ever appears applied to its receiver; standalone
             # is a parser/internal bug.
@@ -502,8 +570,9 @@ def elaborate_check(ctx: ElaborationTypingContext, t: STerm, ty: SType) -> STerm
                 return elaborate_check(ctx, resolved, ty)
             # Fallback: raise error
             raise UnificationUnknownTypeError(t)
-        case (SApplication(SMethodSelector(method), receiver, loc=loc), _):
-            return elaborate_check(ctx, _resolve_method_selector(ctx, receiver, method, loc), ty)
+        case (SApplication(), _) if (_spine := _method_call_spine(t)) is not None:
+            method, receiver, call_args = _spine
+            return elaborate_check(ctx, _build_method_call(ctx, method, receiver, call_args, t.loc), ty)
         case (SApplication(fun, arg, loc=loc), _):
             u = UnificationVar(ctx.fresh_typevar())
             nfun = elaborate_check(ctx, fun, SAbstractionType(Name("_", fresh_counter.fresh()), u, ty))

--- a/aeon/elaboration/context.py
+++ b/aeon/elaboration/context.py
@@ -59,6 +59,25 @@ class ElaborationTypingContext:
                         return ty
         return None
 
+    def resolve_method(self, method: str, type_name: str) -> Name | None:
+        """Resolve a method call ``receiver.method`` (issue #27) to the bound
+        ``Name`` of the ``type_name.method`` definition, given the receiver's
+        base type ``type_name``. Returns the actual in-scope ``Name`` (carrying
+        its unique id, so the produced reference lowers to the right core
+        binder) or ``None`` if no such definition exists.
+
+        The lookup is by the fully-qualified string ``"Type.method"`` — which is
+        exactly how a ``def Type.method`` is named — scanning the most recent
+        binding first so locals shadow globals consistently with ``type_of``.
+        """
+        candidate = f"{type_name}.{method}"
+        for entry in self.entries[::-1]:
+            match entry:
+                case ElabVariableBinder(bname, _) | ElabUninterpretedBinder(bname, _):
+                    if bname.name == candidate:
+                        return bname
+        return None
+
     def with_var(self, name: Name, ty: SType):
         """Creates a new context, with an extra variable."""
         nentries = [x for x in self.entries] + [ElabVariableBinder(name, ty)]

--- a/aeon/elaboration/context.py
+++ b/aeon/elaboration/context.py
@@ -61,20 +61,28 @@ class ElaborationTypingContext:
 
     def resolve_method(self, method: str, type_name: str) -> Name | None:
         """Resolve a method call ``receiver.method`` (issue #27) to the bound
-        ``Name`` of the ``type_name.method`` definition, given the receiver's
-        base type ``type_name``. Returns the actual in-scope ``Name`` (carrying
-        its unique id, so the produced reference lowers to the right core
-        binder) or ``None`` if no such definition exists.
+        ``Name`` of the method defined for the receiver's base type
+        ``type_name``. Returns the actual in-scope ``Name`` (carrying its unique
+        id, so the produced reference lowers to the right core binder) or
+        ``None`` if no such definition exists.
 
-        The lookup is by the fully-qualified string ``"Type.method"`` — which is
-        exactly how a ``def Type.method`` is named — scanning the most recent
-        binding first so locals shadow globals consistently with ``type_of``.
+        Two binder-naming conventions are tried, in order:
+
+        * ``"Type.method"`` — a dotted definition ``def Type.method`` (issue #27);
+        * ``"Type_method"`` — a function ``method`` imported from a module named
+          ``Type`` (modules prefix their members as ``Module_member``). This is
+          what makes library calls like ``xs.length`` dispatch to ``List``'s
+          ``length`` when the element/container type name matches the module
+          name (the issue #26 design: a type and its namespace share a name).
+
+        The most recent binding is scanned first, so locals shadow globals
+        consistently with ``type_of``.
         """
-        candidate = f"{type_name}.{method}"
+        candidates = (f"{type_name}.{method}", f"{type_name}_{method}")
         for entry in self.entries[::-1]:
             match entry:
                 case ElabVariableBinder(bname, _) | ElabUninterpretedBinder(bname, _):
-                    if bname.name == candidate:
+                    if bname.name in candidates:
                         return bname
         return None
 

--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -90,6 +90,28 @@ class UnificationUnknownTypeError(AeonError):
 
 
 @dataclass
+class MethodResolutionError(AeonError):
+    """Raised when a method-call ``receiver.method`` (issue #27) cannot be
+    resolved: either the receiver's type is not concrete enough to pick a
+    qualifier, or no ``Type.method`` definition exists for that type."""
+
+    method: str
+    type_name: str | None
+    loc: Location
+
+    def __str__(self) -> str:
+        if self.type_name is None:
+            return (
+                f"Cannot resolve method call '.{self.method}': the receiver's type "
+                f"could not be determined. Annotate the receiver to fix its type."
+            )
+        return f"No method '{self.method}' defined for type '{self.type_name}' (looked up '{self.type_name}.{self.method}')."
+
+    def position(self) -> Location:
+        return self.loc
+
+
+@dataclass
 class InstanceResolutionError(AeonError):
     class_name: str
     head: str | None

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -43,9 +43,15 @@ cons_rule : _PIPE ID args ":" type                           -> def_ind_cons
 measures : measure_rule*                                  -> list
 measure_rule : "+" ID args ":" type                        -> def_ind_cons
 
-def : soft_constraint "def" ID ":" type "=" expression ";"?                  -> def_cons
-    | soft_constraint "def" ID  args ":" type decreasing_by_opt "=" expression ";"?     -> def_fun_eq
+// A definition name may be a plain identifier or a dotted ``Type.method`` name
+// (issue #27): ``def Int.toString : ...`` declares a method on ``Int`` that
+// ``recv.toString`` dispatches to when the receiver has type ``Int``.
+def : soft_constraint "def" def_name ":" type "=" expression ";"?                  -> def_cons
+    | soft_constraint "def" def_name  args ":" type decreasing_by_opt "=" expression ";"?     -> def_fun_eq
     | instance_decl                                                          -> same
+
+def_name : ID                                                -> same
+         | QUALIFIED_ID                                      -> same
 
 // Lean-style instance declaration. ``inst_constraints`` are instance-implicit
 // requirements written ``[Eq a]``; each member is ``name binders := body ;``.
@@ -204,23 +210,38 @@ expression_b : "\\" ID "->" expression                      -> abstraction_e
              | "Λ" ID ":" kind "=>" expression              -> tabstraction_e
              | application                                  -> same
 
+// Postfix layer. A method call ``receiver.method`` (issue #27) is
+// ``method_recv DOT_ID``; crucially the receiver is a ``method_recv`` (a non-dot
+// atom or a method chain), NOT a bare anonymous constructor. Anonymous
+// constructors keep their own ``DOT_ID`` branch here (as an application head)
+// and in ``expression_simple`` (as an argument), so ``.mk .sc_blue 40`` stays an
+// anon-constructor application instead of being misread as ``.mk`` ``.sc_blue``
+// method access.
 application_t : application_t "[" type "]"                    -> type_application_e
               | application_t "{" expression "}"              -> refinement_application_e
-              | expression_simple                             -> same
+              | method_recv                                  -> same
+              | DOT_ID                                       -> anon_constructor
+
+method_recv : method_recv DOT_ID                             -> method_access
+            | non_dot_simple                                 -> same
 
 application : application expression_simple                  -> application_e
             | application_t                                  -> same
 
-expression_simple : "(" expression ")"                       -> same
+// Atoms that may be a method-call receiver (everything except anonymous
+// constructors, which start with ``.``).
+non_dot_simple : "(" expression ")"                          -> same
         | "(" expression ":" type ")"                        -> annotation
         | INTLIT                                             -> int_lit
         | FLOATLIT                                           -> float_lit
         | BOOLLIT                                            -> bool_lit
         | ESCAPED_STRING                                     -> string_lit
         | QUALIFIED_ID                                       -> qualified_var
-        | DOT_ID                                             -> anon_constructor
         | ID                                                 -> var
         | "?" ID                                             -> hole
+
+expression_simple : non_dot_simple                           -> same
+        | DOT_ID                                             -> anon_constructor
 
 
 kind : "B" -> base_kind
@@ -239,7 +260,15 @@ BOOLLIT.5 : "true" | "false"
 //   plain ``ID``.
 MULT.6 : "0" | "1" | "omega" | "ω" | /n(?=[ \t]+[A-Za-z_])/
 INTLIT : /[0-9][0-9]*/
-FLOATLIT : SIGNED_FLOAT
+// Mirrors ``common.SIGNED_FLOAT`` (fractional, ``.5``, exponent and signed
+// forms — including ``-1.0``) with one carve-out: a bare trailing dot like
+// ``1.`` is only a float when NOT followed by an identifier start, so
+// ``1.toString`` lexes as ``1`` + ``.toString`` (DOT_ID) for method-call
+// syntax (issue #27) instead of ``1.`` + ``toString``.
+FLOATLIT : /[+-]?[0-9]+\.[0-9]+([eE][+-]?[0-9]+)?/
+         | /[+-]?[0-9]+\.([eE][+-]?[0-9]+)?(?![A-Za-z_0-9.])/
+         | /[+-]?\.[0-9]+([eE][+-]?[0-9]+)?/
+         | /[+-]?[0-9]+[eE][+-]?[0-9]+/
 
 TYPENAME : /[a-zA-Z0-9]+/
 QUALIFIED_ID.2 : /[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*/
@@ -254,7 +283,6 @@ COMMENT: /\s*/ "#" /[^\n]/*
 %import common.ESCAPED_STRING
 %import common.WS
 %import common.CNAME
-%import common.SIGNED_FLOAT
 
 %ignore WS
 %ignore COMMENT

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -211,22 +211,31 @@ expression_b : "\\" ID "->" expression                      -> abstraction_e
              | application                                  -> same
 
 // Postfix layer. A method call ``receiver.method`` (issue #27) is
-// ``method_recv DOT_ID``; crucially the receiver is a ``method_recv`` (a non-dot
-// atom or a method chain), NOT a bare anonymous constructor. Anonymous
-// constructors keep their own ``DOT_ID`` branch here (as an application head)
-// and in ``expression_simple`` (as an argument), so ``.mk .sc_blue 40`` stays an
-// anon-constructor application instead of being misread as ``.mk`` ``.sc_blue``
-// method access.
+// ``method_recv METHOD_DOT``. Following Lean, the dot is whitespace-sensitive:
+// ``METHOD_DOT`` is an *attached* dot (no space before it, e.g. ``1.toString``,
+// ``(e).m``) and binds tighter than application; a *spaced* or leading ``DOT_ID``
+// (e.g. ``.mk``, ``f .Ctor``) is an anonymous constructor. The retagging happens
+// in the ``MethodDotPostLex`` post-lexer. Because the method dot binds tightly
+// even in argument position (``app_arg``), ``f 1.toString`` parses as
+// ``f (1.toString)``, while ``.mk .sc_blue 40`` stays an anon-constructor
+// application.
+%declare METHOD_DOT
+
 application_t : application_t "[" type "]"                    -> type_application_e
               | application_t "{" expression "}"              -> refinement_application_e
               | method_recv                                  -> same
               | DOT_ID                                       -> anon_constructor
 
-method_recv : method_recv DOT_ID                             -> method_access
+method_recv : method_recv METHOD_DOT                         -> method_access
             | non_dot_simple                                 -> same
 
-application : application expression_simple                  -> application_e
+application : application app_arg                            -> application_e
             | application_t                                  -> same
+
+// An application argument: a method-receiver (so attached method dots bind
+// tightly, Lean-style) or a leading/spaced anonymous constructor.
+app_arg : method_recv                                        -> same
+        | DOT_ID                                             -> anon_constructor
 
 // Atoms that may be a method-call receiver (everything except anonymous
 // constructors, which start with ``.``).
@@ -239,9 +248,6 @@ non_dot_simple : "(" expression ")"                          -> same
         | QUALIFIED_ID                                       -> qualified_var
         | ID                                                 -> var
         | "?" ID                                             -> hole
-
-expression_simple : non_dot_simple                           -> same
-        | DOT_ID                                             -> anon_constructor
 
 
 kind : "B" -> base_kind

--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -14,6 +14,7 @@ from aeon.sugar.program import (
     Program,
     SAbstraction,
     SAnonConstructor,
+    SMethodSelector,
     SAnnotation,
     SApplication,
     SHole,
@@ -148,6 +149,8 @@ def bind_sterm(t: STerm, subs: RenamingSubstitions) -> STerm:
             return t  # Resolved during desugaring, not during binding
         case SAnonConstructor():
             return t  # Resolved during elaboration, not during binding
+        case SMethodSelector():
+            return t  # Leaf; resolved (with its receiver) during elaboration
         case SVar(name, loc=loc):
             return SVar(apply_subs_name(subs, name), loc=loc)
         case SHole(name, loc=loc):

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -31,6 +31,7 @@ from aeon.sugar.program import (
     SLiteral,
     SIf,
     SQualifiedVar,
+    SMethodSelector,
     SRec,
     SLet,
     SMatch,
@@ -288,7 +289,15 @@ def lower_by_blocks_in_sterm(t: STerm) -> tuple[STerm, dict[Name, tuple[str, ...
         case SBy(steps, loc=loc):
             h = Name("_by", fresh_counter.fresh())
             return SHole(h, loc=loc), {h: tuple(steps)}
-        case SLiteral() | SVar() | SHole() | SImplicitRefinementHole() | SQualifiedVar() | SAnonConstructor():
+        case (
+            SLiteral()
+            | SVar()
+            | SHole()
+            | SImplicitRefinementHole()
+            | SQualifiedVar()
+            | SAnonConstructor()
+            | SMethodSelector()
+        ):
             return t, {}
         case SAnnotation(expr, ty, loc=loc):
             ne, s1 = lower_by_blocks_in_sterm(expr)
@@ -408,6 +417,15 @@ def resolve_qualified_names_in_sterm(
             key = (qualifier, name.name)
             if key in qualified_scope:
                 return SVar(qualified_scope[key], loc=loc)
+            # ``qualifier.name`` where ``qualifier`` names no module or type:
+            # treat it as a method call ``qualifier.name`` on a (local)
+            # variable ``qualifier`` (issue #27). Since the lexer collapses
+            # ``x.m`` into a single QUALIFIED_ID, this is the only place a
+            # variable-receiver method call can be recovered. Elaboration
+            # resolves it against the receiver's type; if ``qualifier`` is not a
+            # bound variable either, it raises there.
+            if qualifier not in {q for (q, _) in qualified_scope}:
+                return SApplication(SMethodSelector(name, loc=loc), SVar(Name(qualifier), loc=loc), loc=loc)
             raise NameError(f"Name '{name.name}' not found in module '{qualifier}'")
         case SVar(name, loc) if name.name in unqualified_scope:
             return SVar(unqualified_scope[name.name], loc=loc)
@@ -607,6 +625,14 @@ def desugar(p: Program, is_main_hole: bool = True, extra_vars: dict[Name, SType]
             # "open IntList" brings constructors into bare scope
             if decl.name.name in open_inductives:
                 unqualified_scope[cons.name.name] = prefixed
+
+    # Register dotted definition names ``def Type.method`` for qualified access
+    # (issue #27), so ``Type.method`` resolves to the same binder that a method
+    # call ``recv.method`` dispatches to during elaboration.
+    for d in defs:
+        if "." in d.name.name:
+            qualifier, _, bare = d.name.name.rpartition(".")
+            qualified_scope[(qualifier, bare)] = d.name
 
     # Resolve qualified names (Math.pow -> pow) and unqualified bare names from open/selective imports
     defs = [

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -19,6 +19,7 @@ from aeon.sugar.program import (
     SRefinementApplication,
     SMatch,
     SMatchBranch,
+    SMethodSelector,
     SHole,
     SBy,
     SIf,
@@ -336,6 +337,17 @@ class TreeToSugar(Transformer):
     @v_args(meta=True)
     def application_e(self, meta, args):
         return SApplication(args[0], args[1], loc=self._loc(meta))
+
+    @v_args(meta=True)
+    def method_access(self, meta, args):
+        # ``receiver.method`` (issue #27). ``args[0]`` is the receiver expression
+        # and ``args[1]`` is the ``DOT_ID`` token ``.method``. The receiver is the
+        # *argument* of the selector so existing ``SApplication``-recursing passes
+        # walk into it without needing a dedicated case.
+        receiver = args[0]
+        method = str(args[1])[1:]  # strip leading dot
+        loc = self._loc(meta)
+        return SApplication(SMethodSelector(Name(method), loc=loc), receiver, loc=loc)
 
     @v_args(meta=True)
     def abstraction_e(self, meta, args):

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -5,6 +5,8 @@ import pathlib
 from typing import Callable
 
 from lark import Lark, Transformer, v_args
+from lark.lark import PostLex
+from lark.lexer import Token
 
 from aeon.core.multiplicity import from_token, Multiplicity, MOmega
 from aeon.core.types import Kind
@@ -87,6 +89,55 @@ def _split_arg_multiplicities(fn_args):
             mults.append(MOmega)
             flags.append(False)
     return plain, tuple(mults), tuple(flags)
+
+
+# Token types that can end a method-call *receiver*. An immediately-following
+# ``.name`` (no intervening whitespace) is then a method dot, Lean-style — not an
+# anonymous constructor. (Bare ``x.name`` never reaches here: the lexer already
+# fuses it into a single ``QUALIFIED_ID``.)
+_RECEIVER_END_TOKENS = frozenset(
+    {
+        "RPAR",  # (e).m
+        "INTLIT",  # 1.m
+        "FLOATLIT",  # 1.5.m
+        "BOOLLIT",
+        "ESCAPED_STRING",
+        "ID",  # ?x.m (hole) and any bare ident not fused into QUALIFIED_ID
+        "QUALIFIED_ID",  # x.a.m  -> (x.a).m
+        "METHOD_DOT",  # 1.a.b chains
+    }
+)
+
+
+class MethodDotPostLex(PostLex):
+    """Distinguish a method/projection dot from an anonymous-constructor dot by
+    whitespace, mirroring Lean (issue #27).
+
+    A ``DOT_ID`` (``.name``) that is *attached* to the previous token — no
+    whitespace, and that token can end a receiver — is retagged ``METHOD_DOT``
+    and binds tighter than application (``f 1.toString`` ≡ ``f (1.toString)``).
+    A leading or space-separated ``.name`` stays a ``DOT_ID`` anonymous
+    constructor (``.mk .sc_blue 40``)."""
+
+    # Ensure the contextual LALR lexer always offers ``DOT_ID`` (``METHOD_DOT``
+    # has no pattern; it is produced only here), so attached dots are lexable in
+    # states that expect a method dot.
+    always_accept = ("DOT_ID",)
+
+    def process(self, stream):
+        prev: Token | None = None
+        for tok in stream:
+            if (
+                tok.type == "DOT_ID"
+                and prev is not None
+                and prev.type in _RECEIVER_END_TOKENS
+                and prev.end_pos is not None
+                and tok.start_pos is not None
+                and prev.end_pos == tok.start_pos
+            ):
+                tok.type = "METHOD_DOT"
+            prev = tok
+            yield tok
 
 
 class AnnotatedStr(str):
@@ -668,6 +719,7 @@ def _get_cached_parser(rule: str) -> Lark:
             start=rule,
             import_paths=[pathlib.Path(__file__).parent.parent.absolute() / "frontend"],
             propagate_positions=True,
+            postlex=MethodDotPostLex(),
         )
     return _parser_cache[rule]
 

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -289,6 +289,35 @@ class SAnonConstructor(STerm):
 
 
 @dataclass(frozen=True)
+class SMethodSelector(STerm):
+    """Deferred, type-directed method lookup (issue #27, *method call* syntax).
+
+    The surface form ``receiver.method`` parses to
+    ``SApplication(SMethodSelector(method), receiver)``. Keeping the selector a
+    *leaf* (it carries only the method name, never the receiver) means every
+    ``SApplication``-recursing pass already walks into the receiver for free, so
+    no desugar/bind/substitution pass needs a bespoke case — only elaboration,
+    which has the receiver's type and rewrites the node to a plain reference to
+    the resolved ``Type.method`` function applied to the receiver.
+
+    A selector never stands alone: it is always the ``fun`` of the application
+    the parser builds around it.
+    """
+
+    method: Name
+    loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
+
+    def __str__(self):
+        return f".{self.method}"
+
+    def __repr__(self):
+        return f"MethodSelector(.{self.method})"
+
+    def __eq__(self, other):
+        return isinstance(other, SMethodSelector) and self.method == other.method
+
+
+@dataclass(frozen=True)
 class SMatchBranch:
     constructor: Name
     binders: list[Name]

--- a/aeon/sugar/substitutions.py
+++ b/aeon/sugar/substitutions.py
@@ -23,6 +23,7 @@ from aeon.sugar.program import (
     SLet,
     SLiteral,
     SQualifiedVar,
+    SMethodSelector,
     SRec,
     SRefinementAbstraction,
     SRefinementApplication,
@@ -122,7 +123,15 @@ def substitution_sterm_in_sterm(t: STerm, beta: STerm, alpha: Name) -> STerm:
         return substitution_sterm_in_stype(x, beta, alpha)
 
     match t:
-        case SLiteral(_, _) | SHole(_) | SImplicitRefinementHole(_) | SBy() | SQualifiedVar() | SAnonConstructor():
+        case (
+            SLiteral(_, _)
+            | SHole(_)
+            | SImplicitRefinementHole(_)
+            | SBy()
+            | SQualifiedVar()
+            | SAnonConstructor()
+            | SMethodSelector()
+        ):
             return t
         case SVar(name):
             if name == alpha:
@@ -228,7 +237,15 @@ def substitution_svartype_in_sterm(t: STerm, rep: SType, name: Name) -> STerm:
         return substitution_svartype_in_sterm(x, rep, name)
 
     match t:
-        case SVar(_) | SHole(_) | SImplicitRefinementHole(_) | SBy() | SQualifiedVar() | SAnonConstructor():
+        case (
+            SVar(_)
+            | SHole(_)
+            | SImplicitRefinementHole(_)
+            | SBy()
+            | SQualifiedVar()
+            | SAnonConstructor()
+            | SMethodSelector()
+        ):
             return t
         case SLiteral(v, ty, loc):
             return SLiteral(v, substitute_svartype_in_stype(ty, rep, name), loc=loc)

--- a/examples/99problems/p01_last.ae
+++ b/examples/99problems/p01_last.ae
@@ -3,8 +3,8 @@
 
 open Array
 
-def last (l: {x:(Array a) | Array.size x > 0}) : a = native "l[-1]"
+def Array.last (l: {x:(Array a) | Array.size x > 0}) : a = native "l[-1]"
 
 def main (args:Int) : Unit =
-    xs = Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3;
-    print (last xs);
+    xs = (((Array.new[Int]).append 1).append 2).append 3;
+    print xs.last;

--- a/examples/99problems/p02_secondLast.ae
+++ b/examples/99problems/p02_secondLast.ae
@@ -3,8 +3,8 @@
 
 open Array
 
-def secondLast (l: {x:(Array a) | Array.size x > 1}) : a = native "l[-2]"
+def Array.secondLast (l: {x:(Array a) | Array.size x > 1}) : a = native "l[-2]"
 
 def main (args:Int) : Unit =
-    xs = Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3;
-    print (secondLast xs);
+    xs = (((Array.new[Int]).append 1).append 2).append 3;
+    print xs.secondLast;

--- a/examples/99problems/p04_length.ae
+++ b/examples/99problems/p04_length.ae
@@ -3,8 +3,8 @@
 
 open Array
 
-def myLength (l: (Array a)) : {n:Int | n == Array.size l} = Array.length l
+def Array.len (l: (Array a)) : {n:Int | n == Array.size l} = l.length
 
 def main (args:Int) : Unit =
-    xs = Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3;
-    print (myLength xs);
+    xs = (((Array.new[Int]).append 1).append 2).append 3;
+    print xs.len;

--- a/examples/99problems/p05_reverse.ae
+++ b/examples/99problems/p05_reverse.ae
@@ -3,9 +3,9 @@
 
 open Array
 
-def myReverse (l: (Array a)) : {r:(Array a) | Array.size r == Array.size l} = native "l[::-1]"
+def Array.rev (l: (Array a)) : {r:(Array a) | Array.size r == Array.size l} = native "l[::-1]"
 
 def main (args:Int) : Unit =
-    xs = Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3;
-    rs : (Array Int) = myReverse xs;
+    xs = (((Array.new[Int]).append 1).append 2).append 3;
+    rs : (Array Int) = xs.rev;
     print rs;

--- a/examples/99problems/p06_palindrome.ae
+++ b/examples/99problems/p06_palindrome.ae
@@ -5,10 +5,10 @@ open Array
 
 def listEq (xs: (Array Int)) (ys: (Array Int)) : Bool = native "xs == ys"
 
-def isPalindrome (l: (Array Int)) : Bool = listEq l (Array.reversed l)
+def Array.isPalindrome (l: (Array Int)) : Bool = listEq l l.reversed
 
 def main (args:Int) : Unit =
-    pal = Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 1;
-    notpal = Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3;
-    _ = print (isPalindrome pal);
-    print (isPalindrome notpal)
+    pal = (((Array.new[Int]).append 1).append 2).append 1;
+    notpal = (((Array.new[Int]).append 1).append 2).append 3;
+    _ = print pal.isPalindrome;
+    print notpal.isPalindrome

--- a/examples/99problems/p08_compress.ae
+++ b/examples/99problems/p08_compress.ae
@@ -3,9 +3,9 @@
 
 open Array
 
-def compress (l: (Array Int)) : {r:(Array Int) | Array.size r <= Array.size l} =
+def Array.compress (l: (Array Int)) : {r:(Array Int) | Array.size r <= Array.size l} =
     native "[x for i, x in enumerate(l) if i == 0 or x != l[i-1]]"
 
 def main (args:Int) : Unit =
-    a : (Array Int) = Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 1) 2) 3) 3;
-    print (compress a)
+    a : (Array Int) = (((((Array.new[Int]).append 1).append 1).append 2).append 3).append 3;
+    print a.compress

--- a/examples/syntax/method_call.ae
+++ b/examples/syntax/method_call.ae
@@ -1,0 +1,23 @@
+# Method-call syntax (issue #27): `receiver.method` dispatches on the receiver's
+# type. `def Int.toString` declares a method on `Int`; `1.toString` then resolves
+# to `Int.toString 1`. Calls chain, and the method result can take further
+# arguments (`1.plus 2` is `(Int.plus 1) 2`).
+
+def Int.toString (n:Int) : String = native "str(n)";
+def Int.plus (x:Int) (y:Int) : Int = x + y;
+def Int.double (n:Int) : Int = n + n;
+
+def main (args:Int) : Unit =
+    # method call on a literal receiver
+    let a : String = 1.toString in
+    # method with an argument, then a chained method on the result
+    let b : String = (1.plus 2).toString in
+    # method call on a variable receiver
+    let n : Int = 4 in
+    let c : String = n.double.toString in
+    # a dotted definition is also callable directly as `Int.double`
+    let d : Int = Int.double 5 in
+    let _ : Unit = print a in        # 1
+    let _ : Unit = print b in        # 3
+    let _ : Unit = print c in        # 8
+    print (d.toString);             # 10

--- a/tests/method_call_test.py
+++ b/tests/method_call_test.py
@@ -1,0 +1,128 @@
+"""Tests for method-call syntax ``receiver.method`` (issue #27).
+
+A method call dispatches on the receiver's (base) type: ``1.toString`` resolves
+to the ``Int.toString`` definition, ``(1.plus 2).toString`` chains. Resolution is
+type-directed and happens during elaboration; the surface form parses to
+``SApplication(SMethodSelector(method), receiver)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.elaboration import elaborate
+from aeon.facade.api import MethodResolutionError
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.desugar import desugar
+from aeon.sugar.parser import parse_expression, parse_program
+from aeon.sugar.program import (
+    SAnonConstructor,
+    SApplication,
+    SLiteral,
+    SMethodSelector,
+)
+from tests.driver import check_compile
+
+
+# --- Parsing -----------------------------------------------------------------
+
+
+def test_parse_method_call_on_literal():
+    """``1.toString`` parses to a selector applied to the receiver literal."""
+    t = parse_expression("1.toString")
+    assert isinstance(t, SApplication)
+    assert isinstance(t.fun, SMethodSelector)
+    assert t.fun.method.name == "toString"
+    assert isinstance(t.arg, SLiteral) and t.arg.value == 1
+
+
+def test_parse_method_call_with_argument():
+    """``1.plus 2`` is ``(1.plus) 2`` — the method result applied to ``2``."""
+    t = parse_expression("1.plus 2")
+    assert isinstance(t, SApplication)  # outer application to `2`
+    assert isinstance(t.arg, SLiteral) and t.arg.value == 2
+    inner = t.fun
+    assert isinstance(inner, SApplication)
+    assert isinstance(inner.fun, SMethodSelector) and inner.fun.method.name == "plus"
+    assert isinstance(inner.arg, SLiteral) and inner.arg.value == 1
+
+
+def test_parse_chained_method_call():
+    """``(1.plus 2).toString`` dispatches ``toString`` on the result of ``1.plus 2``."""
+    t = parse_expression("(1.plus 2).toString")
+    assert isinstance(t, SApplication)
+    assert isinstance(t.fun, SMethodSelector) and t.fun.method.name == "toString"
+    assert isinstance(t.arg, SApplication)  # the `1.plus 2` receiver
+
+
+def test_anon_constructor_application_unaffected():
+    """Regression: space-separated anonymous-constructor application
+    (``.mk .sc_blue 40``) must NOT be reinterpreted as ``.mk`` ``.sc_blue``
+    method access — anonymous constructors are never method receivers."""
+    t = parse_expression(".mk .sc_blue 40")
+    # ((.mk .sc_blue) 40)
+    assert isinstance(t, SApplication)
+    assert isinstance(t.arg, SLiteral) and t.arg.value == 40
+    inner = t.fun
+    assert isinstance(inner, SApplication)
+    assert isinstance(inner.fun, SAnonConstructor) and inner.fun.name == "mk"
+    assert isinstance(inner.arg, SAnonConstructor) and inner.arg.name == "sc_blue"
+
+
+@pytest.mark.parametrize("src", ["1.5", "-1.0", ".5", "1.5e3", "1e5", "-1.0e-2"])
+def test_float_literals_still_parse(src):
+    """The float lexer carve-out for ``1.toString`` must not drop signed/exponent
+    float forms (e.g. ``-1.0`` in ``v > -1.0``)."""
+    assert isinstance(parse_expression(src), SLiteral)
+
+
+# --- Dotted definition names -------------------------------------------------
+
+
+def test_dotted_definition_name_parses():
+    prog = parse_program('def Int.toString (n:Int) : String = native "str(n)";\ndef main (i:Int) : Int = 0;\n')
+    names = [d.name.name for d in prog.definitions]
+    assert "Int.toString" in names
+
+
+# --- End-to-end resolution & evaluation --------------------------------------
+
+_PRELUDE = "def Int.double (n:Int) : Int = n + n;\ndef Int.plus (x:Int) (y:Int) : Int = x + y;\n"
+
+
+def test_method_call_compiles_and_evaluates():
+    src = _PRELUDE + "def main (i:Int) : Int = 3.double;\n"
+    assert check_compile(src, st_top, 6)
+
+
+def test_method_call_with_argument_evaluates():
+    # (1.plus 2) == 3, then .double == 6
+    src = _PRELUDE + "def main (i:Int) : Int = (1.plus 2).double;\n"
+    assert check_compile(src, st_top, 6)
+
+
+def test_qualified_call_resolves_to_same_definition():
+    """A dotted def is also callable directly as ``Int.plus 1 2``."""
+    src = _PRELUDE + "def main (i:Int) : Int = Int.plus 4 5;\n"
+    assert check_compile(src, st_top, 9)
+
+
+def test_method_call_on_variable_receiver():
+    """``x.method`` for a local variable ``x`` (lexed as a single QUALIFIED_ID)
+    is recovered as a method call when ``x`` names no module."""
+    src = _PRELUDE + ("def main (i:Int) : Int =\n  let n : Int = 4 in\n  n.double;\n")
+    assert check_compile(src, st_top, 8)
+
+
+def test_chained_method_call_on_variable_receiver():
+    src = _PRELUDE + (
+        "def main (i:Int) : Int =\n  let n : Int = 3 in\n  n.double.double;\n"  # ((n.double).double) == 12
+    )
+    assert check_compile(src, st_top, 12)
+
+
+def test_unknown_method_raises():
+    prog = parse_program("def Int.double (n:Int) : Int = n + n;\ndef main (i:Int) : Int = 1.nope;\n")
+    desugared = desugar(prog)
+    with pytest.raises(MethodResolutionError):
+        elaborate(desugared.elabcontext, desugared.program, st_top)

--- a/tests/method_call_test.py
+++ b/tests/method_call_test.py
@@ -20,6 +20,7 @@ from aeon.sugar.program import (
     SApplication,
     SLiteral,
     SMethodSelector,
+    SVar,
 )
 from tests.driver import check_compile
 
@@ -76,6 +77,28 @@ def test_float_literals_still_parse(src):
     assert isinstance(parse_expression(src), SLiteral)
 
 
+def test_lean_precedence_attached_dot_binds_tighter_than_application():
+    """Lean-style: an *attached* dot binds tighter than application, so
+    ``f 1.toString`` is ``f (1.toString)`` — the ``.toString`` is a method on the
+    literal ``1``, not an argument to ``f``."""
+    t = parse_expression("f 1.toString")
+    assert isinstance(t, SApplication)
+    assert isinstance(t.fun, SVar) and t.fun.name.name == "f"
+    # argument is the method call `1.toString`
+    assert isinstance(t.arg, SApplication)
+    assert isinstance(t.arg.fun, SMethodSelector) and t.arg.fun.method.name == "toString"
+    assert isinstance(t.arg.arg, SLiteral) and t.arg.arg.value == 1
+
+
+def test_spaced_dot_is_anonymous_constructor_argument():
+    """A *spaced* dot is an anonymous-constructor argument: ``f .mk`` is ``f``
+    applied to the anonymous constructor ``.mk`` (whitespace-sensitive, like Lean)."""
+    t = parse_expression("f .mk")
+    assert isinstance(t, SApplication)
+    assert isinstance(t.fun, SVar) and t.fun.name.name == "f"
+    assert isinstance(t.arg, SAnonConstructor) and t.arg.name == "mk"
+
+
 # --- Dotted definition names -------------------------------------------------
 
 
@@ -119,6 +142,55 @@ def test_chained_method_call_on_variable_receiver():
         "def main (i:Int) : Int =\n  let n : Int = 3 in\n  n.double.double;\n"  # ((n.double).double) == 12
     )
     assert check_compile(src, st_top, 12)
+
+
+# --- Polymorphic types & Lean-style positional insertion ---------------------
+
+_LIST = "open List\n"
+
+
+def test_method_on_polymorphic_container_module_function():
+    """``xs.length`` on a ``List Int`` dispatches to the ``List`` module's
+    ``length`` (receiver is the only/first argument)."""
+    src = _LIST + ("def main (i:Int) : Int =\n  let xs : (List Int) = cons 1 (cons 2 (cons 3 nil)) in\n  xs.length;\n")
+    assert check_compile(src, st_top, 3)
+
+
+def test_receiver_inserted_at_matching_parameter_position():
+    """Lean-style positional insertion: ``xs.map f`` becomes ``List.map f xs``
+    even though ``List.map``'s list parameter is second. map [1,2,3] (+1) then
+    sum == 9."""
+    src = _LIST + (
+        "def inc (x:Int) : Int = x + 1;\n"
+        "def main (i:Int) : Int =\n"
+        "  let xs : (List Int) = cons 1 (cons 2 (cons 3 nil)) in\n"
+        "  (xs.map inc).sum;\n"
+    )
+    assert check_compile(src, st_top, 9)
+
+
+def test_polymorphic_method_chain_with_first_position_receiver():
+    """``xs.append ys`` is ``List.append xs ys`` (receiver first); chained with
+    ``.sum``. append [1,2] [3,4] then sum == 10."""
+    src = _LIST + (
+        "def main (i:Int) : Int =\n"
+        "  let xs : (List Int) = cons 1 (cons 2 nil) in\n"
+        "  let ys : (List Int) = cons 3 (cons 4 nil) in\n"
+        "  (xs.append ys).sum;\n"
+    )
+    assert check_compile(src, st_top, 10)
+
+
+def test_user_defined_polymorphic_dotted_method():
+    """A user ``def List.len`` with a polymorphic ``(List a)`` parameter resolves
+    and instantiates at ``List Int``."""
+    src = _LIST + (
+        "def List.len (l: (List a)) : Int = length l;\n"
+        "def main (i:Int) : Int =\n"
+        "  let xs : (List Int) = cons 1 (cons 2 (cons 3 nil)) in\n"
+        "  xs.len;\n"
+    )
+    assert check_compile(src, st_top, 3)
 
 
 def test_unknown_method_raises():


### PR DESCRIPTION
Implements [#27](https://github.com/alcides/aeon/issues/27): type-directed method-call syntax, matching **Lean's** dot notation.

```aeon
def Int.toString (n:Int) : String = native "str(n)";

1.toString              # → Int.toString 1            == "1"
(1.plus 2).toString     # chains
f 1.toString            # == f (1.toString)  (attached dot binds tighter than application)
xs.map inc              # → List.map inc xs  (receiver inserted at the matching parameter)
xs.length               # → List.length xs   (dispatches to the List module's `length`)
```

## Issue checklist
- [x] **Add MethodCall to the Sugar AST** — leaf `SMethodSelector(method)`; `receiver.method` parses to `SApplication(SMethodSelector(method), receiver)`, so every `SApplication`-recursing pass walks the receiver for free.
- [x] **Pre-annotate with types** — elaboration synthesizes the receiver's type and uses its base type-constructor name as the qualifier.
- [x] **Replace MethodCalls with Core syntax during elaboration** — the whole call spine is resolved to a plain application of the resolved method function with the receiver inserted.

## Lean-style precedence (whitespace-sensitive)
Like Lean, the dot is disambiguated by whitespace:
- An **attached** dot (`1.toString`, `(e).m`) is a method/projection and binds **tighter than application** — `f 1.toString` is `f (1.toString)`.
- A **spaced**/leading dot (`.mk`, `f .Ctor`) is an **anonymous constructor**.

A `MethodDotPostLex` retags an attached `DOT_ID` as the `%declare`d `METHOD_DOT`; the grammar binds `METHOD_DOT` tighter than application (including in argument position) while anonymous constructors keep `DOT_ID` — so the common `.mk .sc_blue 40` / `.node 1 .empty` anon-constructor applications are unaffected.

## Lean-style positional receiver insertion
The receiver is inserted at the **first explicit parameter whose type matches the receiver's type**, not blindly first: `xs.map f` becomes `List.map f xs` even though `List.map`'s list parameter is second. Elaboration resolves the entire `receiver.method a1..an` spine at once, so the normal case is a plain reordered application (no lambda); only a partial call omitting pre-receiver arguments eta-expands.

## Resolution
- **Dotted defs** `def Int.toString` are accepted, registered for qualified access, and resolve as methods.
- **Module functions** dispatch too: `resolve_method` also tries the `Type_method` binder convention, so `xs.length` / `xs.map f` reach the `List` module's members (issue #26 design: a type and its namespace share a name).
- **Variable receivers** `x.method` (one `QUALIFIED_ID` token) are recovered as method calls in desugar when the qualifier names no module/type.
- Unresolved calls raise `MethodResolutionError`. `FLOATLIT` keeps signed/exponent forms but no longer eats a trailing dot before an identifier.

## Polymorphic types — validated
- `xs.length` on `List Int` → 3
- `(xs.map inc).sum` → 9 (positional insertion at a polymorphic parameter)
- `(xs.append ys).sum` → 10
- user `def List.len (l: (List a))` instantiated at `List Int`

## Migration
`examples/99problems/p01,p02,p04,p05,p06,p08` migrated to method style — `def Array.last`, method-chain builders (`(((Array.new[Int]).append 1).append 2).append 3`), and module methods (`l.length`, `l.reversed`). Each produces output identical to before.

## Verification
- Full suite: **1388 passed, 9 skipped, 0 failed**
- `mypy` / `ruff` / pre-commit hooks pass
- `tests/method_call_test.py` (23 tests) and `examples/syntax/method_call.ae`

🤖 Generated with [Claude Code](https://claude.com/claude-code)