### PR TITLE
feat(refinements): generalise abstract refinements to n-ary relations

### DIFF
--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -236,6 +236,21 @@ def instantiate_refinement_in_type(
             assert False, f"Unknown type {t} ({type(t)})"
 
 
+def predicate_domains(sort: Type) -> list[Type]:
+    """Domain types of an abstract-refinement predicate sort ``d1 -> ... -> Bool``.
+
+    ``sort`` is the full (possibly n-ary) predicate type; this returns
+    ``[d1, ..., dn]`` (the ``Bool`` codomain is dropped). A bare domain type
+    (degenerate case) yields a singleton.
+    """
+    domains: list[Type] = []
+    cur = sort
+    while isinstance(cur, AbstractionType):
+        domains.append(cur.var_type)
+        cur = cur.type
+    return domains if domains else [sort]
+
+
 def instantiate_refinement_with_horn_in_liquid(
     t: LiquidTerm,
     pred_name: Name,
@@ -260,8 +275,15 @@ def instantiate_refinement_with_horn_in_liquid(
             return t
         case LiquidApp(aname, args, loc):
             if aname == pred_name:
-                assert isinstance(sort, TypeConstructor) or isinstance(sort, TypeVar)
-                return LiquidHornApplication(horn_name, [(a, sort) for a in args], loc=loc)
+                # ``sort`` is the predicate's full (n-ary) type; pair each
+                # argument with its corresponding domain type.
+                domains = predicate_domains(sort)
+                paired: list[tuple[LiquidTerm, TypeConstructor | TypeVar]] = []
+                for i, a in enumerate(args):
+                    d = domains[i] if i < len(domains) else domains[-1]
+                    assert isinstance(d, (TypeConstructor, TypeVar))
+                    paired.append((a, d))
+                return LiquidHornApplication(horn_name, paired, loc=loc)
             return LiquidApp(aname, [rec(a) for a in args], loc=loc)
         case LiquidHornApplication(aname, argtypes, loc):
             return LiquidHornApplication(

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -134,7 +134,7 @@ class RefinementPolymorphism(Type):
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __str__(self):
-        return f"forall <{self.name}:{self.sort} -> Bool>, {self.body}"
+        return f"forall <{self.name}:{self.sort}>, {self.body}"
 
     def __hash__(self) -> int:
         return hash(self.name) + hash(self.sort) + hash(self.body)

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -455,7 +455,9 @@ def elaborate_synth(ctx: ElaborationTypingContext, t: STerm) -> tuple[STerm, STy
             (inner, innert) = elaborate_synth(ctx, body)
             assert isinstance(innert, SRefinementPolymorphism)
 
-            ref_type = SAbstractionType(Name("_", fresh_counter.fresh()), innert.sort, st_bool)
+            # ``innert.sort`` is the full predicate type (``d1 -> ... -> Bool``,
+            # possibly n-ary), so the refinement is checked against it directly.
+            ref_type = innert.sort
             nrefinement = elaborate_check(ctx, refinement, ref_type)
 
             nty = substitution_sterm_in_stype(innert.body, nrefinement, innert.name)

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -37,7 +37,7 @@ type_def : "inductive" ID iargs inductive_rforalls constructors measures      ->
 iargs: (ID)*                                                -> list
 // Abstract refinements on the datatype (Liquid Haskell ``data T <p :: S -> Bool>``): zero or more ``forall <p : S -> Bool>`` binders shared by all constructors. Also accepted on opaque ``type`` declarations to mark a phantom refinement parameter on the type.
 inductive_rforalls: inductive_rforall*                     -> list
-inductive_rforall: "forall" "<" ID ":" type "->" "Bool" ">"   -> inductive_rforall_binding
+inductive_rforall: "forall" "<" ID ":" pred_sort ">"   -> inductive_rforall_binding
 constructors : cons_rule*                                  -> list
 cons_rule : _PIPE ID args ":" type                           -> def_ind_cons
 measures : measure_rule*                                  -> list
@@ -111,11 +111,19 @@ type : "{" ID ":" type _PIPE expression "}"                -> refined_t // TODO 
      | "(" ID ":" type _PIPE expression ")" "->" type      -> abstraction_refined_t
      | "(" MULT ID ":" type _PIPE expression ")" "->" type -> mult_abstraction_refined_t
      | "forall" ID ":" kind "," type                       -> polymorphism_t // TODO: desugar
-     | "forall" "<" ID ":" type "->" "Bool" ">" "," type   -> refinement_polymorphism_t
+     | "forall" "<" ID ":" pred_sort ">" "," type   -> refinement_polymorphism_t
      | ID "<" ID ">"                                       -> base_angle_refined_t
      | ID                                                  -> simple_t
      | "(" ID type+ ")"                                            -> constructor_t
      | "(" type ")"                                        -> same
+
+
+// The sort of an abstract refinement parameter: an n-ary predicate
+// ``d1 -> d2 -> ... -> Bool`` (unary ``d -> Bool``, binary ``d -> d -> Bool``,
+// ...). Parsed as a bare arrow chain (the trailing ``Bool`` is an ordinary
+// ``type``, avoiding a literal/identifier lexer clash) and folded by the parser
+// into the curried predicate type stored as the refinement's ``sort``.
+pred_sort : type ("->" type)+                              -> pred_sort
 
 
 expression : "-" expression_i                           -> minus
@@ -206,7 +214,7 @@ expression_fact : expression_b                           -> same
 
 expression_b : "\\" ID "->" expression                      -> abstraction_e
              | "\\" ID ":" type "->" expression             -> abstraction_et
-             | "Λ" "<" ID ":" type "->" "Bool" ">" "=>" expression -> rabstraction_e
+             | "Λ" "<" ID ":" pred_sort ">" "=>" expression -> rabstraction_e
              | "Λ" ID ":" kind "=>" expression              -> tabstraction_e
              | application                                  -> same
 

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -61,7 +61,7 @@ from aeon.sugar.stypes import (
 )
 from aeon.sugar.substitutions import substitute_svartype_in_stype, substitution_svartype_in_sterm
 from aeon.utils.name import Name, fresh_counter
-from aeon.sugar.ast_helpers import st_int, st_string, st_unit
+from aeon.sugar.ast_helpers import st_int, st_string, st_unit, st_bool
 from aeon.sugar.instance_registry import InstanceInfo, register_instance
 
 from aeon.facade.api import ImportError
@@ -831,16 +831,18 @@ def _collect_implicit_refinement_params_for_inductive(
             rec(base, bound_rho)
             match ref:
                 case SApplication(SVar(p), SVar(b)) if b == binder and p not in bound_rho:
+                    # The inferred sort is the full predicate type ``base -> Bool``.
+                    pred_ty = SAbstractionType(Name("_"), base, st_bool)
                     if not _eligible_refinement_base_for_inductive(ind, base):
                         pass
                     elif p in acc:
-                        if not type_equality(acc[p], base):
+                        if not type_equality(acc[p], pred_ty):
                             raise TypeError(
                                 f"Inconsistent sorts for inferred datatype refinement {p.name} "
-                                f"on {ind.name.name}: {acc[p]} vs {base}"
+                                f"on {ind.name.name}: {acc[p]} vs {pred_ty}"
                             )
                     else:
-                        acc[p] = base
+                        acc[p] = pred_ty
                 case _:
                     pass
         case STypeConstructor(_, ty_args):
@@ -1517,13 +1519,15 @@ def _collect_implicit_refinement_params(ty: SType, bound_rho: set[Name], acc: di
             rec(base, bound_rho)
             match ref:
                 case SApplication(SVar(p), SVar(b)) if b == binder and p not in bound_rho:
+                    # The inferred sort is the full predicate type ``base -> Bool``.
+                    pred_ty = SAbstractionType(Name("_"), base, st_bool)
                     if p in acc:
-                        if acc[p] != base:
+                        if acc[p] != pred_ty:
                             raise TypeError(
-                                f"Inconsistent sorts for implicit refinement parameter {p.name}: {acc[p]} vs {base}"
+                                f"Inconsistent sorts for implicit refinement parameter {p.name}: {acc[p]} vs {pred_ty}"
                             )
                     else:
-                        acc[p] = base
+                        acc[p] = pred_ty
                 case _:
                     pass
         case STypeConstructor(_, ty_args):

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -171,6 +171,18 @@ class TreeToSugar(Transformer):
     def polymorphism_t(self, args):
         return STypePolymorphism(Name(args[0]), args[1], args[2])
 
+    def pred_sort(self, args):
+        # The sort of an abstract-refinement parameter, parsed as a bare arrow
+        # chain ``d1 -> d2 -> ... -> Bool``. Fold it (right-associatively) into
+        # the curried predicate type, which is stored directly as the
+        # refinement's ``sort``. Unary ``d -> Bool`` yields ``SAbstractionType(d,
+        # Bool)``; binary ``d -> d -> Bool`` yields ``d -> (d -> Bool)``; etc.
+        domains = list(args[:-1])
+        sort: SType = args[-1]
+        for d in reversed(domains):
+            sort = SAbstractionType(Name("_"), d, sort)
+        return sort
+
     def refinement_polymorphism_t(self, args):
         return SRefinementPolymorphism(Name(args[0]), args[1], args[2])
 

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -360,7 +360,8 @@ class STypeAbstraction(STerm):
 
 @dataclass(frozen=True)
 class SRefinementAbstraction(STerm):
-    """Binds a refinement parameter ρ with sort (domain type) ρ : sort -> Bool."""
+    """Binds a refinement parameter ρ whose sort is the full (possibly n-ary)
+    predicate type ρ : d1 -> ... -> Bool."""
 
     name: Name
     sort: SType
@@ -368,7 +369,7 @@ class SRefinementAbstraction(STerm):
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __str__(self):
-        return f"Λ<{self.name}:{self.sort} -> Bool>=> ({self.body})"
+        return f"Λ<{self.name}:{self.sort}>=> ({self.body})"
 
 
 @dataclass()  # frozen=True

--- a/aeon/sugar/stypes.py
+++ b/aeon/sugar/stypes.py
@@ -80,7 +80,7 @@ class SRefinementPolymorphism(SType):
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __str__(self):
-        return f"∀<{self.name}:{self.sort} -> Bool>. {self.body}"
+        return f"∀<{self.name}:{self.sort}>. {self.body}"
 
 
 @dataclass

--- a/aeon/synthesis/modules/sygus/synthesizer.py
+++ b/aeon/synthesis/modules/sygus/synthesizer.py
@@ -42,6 +42,7 @@ class SygusSynthesizer(Synthesizer):
         metadata: Metadata,
         budget: float = 60,
         ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
     ) -> Term:
         start = time.time()
 

--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -263,7 +263,13 @@ def type_infer_liquid(
                                 )
                         else:
                             assert isinstance(resolved, (TypeConstructor, TypeVar))
-                            equalities[name] = resolved
+                            # Skip a self-referential binding ``a := a``: it is
+                            # vacuous and would make ``resolve_type`` loop. This
+                            # arises when a function reuses a type variable across
+                            # argument positions, e.g. an n-ary abstract-refinement
+                            # relation ``r : a -> a -> Bool``.
+                            if not (isinstance(resolved, TypeVar) and resolved.name == name):
+                                equalities[name] = resolved
                     case (TypeConstructor(t, a_args), TypeConstructor(e, e_args)) if t == e and len(a_args) == len(
                         e_args
                     ):

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -365,6 +365,19 @@ def renamed_refined_type(ty: RefinedType) -> RefinedType:
     return RefinedType(new_name, ty.type, refinement)
 
 
+def _as_predicate_type(sort: Type) -> AbstractionType:
+    """The full predicate type of an abstract-refinement sort.
+
+    Refinement sorts now carry the full (possibly n-ary) predicate type
+    ``d1 -> ... -> Bool``. Legacy callers (and a few unit tests that build core
+    nodes directly) may still pass a bare domain ``d``, which is wrapped as
+    ``d -> Bool`` so downstream code always sees an ``AbstractionType``.
+    """
+    if isinstance(sort, AbstractionType):
+        return sort
+    return AbstractionType(Name("_", fresh_counter.fresh()), sort, t_bool)
+
+
 # patterm matching term
 def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
     match t:
@@ -580,7 +593,8 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                 nty = instantiate_refinement_with_horn_in_type(rp.body, rp.name, rp.sort, horn_name)
                 return (c, nty)
             assert isinstance(refinement, Abstraction)
-            pred_type = AbstractionType(Name("_", fresh_counter.fresh()), rp.sort, t_bool)
+            # ``rp.sort`` is the full (possibly n-ary) predicate type.
+            pred_type = rp.sort
             c_ref = check(ctx, refinement, pred_type)
             nty = instantiate_refinement_in_type(rp.body, rp.name, refinement)
             return (Conjunction(c, c_ref), nty)
@@ -589,7 +603,8 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             # Synth-mode Λρ: mirror Chk-RAbs (lines 505-512) but without an expected type.
             # Introduce fκ : psort -> bool, synth the body, wrap the resulting type with
             # RefinementPolymorphism and gate the constraint behind the UF declaration.
-            fk_type = AbstractionType(Name("_", fresh_counter.fresh()), psort, t_bool)
+            # ``psort`` is the full (possibly n-ary) predicate type.
+            fk_type = _as_predicate_type(psort)
             ctx_ext = ctx.with_var(pname, fk_type)
             (c_body, body_ty) = synth(ctx_ext, inner)
             return (
@@ -791,7 +806,8 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
 
         case RefinementAbstraction(pname, psort, inner), RefinementPolymorphism(rname, rsort, rbody):
             c_sort = sub(ctx, psort, rsort, t.loc)
-            fk_type = AbstractionType(Name("_", fresh_counter.fresh()), rsort, t_bool)
+            # ``rsort`` is the full (possibly n-ary) predicate type.
+            fk_type = _as_predicate_type(rsort)
             ctx_ext = ctx.with_var(pname, fk_type)
             body_open = substitution_liquid_in_type(rbody, LiquidVar(pname), rname)
             inner_sub = substitution_liquid_in_term(inner, LiquidVar(pname), rname)
@@ -800,10 +816,11 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
 
         # per tutorial fig 8.4 Chk-RAbs
         case _, RefinementPolymorphism(name, sort, body):
-            # ρ = κ : sort → bool; φ = λx.fκ(x)
+            # ρ = κ : sort; φ = λx.fκ(x). ``sort`` is the full (possibly n-ary)
+            # predicate type ``d1 -> ... -> Bool``.
             fk_name = Name("_f" + name.name, fresh_counter.fresh())
-            fk_type = AbstractionType(Name("_", fresh_counter.fresh()), sort, t_bool)
-            # Γ' = Γ; fκ : sort → bool
+            fk_type = _as_predicate_type(sort)
+            # Γ' = Γ; fκ : sort
             ctx_ext = ctx.with_var(fk_name, fk_type)
             # s[ρ := fκ] — substitute κ → fk in the body type
             body_sub = substitution_liquid_in_type(body, LiquidVar(fk_name), name)

--- a/aeon/typechecking/well_formed.py
+++ b/aeon/typechecking/well_formed.py
@@ -11,7 +11,6 @@ from aeon.core.types import TypePolymorphism
 from aeon.core.types import TypeVar
 from aeon.typechecking.context import TypingContext
 from aeon.typechecking.liquid import typecheck_liquid
-from aeon.utils.name import Name
 
 
 def wf_inner(ctx: TypingContext, t: Type, k: Kind = Kind.STAR) -> bool:
@@ -36,8 +35,9 @@ def wf_inner(ctx: TypingContext, t: Type, k: Kind = Kind.STAR) -> bool:
         case TypePolymorphism(name, kind, body):
             return k == Kind.STAR and wellformed(ctx.with_typevar(name, kind), body)
         case RefinementPolymorphism(name, sort, body):
-            pred_type = AbstractionType(Name("_", 0), sort, t_bool)
-            return k == Kind.STAR and wellformed(ctx, sort) and wellformed(ctx.with_var(name, pred_type), body)
+            # ``sort`` is the full (possibly n-ary) predicate type
+            # ``d1 -> ... -> Bool``; bind the refinement parameter at it directly.
+            return k == Kind.STAR and wellformed(ctx, sort) and wellformed(ctx.with_var(name, sort), body)
         case TypeConstructor(name, args):
             if not args:
                 return ctx.get_type_constructor(name) is not None

--- a/tests/nary_refinements_test.py
+++ b/tests/nary_refinements_test.py
@@ -1,0 +1,50 @@
+"""N-ary abstract refinements: ``forall <r : a -> ... -> Bool>``.
+
+Abstract-refinement parameters generalise from unary predicates
+(``<p : a -> Bool>``) to n-ary relations (``<r : a -> a -> Bool>``, ...). The
+refinement's ``sort`` now stores the *full* predicate type (a curried
+``AbstractionType`` chain ending in ``Bool``); ``predicate_domains`` recovers
+the domain types, and the back end (liquefaction + Horn) already handles any
+arity.
+"""
+
+from __future__ import annotations
+
+from aeon.core.substitutions import predicate_domains
+from aeon.core.types import AbstractionType, TypeVar, t_bool, t_int
+from aeon.sugar.parser import parse_type
+from aeon.sugar.stypes import SAbstractionType, SRefinementPolymorphism
+from aeon.utils.name import Name
+
+
+def test_unary_refinement_sort_parses_as_predicate_type():
+    ty = parse_type("forall <p : a -> Bool>, (List a)")
+    assert isinstance(ty, SRefinementPolymorphism)
+    # ``a -> Bool`` — a single-arrow predicate type, not nested.
+    assert isinstance(ty.sort, SAbstractionType)
+    assert not isinstance(ty.sort.type, SAbstractionType)
+
+
+def test_binary_refinement_sort_parses_as_curried_predicate_type():
+    ty = parse_type("forall <r : a -> a -> Bool>, (List a)")
+    assert isinstance(ty, SRefinementPolymorphism)
+    # ``a -> (a -> Bool)`` — a two-arrow (binary-relation) predicate type.
+    assert isinstance(ty.sort, SAbstractionType)
+    assert isinstance(ty.sort.type, SAbstractionType)
+
+
+def test_ternary_refinement_sort_parses():
+    ty = parse_type("forall <r : a -> a -> a -> Bool>, (List a)")
+    assert isinstance(ty, SRefinementPolymorphism)
+    assert isinstance(ty.sort, SAbstractionType)
+    assert isinstance(ty.sort.type, SAbstractionType)
+    assert isinstance(ty.sort.type.type, SAbstractionType)
+
+
+def test_predicate_domains_recovers_arity():
+    a = TypeVar(Name("a"))
+    unary = AbstractionType(Name("_"), a, t_bool)
+    assert predicate_domains(unary) == [a]
+
+    binary = AbstractionType(Name("_"), t_int, AbstractionType(Name("_"), t_int, t_bool))
+    assert predicate_domains(binary) == [t_int, t_int]

--- a/tests/synth_gaps_test.py
+++ b/tests/synth_gaps_test.py
@@ -80,11 +80,13 @@ def test_synth_refinement_abstraction_wraps_with_polymorphism():
     we don't depend on the still-open `synth(Abstraction)` gap (#207)."""
     ctx = TypingContext()
     p = Name("p")
-    term = RefinementAbstraction(p, t_int, Literal(0, t_int))
+    # The sort is the full predicate type (Int -> Bool).
+    pred_sort = AbstractionType(Name("_"), t_int, t_bool)
+    term = RefinementAbstraction(p, pred_sort, Literal(0, t_int))
     (_, ty) = synth(ctx, term)
     assert isinstance(ty, RefinementPolymorphism)
     assert ty.name == p
-    assert ty.sort == t_int
+    assert ty.sort == pred_sort
     assert isinstance(ty.body, RefinedType)
     assert ty.body.type == t_int
 
@@ -94,9 +96,10 @@ def test_synth_refinement_abstraction_introduces_fresh_uf_in_context():
     the body. Synth-ing a body that references `p` must succeed."""
     ctx = TypingContext()
     p = Name("p")
-    # Λρ:Int. p   — Var(p) reads the UF symbol.
+    # Λρ:(Int -> Bool). p   — the sort is the full predicate type; Var(p) reads the UF symbol.
+    pred_sort = AbstractionType(Name("_"), t_int, t_bool)
     body = Var(p)
-    term = RefinementAbstraction(p, t_int, body)
+    term = RefinementAbstraction(p, pred_sort, body)
     (constraint, ty) = synth(ctx, term)
     assert isinstance(ty, RefinementPolymorphism)
     # Body type is the UF type `(_:Int) -> Bool`, lifted through Var-selfification.
@@ -113,7 +116,7 @@ def test_synth_refinement_abstraction_constraint_is_valid():
     introduced by the new arm)."""
     ctx = TypingContext()
     p = Name("p")
-    # Λρ:Int. 0  — body is a trivially well-typed literal.
-    term = RefinementAbstraction(p, t_int, Literal(0, t_int))
+    # Λρ:(Int -> Bool). 0  — body is a trivially well-typed literal.
+    term = RefinementAbstraction(p, AbstractionType(Name("_"), t_int, t_bool), Literal(0, t_int))
     (constraint, _) = synth(ctx, term)
     assert smt_valid(constraint)


### PR DESCRIPTION
## Summary

Generalises abstract-refinement parameters on inductive datatypes from **unary** predicates `<p> Bool>` to **n-ary** relations ` a -> ... -> Bool>` — the relational refinements Synquid/Liquid-Haskell use for sortedness and search-tree order. This is step **#1** of the Synquid-alignment plan (after #3, polymorphism).

> **Rebased on current `master`.** This branch also folds in a **one-line CI fix** (separate commit): the SyGuS backend (#347) and SyMetric's `output_value` parameter (#342) merged to master concurrently, leaving the SyGuS `synthesize` override incompatible with the new base-class signature — mypy fails on master HEAD. The override now accepts `output_value`. Until this PR merges, other open PRs (e.g. #343) inherit the master mypy breakage on their `pull_request` CI.

## Design

The refinement's `sort` now stores the **full predicate type** (a curried `AbstractionType` chain ending in `Bool`) instead of a single domain type. The grammar parses the arrow chain via a new `pred_sort` rule (`type ("->" type)+`, folded by the parser); `predicate_domains` recovers the domain list.

The **back end already supported n-ary** — liquefaction chains multi-arg applications (`LiquidApp(f, args+[arg])`) and Horn arity is generic (`len(ftype)-1`, `get_possible_args`). The work was in the front end, where arity 1 was baked in.

## Changes

- **Grammar/parser**: new `pred_sort`; the three `forall <… -> Bool>` rules now take `pred_sort`.
- **AST**: `sort` holds the full predicate type; `__str__` no longer hardcodes `-> Bool`.
- **Type system** (stop re-wrapping a domain into `-> Bool`, use the sort directly): `well_formed`, `typeinfer` (RApp/RAbs synth + check), `elaboration` (RApp), and `substitutions.instantiate_refinement_with_horn_in_liquid` (now pairs each argument with its own domain via `predicate_domains`).
- **Implicit inference** (desugar): the inferred sort is now `base -> Bool`.
- **Latent bug fix**: a relation reusing a type variable across argument positions (`a -> a -> Bool`) made the liquid unifier record the vacuous equality `a := a`, looping `resolve_type` on the second argument. Self-referential bindings are now skipped.
- **CI fix (folded in)**: SyGuS `synthesize` override accepts the new `output_value` parameter (see note above).

## Tests

- New `tests/nary_refinements_test.py`: unary/binary/ternary parsing + `predicate_domains`.
- `tests/synth_gaps_test.py` updated to the full-predicate-type convention.
- **Full suite: 1365 passed, 9 skipped** (backward compatible; unary `List`/`parametric_refinements` all green).

## Scope / what's next

This lands the **type-system machinery**: n-ary refinement declarations parse, elaborate, and Horn-typecheck (e.g. a tree node whose `lo` field is `{v:a | r v x}`). **Wiring it into the sorted-list/BST benchmarks** to carry their real invariants additionally needs three **pre-existing** gaps closed (each reproducible on `master`, independent of this PR):

1. **Element-typed measures** (`head : a`) recurse in `liquid.py:resolve_type`.
2. **Polymorphic nullary-constructor access** (`nil` of a locally-defined `T a`) reports "not in context".
3. **Measure instantiation** on refinement-parameterised inductives (`size t` where `T` has a `forall `).

There is also a residual hang when *solving* a binary-refinement constructor that lacks a constraining measure — likely entangled with (3). I'd tackle these next before adopting n-ary in the Synquid suite.

https://claude.ai/code/session_01HLPufK3ESWM9RwQ143WndW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLPufK3ESWM9RwQ143WndW)_