### PR TITLE
fix(synthesis): don't crash grammar identification on hole-free library code

### DIFF
--- a/aeon/synthesis/identification.py
+++ b/aeon/synthesis/identification.py
@@ -50,6 +50,16 @@ def get_holes_info(
         refined_types (bool): Whether to use refined types.
     """
     # ty = ty if refined_types else refined_to_unrefined_type(ty)
+    # Hole identification only needs to descend into subterms that actually
+    # contain a hole. Skipping hole-free subterms avoids re-typing
+    # already-elaborated library code: a polymorphic definition such as
+    # ``List.map`` (whose body mentions ``cons``/``map`` carrying abstract
+    # refinements) produces term/type shapes the arms below do not model, and
+    # previously aborted the whole traversal with ``assert False``. Such
+    # subterms contribute no holes, so returning early is both correct and
+    # strictly faster.
+    if not get_holes(t):
+        return {}
     match t:
         case Annotation(expr=Hole(name=hname), type=hty):
             hty = hty if refined_types else refined_to_unrefined_type(hty)

--- a/tests/synthesis/list_grammar_test.py
+++ b/tests/synthesis/list_grammar_test.py
@@ -1,0 +1,27 @@
+"""Regression test: opening the polymorphic ``List`` library and leaving a hole
+must not crash synthesis hole-identification.
+
+``List.map`` (and friends) elaborate to terms that mention ``cons``/``map``
+carrying abstract refinements (``?rho_pred`` / ``?k``). ``get_holes_info`` used
+to walk *every* top-level definition — including these hole-free library
+bodies — and re-type each subterm, aborting with ``assert False`` on a shape it
+did not model. Hole identification only needs to descend into subterms that
+actually contain a hole, so hole-free library code is now skipped.
+"""
+
+from aeon.core.types import top
+from aeon.synthesis.identification import get_holes_info
+from tests.driver import check_and_return_core
+
+
+def test_open_list_hole_does_not_crash_grammar_identification():
+    code = """open List
+
+def reverse (xs: (List Int)) : {l:(List Int) | List.size l == List.size xs} = ?hole;
+"""
+    term, ctx, _ectx, _metadata = check_and_return_core(code)
+
+    # Previously raised AssertionError("Synthesis cannot infer the type ...").
+    holes = get_holes_info(ctx, term, top, [], refined_types=True)
+
+    assert any(name.name == "hole" for name in holes), holes


### PR DESCRIPTION
## Problem

Any program that `open`s the polymorphic `List` library (or another library with polymorphic-refinement functions) **and** contains a `?hole` crashed synthesis during grammar identification:

```
AssertionError: Synthesis cannot infer the type of
  (\hd -> (\tl -> (((List_cons[b])[?ρ_pred] (f hd)) (((List_map[a])[{self:b | ?k(self:b)}] f) tl))))
  with type List b
```

(This is the limitation noted in the Synquid-benchmark port, where every file had to declare its datatypes inline instead of using the stdlib `List`.)

## Root cause

`get_holes_info` (in `aeon/synthesis/identification.py`) walks the **entire** elaborated program — including hole-free library bodies like `List.map` — and re-types each subterm to build the synthesis grammar context. `List.map` elaborates to terms mentioning `cons`/`map` that carry **abstract refinements** (`?ρ_pred` / `?k`). The `Application` arm's arg-type fallback (`arg_ty = ty` when `synth` doesn't yield an `AbstractionType`) then hands an *abstraction* subterm the wrong expected type — the inductive `List b` instead of a function type — so the `Abstraction` arm falls through to `assert False` and aborts the whole synthesis.

The traversal of hole-free code is pointless: hole identification only needs the typing context along paths that actually reach a hole.

## Fix

Short-circuit hole-free subterms at the top of `get_holes_info`:

```python
if not get_holes(t):
    return {}
```

This is **semantically exact** (a subterm with no holes contributes no holes), removes the crash, and avoids needless—and fragile—re-typing of already-elaborated library code. `get_holes` already handles every relevant term shape, so it doesn't reintroduce the problem.

## Verification

- The original repro (`open List` + a refined hole) now builds the grammar and runs (exit 2) instead of crashing.
- New regression test `tests/synthesis/list_grammar_test.py` (asserts `get_holes_info` no longer raises on `open List` + a hole).
- **Full suite: 1366 passed, 9 skipped, 0 failures**; `tests/synthesis` 176 passed; existing hole examples (`int.ae`, `smt/coin_change.ae`) unaffected; ruff + format clean on the changed files.

One-line behavioural change plus a test; no public API change.

https://claude.ai/code/session_01HLPufK3ESWM9RwQ143WndW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLPufK3ESWM9RwQ143WndW)_