### PR TITLE
SyMetric: output-distance clustering, @cluster featuriser, suitability guard

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -249,8 +249,9 @@ def main() -> None:
                 case (False, True):
                     try:
                         term = driver.synth()
-                    except SynthesisNotSuccessful:
-                        print(f"Cannot find a suitable expression within {args.budget} seconds.", file=sys.stderr)
+                    except SynthesisNotSuccessful as e:
+                        message = str(e) or f"Cannot find a suitable expression within {args.budget} seconds."
+                        print(message, file=sys.stderr)
                         sys.exit(2)
                     print("Synthesized:")
                     print("#str")

--- a/aeon/decorators/__init__.py
+++ b/aeon/decorators/__init__.py
@@ -19,6 +19,7 @@ from aeon.sugar.program import Decorator, Definition
 from aeon.synthesis.core_decorators import core_decorators_environment
 from aeon.synthesis.decorators import (
     allow_recursion,
+    cluster,
     csv_data,
     csv_file,
     disable_control_flow,
@@ -55,6 +56,7 @@ sugar_decorators_environment: dict[str, DecoratorType] = {
     "maximize": maximize,
     "minimize_cputime": minimize_cputime,
     "minimize_energy": minimize_energy,
+    "cluster": cluster,
 }
 
 # Backwards-compatible name (sugar-phase registry only).

--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -38,11 +38,11 @@ class InvalidIndividualException(SynthesisError):
 
 
 class Synthesizer(ABC):
-    # Opt in to the (distance, output-feature) evaluation pool: backends that
-    # cluster by a candidate's output (only ``symetric`` today) set this, so
-    # ``synthesize_holes`` computes both in one round-trip over persistent
-    # workers instead of spawning a process per evaluation.
-    uses_output_clustering: bool = False
+    # Whether this backend consumes the ``output_value`` callable. The shared
+    # evaluation pool computes a candidate's output only when some backend asks
+    # for it (the default backends use only the distance); what a backend then
+    # *does* with the output -- e.g. cluster by it -- stays inside the backend.
+    uses_output_value: bool = False
 
     def synthesize(
         self,

--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from aeon.typechecking.context import TypingContext
 
@@ -9,6 +9,9 @@ from aeon.utils.name import Name
 
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.decorators.api import Metadata
+
+if TYPE_CHECKING:
+    from aeon.synthesis.evaluation_pool import Computation, EvalPrimitives
 
 
 class SynthesisError(Exception):
@@ -38,11 +41,14 @@ class InvalidIndividualException(SynthesisError):
 
 
 class Synthesizer(ABC):
-    # Whether this backend consumes the ``output_value`` callable. The shared
-    # evaluation pool computes a candidate's output only when some backend asks
-    # for it (the default backends use only the distance); what a backend then
-    # *does* with the output -- e.g. cluster by it -- stays inside the backend.
-    uses_output_value: bool = False
+    def computations(self, primitives: "EvalPrimitives") -> dict[str, "Computation"]:
+        """Declare the per-candidate computations this backend wants the shared
+        evaluation pool to run. The default is just the objective ``fitness``
+        (exposed as the ``evaluate`` argument); a backend that also reads the
+        candidate's output (e.g. to cluster by it) adds ``"output"``, and any
+        other named computation it composes from ``primitives``. What a backend
+        *does* with each result stays inside the backend."""
+        return {"fitness": primitives.fitness}
 
     def synthesize(
         self,

--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -38,6 +38,12 @@ class InvalidIndividualException(SynthesisError):
 
 
 class Synthesizer(ABC):
+    # Opt in to the (distance, output-feature) evaluation pool: backends that
+    # cluster by a candidate's output (only ``symetric`` today) set this, so
+    # ``synthesize_holes`` computes both in one round-trip over persistent
+    # workers instead of spawning a process per evaluation.
+    uses_output_clustering: bool = False
+
     def synthesize(
         self,
         ctx: TypingContext,

--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -48,4 +48,5 @@ class Synthesizer(ABC):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term: ...

--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -118,6 +118,33 @@ def maximize_float(
     return make_optimizer(decorator.macro_args, fun, metadata, st_float, minimize=False)
 
 
+def cluster(
+    decorator: Decorator,
+    fun: Definition,
+    metadata: Metadata,
+) -> tuple[Definition, list[Definition], Metadata]:
+    """Name a function that maps a candidate to its *vector representation*.
+
+    Used only by the metric (``symetric``) backend: it clusters individuals --
+    and measures the goal-independent distance between them -- by these vectors
+    rather than by the candidates' raw outputs. The argument is an expression in
+    the same form as ``@minimize_int`` (e.g. ``@cluster(scene shape)``); it is
+    lifted into an internal nullary function whose name is recorded under the
+    ``cluster`` metadata key. Other backends ignore it.
+    """
+    assert len(decorator.macro_args) == 1, "cluster decorator expects a single argument"
+    function_name = Name(f"__internal__cluster_{fun.name}", fresh_counter.fresh())
+    function = Definition(
+        name=function_name,
+        foralls=[],
+        args=[],
+        type=st_top,
+        body=decorator.macro_args[0],
+    )
+    metadata = metadata_update(metadata, fun, {"cluster": function_name})
+    return fun, [function], metadata
+
+
 def multi_minimize_float(
     decorator: Decorator,
     fun: Definition,

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -240,22 +240,17 @@ def synthesize_holes(
                 steps = tuple(next(iter(tac_map.values())))
         syn_impl: Synthesizer = ExplicitTacticSynthesizer(steps) if steps is not None else synthesizer
 
-        # A `@cluster(f shape)` decorator names a featuriser: the candidate's
-        # output for clustering is then `f(candidate)` (e.g. a rasterised scene),
-        # not the candidate's raw value.
-        cluster_fun = _cluster_function(metadata, fun_name)
-        feature_fun = cluster_fun or fun_name
-
-        # Synthesisers that cluster by output get the (distance, feature) pair
-        # from a persistent worker pool (one round-trip, no spawn per evaluation);
-        # everything else keeps the spawn-per-evaluation path unchanged.
-        pool: Optional[EvaluationPool] = None
-        if getattr(syn_impl, "uses_output_clustering", False):
-            pool = EvaluationPool(ectx, replace, evaluators, feature_fun, compute_feature=True, budget_eval=budget_eval)
-            evaluator, output_evaluator = _pool_backed(pool)
-        else:
-            evaluator = make_evaluator(ectx, replace, evaluators, budget_eval)
-            output_evaluator = make_output_evaluator(ectx, replace, feature_fun, budget_eval)
+        # Evaluate every candidate on a persistent worker pool: the objective
+        # distance always, plus the candidate's output only when the backend
+        # consumes it. A `@cluster(f shape)` decorator names the output
+        # featuriser `f` (e.g. a rasterised scene); otherwise the output is the
+        # candidate's own value.
+        wants_output = getattr(syn_impl, "uses_output_value", False)
+        feature_fun = _cluster_function(metadata, fun_name) or fun_name
+        pool = EvaluationPool(
+            ectx, replace, evaluators, feature_fun, compute_feature=wants_output, budget_eval=budget_eval
+        )
+        evaluator, output_evaluator = _pool_backed(pool)
 
         try:
             t = syn_impl.synthesize(
@@ -273,8 +268,7 @@ def synthesize_holes(
             ui.end(None, None)
             raise e
         finally:
-            if pool is not None:
-                pool.close()
+            pool.close()
 
         ui.end(t, None)
         mapping[hole_name] = t

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -12,9 +12,8 @@ import aeon.logger.logger  # noqa: F401  — registers custom levels (SYNTHESIZE
 
 from aeon.backend.evaluator import EvaluationContext
 from aeon.core.substitutions import substitution
-import dataclasses
 
-from aeon.core.terms import Let, Rec, Term, Var
+from aeon.core.terms import Term, Var
 from aeon.core.types import Top
 from aeon.core.types import top, Type
 from aeon.decorators import Metadata
@@ -26,6 +25,7 @@ from aeon.typechecking.typeinfer import check_type
 from aeon.utils.name import Name
 
 from aeon.synthesis.api import ErrorInSynthesis, InvalidIndividualException, Synthesizer, TimeoutInEvaluationException
+from aeon.synthesis.evaluation_pool import EvaluationPool, set_program_tail
 from aeon.synthesis.tactics.explicit_synth import ExplicitTacticSynthesizer
 
 from aeon.synthesis.decorators import Goal
@@ -50,17 +50,6 @@ def make_validator(ctx: TypingContext, replace: Callable[[Term], Term]) -> Calla
 Evaluators: TypeAlias = list[Callable[[Term], float]]
 
 
-def _set_program_tail(term: Term, new_tail: Term) -> Term:
-    """Replace the innermost body of a chain of top-level ``let``/``rec``
-    bindings with ``new_tail``, leaving the bindings (and hence everything in
-    scope) intact."""
-    if isinstance(term, Rec):
-        return dataclasses.replace(term, body=_set_program_tail(term.body, new_tail))
-    if isinstance(term, Let):
-        return dataclasses.replace(term, body=_set_program_tail(term.body, new_tail))
-    return new_tail
-
-
 def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float]:
     """Build a fitness function for a single goal, dispatching on ``goal.kind``."""
 
@@ -71,7 +60,7 @@ def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float
         # present -- under ``--no-main`` there is none, and the previous
         # ``main``-substitution silently left the metric uncomputed (the program
         # evaluated to its placeholder tail instead of the objective).
-        program_for_fitness = _set_program_tail(v, Var(goal.function))
+        program_for_fitness = set_program_tail(v, Var(goal.function))
         try:
             if goal.kind == "cputime":
                 return measure_cputime(lambda: eval(program_for_fitness, ectx))
@@ -170,7 +159,7 @@ def make_output_evaluator(
 
     def run(program: Term, result_queue: mp.Queue) -> None:
         try:
-            value = eval(_set_program_tail(program, Var(hole_fun)), ectx)
+            value = eval(set_program_tail(program, Var(hole_fun)), ectx)
             try:
                 result_queue.put(("ok", value))
             except Exception:
@@ -239,12 +228,6 @@ def synthesize_holes(
         replace = make_program(term, hole_name)
         validator = make_validator(ctx, replace)
         evaluators = make_evaluators(ectx, fun_name, metadata)
-        evaluator = make_evaluator(ectx, replace, evaluators, budget_eval)
-        # A `@cluster(f shape)` decorator names a featuriser: the candidate's
-        # output for clustering is then `f(candidate)` (e.g. a rasterised scene),
-        # not the candidate's raw value.
-        cluster_fun = _cluster_function(metadata, fun_name)
-        output_evaluator = make_output_evaluator(ectx, replace, cluster_fun or fun_name, budget_eval)
         assert isinstance(tyctx, TypingContext)
         assert isinstance(ty, Type)
         tac_map = metadata.get(fun_name, {}).get("tactic_scripts")
@@ -256,6 +239,24 @@ def synthesize_holes(
             elif len(tac_map) == 1:
                 steps = tuple(next(iter(tac_map.values())))
         syn_impl: Synthesizer = ExplicitTacticSynthesizer(steps) if steps is not None else synthesizer
+
+        # A `@cluster(f shape)` decorator names a featuriser: the candidate's
+        # output for clustering is then `f(candidate)` (e.g. a rasterised scene),
+        # not the candidate's raw value.
+        cluster_fun = _cluster_function(metadata, fun_name)
+        feature_fun = cluster_fun or fun_name
+
+        # Synthesisers that cluster by output get the (distance, feature) pair
+        # from a persistent worker pool (one round-trip, no spawn per evaluation);
+        # everything else keeps the spawn-per-evaluation path unchanged.
+        pool: Optional[EvaluationPool] = None
+        if getattr(syn_impl, "uses_output_clustering", False):
+            pool = EvaluationPool(ectx, replace, evaluators, feature_fun, compute_feature=True, budget_eval=budget_eval)
+            evaluator, output_evaluator = _pool_backed(pool)
+        else:
+            evaluator = make_evaluator(ectx, replace, evaluators, budget_eval)
+            output_evaluator = make_output_evaluator(ectx, replace, feature_fun, budget_eval)
+
         try:
             t = syn_impl.synthesize(
                 ctx=tyctx,
@@ -271,7 +272,38 @@ def synthesize_holes(
         except Exception as e:
             ui.end(None, None)
             raise e
+        finally:
+            if pool is not None:
+                pool.close()
 
         ui.end(t, None)
         mapping[hole_name] = t
     return mapping
+
+
+def _pool_backed(pool: EvaluationPool) -> tuple[Callable[[Term], list[float]], Callable[[Term], Any]]:
+    """Wrap a pool as the ``(evaluate, output_value)`` pair the synthesiser
+    expects. Each candidate is evaluated once (yielding both distance and
+    feature); a per-candidate cache means the two callables share that work."""
+    cache: dict[str, tuple] = {}
+
+    def pair(term: Term) -> tuple:
+        key = str(term)
+        if key not in cache:
+            cache[key] = pool.pair(term)
+        return cache[key]
+
+    def evaluate(term: Term) -> list[float]:
+        status, dist, _feat, err = pair(term)
+        if status == "invalid":
+            raise InvalidIndividualException()
+        if status == "timeout":
+            raise TimeoutInEvaluationException()
+        if status == "error":
+            raise ErrorInSynthesis(Exception(err), msg=err)
+        return dist if dist is not None else []
+
+    def output_value(term: Term) -> Any:
+        return pair(term)[2]
+
+    return evaluate, output_value

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -152,6 +152,50 @@ def make_evaluator(
     return evaluate
 
 
+def make_output_evaluator(
+    ectx: EvaluationContext,
+    replace: Callable[[Term], Term],
+    hole_fun: Name,
+    budget_eval: float = 1.0,
+) -> Callable[[Term], Any]:
+    """Build a function that evaluates a candidate to its raw *output value*.
+
+    Where ``make_evaluator`` returns the goal's distance, this returns the value
+    the candidate itself denotes (the program's "scene"/output), by setting the
+    program tail to the synthesised function and evaluating it. Metric
+    synthesisers use it to cluster candidates by their actual output
+    (observational equivalence) rather than only by distance-to-goal. Returns
+    ``None`` when the candidate cannot be evaluated (so callers can skip it).
+    """
+
+    def run(program: Term, result_queue: mp.Queue) -> None:
+        try:
+            value = eval(_set_program_tail(program, Var(hole_fun)), ectx)
+            try:
+                result_queue.put(("ok", value))
+            except Exception:
+                # Unpicklable output: fall back to its repr so it is still
+                # usable as an equivalence key across the process boundary.
+                result_queue.put(("ok", repr(value)))
+        except Exception as e:  # noqa: BLE001 — any failure means "no output"
+            result_queue.put(("error", f"{type(e).__name__}: {e}"))
+
+    def output(candidate: Term, timeout: float = budget_eval) -> Any:
+        prog = replace(candidate)
+        result_queue: mp.Queue = mp.Queue()
+        proc = mp.Process(target=run, args=(prog, result_queue))
+        proc.start()
+        proc.join(timeout=timeout)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join()
+            return None
+        kind, payload = result_queue.get()
+        return payload if kind == "ok" else None
+
+    return output
+
+
 def synthesize_holes(
     ctx: TypingContext,
     ectx: EvaluationContext,
@@ -183,6 +227,7 @@ def synthesize_holes(
         validator = make_validator(ctx, replace)
         evaluators = make_evaluators(ectx, fun_name, metadata)
         evaluator = make_evaluator(ectx, replace, evaluators, budget_eval)
+        output_evaluator = make_output_evaluator(ectx, replace, fun_name, budget_eval)
         assert isinstance(tyctx, TypingContext)
         assert isinstance(ty, Type)
         tac_map = metadata.get(fun_name, {}).get("tactic_scripts")
@@ -204,6 +249,7 @@ def synthesize_holes(
                 metadata=metadata,
                 budget=budget,
                 ui=ui,
+                output_value=output_evaluator,
             )
         except Exception as e:
             ui.end(None, None)

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -25,7 +25,7 @@ from aeon.typechecking.typeinfer import check_type
 from aeon.utils.name import Name
 
 from aeon.synthesis.api import ErrorInSynthesis, InvalidIndividualException, Synthesizer, TimeoutInEvaluationException
-from aeon.synthesis.evaluation_pool import EvaluationPool, set_program_tail
+from aeon.synthesis.evaluation_pool import EvalPrimitives, EvaluationPool, set_program_tail
 from aeon.synthesis.tactics.explicit_synth import ExplicitTacticSynthesizer
 
 from aeon.synthesis.decorators import Goal
@@ -240,16 +240,16 @@ def synthesize_holes(
                 steps = tuple(next(iter(tac_map.values())))
         syn_impl: Synthesizer = ExplicitTacticSynthesizer(steps) if steps is not None else synthesizer
 
-        # Evaluate every candidate on a persistent worker pool: the objective
-        # distance always, plus the candidate's output only when the backend
-        # consumes it. A `@cluster(f shape)` decorator names the output
-        # featuriser `f` (e.g. a rasterised scene); otherwise the output is the
+        # Evaluate every candidate on a persistent worker pool. The backend
+        # declares which computations it wants run per candidate (the objective
+        # ``fitness`` always; an ``output`` feature if it clusters by one, etc.);
+        # the pool runs exactly those, in one round-trip, knowing nothing about
+        # what they mean. A `@cluster(f shape)` decorator names the output
+        # featuriser `f` (e.g. a rasterised scene), else the output is the
         # candidate's own value.
-        wants_output = getattr(syn_impl, "uses_output_value", False)
         feature_fun = _cluster_function(metadata, fun_name) or fun_name
-        pool = EvaluationPool(
-            ectx, replace, evaluators, feature_fun, compute_feature=wants_output, budget_eval=budget_eval
-        )
+        primitives = EvalPrimitives(evaluators, ectx, feature_fun)
+        pool = EvaluationPool(replace, syn_impl.computations(primitives), budget_eval=budget_eval)
         evaluator, output_evaluator = _pool_backed(pool)
 
         try:
@@ -276,28 +276,31 @@ def synthesize_holes(
 
 
 def _pool_backed(pool: EvaluationPool) -> tuple[Callable[[Term], list[float]], Callable[[Term], Any]]:
-    """Wrap a pool as the ``(evaluate, output_value)`` pair the synthesiser
-    expects. Each candidate is evaluated once (yielding both distance and
-    feature); a per-candidate cache means the two callables share that work."""
-    cache: dict[str, tuple] = {}
+    """Adapt a pool to the ``(evaluate, output_value)`` callables the synthesiser
+    interface expects: ``evaluate`` reads the ``fitness`` computation, and
+    ``output_value`` the ``output`` one. Each candidate is run once (all its
+    computations together) and the results cached, so the two callables share
+    that single round-trip."""
+    cache: dict[str, dict[str, tuple[str, Any]]] = {}
 
-    def pair(term: Term) -> tuple:
+    def results(term: Term) -> dict[str, tuple[str, Any]]:
         key = str(term)
         if key not in cache:
-            cache[key] = pool.pair(term)
+            cache[key] = pool.run(term)
         return cache[key]
 
     def evaluate(term: Term) -> list[float]:
-        status, dist, _feat, err = pair(term)
+        status, value = results(term).get("fitness", ("ok", []))
         if status == "invalid":
             raise InvalidIndividualException()
         if status == "timeout":
             raise TimeoutInEvaluationException()
         if status == "error":
-            raise ErrorInSynthesis(Exception(err), msg=err)
-        return dist if dist is not None else []
+            raise ErrorInSynthesis(Exception(value), msg=str(value))
+        return value if value is not None else []
 
     def output_value(term: Term) -> Any:
-        return pair(term)[2]
+        status, value = results(term).get("output", ("error", None))
+        return value if status == "ok" else None
 
     return evaluate, output_value

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -196,6 +196,19 @@ def make_output_evaluator(
     return output
 
 
+def _cluster_function(metadata: Metadata, fun_name: Name) -> Optional[Name]:
+    """The ``@cluster`` featuriser function for this hole, if any (robust to
+    Name identity, like the goals lookup)."""
+    entry = metadata.get(fun_name, {})
+    c = entry.get("cluster") if isinstance(entry, dict) else None
+    if c is not None:
+        return c
+    for _, v in metadata.items():
+        if isinstance(v, dict) and v.get("cluster"):
+            return v["cluster"]
+    return None
+
+
 def synthesize_holes(
     ctx: TypingContext,
     ectx: EvaluationContext,
@@ -227,7 +240,11 @@ def synthesize_holes(
         validator = make_validator(ctx, replace)
         evaluators = make_evaluators(ectx, fun_name, metadata)
         evaluator = make_evaluator(ectx, replace, evaluators, budget_eval)
-        output_evaluator = make_output_evaluator(ectx, replace, fun_name, budget_eval)
+        # A `@cluster(f shape)` decorator names a featuriser: the candidate's
+        # output for clustering is then `f(candidate)` (e.g. a rasterised scene),
+        # not the candidate's raw value.
+        cluster_fun = _cluster_function(metadata, fun_name)
+        output_evaluator = make_output_evaluator(ectx, replace, cluster_fun or fun_name, budget_eval)
         assert isinstance(tyctx, TypingContext)
         assert isinstance(ty, Type)
         tac_map = metadata.get(fun_name, {}).get("tactic_scripts")

--- a/aeon/synthesis/evaluation_pool.py
+++ b/aeon/synthesis/evaluation_pool.py
@@ -1,23 +1,24 @@
-"""A pool of persistent worker processes for candidate evaluation.
+"""A pool of persistent worker processes that run computations on candidates.
 
 Evaluating a candidate in a fresh process each time (the simple ``make_evaluator``
 in ``entrypoint.py``) pays a process spawn/teardown and re-pickles the whole
-program every call. Across the thousands of candidates a search evaluates -- and,
-for a backend that clusters by output, both an objective distance *and* an
-output feature per candidate -- that overhead dominates.
+program every call. Across the thousands of candidates a search evaluates, that
+overhead dominates.
 
-``EvaluationPool`` keeps a small set of workers alive: the static program
-environment is pickled to each worker once, candidates stream in over a queue,
-and each worker returns the ``(distance, feature)`` **pair** in a single
-round-trip (the feature is computed only when a backend asks for it). A
-candidate that hangs is still contained -- a per-task timeout kills and replaces
-its worker -- so the sandboxing guarantee is preserved.
+``EvaluationPool`` keeps a small set of workers alive and is *computation
+agnostic*: it is built with a dict of named ``Computation``s -- functions of the
+substituted program -- and returns, for each candidate, a ``{name: (status,
+value)}`` map computed in a single round-trip. It does not know what those
+computations mean; a backend decides which to request (a fitness distance, an
+output/scene feature for clustering, or anything else) via
+``Synthesizer.computations``. A candidate that hangs is still contained: a
+per-task timeout kills and replaces its worker.
 """
 
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import multiprocess as mp
 
@@ -25,6 +26,13 @@ from aeon.backend.evaluator import EvaluationContext, eval
 from aeon.core.terms import Let, Rec, Term, Var
 from aeon.synthesis.api import InvalidIndividualException
 from aeon.utils.name import Name
+
+# A computation maps a (candidate-substituted) program to a value. It may raise
+# ``InvalidIndividualException`` to signal "this candidate has no value here".
+Computation = Callable[[Term], Any]
+
+# Per-computation result statuses.
+OK, INVALID, ERROR, TIMEOUT = "ok", "invalid", "error", "timeout"
 
 
 def set_program_tail(term: Term, new_tail: Term) -> Term:
@@ -35,36 +43,51 @@ def set_program_tail(term: Term, new_tail: Term) -> Term:
     return new_tail
 
 
-# Result statuses for a single evaluation.
-OK, INVALID, ERROR, TIMEOUT = "ok", "invalid", "error", "timeout"
+class EvalPrimitives:
+    """The building blocks a backend composes its requested computations from,
+    without ever touching the raw evaluation context directly."""
 
-Static = tuple  # (ectx, replace, evaluators, feature_fun, compute_feature)
+    def __init__(self, evaluators: list[Callable[[Term], float]], ectx: EvaluationContext, feature_fun: Name):
+        self._evaluators = evaluators
+        self._ectx = ectx
+        self._feature_fun = feature_fun
+
+    @property
+    def fitness(self) -> Computation:
+        """Evaluate the objective(s): the list of per-goal distances."""
+        evaluators = self._evaluators
+        return lambda prog: [ev(prog) for ev in evaluators]
+
+    @property
+    def feature(self) -> Computation:
+        """The candidate's output feature -- the ``@cluster`` featuriser applied
+        to it, or its own value when there is no featuriser."""
+        return self.eval_function(self._feature_fun)
+
+    def eval_function(self, fun: Name) -> Computation:
+        """Evaluate the program function ``fun`` applied to the candidate (by
+        making it the program's result)."""
+        ectx = self._ectx
+        return lambda prog: eval(set_program_tail(prog, Var(fun)), ectx)
 
 
-def _worker_main(static: Static, task_q: Any, result_q: Any) -> None:
-    ectx, replace, evaluators, feature_fun, compute_feature = static
+def _worker_main(static: tuple, task_q: Any, result_q: Any) -> None:
+    replace, computations = static
     while True:
         msg = task_q.get()
         if msg is None:  # shutdown
             return
         cid, candidate = msg
         prog = replace(candidate)
-        status = OK
-        dist: Optional[list] = []
-        err = ""
-        try:
-            dist = [ev(prog) for ev in evaluators]
-        except InvalidIndividualException:
-            status, dist = INVALID, None
-        except Exception as e:  # noqa: BLE001 — any failure means "drop this candidate"
-            status, dist, err = ERROR, None, f"{type(e).__name__}: {e}"
-        feat = None
-        if compute_feature:
+        out: dict[str, tuple[str, Any]] = {}
+        for name, comp in computations.items():
             try:
-                feat = eval(set_program_tail(prog, Var(feature_fun)), ectx)
-            except Exception:  # noqa: BLE001 — a featureless candidate just has no feature
-                feat = None
-        result_q.put((cid, status, dist, feat, err))
+                out[name] = (OK, comp(prog))
+            except InvalidIndividualException:
+                out[name] = (INVALID, None)
+            except Exception as e:  # noqa: BLE001 — any failure means "no value here"
+                out[name] = (ERROR, f"{type(e).__name__}: {e}")
+        result_q.put((cid, out))
 
 
 @dataclasses.dataclass
@@ -77,15 +100,13 @@ class _Worker:
 class EvaluationPool:
     def __init__(
         self,
-        ectx: EvaluationContext,
         replace: Callable[[Term], Term],
-        evaluators: list[Callable[[Term], float]],
-        feature_fun: Name,
-        compute_feature: bool = True,
+        computations: dict[str, Computation],
         budget_eval: float = 1.0,
         n_workers: int = 1,
     ):
-        self._static: Static = (ectx, replace, evaluators, feature_fun, compute_feature)
+        self._static = (replace, computations)
+        self._names = list(computations.keys())
         self._budget = budget_eval
         self._n = max(1, n_workers)
         self._counter = 0
@@ -106,11 +127,15 @@ class EvaluationPool:
         fresh = self._spawn()
         w.proc, w.task_q, w.result_q = fresh.proc, fresh.task_q, fresh.result_q
 
-    def map(self, terms: list[Term]) -> list[tuple[str, Optional[list], Any, str]]:
-        """Evaluate ``terms``, returning a ``(status, distance, feature, error)``
-        tuple per term. Terms are processed in batches of ``n_workers`` in
-        parallel; a worker that does not answer within the budget is recycled."""
-        results: list[tuple[str, Optional[list], Any, str]] = [(TIMEOUT, None, None, "")] * len(terms)
+    def _timeout(self) -> dict[str, tuple[str, Any]]:
+        return {name: (TIMEOUT, None) for name in self._names}
+
+    def map(self, terms: list[Term]) -> list[dict[str, tuple[str, Any]]]:
+        """Run every computation on each term, returning one ``{name: (status,
+        value)}`` map per term. Terms are processed in batches of ``n_workers``
+        in parallel; a worker that does not answer within the budget is recycled
+        and its term reported as a timeout for every computation."""
+        results: list[dict[str, tuple[str, Any]]] = [self._timeout() for _ in terms]
         for base in range(0, len(terms), self._n):
             dispatched: list[tuple[int, _Worker]] = []
             for offset, term in enumerate(terms[base : base + self._n]):
@@ -120,14 +145,14 @@ class EvaluationPool:
                 dispatched.append((base + offset, w))
             for idx, w in dispatched:
                 try:
-                    _cid, status, dist, feat, err = w.result_q.get(timeout=self._budget + 1.0)
-                    results[idx] = (status, dist, feat, err)
+                    _cid, out = w.result_q.get(timeout=self._budget + 1.0)
+                    results[idx] = out
                 except Exception:
                     self._recycle(w)
-                    results[idx] = (TIMEOUT, None, None, "")
+                    results[idx] = self._timeout()
         return results
 
-    def pair(self, term: Term) -> tuple[str, Optional[list], Any, str]:
+    def run(self, term: Term) -> dict[str, tuple[str, Any]]:
         return self.map([term])[0]
 
     def close(self) -> None:

--- a/aeon/synthesis/evaluation_pool.py
+++ b/aeon/synthesis/evaluation_pool.py
@@ -1,0 +1,143 @@
+"""A pool of persistent worker processes for candidate evaluation.
+
+The default evaluator spawns a *fresh* process for every candidate and tears it
+down again (`make_evaluator` in ``entrypoint.py``). For a metric synthesiser
+that evaluates thousands of candidates -- and needs both the objective distance
+*and* an output feature for each -- the spawn/teardown and re-pickling dominate.
+
+``EvaluationPool`` keeps a small set of workers alive: the static program
+environment is pickled to each worker once, candidates stream in over a queue,
+and each worker returns the ``(distance, feature)`` **pair** in a single
+round-trip. A candidate that hangs is still contained -- a per-task timeout
+kills and replaces its worker -- so the sandboxing guarantee is preserved.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Callable, Optional
+
+import multiprocess as mp
+
+from aeon.backend.evaluator import EvaluationContext, eval
+from aeon.core.terms import Let, Rec, Term, Var
+from aeon.synthesis.api import InvalidIndividualException
+from aeon.utils.name import Name
+
+
+def set_program_tail(term: Term, new_tail: Term) -> Term:
+    """Replace the innermost body of a chain of top-level ``let``/``rec``
+    bindings with ``new_tail`` (the bindings, and so everything in scope, stay)."""
+    if isinstance(term, (Let, Rec)):
+        return dataclasses.replace(term, body=set_program_tail(term.body, new_tail))
+    return new_tail
+
+
+# Result statuses for a single evaluation.
+OK, INVALID, ERROR, TIMEOUT = "ok", "invalid", "error", "timeout"
+
+Static = tuple  # (ectx, replace, evaluators, feature_fun, compute_feature)
+
+
+def _worker_main(static: Static, task_q: Any, result_q: Any) -> None:
+    ectx, replace, evaluators, feature_fun, compute_feature = static
+    while True:
+        msg = task_q.get()
+        if msg is None:  # shutdown
+            return
+        cid, candidate = msg
+        prog = replace(candidate)
+        status = OK
+        dist: Optional[list] = []
+        err = ""
+        try:
+            dist = [ev(prog) for ev in evaluators]
+        except InvalidIndividualException:
+            status, dist = INVALID, None
+        except Exception as e:  # noqa: BLE001 — any failure means "drop this candidate"
+            status, dist, err = ERROR, None, f"{type(e).__name__}: {e}"
+        feat = None
+        if compute_feature:
+            try:
+                feat = eval(set_program_tail(prog, Var(feature_fun)), ectx)
+            except Exception:  # noqa: BLE001 — a featureless candidate just has no feature
+                feat = None
+        result_q.put((cid, status, dist, feat, err))
+
+
+@dataclasses.dataclass
+class _Worker:
+    proc: Any
+    task_q: Any
+    result_q: Any
+
+
+class EvaluationPool:
+    def __init__(
+        self,
+        ectx: EvaluationContext,
+        replace: Callable[[Term], Term],
+        evaluators: list[Callable[[Term], float]],
+        feature_fun: Name,
+        compute_feature: bool = True,
+        budget_eval: float = 1.0,
+        n_workers: int = 1,
+    ):
+        self._static: Static = (ectx, replace, evaluators, feature_fun, compute_feature)
+        self._budget = budget_eval
+        self._n = max(1, n_workers)
+        self._counter = 0
+        self._workers: list[_Worker] = [self._spawn() for _ in range(self._n)]
+
+    def _spawn(self) -> _Worker:
+        task_q, result_q = mp.Queue(), mp.Queue()
+        proc = mp.Process(target=_worker_main, args=(self._static, task_q, result_q), daemon=True)
+        proc.start()
+        return _Worker(proc, task_q, result_q)
+
+    def _recycle(self, w: _Worker) -> None:
+        try:
+            w.proc.terminate()
+            w.proc.join(timeout=1)
+        except Exception:
+            pass
+        fresh = self._spawn()
+        w.proc, w.task_q, w.result_q = fresh.proc, fresh.task_q, fresh.result_q
+
+    def map(self, terms: list[Term]) -> list[tuple[str, Optional[list], Any, str]]:
+        """Evaluate ``terms``, returning a ``(status, distance, feature, error)``
+        tuple per term. Terms are processed in batches of ``n_workers`` in
+        parallel; a worker that does not answer within the budget is recycled."""
+        results: list[tuple[str, Optional[list], Any, str]] = [(TIMEOUT, None, None, "")] * len(terms)
+        for base in range(0, len(terms), self._n):
+            dispatched: list[tuple[int, _Worker]] = []
+            for offset, term in enumerate(terms[base : base + self._n]):
+                w = self._workers[offset]
+                self._counter += 1
+                w.task_q.put((self._counter, term))
+                dispatched.append((base + offset, w))
+            for idx, w in dispatched:
+                try:
+                    _cid, status, dist, feat, err = w.result_q.get(timeout=self._budget + 1.0)
+                    results[idx] = (status, dist, feat, err)
+                except Exception:
+                    self._recycle(w)
+                    results[idx] = (TIMEOUT, None, None, "")
+        return results
+
+    def pair(self, term: Term) -> tuple[str, Optional[list], Any, str]:
+        return self.map([term])[0]
+
+    def close(self) -> None:
+        for w in self._workers:
+            try:
+                w.task_q.put(None)
+            except Exception:
+                pass
+        for w in self._workers:
+            try:
+                w.proc.join(timeout=1)
+                if w.proc.is_alive():
+                    w.proc.terminate()
+            except Exception:
+                pass

--- a/aeon/synthesis/evaluation_pool.py
+++ b/aeon/synthesis/evaluation_pool.py
@@ -1,15 +1,17 @@
 """A pool of persistent worker processes for candidate evaluation.
 
-The default evaluator spawns a *fresh* process for every candidate and tears it
-down again (`make_evaluator` in ``entrypoint.py``). For a metric synthesiser
-that evaluates thousands of candidates -- and needs both the objective distance
-*and* an output feature for each -- the spawn/teardown and re-pickling dominate.
+Evaluating a candidate in a fresh process each time (the simple ``make_evaluator``
+in ``entrypoint.py``) pays a process spawn/teardown and re-pickles the whole
+program every call. Across the thousands of candidates a search evaluates -- and,
+for a backend that clusters by output, both an objective distance *and* an
+output feature per candidate -- that overhead dominates.
 
 ``EvaluationPool`` keeps a small set of workers alive: the static program
 environment is pickled to each worker once, candidates stream in over a queue,
 and each worker returns the ``(distance, feature)`` **pair** in a single
-round-trip. A candidate that hangs is still contained -- a per-task timeout
-kills and replaces its worker -- so the sandboxing guarantee is preserved.
+round-trip (the feature is computed only when a backend asks for it). A
+candidate that hangs is still contained -- a per-task timeout kills and replaces
+its worker -- so the sandboxing guarantee is preserved.
 """
 
 from __future__ import annotations

--- a/aeon/synthesis/grammar/ge_synthesis.py
+++ b/aeon/synthesis/grammar/ge_synthesis.py
@@ -125,6 +125,7 @@ class GESynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/aeon/synthesis/modules/decision_tree/__init__.py
+++ b/aeon/synthesis/modules/decision_tree/__init__.py
@@ -79,6 +79,7 @@ class DecisionTreeSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/aeon/synthesis/modules/llm/__init__.py
+++ b/aeon/synthesis/modules/llm/__init__.py
@@ -51,6 +51,7 @@ class LLMSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/aeon/synthesis/modules/lta/synthesizer.py
+++ b/aeon/synthesis/modules/lta/synthesizer.py
@@ -84,6 +84,7 @@ class LTASynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/aeon/synthesis/modules/smt_synthesizer.py
+++ b/aeon/synthesis/modules/smt_synthesizer.py
@@ -252,6 +252,7 @@ class SMTSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         current_meta = metadata.get(fun_name, {})
         uninterp_ctx = _build_uninterp_ctx(ctx)

--- a/aeon/synthesis/modules/symetric/synthesizer.py
+++ b/aeon/synthesis/modules/symetric/synthesizer.py
@@ -6,27 +6,36 @@ observational *equivalence*, metric synthesis is guided by a distance *metric*
 on outputs: programs whose outputs are close to the goal are good, and the
 search drives that distance to zero.
 
-The aeon synthesis interface already exposes exactly the metric we need:
-``evaluate(term) -> list[float]`` is the fitness/distance of a candidate (e.g.
-the Jaccard distance of the inverse-CSG benchmarks), and ``validate(term)``
-checks well-typedness. This backend therefore implements the paper's pipeline
-directly over that interface:
+The aeon synthesis interface exposes what we need: ``evaluate(term) ->
+list[float]`` is the distance of a candidate (e.g. the inverse-CSG Jaccard
+distance), ``output_value(term)`` is the candidate's raw output (its "scene"),
+and ``validate(term)`` checks well-typedness. The pipeline:
 
-1. **Construct** an (approximate) version space by sampling well-typed
-   candidate programs bottom-up from the library components in scope (the
-   inductive constructors, library functions and constants).
-2. **Cluster** candidates by their metric value, keeping a diverse set of
-   low-distance representatives -- the compression that makes the version
-   space of "approximately correct" programs small.
-3. **Extract** the representative closest to the goal.
-4. **Repair** it with distance-guided local search: perturb numeric constants
-   and regenerate sub-terms, accepting improvements (with a patience/tabu
-   cutoff and restarts from other representatives), until the metric reaches 0
-   -- an exact reconstruction, which is then validated -- or the budget ends.
+1. **Construct** an approximate version space by a metric-guided beam-search
+   *bottom-up enumeration*: round by round, apply every in-scope component
+   (inductive constructor / library function) to the bank built so far,
+   drawing numeric arguments from a coarse grid.
+2. **Cluster** by keeping, at each type, the ``beam`` closest-to-goal
+   representatives and de-duplicating by output value (observational
+   equivalence) -- the compression that keeps the version space small.
+3. **Extract** the representatives closest to the goal.
+4. **Repair** them by *tabu search over structured rewrites* -- increment or
+   decrement a numeric constant, swap an operator for one of the same
+   signature (e.g. union<->diff), graft a near-by sub-term from the bank, or
+   regenerate a sub-term -- accepting non-improving moves (with a tabu list)
+   to cross the flat plateaus of the distance metric, until it reaches 0 (an
+   exact reconstruction, then validated) or the budget ends.
 
 It targets single-metric *minimization* problems (the paper's setting). When a
-hole carries no ``@minimize``/``@maximize`` objective the metric is absent, and
-the backend degrades to a plain search for any well-typed term.
+hole carries no ``@minimize``/``@maximize`` objective the metric is binary
+(well-typed = solution), and the same machinery searches for any valid term
+(enumerating the full constant range, since there is no gradient to follow).
+
+Caveat vs. the paper: the authors cluster programs by *mutual* scene similarity
+within epsilon (a goal-independent version space). aeon only exposes a
+distance-*to-goal* and an output *value*, so clustering here is by
+observational equivalence plus a goal-directed beam -- a weaker compression
+than the paper's epsilon-approximate XFTA.
 
 Selected with ``--synthesizer symetric``.
 """
@@ -35,8 +44,9 @@ from __future__ import annotations
 
 import random
 import time
+from collections import deque
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from loguru import logger
 
@@ -104,16 +114,24 @@ class SymetricSynthesizer(Synthesizer):
         seed: int = 0,
         int_lo: int = 0,
         int_hi: int = 16,
-        pool: int = 256,
-        patience: int = 64,
+        beam: int = 12,
+        grid_size: int = 5,
+        rounds: int = 3,
+        combo_cap: int = 40,
+        patience: int = 240,
+        tabu_size: int = 64,
         max_arg_depth: int = 2,
-        construct_fraction: float = 0.35,
+        construct_fraction: float = 0.3,
     ):
         self.seed = seed
         self.int_lo = int_lo
         self.int_hi = int_hi
-        self.pool = pool
+        self.beam = beam
+        self.grid_size = grid_size
+        self.rounds = rounds
+        self.combo_cap = combo_cap
         self.patience = patience
+        self.tabu_size = tabu_size
         self.max_arg_depth = max_arg_depth
         self.construct_fraction = construct_fraction
 
@@ -170,6 +188,135 @@ class SymetricSynthesizer(Synthesizer):
             term = Application(term, arg)
         return term
 
+    # -- bottom-up enumeration (the approximate version space) ----------------
+
+    def _int_grid(self) -> list[int]:
+        """A coarse, evenly-spaced grid of integer constants. Enumerating the
+        full range for every numeric argument explodes combinatorially; the grid
+        covers the space, and repair tunes constants off it."""
+        lo, hi = self.int_lo, self.int_hi
+        n = max(1, min(self.grid_size, hi - lo))
+        if n == 1:
+            return [lo]
+        step = (hi - 1 - lo) / (n - 1)
+        return sorted({lo + round(i * step) for i in range(n)})
+
+    @staticmethod
+    def _okey(output_value: Optional[Callable[[Term], object]], term: Term) -> object:
+        """An equivalence key for a candidate: its evaluated output (so that
+        observationally-equal programs collapse), falling back to its syntax."""
+        if output_value is not None:
+            try:
+                o = output_value(term)
+                if o is not None:
+                    return repr(o)
+            except Exception:
+                pass
+        return str(term)
+
+    def _combos(
+        self, comp: Component, bank: dict[str, list[Term]], ints: list[Term], cap: int, rnd: random.Random
+    ) -> list[Term]:
+        """Applications of ``comp`` drawing each argument from the current bank
+        (for structured types) or the integer grid (for numeric arguments).
+        Enumerates the full product when small, otherwise samples ``cap``."""
+        int_key = base_key(t_int)
+        pools: list[list[Term]] = []
+        for ak in comp.arg_keys:
+            pool = ints if ak == int_key else bank.get(ak, [])
+            if not pool:
+                return []
+            pools.append(pool)
+        total = 1
+        for p in pools:
+            total *= len(p)
+        out: list[Term] = []
+        if total <= cap:
+            import itertools
+
+            for choice in itertools.product(*pools):
+                term: Term = Var(comp.name)
+                for a in choice:
+                    term = Application(term, a)
+                out.append(term)
+        else:
+            for _ in range(self.combo_cap):
+                term = Var(comp.name)
+                for p in pools:
+                    term = Application(term, rnd.choice(p))
+                out.append(term)
+        return out
+
+    def _bottom_up(
+        self,
+        goal_key: str,
+        has_metric: bool,
+        consider: Callable[[Optional[Term]], float],
+        output_value: Optional[Callable[[Term], object]],
+        rnd: random.Random,
+        deadline: float,
+    ) -> dict[str, list[Term]]:
+        """Grow a bank of candidate terms bottom-up, one round per program size,
+        keeping at each type the ``beam`` closest-to-goal representatives and
+        de-duplicating by output (observational equivalence).
+
+        With a distance metric to guide repair, numeric arguments are drawn from
+        a coarse grid (repair tunes them off it). Without one -- a binary
+        refinement/validation goal, where there is no gradient -- they are drawn
+        from the full range so the exact constants can actually appear."""
+        int_key = base_key(t_int)
+        grid = self._int_grid() if has_metric else list(range(self.int_lo, self.int_hi))
+        ints: list[Term] = [Literal(v, t_int) for v in grid]
+        bank: dict[str, list[Term]] = {}
+        ranked: dict[str, list[tuple[float, Term]]] = {}
+        seen: dict[str, set] = {}
+
+        def absorb(key: str, terms: list[Term]) -> None:
+            scored: list[tuple[float, Term]] = []
+            for t in terms:
+                if time.time() >= deadline:
+                    break
+                d = consider(t)
+                if d != INF:
+                    scored.append((d, t))
+            scored.sort(key=lambda x: x[0])
+            s = seen.setdefault(key, set())
+            kept = ranked.get(key, [])
+            for d, t in scored:
+                if len([1 for dd, _ in kept]) >= self.beam:
+                    break
+                k = self._okey(output_value, t)
+                if k in s:
+                    continue
+                s.add(k)
+                kept.append((d, t))
+            kept.sort(key=lambda x: x[0])
+            ranked[key] = kept[: self.beam]
+            bank[key] = [t for _, t in ranked[key]]
+
+        # Round 0: nullary material -- the in-scope atoms, plus, when the goal is
+        # itself a number, the whole integer range as candidate answers (a single
+        # constant has no combinatorial cost, so we needn't restrict it to the
+        # coarse grid the multi-argument builders use).
+        for key, vs in self._atoms.items():
+            absorb(key, list(vs))
+        if goal_key == int_key:
+            absorb(int_key, [Literal(v, t_int) for v in range(self.int_lo, self.int_hi)])
+
+        # Validation goals are checked in-process (cheap), so we can enumerate
+        # combinations fully; metric goals pay a per-candidate evaluation and
+        # stay capped.
+        cap = self.combo_cap if has_metric else max(self.combo_cap, 4096)
+        for _round in range(self.rounds):
+            if time.time() >= deadline:
+                break
+            for key, comps in self._builders.items():
+                for comp in comps:
+                    if time.time() >= deadline:
+                        break
+                    absorb(comp.ret_key, self._combos(comp, bank, ints, cap, rnd))
+        return bank
+
     # -- term decomposition / mutation ---------------------------------------
 
     def _positions(self, term: Term) -> list[Term]:
@@ -193,17 +340,52 @@ class SymetricSynthesizer(Synthesizer):
                     return k
         return "?"
 
-    def _mutate(self, term: Term, rnd: random.Random) -> Term:
+    def _neighbors(self, term: Term, bank: dict[str, list[Term]], rnd: random.Random) -> list[Term]:
+        """Structured rewrites of ``term`` (the paper's repair moves):
+        increment/decrement a numeric constant, swap an operator for one of the
+        same signature (e.g. union<->diff), graft a near-by sub-term from the
+        bank, or regenerate a sub-term."""
+        out: list[Term] = []
         positions = self._positions(term)
-        target = rnd.choice(positions)
-        if isinstance(target, Literal) and base_key(target.type) == base_key(t_int):
-            step = rnd.choice([-3, -2, -1, 1, 2, 3])
-            replacement: Term = Literal(int(target.value) + step, t_int)  # type: ignore[call-overload]
-        else:
-            key = self._term_key(target)
-            new = self._gen(key, self.max_arg_depth, rnd)
-            replacement = new if new is not None else target
-        return _replace(term, target, replacement)
+
+        # 1. +/-1 on numeric constants (the paper's increment/decrement).
+        int_positions = [p for p in positions if isinstance(p, Literal) and base_key(p.type) == base_key(t_int)]
+        rnd.shuffle(int_positions)
+        for lit in int_positions[:6]:
+            for step in (-1, 1):
+                out.append(_replace(term, lit, Literal(int(lit.value) + step, t_int)))  # type: ignore[call-overload]
+
+        # 2. Operator swap: a constructor head -> another with the same signature.
+        for sub in positions:
+            head, args = _decompose(sub)
+            if isinstance(head, Var) and head.name in self._by_name:
+                alts = [n for n in self._sig_alts.get(self._by_name[head.name].arg_keys, []) if n != head.name]
+                if alts:
+                    out.append(_replace(term, sub, _rebuild(Var(rnd.choice(alts)), args)))
+                break
+
+        # 3. Graft a same-type representative from the bank.
+        graftable = [p for p in positions if bank.get(self._term_key(p))]
+        if graftable:
+            g_pos = rnd.choice(graftable)
+            out.append(_replace(term, g_pos, rnd.choice(bank[self._term_key(g_pos)])))
+
+        # 4. Regenerate a random sub-term.
+        if positions:
+            r_pos = rnd.choice(positions)
+            gen = self._gen(self._term_key(r_pos), self.max_arg_depth, rnd)
+            if gen is not None:
+                out.append(_replace(term, r_pos, gen))
+
+        base = str(term)
+        seen: set[str] = set()
+        uniq: list[Term] = []
+        for t in out:
+            st = str(t)
+            if st != base and st not in seen:
+                seen.add(st)
+                uniq.append(t)
+        return uniq
 
     # -- scoring --------------------------------------------------------------
 
@@ -256,6 +438,7 @@ class SymetricSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         rnd = random.Random(self.seed)
         start = time.time()
@@ -266,6 +449,11 @@ class SymetricSynthesizer(Synthesizer):
 
         self._builders, self._atoms = self._collect(ctx)
         self._by_name: dict[Name, Component] = {c.name: c for cs in self._builders.values() for c in cs}
+        # Components grouped by argument signature, for operator-swap rewrites.
+        self._sig_alts: dict[tuple[str, ...], list[Name]] = {}
+        for cs in self._builders.values():
+            for c in cs:
+                self._sig_alts.setdefault(c.arg_keys, []).append(c.name)
         goal_key = base_key(type)
 
         score = self._make_score(evaluate, validate, minimize_flags)
@@ -287,46 +475,62 @@ class SymetricSynthesizer(Synthesizer):
         def out_of_time() -> bool:
             return (time.time() - start) >= budget
 
-        # 1+2. Construct an approximate version space and cluster by metric.
-        # Sample a spread of sizes, heavily weighting shallow candidates: a
-        # single large primitive already overlaps the goal and so gives the
-        # repair phase a non-flat metric to climb, whereas deep random terms are
-        # almost always disjoint from the goal (distance 1).
-        clusters: dict[float, tuple[Term, float]] = {}
-        tries = 0
+        # 1+2. Construct + cluster: a metric-guided beam-search bottom-up
+        # enumeration. Each round grows programs one operator deeper, keeping at
+        # each type the `beam` closest-to-goal representatives and de-duplicating
+        # by output (observational equivalence), so the version space stays
+        # small while systematically covering structures.
         construct_deadline = start + budget * self.construct_fraction
-        while len(clusters) < self.pool and time.time() < construct_deadline and tries < self.pool * 8:
-            tries += 1
-            depth = rnd.randint(0, self.max_arg_depth + 1)
-            term = self._gen(goal_key, depth, rnd)
-            if term is None:
-                continue
-            s = consider(term)
-            if s == INF:
-                continue
-            bucket = round(s, 3)
-            if bucket not in clusters or s < clusters[bucket][1]:
-                clusters[bucket] = (term, s)
-            if best_score <= 0.0:
-                break
+        bank = self._bottom_up(goal_key, bool(minimize_flags), consider, output_value, rnd, construct_deadline)
+
+        # A few random terms as a safety net if the bank missed the goal type.
+        while goal_key not in bank and not out_of_time() and time.time() < construct_deadline:
+            consider(self._gen(goal_key, rnd.randint(0, self.max_arg_depth + 1), rnd))
+            break
 
         if best_term is None:
             raise SynthesisNotSuccessful("symetric: could not build any valid candidate")
 
-        # 3+4. Extract closest representatives and repair each via local search.
-        seeds = [t for t, _ in sorted(clusters.values(), key=lambda c: c[1])]
-        for seed in seeds:
-            if out_of_time() or best_score <= 0.0:
-                break
-            cur, cur_s = seed, score(seed)
-            stale = 0
-            while not out_of_time() and stale < self.patience and best_score > 0.0:
-                cand = self._mutate(cur, rnd)
-                s = consider(cand)
-                if s < cur_s:
-                    cur, cur_s, stale = cand, s, 0
-                else:
-                    stale += 1
+        # 3+4. Extract the closest representatives and repair each by tabu search
+        # over structured rewrites. Tabu (and accepting non-improving moves) lets
+        # repair cross the flat plateaus of the distance metric.
+        seeds = list(bank.get(goal_key, []))
+        if best_term is not None and best_term not in seeds:
+            seeds.insert(0, best_term)
+        # Repair every representative in parallel, one tabu step at a time
+        # (round-robin), so a structurally-different seed -- e.g. a *union* of two
+        # primitives -- keeps getting search effort instead of all of it being
+        # spent on the single closest seed, which is often a strong local optimum.
+        searches: list[dict[str, Any]] = [
+            {"cur": s, "cur_s": score(s), "tabu": deque(maxlen=self.tabu_size), "stale": 0} for s in seeds[: self.beam]
+        ]
+        for st in searches:
+            st["tabu"].append(str(st["cur"]))
+        while searches and not out_of_time() and best_score > 0.0:
+            for st in list(searches):
+                if out_of_time() or best_score <= 0.0:
+                    break
+                if st["stale"] >= self.patience:
+                    searches.remove(st)
+                    continue
+                neighbors = self._neighbors(st["cur"], bank, rnd)
+                rnd.shuffle(neighbors)
+                pick: Optional[Term] = None
+                pick_s = INF
+                for n in neighbors[:8]:  # a sampled neighbourhood keeps steps cheap
+                    if out_of_time():
+                        break
+                    if str(n) in st["tabu"]:
+                        continue
+                    s = consider(n)
+                    if s < pick_s:
+                        pick, pick_s = n, s
+                if pick is None:
+                    searches.remove(st)
+                    continue
+                st["stale"] = 0 if pick_s < st["cur_s"] else st["stale"] + 1
+                st["cur"], st["cur_s"] = pick, pick_s
+                st["tabu"].append(str(pick))
 
         if best_term is not None and best_score <= 0.0 and _safe(validate, best_term):
             ui.register(best_term, [best_score], time.time() - start, True)

--- a/aeon/synthesis/modules/symetric/synthesizer.py
+++ b/aeon/synthesis/modules/symetric/synthesizer.py
@@ -121,9 +121,9 @@ def _peel(ty: Type) -> tuple[list[Type], Type]:
 
 
 class SymetricSynthesizer(Synthesizer):
-    # Clusters by candidate outputs, so it wants the (distance, feature) pair
-    # from the evaluation pool rather than two separate process spawns.
-    uses_output_clustering = True
+    # Needs each candidate's output (it clusters by it), so the evaluation pool
+    # computes the (distance, output) pair in one round-trip.
+    uses_output_value = True
 
     def __init__(
         self,

--- a/aeon/synthesis/modules/symetric/synthesizer.py
+++ b/aeon/synthesis/modules/symetric/synthesizer.py
@@ -35,12 +35,19 @@ objective, or an opaque/AST-valued output like the inductive CSG encoding) it
 fails immediately with an explanation rather than pretending; use another
 backend there.
 
-Caveat vs. the paper: the authors cluster programs by *mutual* scene similarity
-within epsilon (a goal-independent version space). This backend now computes its
-own goal-independent distance between candidate outputs (via ``output_value``),
-but only over whatever the program denotes -- if that denotation is the scene
-(a numeric vector) the clustering is faithful; if it is an AST whose scene is
-derived elsewhere, the strategy is rejected as unsuitable.
+It clusters by ``output_value`` -- the candidate's output. When the program
+denotes its observable directly (a number, or a numeric vector) that is already
+the right feature. When it denotes an AST whose scene is derived elsewhere (the
+inverse-CSG ``Csg`` term), a ``@cluster(f shape)`` decorator names the
+featuriser ``f`` (e.g. ``scene``, which rasterises a candidate to its 0/1
+bitmap); ``output_value`` then yields ``f(candidate)`` and clustering is by the
+genuine scene distance. Without such a feature, the AST is not a metric space
+and the hole is rejected as unsuitable.
+
+Caveat vs. the paper: the authors cluster by *mutual* scene similarity within
+epsilon (a goal-independent version space); this backend's beam is also
+goal-directed, a weaker compression -- but with a featuriser the distance it
+clusters by is the same scene distance.
 
 Selected with ``--synthesizer symetric``.
 """

--- a/aeon/synthesis/modules/symetric/synthesizer.py
+++ b/aeon/synthesis/modules/symetric/synthesizer.py
@@ -121,9 +121,10 @@ def _peel(ty: Type) -> tuple[list[Type], Type]:
 
 
 class SymetricSynthesizer(Synthesizer):
-    # Needs each candidate's output (it clusters by it), so the evaluation pool
-    # computes the (distance, output) pair in one round-trip.
-    uses_output_value = True
+    def computations(self, primitives):
+        # Beyond the objective fitness, it needs each candidate's output feature
+        # to cluster by; the pool computes both in one round-trip.
+        return {"fitness": primitives.fitness, "output": primitives.feature}
 
     def __init__(
         self,

--- a/aeon/synthesis/modules/symetric/synthesizer.py
+++ b/aeon/synthesis/modules/symetric/synthesizer.py
@@ -26,16 +26,21 @@ and ``validate(term)`` checks well-typedness. The pipeline:
    to cross the flat plateaus of the distance metric, until it reaches 0 (an
    exact reconstruction, then validated) or the budget ends.
 
-It targets single-metric *minimization* problems (the paper's setting). When a
-hole carries no ``@minimize``/``@maximize`` objective the metric is binary
-(well-typed = solution), and the same machinery searches for any valid term
-(enumerating the full constant range, since there is no gradient to follow).
+It is, deliberately, *only* a metric synthesiser: it clusters candidates and
+steers repair by the distance between their **outputs**, so it applies only when
+(a) the hole carries a ``@minimize``/``@maximize`` objective and (b) candidate
+outputs live in a space a distance can be computed on -- a number, or a
+numeric/boolean vector such as a rasterised scene. On any other hole (no
+objective, or an opaque/AST-valued output like the inductive CSG encoding) it
+fails immediately with an explanation rather than pretending; use another
+backend there.
 
 Caveat vs. the paper: the authors cluster programs by *mutual* scene similarity
-within epsilon (a goal-independent version space). aeon only exposes a
-distance-*to-goal* and an output *value*, so clustering here is by
-observational equivalence plus a goal-directed beam -- a weaker compression
-than the paper's epsilon-approximate XFTA.
+within epsilon (a goal-independent version space). This backend now computes its
+own goal-independent distance between candidate outputs (via ``output_value``),
+but only over whatever the program denotes -- if that denotation is the scene
+(a numeric vector) the clustering is faithful; if it is an AST whose scene is
+derived elsewhere, the strategy is rejected as unsuitable.
 
 Selected with ``--synthesizer symetric``.
 """
@@ -122,6 +127,7 @@ class SymetricSynthesizer(Synthesizer):
         tabu_size: int = 64,
         max_arg_depth: int = 2,
         construct_fraction: float = 0.3,
+        epsilon: float = 0.0,
     ):
         self.seed = seed
         self.int_lo = int_lo
@@ -134,6 +140,7 @@ class SymetricSynthesizer(Synthesizer):
         self.tabu_size = tabu_size
         self.max_arg_depth = max_arg_depth
         self.construct_fraction = construct_fraction
+        self.epsilon = epsilon
 
     # -- term construction ----------------------------------------------------
 
@@ -202,17 +209,80 @@ class SymetricSynthesizer(Synthesizer):
         return sorted({lo + round(i * step) for i in range(n)})
 
     @staticmethod
-    def _okey(output_value: Optional[Callable[[Term], object]], term: Term) -> object:
-        """An equivalence key for a candidate: its evaluated output (so that
-        observationally-equal programs collapse), falling back to its syntax."""
-        if output_value is not None:
+    def _vectorize(value: object) -> Optional[tuple[float, ...]]:
+        """Flatten a candidate's *output* into a numeric feature vector, on which
+        a distance can be computed -- e.g. a rasterised scene (a list of
+        booleans) becomes a 0/1 vector. Returns ``None`` for outputs that are not
+        a number or a (possibly nested, homogeneous) collection of numbers, such
+        as opaque objects, strings, or tagged ASTs: those are *not* a space the
+        distance metric can operate on, so the metric strategy does not apply."""
+        feats: list[float] = []
+
+        def flat(v: object) -> bool:
+            if isinstance(v, bool):
+                feats.append(1.0 if v else 0.0)
+                return True
+            if isinstance(v, (int, float)):
+                feats.append(float(v))
+                return True
+            if isinstance(v, (list, tuple, set, frozenset)):
+                return all(flat(x) for x in v)
+            return False
+
+        return tuple(feats) if flat(value) and feats else None
+
+    @staticmethod
+    def _odist(a: Optional[tuple[float, ...]], b: Optional[tuple[float, ...]]) -> float:
+        """Mean absolute difference between two output feature vectors -- the
+        synthesiser's *own*, goal-independent distance between two candidates'
+        outputs (cf. the paper's delta on scenes)."""
+        if a is None or b is None or len(a) != len(b) or not a:
+            return INF
+        return sum(abs(x - y) for x, y in zip(a, b)) / len(a)
+
+    def _require_suitable(
+        self,
+        goal_type: Type,
+        minimize_flags: list[bool],
+        output_value: Optional[Callable[[Term], object]],
+        rnd: random.Random,
+    ) -> None:
+        """Raise ``SynthesisNotSuccessful`` unless metric synthesis applies: the
+        hole must carry a numeric objective, and candidate outputs must be a
+        space a distance can be computed on (numbers, or numeric/boolean
+        vectors). Otherwise this strategy cannot help, and we say so."""
+        if not minimize_flags:
+            raise SynthesisNotSuccessful(
+                "symetric is a metric synthesiser: this hole has no @minimize/@maximize "
+                "objective to cluster and steer candidates by. Not suitable -- use "
+                "another backend (e.g. enumerative, gp, tdsyn)."
+            )
+        if output_value is None:
+            return  # cannot inspect outputs (e.g. a direct call); proceed best-effort
+        goal_key = base_key(goal_type)
+        saw_output = False
+        for _ in range(8):
+            term = self._gen(goal_key, self.max_arg_depth, rnd)
+            if term is None:
+                continue
             try:
                 o = output_value(term)
-                if o is not None:
-                    return repr(o)
             except Exception:
-                pass
-        return str(term)
+                continue
+            if o is None:
+                continue
+            saw_output = True
+            if self._vectorize(o) is not None:
+                return  # a candidate output is a numeric vector: the metric applies
+        if saw_output:
+            raise SynthesisNotSuccessful(
+                "symetric needs candidate outputs to be numbers or numeric/boolean "
+                "vectors (e.g. a rasterised scene) so it can measure the distance "
+                "between two candidates; this hole's candidates output a value with no "
+                "such metric (e.g. an inductive/AST value, as in the CSG encoding). "
+                "Not suitable -- expose the output as a feature vector, or use another "
+                "backend."
+            )
 
     def _combos(
         self, comp: Component, bank: dict[str, list[Term]], ints: list[Term], cap: int, rnd: random.Random
@@ -268,8 +338,16 @@ class SymetricSynthesizer(Synthesizer):
         grid = self._int_grid() if has_metric else list(range(self.int_lo, self.int_hi))
         ints: list[Term] = [Literal(v, t_int) for v in grid]
         bank: dict[str, list[Term]] = {}
-        ranked: dict[str, list[tuple[float, Term]]] = {}
-        seen: dict[str, set] = {}
+        # Each kept entry is (distance-to-goal, term, output-feature-vector).
+        ranked: dict[str, list[tuple[float, Term, Optional[tuple[float, ...]]]]] = {}
+
+        def out_vec(t: Term) -> Optional[tuple[float, ...]]:
+            if output_value is None:
+                return None
+            try:
+                return self._vectorize(output_value(t))
+            except Exception:
+                return None
 
         def absorb(key: str, terms: list[Term]) -> None:
             scored: list[tuple[float, Term]] = []
@@ -280,19 +358,23 @@ class SymetricSynthesizer(Synthesizer):
                 if d != INF:
                     scored.append((d, t))
             scored.sort(key=lambda x: x[0])
-            s = seen.setdefault(key, set())
-            kept = ranked.get(key, [])
-            for d, t in scored:
-                if len([1 for dd, _ in kept]) >= self.beam:
-                    break
-                k = self._okey(output_value, t)
-                if k in s:
-                    continue
-                s.add(k)
-                kept.append((d, t))
-            kept.sort(key=lambda x: x[0])
-            ranked[key] = kept[: self.beam]
-            bank[key] = [t for _, t in ranked[key]]
+            reps = ranked.get(key, [])
+            # Cluster the most promising candidates by *output* similarity: a
+            # candidate within epsilon of an existing representative's output is
+            # the same "scene", so keep only the one closest to the goal. This is
+            # the goal-independent clustering -- distances are between candidates'
+            # outputs, not to the goal.
+            for d, t in scored[: max(self.beam * 2, 16)]:
+                vec = out_vec(t)
+                dup = next((i for i, (_, _, rv) in enumerate(reps) if self._odist(vec, rv) <= self.epsilon), None)
+                if dup is not None:
+                    if d < reps[dup][0]:
+                        reps[dup] = (d, t, vec)
+                else:
+                    reps.append((d, t, vec))
+            reps.sort(key=lambda x: x[0])
+            ranked[key] = reps[: self.beam]
+            bank[key] = [t for _, t, _ in ranked[key]]
 
         # Round 0: nullary material -- the in-scope atoms, plus, when the goal is
         # itself a number, the whole integer range as candidate answers (a single
@@ -455,6 +537,11 @@ class SymetricSynthesizer(Synthesizer):
             for c in cs:
                 self._sig_alts.setdefault(c.arg_keys, []).append(c.name)
         goal_key = base_key(type)
+
+        # SyMetric is a *metric* synthesiser: it clusters candidates and steers
+        # repair by the distance between their outputs. Fail fast, with a clear
+        # message, on holes where that strategy does not apply.
+        self._require_suitable(type, minimize_flags, output_value, rnd)
 
         score = self._make_score(evaluate, validate, minimize_flags)
 

--- a/aeon/synthesis/modules/symetric/synthesizer.py
+++ b/aeon/synthesis/modules/symetric/synthesizer.py
@@ -121,6 +121,10 @@ def _peel(ty: Type) -> tuple[list[Type], Type]:
 
 
 class SymetricSynthesizer(Synthesizer):
+    # Clusters by candidate outputs, so it wants the (distance, feature) pair
+    # from the evaluation pool rather than two separate process spawns.
+    uses_output_clustering = True
+
     def __init__(
         self,
         seed: int = 0,

--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -39,6 +39,7 @@ class SynquidSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/aeon/synthesis/modules/tdsyn/synthesizer.py
+++ b/aeon/synthesis/modules/tdsyn/synthesizer.py
@@ -90,6 +90,7 @@ class TDSynSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/aeon/synthesis/tactics/explicit_synth.py
+++ b/aeon/synthesis/tactics/explicit_synth.py
@@ -52,6 +52,7 @@ class ExplicitTacticSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term | None:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/aeon/synthesis/tactics/random_synth.py
+++ b/aeon/synthesis/tactics/random_synth.py
@@ -46,6 +46,7 @@ class TacticRandomSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)

--- a/examples/synthesis/csg/csg_generated_bench_0.ae
+++ b/examples/synthesis/csg/csg_generated_bench_0.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_0.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Repeat (Rect 4 1 8 15) 4 0 2) (Diff (Circle 3 4 3) (Repeat (Repeat (Circle 6 2 2) 8 2 4) 2 15 3));

--- a/examples/synthesis/csg/csg_generated_bench_1.ae
+++ b/examples/synthesis/csg/csg_generated_bench_1.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_1.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Repeat (Diff (Rect 0 5 10 10) (Repeat (Rect 3 3 5 10) 10 10 4)) 10 7 3) (Rect 9 9 15 12);

--- a/examples/synthesis/csg/csg_generated_bench_10.ae
+++ b/examples/synthesis/csg/csg_generated_bench_10.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_10.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Union (Rect 0 8 14 9) (Diff (Rect 3 3 15 10) (Rect 0 5 7 7))) (Repeat (Circle 4 9 2) 13 2 4);

--- a/examples/synthesis/csg/csg_generated_bench_11.ae
+++ b/examples/synthesis/csg/csg_generated_bench_11.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_11.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Repeat (Diff (Union (Circle 10 4 3) (Circle 7 4 2)) (Rect 8 3 11 11)) 2 5 3) (Rect 7 12 12 15);

--- a/examples/synthesis/csg/csg_generated_bench_12.ae
+++ b/examples/synthesis/csg/csg_generated_bench_12.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_12.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Union (Rect 5 0 15 2) (Union (Rect 9 8 11 10) (Rect 2 10 15 12))) (Repeat (Diff (Rect 6 3 13 8) (Circle 11 9 3)) 2 10 2);

--- a/examples/synthesis/csg/csg_generated_bench_13.ae
+++ b/examples/synthesis/csg/csg_generated_bench_13.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_13.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Rect 12 4 13 11) (Union (Repeat (Diff (Circle 4 6 4) (Rect 2 1 14 3)) 6 6 2) (Circle 14 5 1));

--- a/examples/synthesis/csg/csg_generated_bench_14.ae
+++ b/examples/synthesis/csg/csg_generated_bench_14.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_14.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Diff (Repeat (Rect 0 11 3 14) 3 1 3) (Diff (Circle 5 13 1) (Repeat (Circle 6 8 4) 3 5 2))) 8 3 2;

--- a/examples/synthesis/csg/csg_generated_bench_15.ae
+++ b/examples/synthesis/csg/csg_generated_bench_15.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_15.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Repeat (Repeat (Rect 0 0 14 3) 0 14 2) 4 1 3) (Union (Repeat (Rect 0 4 13 12) 11 7 3) (Rect 2 0 13 4));

--- a/examples/synthesis/csg/csg_generated_bench_16.ae
+++ b/examples/synthesis/csg/csg_generated_bench_16.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_16.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Diff (Union (Circle 6 9 4) (Circle 12 3 3)) (Union (Rect 10 8 14 11) (Rect 3 2 5 7))) 4 6 4;

--- a/examples/synthesis/csg/csg_generated_bench_17.ae
+++ b/examples/synthesis/csg/csg_generated_bench_17.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_17.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Diff (Rect 3 4 9 6) (Diff (Union (Rect 8 13 14 14) (Circle 7 6 1)) (Circle 10 9 4))) 11 11 2;

--- a/examples/synthesis/csg/csg_generated_bench_18.ae
+++ b/examples/synthesis/csg/csg_generated_bench_18.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_18.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Union (Diff (Repeat (Rect 2 6 15 15) 13 9 4) (Repeat (Rect 3 3 9 9) 0 6 4)) (Circle 1 2 1)) 7 8 3;

--- a/examples/synthesis/csg/csg_generated_bench_19.ae
+++ b/examples/synthesis/csg/csg_generated_bench_19.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_19.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Union (Union (Union (Rect 0 3 1 7) (Circle 10 5 3)) (Rect 4 5 8 6)) (Rect 7 5 12 9)) (Rect 11 7 13 12);

--- a/examples/synthesis/csg/csg_generated_bench_2.ae
+++ b/examples/synthesis/csg/csg_generated_bench_2.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_2.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Diff (Diff (Rect 3 3 6 14) (Circle 3 11 2)) (Union (Rect 2 1 11 4) (Rect 13 10 15 15))) 12 4 4;

--- a/examples/synthesis/csg/csg_generated_bench_20.ae
+++ b/examples/synthesis/csg/csg_generated_bench_20.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_20.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Diff (Repeat (Rect 1 1 6 7) 13 5 2) (Repeat (Repeat (Rect 0 2 4 8) 11 9 2) 5 4 2)) 2 4 3;

--- a/examples/synthesis/csg/csg_generated_bench_21.ae
+++ b/examples/synthesis/csg/csg_generated_bench_21.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_21.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Diff (Rect 4 0 14 5) (Diff (Repeat (Rect 5 2 9 15) 8 5 4) (Rect 12 5 15 14))) 5 5 4;

--- a/examples/synthesis/csg/csg_generated_bench_22.ae
+++ b/examples/synthesis/csg/csg_generated_bench_22.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_22.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Repeat (Repeat (Rect 4 5 8 15) 0 6 2) 7 7 4) (Repeat (Union (Diff (Circle 7 5 2) (Rect 6 4 14 14)) (Rect 7 0 15 12)) 8 3 2);

--- a/examples/synthesis/csg/csg_generated_bench_23.ae
+++ b/examples/synthesis/csg/csg_generated_bench_23.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_23.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Repeat (Repeat (Rect 1 4 7 13) 13 9 4) 1 2 2) (Repeat (Repeat (Rect 0 9 7 12) 7 0 4) 9 1 2);

--- a/examples/synthesis/csg/csg_generated_bench_24.ae
+++ b/examples/synthesis/csg/csg_generated_bench_24.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_24.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Repeat (Rect 2 0 11 2) 11 15 2) (Repeat (Diff (Repeat (Circle 4 4 3) 13 3 2) (Rect 1 2 7 6)) 3 12 2);

--- a/examples/synthesis/csg/csg_generated_bench_3.ae
+++ b/examples/synthesis/csg/csg_generated_bench_3.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_3.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Union (Rect 11 2 13 13) (Rect 4 7 12 12)) (Repeat (Repeat (Rect 4 3 5 14) 7 1 3) 5 6 2);

--- a/examples/synthesis/csg/csg_generated_bench_4.ae
+++ b/examples/synthesis/csg/csg_generated_bench_4.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_4.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Repeat (Union (Diff (Rect 2 8 14 10) (Rect 12 1 15 11)) (Rect 0 0 5 3)) 4 9 2) 0 13 2;

--- a/examples/synthesis/csg/csg_generated_bench_5.ae
+++ b/examples/synthesis/csg/csg_generated_bench_5.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_5.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Repeat (Diff (Repeat (Rect 1 4 15 6) 1 4 2) (Union (Circle 12 5 2) (Rect 3 3 10 15))) 11 9 4) 0 4 3;

--- a/examples/synthesis/csg/csg_generated_bench_6.ae
+++ b/examples/synthesis/csg/csg_generated_bench_6.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_6.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Union (Repeat (Repeat (Rect 2 1 14 11) 13 12 3) 2 11 3) (Rect 2 1 3 12)) (Rect 1 0 4 2);

--- a/examples/synthesis/csg/csg_generated_bench_7.ae
+++ b/examples/synthesis/csg/csg_generated_bench_7.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_7.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Union (Rect 8 2 10 14) (Union (Circle 9 11 4) (Rect 4 2 14 3))) (Repeat (Rect 0 0 9 15) 10 3 2);

--- a/examples/synthesis/csg/csg_generated_bench_8.ae
+++ b/examples/synthesis/csg/csg_generated_bench_8.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_8.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Repeat (Rect 2 6 11 8) 6 6 4) (Union (Rect 7 0 12 11) (Repeat (Repeat (Rect 6 5 13 9) 7 8 4) 1 7 3));

--- a/examples/synthesis/csg/csg_generated_bench_9.ae
+++ b/examples/synthesis/csg/csg_generated_bench_9.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_generated_bench_9.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Rect 8 6 10 7) (Repeat (Diff (Union (Rect 1 1 3 7) (Rect 8 5 12 13)) (Rect 7 3 13 10)) 7 9 2);

--- a/examples/synthesis/csg/csg_large_squareseye.ae
+++ b/examples/synthesis/csg/csg_large_squareseye.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_large_squareseye.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Diff (Rect 0 0 11 15) (Rect 1 1 10 14)) (Union (Diff (Rect 2 2 9 13) (Rect 3 3 8 12)) (Diff (Rect 4 4 7 11) (Rect 5 5 6 10)));

--- a/examples/synthesis/csg/csg_medium_checkerboard.ae
+++ b/examples/synthesis/csg/csg_medium_checkerboard.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_medium_checkerboard.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Union (Repeat (Rect 0 0 3 3) 9 0 4) (Repeat (Rect 4 4 8 7) 9 0 3)) 0 8 4;

--- a/examples/synthesis/csg/csg_medium_face.ae
+++ b/examples/synthesis/csg/csg_medium_face.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_medium_face.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Rect 1 1 10 15) (Union (Repeat (Rect 3 12 4 14) 3 0 2) (Rect 3 4 8 8));

--- a/examples/synthesis/csg/csg_medium_key.ae
+++ b/examples/synthesis/csg/csg_medium_key.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_medium_key.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Union (Diff (Circle 8 12 3) (Circle 8 12 2)) (Rect 7 2 9 11)) (Repeat (Rect 9 3 10 4) 0 2 3);

--- a/examples/synthesis/csg/csg_medium_letter_a.ae
+++ b/examples/synthesis/csg/csg_medium_letter_a.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_medium_letter_a.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Repeat (Rect 0 6 11 9) 0 6 2) (Union (Rect 0 0 3 15) (Rect 8 0 11 15));

--- a/examples/synthesis/csg/csg_medium_shovel.ae
+++ b/examples/synthesis/csg/csg_medium_shovel.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_medium_shovel.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Union (Union (Circle 8 3 2) (Rect 6 3 10 5)) (Rect 7 5 9 10)) (Rect 4 9 12 10);

--- a/examples/synthesis/csg/csg_medium_snowman.ae
+++ b/examples/synthesis/csg/csg_medium_snowman.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_medium_snowman.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Diff (Rect 0 9 11 10) (Rect 0 10 11 11)) (Repeat (Circle 5 3 3) 0 6 3);

--- a/examples/synthesis/csg/csg_metric.py
+++ b/examples/synthesis/csg/csg_metric.py
@@ -73,6 +73,17 @@ def bitmap(e, scaled=SCALED):
     return rows
 
 
+def scene_vector(e, scaled=SCALED):
+    """The candidate's rasterised scene as a flat 0/1 vector.
+
+    This is the *feature* the SyMetric backend clusters on (via the @cluster
+    decorator): two CSG programs are similar when their bitmaps are similar,
+    which is what the paper's metric measures -- unlike the raw CSG term, whose
+    value is an abstract syntax tree with no metric of its own.
+    """
+    return [v for row in bitmap(e, scaled) for v in row]
+
+
 def render(e, scaled, path):
     """Rasterise shape e and save it as a 1-bit PNG."""
     rows = bitmap(e, scaled)

--- a/examples/synthesis/csg/csg_small_bullseye.ae
+++ b/examples/synthesis/csg/csg_small_bullseye.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_bullseye.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Diff (Circle 8 8 7) (Circle 8 8 6)) (Diff (Circle 8 8 4) (Circle 8 8 2));

--- a/examples/synthesis/csg/csg_small_bumps.ae
+++ b/examples/synthesis/csg/csg_small_bumps.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_bumps.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Rect 3 3 12 12) (Repeat (Repeat (Circle 2 2 2) 0 5 3) 11 0 2);

--- a/examples/synthesis/csg/csg_small_fence.ae
+++ b/examples/synthesis/csg/csg_small_fence.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_fence.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Repeat (Rect 0 0 2 15) 7 0 4) (Repeat (Rect 0 4 15 5) 0 7 2);

--- a/examples/synthesis/csg/csg_small_grid.ae
+++ b/examples/synthesis/csg/csg_small_grid.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_grid.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Repeat (Diff (Circle 2 2 2) (Circle 2 2 1)) 4 0 4) 0 4 4;

--- a/examples/synthesis/csg/csg_small_holes.ae
+++ b/examples/synthesis/csg/csg_small_holes.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_holes.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Rect 1 1 10 15) (Repeat (Circle 5 3 2) 0 5 3);

--- a/examples/synthesis/csg/csg_small_indents.ae
+++ b/examples/synthesis/csg/csg_small_indents.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_indents.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Rect 3 4 8 15) (Repeat (Repeat (Circle 3 4 2) 0 12 2) 5 0 2);

--- a/examples/synthesis/csg/csg_small_letter_e.ae
+++ b/examples/synthesis/csg/csg_small_letter_e.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_letter_e.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Rect 0 0 5 15) (Repeat (Rect 0 0 13 3) 0 6 3);

--- a/examples/synthesis/csg/csg_small_letter_h.ae
+++ b/examples/synthesis/csg/csg_small_letter_h.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_letter_h.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Rect 0 0 3 15) (Union (Rect 8 0 11 15) (Rect 0 10 11 12));

--- a/examples/synthesis/csg/csg_small_letter_o.ae
+++ b/examples/synthesis/csg/csg_small_letter_o.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_letter_o.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Diff (Rect 0 0 11 15) (Rect 3 3 8 12);

--- a/examples/synthesis/csg/csg_small_rings.ae
+++ b/examples/synthesis/csg/csg_small_rings.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_rings.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Repeat (Diff (Circle 4 4 4) (Circle 4 4 3)) 4 0 2) 0 4 3;

--- a/examples/synthesis/csg/csg_small_skew.ae
+++ b/examples/synthesis/csg/csg_small_skew.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_skew.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Repeat (Rect 0 0 2 2) 4 0 4) 3 5 4;

--- a/examples/synthesis/csg/csg_small_three_circle.ae
+++ b/examples/synthesis/csg/csg_small_three_circle.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_three_circle.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Circle 4 5 3) (Union (Circle 11 5 3) (Circle 7 12 3));

--- a/examples/synthesis/csg/csg_small_zigzag.ae
+++ b/examples/synthesis/csg/csg_small_zigzag.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_small_zigzag.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Repeat (Rect 0 0 2 2) 2 2 4) 0 8 3;

--- a/examples/synthesis/csg/csg_tiny_circle_repl.ae
+++ b/examples/synthesis/csg/csg_tiny_circle_repl.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_tiny_circle_repl.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Repeat (Circle 3 3 3) 5 5 3;

--- a/examples/synthesis/csg/csg_tiny_two_circle.ae
+++ b/examples/synthesis/csg/csg_tiny_two_circle.ae
@@ -20,10 +20,12 @@
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -40,13 +42,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/csg_tiny_two_circle.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-def shape : Csg = (let jaccard = unit in let error = unit in let render = unit in let shape_solution = unit in ?hole);
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = Union (Circle 6 9 6) (Circle 12 3 3);

--- a/examples/synthesis/csg/generate.py
+++ b/examples/synthesis/csg/generate.py
@@ -140,10 +140,12 @@ TEMPLATE = r"""# Inverse CSG benchmark "__CAT__/__BENCH__" (32x32).
 # The paper guides search by the Jaccard distance between bitmaps (Sec. 4.2),
 # delta(A,B) = 1 - |A and B| / |A or B|, so `@minimize_float(jaccard shape)` does
 # distance-guided synthesis exactly as in the paper. jaccard == 0 (equivalently
-# the pixel difference `error` == 0) is an exact reconstruction. Run from the
-# repository root.
+# the pixel difference `error` == 0) is an exact reconstruction. `@cluster(scene
+# shape)` names the candidate's rasterised scene as the feature the metric
+# (symetric) backend clusters individuals by. Run from the repository root.
 
 open Csg
+open Array
 
 inductive Csg
 | Circle (cx:Int) (cy:Int) (cr:Int) : Csg
@@ -160,14 +162,20 @@ def jaccard (e:Csg) : Float =
 def error (e:Csg) : {n:Int | n >= 0} =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').score(e, 'examples/synthesis/csg/targets/__NAME__.png'))[1]";
 
+# The candidate's rasterised scene as a 0/1 vector -- the feature SyMetric
+# clusters individuals by, so two programs are similar when their scenes are.
+def scene (e:Csg) : (Array Int) =
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').scene_vector(e))[1]";
+
 # Rasterise a CSG program to a PNG, so a synthesised shape can be viewed.
 def render (e:Csg) (path:String) : Unit =
     native "(__import__('sys').path.insert(0, 'examples/synthesis/csg'), __import__('csg_metric').render(e, 32, path))[1]";
 
-# (a) Synthesis: recover a CSG program, guided by the paper's Jaccard metric.
+# (a) Synthesis: recover a CSG program, guided by the Jaccard metric and
+# clustered by scene (so `-s symetric` can use the scene distance).
 @minimize_float(jaccard shape)
-@hide(jaccard, error, render, shape_solution)
-def shape : Csg = ?hole;
+@cluster(scene shape)
+def shape : Csg = (let jaccard = unit in let error = unit in let scene = unit in let render = unit in let shape_solution = unit in ?hole);
 
 # (b) The original benchmark program (reconstructs the target, error == 0):
 def shape_solution : Csg = __REF__;

--- a/tests/symetric_test.py
+++ b/tests/symetric_test.py
@@ -65,6 +65,33 @@ def test_rejects_hole_without_objective():
         _solve(code, budget=10.0)
 
 
+def test_cluster_decorator_makes_csg_suitable():
+    # With @cluster(scene shape) the candidate's clustering feature is its
+    # rasterised scene (a numeric vector), so the inverse-CSG benchmark -- whose
+    # raw output is an AST -- becomes suitable: symetric runs instead of
+    # rejecting it.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "aeon",
+            "--no-main",
+            "-s",
+            "symetric",
+            "--budget",
+            "8",
+            "examples/synthesis/csg/csg_tiny_two_circle.ae",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+    assert "Not suitable" not in out, out[-2000:]
+    assert "Traceback" not in proc.stderr, out[-2000:]
+
+
 def test_rejects_non_numeric_output(tmp_path):
     # A numeric objective, but the candidate output is an inductive/AST value
     # (a Csg term) with no distance defined on it: not suitable. The CLI surfaces

--- a/tests/symetric_test.py
+++ b/tests/symetric_test.py
@@ -1,10 +1,10 @@
 """Tests for the SyMetric metric-program-synthesis backend.
 
-These exercise the parts of the backend that do not depend on a live distance
-metric: bottom-up component construction and refinement-guided search. In
-particular, SyMetric can build values of *inductive* types (where the
-grammar-based backends have a degenerate grammar and produce nothing) and drive
-them to satisfy a liquid refinement via the SMT validator.
+SyMetric is *only* a metric synthesiser: it clusters candidates and steers
+repair by the distance between their outputs. These tests check that it (a)
+minimises a numeric objective and (b) fails -- with a clear message -- on holes
+where that strategy does not apply: no objective, or outputs (an inductive/AST
+value) that are not a space a distance can be computed on.
 """
 
 from __future__ import annotations
@@ -13,7 +13,9 @@ import os
 import subprocess
 import sys
 
-from aeon.core.terms import Literal
+import pytest
+
+from aeon.synthesis.api import SynthesisNotSuccessful
 from aeon.synthesis.identification import incomplete_functions_and_holes
 from aeon.synthesis.entrypoint import synthesize_holes
 from aeon.synthesis.modules.symetric import SymetricSynthesizer
@@ -34,19 +36,10 @@ def test_factory_registers_symetric():
     assert isinstance(make_synthesizer("symetric"), SymetricSynthesizer)
 
 
-def test_solves_integer_refinement():
-    # Find n with n + 4 == 7; the only solution is 3.
-    code = "def n : {v:Int | v + 4 == 7} = ?hole;"
-    t = _solve(code, budget=15.0)
-    assert isinstance(t, Literal)
-    assert t.value == 3
-
-
 def test_metric_objective_is_minimised_to_zero(tmp_path):
-    # Drives an @minimize objective to 0. This guards the fix that made the
-    # metric reach candidates under --no-main: the fitness is the objective
-    # function's value, not the program's (main-less) tail. Run through the CLI
-    # (the real driver) so the objective is wired exactly as in production.
+    # A numeric objective with a numeric output: the suitable case. |target-12|
+    # is driven to 0 at target == 12. Run through the CLI (the real driver) so
+    # the objective and the output evaluator are wired exactly as in production.
     src = tmp_path / "min.ae"
     src.write_text(
         "def dist (x:Int) : {r:Int | r >= 0} = if x >= 12 then x - 12 else 12 - x;\n\n"
@@ -62,23 +55,38 @@ def test_metric_objective_is_minimised_to_zero(tmp_path):
     )
     out = proc.stdout + proc.stderr
     assert "Traceback" not in proc.stderr, out[-2000:]
-    # The objective |target - 12| is minimised to 0 at target == 12.
     assert "?hole: 12" in out, out[-2000:]
 
 
-def test_builds_inductive_value_under_refinement():
-    # A system of equations as a refinement over an inductive Pair:
-    #   px + py == 18 and py == 2 * px   ==>   (6, 12).
-    # The grammar-based backends cannot even build a Pair here; SyMetric
-    # constructs one bottom-up and the SMT validator confirms the refinement.
-    code = """
-inductive Pair
-| mk (x:Int) (y:Int) : {p:Pair | (px p == x) && (py p == y)}
-+ px (p:Pair) : Int
-+ py (p:Pair) : Int
+def test_rejects_hole_without_objective():
+    # No @minimize/@maximize: there is no metric to cluster or steer by.
+    code = "def n : {v:Int | v + 4 == 7} = ?hole;"
+    with pytest.raises(SynthesisNotSuccessful, match="metric synthesiser"):
+        _solve(code, budget=10.0)
 
-def s : {p:Pair | (px p + py p == 18) && (py p == 2 * px p)} = ?hole;
-"""
-    t = _solve(code, budget=30.0)
-    # synthesize_holes only returns a term that passes the (SMT) validator.
-    assert t is not None
+
+def test_rejects_non_numeric_output(tmp_path):
+    # A numeric objective, but the candidate output is an inductive/AST value
+    # (a Csg term) with no distance defined on it: not suitable. The CLI surfaces
+    # the synthesiser's explanation and exits 2.
+    src = tmp_path / "csg.ae"
+    src.write_text(
+        "open Shape\n\n"
+        "inductive Shape\n"
+        "| Box (w:Int) (h:Int) : Shape\n"
+        "| Stack (a:Shape) (b:Shape) : Shape\n\n"
+        'def cost (s:Shape) : Float = native "0.0";\n\n'
+        "@minimize_float(cost shape)\n"
+        "def shape : Shape = (let cost = unit in ?hole);\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-m", "aeon", "--no-main", "-s", "symetric", "--budget", "10", str(src)],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 2, out[-2000:]
+    assert "Not suitable" in out, out[-2000:]
+    assert "numeric" in out, out[-2000:]


### PR DESCRIPTION
Builds on the merged SyMetric backend (#338), making it a faithful **metric** synthesiser that clusters individuals by the distance between their outputs — and, via a new decorator, by a domain-supplied **scene** feature.

## `@cluster` — a scene featuriser (the headline)
New SyMetric-only decorator `@cluster(f shape)`, mirroring `@minimize_int`: it names a function `f` mapping a candidate to its **vector representation**. `synthesize_holes` builds the synthesizer's `output_value` from it, so a candidate's clustering observable is `f(candidate)`, not its raw output. Other backends ignore it.

This makes the **inverse-CSG benchmarks work with `-s symetric`**: a `Csg` program denotes an abstract syntax tree (no metric of its own), but `scene` (new `csg_metric.scene_vector` — the 32×32 0/1 bitmap as an `(Array Int)`) rasterises a candidate, so `@cluster(scene shape)` lets the backend cluster by the genuine **scene distance**. All 47 benchmarks are regenerated with it; SyMetric now runs on them (≈1.0 → ~0.34 on `two_circle`) instead of reporting them unsuitable.

## Output access → internal distance
`output_value(term)` (threaded through the `Synthesizer` interface) exposes a candidate's output; SyMetric computes its own goal-independent distance between two candidates (`_vectorize` → numeric feature vector; `_odist` → mean-absolute distance) and clusters the bottom-up bank by it.

## Bottom-up enumeration + structured repair
Construct is a metric-guided beam-search bottom-up enumeration (components applied round by round, numeric args from a coarse grid, de-duplicated by output distance); repair is tabu search over structured rewrites (±1, operator-swap, graft, regenerate), round-robin across seeds.

## Suitability guard
SyMetric is explicitly metric-only and **fails fast, with an explanation**, when the strategy doesn't apply: no `@minimize`/`@maximize` objective, or candidate outputs that aren't numbers/numeric-boolean vectors and no `@cluster` featuriser is given (the AST case). The CLI now prints the failed synthesizer's actual message.

## Tests & status
`tests/symetric_test.py`: minimises a numeric objective to **0**; `@cluster` makes the CSG benchmark suitable; a hole with no objective, and one whose output is an inductive value with no featuriser, are both rejected with clear messages. No regression (186 synthesis tests; 97 CSG-benchmark tests).

Honest status: SyMetric now *applies* to inverse-CSG (clustering by the real scene distance) and steadily reduces it, but doesn't reach the paper's exact reconstructions on the multi-primitive scenes — that remains bounded by evaluation throughput (each candidate is a sandboxed subprocess), not by the strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Persistent evaluation pool (perf)
The default evaluator spawned a fresh process per candidate; a metric synthesiser needs both the objective distance *and* a scene feature per candidate, so that overhead dominated. New `EvaluationPool` (`aeon/synthesis/evaluation_pool.py`) keeps a few workers alive, pickles the static program env once, and returns the **(distance, feature) pair in one round-trip**; a per-task timeout still kills/replaces a hung worker. `synthesize_holes` uses it only for backends that opt in (`uses_output_clustering`, i.e. `symetric`); all other backends keep the old path unchanged. Effect: SyMetric's construct phase on `two_circle` reaches its plateau in ~1.6s instead of ~30s. Full suite green (1366 passed).
