### PR TITLE
feat(synthesis): SyGuS backend over the cvc5 Python API (#49)

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -94,7 +94,8 @@ def _parse_common_arguments(parser: ArgumentParser):
         help=(
             "Select a synthesizer: tdsyn_enumerative (default, type-directed BFS), tdsyn (same as tdsyn_enumerative), "
             "tdsyn_random (type-directed random walk), tactics (random tactic search), gp, synquid, "
-            "random_search, enumerative (grammar enumeration), hc, 1p1, smt, decision_tree, llm, "
+            "random_search, enumerative (grammar enumeration), hc, 1p1, smt, "
+            "sygus (reduce to SyGuS and solve with cvc5), decision_tree, llm, "
             "lta (Liquid Tree Automata, arXiv:2605.13456), "
             "symetric (metric program synthesis, arXiv:2206.06164)"
         ),

--- a/aeon/synthesis/modules/sygus/__init__.py
+++ b/aeon/synthesis/modules/sygus/__init__.py
@@ -1,0 +1,20 @@
+"""SyGuS-based synthesis backend (issue #49).
+
+Synthesises code for a *valid subset* of Aeon-core synthesis problems by
+translating them into a SyGuS problem, solving it with the cvc5 SyGuS
+engine (via its Python API), and translating the answer back into
+Aeon-core.
+
+The valid subset is the holes whose type is a refined base type
+``{v:T | phi}`` with ``T in {Int, Bool, Float}``.  SMT-typed context
+variables become the inputs of the function to synthesise, their
+refinements become preconditions, and ``phi`` becomes the specification.
+
+Polymorphism, non-native operators, and non-SMT types are out of scope:
+the translation then *fails gracefully* (returns ``None``) and the
+synthesizer raises ``SynthesisNotSuccessful`` without crashing.
+"""
+
+from aeon.synthesis.modules.sygus.synthesizer import SygusSynthesizer
+
+__all__ = ["SygusSynthesizer"]

--- a/aeon/synthesis/modules/sygus/solver.py
+++ b/aeon/synthesis/modules/sygus/solver.py
@@ -1,0 +1,277 @@
+"""Phases 2 & 3 of issue #49: solve a ``SygusProblem`` with cvc5.
+
+The synthesis problem is built directly through the cvc5 SyGuS Python API
+(``synthFun`` / ``declareSygusVar`` / ``addSygusConstraint`` / ``checkSynth``
+/ ``getSynthSolution``) — no SyGuS-IF text is shipped to a subprocess.  The
+cvc5 ``Term`` that comes back is then walked into a well-typed Aeon-core
+``Term`` (the issue's phase 3).
+
+cvc5 is imported lazily and only here: the rest of the project never touches
+this API, and a missing cvc5 turns into a clean ``SynthesisNotSuccessful``
+in the synthesizer rather than an import-time crash.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aeon.core.terms import Application, If, Literal, Term, TypeApplication, Var
+from aeon.core.types import RefinedType, TypeConstructor, t_bool, t_float, t_int
+from aeon.synthesis.modules.sygus.translation import SygusProblem
+from aeon.utils.name import Name
+
+
+class CVC5Unavailable(Exception):
+    """Raised when the cvc5 Python bindings cannot be imported."""
+
+
+def _import_cvc5() -> Any:
+    try:
+        import cvc5  # noqa: PLC0415  (lazy, kept local to this backend)
+
+        return cvc5
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise CVC5Unavailable(
+            "cvc5 Python bindings are not installed; `pip install cvc5` to use the sygus backend",
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Aeon-core term construction helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_op(sym: str, base: TypeConstructor, *args: Term) -> Term:
+    """Build ``sym`` applied to ``args`` as a native (polymorphic) operator."""
+    out: Term = TypeApplication(Var(Name(sym, 0)), base)
+    for a in args:
+        out = Application(out, a)
+    return out
+
+
+def _num_literal(value: int | float, base: TypeConstructor) -> Term:
+    """A possibly-negative numeric literal.
+
+    Aeon has no negative-literal syntax, so negatives are emitted as ``0 - n``
+    (mirroring ``examples/synthesis/quadratic.ae``).
+    """
+    if base == t_float:
+        value = float(value)
+        zero: int | float = 0.0
+    else:
+        value = int(value)
+        zero = 0
+    if value >= 0:
+        return Literal(value, base)
+    return _apply_op("-", base, Literal(zero, base), Literal(-value, base))
+
+
+# ---------------------------------------------------------------------------
+# cvc5 solving
+# ---------------------------------------------------------------------------
+
+
+def _base_of_sort(sort: str) -> TypeConstructor:
+    return t_float if sort == "Real" else (t_bool if sort == "Bool" else t_int)
+
+
+def _liquid_to_cvc5(t: Any, env: dict[Name, Any], slv: Any, kinds: Any, is_real: bool) -> Any:
+    """Translate a liquid refinement term into a cvc5 ``Term``.
+
+    ``env`` maps the Aeon Names that may appear (params + binder) to their
+    cvc5 terms.  Raises on anything unsupported; the caller guards with the
+    same subset check ``build_sygus_problem`` already enforced.
+    """
+    from aeon.core.liquid import (
+        LiquidApp,
+        LiquidLiteralBool,
+        LiquidLiteralFloat,
+        LiquidLiteralInt,
+        LiquidVar,
+    )
+
+    Kind = kinds
+    binary = {
+        "<": Kind.LT,
+        "<=": Kind.LEQ,
+        ">": Kind.GT,
+        ">=": Kind.GEQ,
+        "&&": Kind.AND,
+        "||": Kind.OR,
+        "-->": Kind.IMPLIES,
+        "+": Kind.ADD,
+        "-": Kind.SUB,
+        "*": Kind.MULT,
+        "%": Kind.INTS_MODULUS,
+        "==": Kind.EQUAL,
+    }
+    match t:
+        case LiquidLiteralBool(b):
+            return slv.mkBoolean(bool(b))
+        case LiquidLiteralInt(i):
+            return slv.mkInteger(int(i))
+        case LiquidLiteralFloat(f):
+            return slv.mkReal(str(float(f)))
+        case LiquidVar(name):
+            if name not in env:
+                raise ValueError(f"unbound variable {name} in spec")
+            return env[name]
+        case LiquidApp(fun, args):
+            cargs = [_liquid_to_cvc5(a, env, slv, kinds, is_real) for a in args]
+            op = fun.name
+            if op == "!":
+                return slv.mkTerm(Kind.NOT, cargs[0])
+            if op == "!=":
+                return slv.mkTerm(Kind.DISTINCT, cargs[0], cargs[1])
+            if op == "/":
+                return slv.mkTerm(Kind.DIVISION if is_real else Kind.INTS_DIVISION, cargs[0], cargs[1])
+            if op in binary:
+                return slv.mkTerm(binary[op], *cargs)
+            raise ValueError(f"unsupported operator {op} in spec")
+        case _:
+            raise ValueError(f"cannot translate liquid term {t}")
+
+
+def solve_with_cvc5(problem: SygusProblem, timeout_ms: int) -> Term | None:
+    """Solve a ``SygusProblem`` with cvc5 and return an Aeon-core term, or None."""
+    cvc5 = _import_cvc5()
+    Kind = cvc5.Kind
+
+    slv = cvc5.Solver()
+    slv.setOption("sygus", "true")
+    slv.setOption("tlimit", str(max(1, timeout_ms)))
+    try:
+        slv.setLogic(problem.logic)
+    except Exception:
+        slv.setLogic("ALL")
+
+    def sort_of(name: str) -> Any:
+        return {
+            "Int": slv.getIntegerSort(),
+            "Bool": slv.getBooleanSort(),
+            "Real": slv.getRealSort(),
+        }[name]
+
+    # synth-fun f ((p Sort)...) RetSort   — the formal arguments are mkVars.
+    arg_vars = [slv.mkVar(sort_of(p.sort), p.smt_name) for p in problem.params]
+    f = slv.synthFun(problem.fun_name, arg_vars, sort_of(problem.ret_sort))
+
+    # declare-var for each universally-quantified spec variable, and the
+    # application of the synthesised function that replaces the binder.
+    env: dict[Name, Any] = {}
+    decl_vars: list[Any] = []
+    for p in problem.params:
+        v = slv.declareSygusVar(p.smt_name, sort_of(p.sort))
+        env[p.aeon_name] = v
+        decl_vars.append(v)
+    f_app = f if not decl_vars else slv.mkTerm(Kind.APPLY_UF, f, *decl_vars)
+    env[problem.binder] = f_app
+
+    # Preconditions (input refinements) imply the goal refinement.
+    try:
+        post = _liquid_to_cvc5(problem.refinement, env, slv, Kind, problem.is_real)
+        pres: list[Any] = []
+        for p, v in zip(problem.params, decl_vars):
+            if isinstance(p.aeon_type, RefinedType):
+                pre_env = dict(env)
+                pre_env[p.aeon_type.name] = v
+                pres.append(_liquid_to_cvc5(p.aeon_type.refinement, pre_env, slv, Kind, problem.is_real))
+    except ValueError:
+        return None
+
+    if not pres:
+        constraint = post
+    else:
+        antecedent = pres[0] if len(pres) == 1 else slv.mkTerm(Kind.AND, *pres)
+        constraint = slv.mkTerm(Kind.IMPLIES, antecedent, post)
+    slv.addSygusConstraint(constraint)
+
+    try:
+        result = slv.checkSynth()
+    except Exception:
+        return None
+    if not result.hasSolution():
+        return None
+
+    solution = slv.getSynthSolution(f)
+    return _cvc5_solution_to_term(solution, problem, Kind)
+
+
+# ---------------------------------------------------------------------------
+# cvc5 Term -> Aeon-core Term (phase 3)
+# ---------------------------------------------------------------------------
+
+
+def _cvc5_solution_to_term(solution: Any, problem: SygusProblem, Kind: Any) -> Term | None:
+    """Translate the cvc5 synthesis answer into an Aeon-core term.
+
+    For an n-ary function the answer is ``(lambda (vars...) body)``; for a
+    nullary one it is the body directly.
+    """
+    varmap: dict[Any, Name] = {}
+    if solution.getKind() == Kind.LAMBDA:
+        var_list = list(solution[0])
+        for cvc_var, param in zip(var_list, problem.params):
+            varmap[cvc_var] = param.aeon_name
+        body = solution[1]
+    else:
+        body = solution
+    try:
+        return _cvc5_term_to_core(body, varmap, problem, Kind)
+    except (ValueError, KeyError):
+        return None
+
+
+def _cvc5_term_to_core(node: Any, varmap: dict[Any, Name], problem: SygusProblem, Kind: Any) -> Term:
+    base = problem.ret_base
+    kind = node.getKind()
+
+    # Leaves -----------------------------------------------------------------
+    if kind == Kind.CONST_INTEGER:
+        return _num_literal(node.getIntegerValue(), t_int)
+    if kind == Kind.CONST_BOOLEAN:
+        return Literal(node.getBooleanValue(), t_bool)
+    if kind == Kind.CONST_RATIONAL:
+        return _num_literal(float(node.getRealValue()), t_float)
+    if kind == Kind.VARIABLE:
+        if node not in varmap:
+            raise ValueError(f"unmapped variable {node}")
+        return Var(varmap[node])
+
+    children = [_cvc5_term_to_core(c, varmap, problem, Kind) for c in node]
+
+    # Operators --------------------------------------------------------------
+    if kind == Kind.NEG:  # unary minus -> 0 - x
+        zero = Literal(0.0 if base == t_float else 0, base)
+        return _apply_op("-", base, zero, children[0])
+    if kind == Kind.ITE:
+        return If(children[0], children[1], children[2])
+    if kind == Kind.DISTINCT:
+        return _apply_op("!=", base, children[0], children[1])
+
+    binary_op = {
+        Kind.ADD: "+",
+        Kind.SUB: "-",
+        Kind.MULT: "*",
+        Kind.INTS_DIVISION: "/",
+        Kind.DIVISION: "/",
+        Kind.INTS_MODULUS: "%",
+        Kind.LT: "<",
+        Kind.LEQ: "<=",
+        Kind.GT: ">",
+        Kind.GEQ: ">=",
+        Kind.EQUAL: "==",
+        Kind.AND: "&&",
+        Kind.OR: "||",
+        Kind.IMPLIES: "-->",
+    }
+    if kind == Kind.NOT:
+        return _apply_op("!", base, children[0])
+    op = binary_op.get(kind)
+    if op is None:
+        raise ValueError(f"unsupported cvc5 kind {kind}")
+    # cvc5 emits variadic and/or/+/* ; fold left into binary applications.
+    result = _apply_op(op, base, children[0], children[1])
+    for extra in children[2:]:
+        result = _apply_op(op, base, result, extra)
+    return result

--- a/aeon/synthesis/modules/sygus/synthesizer.py
+++ b/aeon/synthesis/modules/sygus/synthesizer.py
@@ -1,0 +1,76 @@
+"""The ``sygus`` synthesizer backend (issue #49).
+
+Glues the three phases together:
+
+1. translate the hole + context to a SyGuS problem (``build_sygus_problem``),
+2. solve it with the cvc5 SyGuS Python API (``solve_with_cvc5``),
+3. take the reverse-translated Aeon-core term, type-check it with the
+   supplied ``validate`` callback, and return it.
+
+Outside the supported subset, when cvc5 is unavailable, or when no solution
+validates, it raises ``SynthesisNotSuccessful`` cleanly.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from loguru import logger
+
+from aeon.core.terms import Term
+from aeon.core.types import Type
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.modules.sygus.solver import CVC5Unavailable, solve_with_cvc5
+from aeon.synthesis.modules.sygus.translation import build_sygus_problem, problem_to_sl
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+
+
+class SygusSynthesizer(Synthesizer):
+    """Synthesize refined-base-type holes by reduction to SyGuS, solved by cvc5."""
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+    ) -> Term:
+        start = time.time()
+
+        problem = build_sygus_problem(ctx, type, fun_name=fun_name.name)
+        if problem is None:
+            raise SynthesisNotSuccessful(
+                f"SygusSynthesizer: hole of type {type} is outside the SyGuS-supported subset "
+                "(needs a refined Int/Bool/Float type over native operators).",
+            )
+
+        logger.log("SYNTHESIZER", f"SyGuS problem:\n{problem_to_sl(problem)}")
+
+        timeout_ms = max(1000, int(budget * 1000))
+        try:
+            candidate = solve_with_cvc5(problem, timeout_ms)
+        except CVC5Unavailable as exc:
+            raise SynthesisNotSuccessful(str(exc)) from exc
+
+        if candidate is None:
+            raise SynthesisNotSuccessful("SygusSynthesizer: cvc5 found no candidate within budget")
+
+        try:
+            ok = validate(candidate)
+        except Exception:
+            ok = False
+        if not ok:
+            raise SynthesisNotSuccessful(
+                f"SygusSynthesizer: candidate {candidate} did not type-check against {type}",
+            )
+
+        ui.register(candidate, [], time.time() - start, True)
+        return candidate

--- a/aeon/synthesis/modules/sygus/translation.py
+++ b/aeon/synthesis/modules/sygus/translation.py
@@ -1,0 +1,238 @@
+"""Phase 1 of issue #49: convert an Aeon-core synthesis problem to SyGuS.
+
+``build_sygus_problem`` inspects the hole type and its typing context and,
+when the problem falls inside the supported subset, produces a
+``SygusProblem`` — a solver-agnostic description that the cvc5 solver
+(``solver.py``) consumes.  ``problem_to_sl`` renders the same problem into
+SyGuS-IF (``.sl``) text, which is handy for logging and debugging.
+
+Anything outside the subset makes ``build_sygus_problem`` return ``None`` so
+the caller can report a clean failure (the issue's "graceful failure if
+conversion isn't feasible").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aeon.core.liquid import (
+    LiquidApp,
+    LiquidLiteralBool,
+    LiquidLiteralFloat,
+    LiquidLiteralInt,
+    LiquidLiteralString,
+    LiquidTerm,
+    LiquidVar,
+    liquid_free_vars,
+)
+from aeon.core.types import RefinedType, Type, TypeConstructor, t_bool, t_float, t_int
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+
+# SyGuS / SMT-LIB sort for each Aeon base type.
+_SORT_OF_BASE: dict[TypeConstructor, str] = {t_int: "Int", t_bool: "Bool", t_float: "Real"}
+
+# Aeon native operator -> SMT-LIB symbol (same arity).  ``==``/``!=`` and
+# integer division are handled specially in ``liquid_to_smt``.
+_OP_TO_SMT: dict[str, str] = {
+    "<": "<",
+    "<=": "<=",
+    ">": ">",
+    ">=": ">=",
+    "&&": "and",
+    "||": "or",
+    "!": "not",
+    "-->": "=>",
+    "+": "+",
+    "-": "-",
+    "*": "*",
+    "%": "mod",
+}
+
+
+def smt_sort_of(ty: Type) -> str | None:
+    """Return the SMT-LIB sort for an Aeon base/refined base type, else None."""
+    base = ty.type if isinstance(ty, RefinedType) else ty
+    if isinstance(base, TypeConstructor):
+        return _SORT_OF_BASE.get(base)
+    return None
+
+
+@dataclass
+class SygusParam:
+    """A context variable lifted into an input of the synthesised function."""
+
+    aeon_name: Name
+    aeon_type: Type
+    smt_name: str
+    sort: str
+
+
+@dataclass
+class SygusProblem:
+    """A synthesis problem in the SyGuS-supported subset.
+
+    Solver-agnostic: both the textual SyGuS-IF emitter and the cvc5 API
+    solver derive what they need from this.
+    """
+
+    fun_name: str
+    params: list[SygusParam]
+    ret_sort: str
+    ret_base: TypeConstructor
+    binder: Name  # the refined type's bound variable (the value being synthesised)
+    refinement: LiquidTerm  # the specification phi, over ``binder`` and the params
+    logic: str
+
+    @property
+    def is_real(self) -> bool:
+        return self.ret_sort == "Real" or any(p.sort == "Real" for p in self.params)
+
+
+def _smt_name(n: Name) -> str:
+    """A legal SMT-LIB identifier that is stable for one Name.
+
+    Aeon Names carry a disambiguating integer id; we keep it so two distinct
+    binders never collide in the emitted text.
+    """
+    safe = "".join(c if (c.isalnum() or c == "_") else "_" for c in n.name)
+    if not safe or not (safe[0].isalpha() or safe[0] == "_"):
+        safe = "v_" + safe
+    return f"{safe}_{n.id}"
+
+
+def liquid_to_smt(t: LiquidTerm, names: dict[Name, str], is_real: bool) -> str | None:
+    """Render a liquid term as an SMT-LIB S-expression, or None if unsupported.
+
+    ``names`` maps the Aeon Names that may appear (params + binder) to their
+    SMT-LIB identifiers.  Used for the textual (``.sl``) rendering.
+    """
+    match t:
+        case LiquidLiteralBool(b):
+            return "true" if b else "false"
+        case LiquidLiteralInt(i):
+            return str(i) if i >= 0 else f"(- {-i})"
+        case LiquidLiteralFloat(f):
+            lit = repr(float(abs(f)))
+            return lit if f >= 0 else f"(- {lit})"
+        case LiquidLiteralString():
+            return None  # strings are outside the supported subset
+        case LiquidVar(name):
+            return names.get(name)
+        case LiquidApp(fun, args):
+            rendered = [liquid_to_smt(a, names, is_real) for a in args]
+            if any(r is None for r in rendered):
+                return None
+            op = fun.name
+            if op == "==":
+                return f"(= {rendered[0]} {rendered[1]})"
+            if op == "!=":
+                return f"(not (= {rendered[0]} {rendered[1]}))"
+            if op == "/":
+                smt_op = "/" if is_real else "div"
+                return f"({smt_op} {rendered[0]} {rendered[1]})"
+            smt_op = _OP_TO_SMT.get(op)
+            if smt_op is None:
+                return None
+            return f"({smt_op} {' '.join(rendered)})"
+        case _:
+            return None
+
+
+def build_sygus_problem(ctx: TypingContext, ty: Type, fun_name: str = "f") -> SygusProblem | None:
+    """Translate a hole type + context into a ``SygusProblem`` (or None).
+
+    Supported subset: ``ty`` is ``{v:T | phi}`` with ``T`` a base SMT type,
+    ``phi`` built only from native operators over SMT-typed variables.
+    """
+    if not isinstance(ty, RefinedType):
+        return None
+    ret_base = ty.type
+    ret_sort = smt_sort_of(ret_base)
+    if ret_sort is None or not isinstance(ret_base, TypeConstructor):
+        return None
+
+    binder = ty.name
+    spec_vars = set(liquid_free_vars(ty.refinement))
+
+    # Lift the SMT-typed context variables referenced by the spec into inputs.
+    params: list[SygusParam] = []
+    names: dict[Name, str] = {binder: _smt_name(binder)}
+    for n, t in ctx.concrete_vars():
+        if n == binder or n not in spec_vars:
+            continue
+        sort = smt_sort_of(t)
+        if sort is None:
+            continue
+        smt_name = _smt_name(n)
+        params.append(SygusParam(aeon_name=n, aeon_type=t, smt_name=smt_name, sort=sort))
+        names[n] = smt_name
+
+    # The spec must render to SMT-LIB end-to-end; bail out otherwise.
+    is_real = ret_sort == "Real" or any(p.sort == "Real" for p in params)
+    if liquid_to_smt(ty.refinement, names, is_real) is None:
+        return None
+
+    # Any free var of the spec that is neither the binder nor a lifted param
+    # is an unsupported reference (e.g. a non-SMT context value): fail.
+    known = {binder} | {p.aeon_name for p in params}
+    for v in spec_vars:
+        if v in known:
+            continue
+        # Operators contribute their name to free vars but are not real refs.
+        if v.name in _OP_TO_SMT or v.name in {"==", "!=", "/"}:
+            continue
+        return None
+
+    logic = "NRA" if is_real else "NIA"
+    return SygusProblem(
+        fun_name=fun_name,
+        params=params,
+        ret_sort=ret_sort,
+        ret_base=ret_base,
+        binder=binder,
+        refinement=ty.refinement,
+        logic=logic,
+    )
+
+
+def problem_to_sl(problem: SygusProblem) -> str:
+    """Render a ``SygusProblem`` as SyGuS-IF (``.sl``) text.
+
+    Universally quantifies the inputs and constrains the function so that the
+    parameters' refinements imply the goal refinement.
+    """
+    # The binder is replaced by an application of the synthesised function.
+    app = (
+        problem.fun_name
+        if not problem.params
+        else f"({problem.fun_name} {' '.join(p.smt_name for p in problem.params)})"
+    )
+    names: dict[Name, str] = {problem.binder: app}
+    for p in problem.params:
+        names[p.aeon_name] = p.smt_name
+
+    post = liquid_to_smt(problem.refinement, names, problem.is_real)
+    assert post is not None  # build_sygus_problem already checked translatability
+
+    pres: list[str] = []
+    for p in problem.params:
+        if isinstance(p.aeon_type, RefinedType):
+            pre_names = dict(names)
+            pre_names[p.aeon_type.name] = p.smt_name
+            rendered = liquid_to_smt(p.aeon_type.refinement, pre_names, problem.is_real)
+            if rendered is not None:
+                pres.append(rendered)
+
+    constraint = post if not pres else f"(=> {pres[0] if len(pres) == 1 else '(and ' + ' '.join(pres) + ')'} {post})"
+
+    param_decl = " ".join(f"({p.smt_name} {p.sort})" for p in problem.params)
+    lines = [
+        f"(set-logic {problem.logic})",
+        f"(synth-fun {problem.fun_name} ({param_decl}) {problem.ret_sort})",
+    ]
+    for p in problem.params:
+        lines.append(f"(declare-var {p.smt_name} {p.sort})")
+    lines.append(f"(constraint {constraint})")
+    lines.append("(check-synth)")
+    return "\n".join(lines) + "\n"

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -5,6 +5,7 @@ from aeon.synthesis.modules.synquid.synthesizer import SynquidSynthesizer
 from aeon.synthesis.modules.llm import LLMSynthesizer
 from aeon.synthesis.modules.decision_tree import DecisionTreeSynthesizer
 from aeon.synthesis.modules.smt_synthesizer import SMTSynthesizer
+from aeon.synthesis.modules.sygus import SygusSynthesizer
 from aeon.synthesis.modules.tdsyn.synthesizer import TDSynSynthesizer
 from aeon.synthesis.modules.symetric import SymetricSynthesizer
 from aeon.synthesis.tactics import TacticRandomSynthesizer
@@ -30,6 +31,8 @@ def make_synthesizer(module: str) -> Synthesizer:
             return DecisionTreeSynthesizer()
         case "smt":
             return SMTSynthesizer()
+        case "sygus":
+            return SygusSynthesizer()
         case "tdsyn" | "tdsyn_enumerative":
             return TDSynSynthesizer(mode="enumerative")
         case "tdsyn_random":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     'scikit-image',
     'sympy',
     'textdistance',
+    'cvc5 >= 1.1',
     'z3-solver >= 4',
     'zstandard==0.25.0',
     'zss',

--- a/tests/sygus_synthesis_test.py
+++ b/tests/sygus_synthesis_test.py
@@ -1,0 +1,129 @@
+"""Tests for the SyGuS synthesis backend (issue #49).
+
+Covers the three phases: translating an Aeon-core hole to a SyGuS problem,
+solving it with the cvc5 SyGuS Python API, and validating that the
+reverse-translated Aeon-core term type-checks against the hole's refined type.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.backend.evaluator import eval as aeon_eval
+from aeon.core.substitutions import substitution
+from aeon.core.terms import Var
+from aeon.core.types import top
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.api import SynthesisNotSuccessful
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.identification import get_holes_info, incomplete_functions_and_holes
+from aeon.synthesis.modules.sygus import SygusSynthesizer
+from aeon.synthesis.modules.sygus.translation import build_sygus_problem, problem_to_sl
+from aeon.utils.name import Name
+
+from tests.driver import check_and_return_core
+
+setup_logger()
+
+cvc5 = pytest.importorskip("cvc5")
+
+
+def _synthesize(source: str, budget: float = 5.0):
+    core, ctx, ectx, md = check_and_return_core(source)
+    targets = incomplete_functions_and_holes(ctx, core)
+    mapping = synthesize_holes(ctx, ectx, core, targets, md, SygusSynthesizer(), budget=budget)
+    return core, ectx, mapping
+
+
+def test_constant_int_synthesis():
+    """``{x:Int | x == 35}`` should synthesize the constant 35."""
+    _, _, mapping = _synthesize("def n : {x:Int | x == 35} = ?hole;")
+    (term,) = mapping.values()
+    assert term is not None
+    assert eval_int_program("def n : {x:Int | x == 35} = ?hole;", term) == 35
+
+
+def test_linear_equation_synthesis():
+    """``{n:Int | n + 4 == 7}`` should synthesize 3."""
+    src = "def x_solution : {n:Int | n + 4 == 7} = ?hole"
+    _, _, mapping = _synthesize(src)
+    (term,) = mapping.values()
+    assert eval_int_program(src, term) == 3
+
+
+def test_quadratic_synthesis():
+    """``{n:Int | n * n == 4}`` should synthesize a value whose square is 4."""
+    src = "def x_solution : {n:Int | n * n == 4} = ?hole"
+    _, _, mapping = _synthesize(src)
+    (term,) = mapping.values()
+    val = eval_int_program(src, term)
+    assert val * val == 4
+
+
+def test_function_of_input_synthesis():
+    """A hole that must depend on an input: ``z == x + 1`` -> ``x + 1``."""
+    src = "def f(x:{k:Int | k > 0}) : {z:Int | z == x + 1} = ?h"
+    _, _, mapping = _synthesize(src)
+    (term,) = mapping.values()
+    assert term is not None  # validated inside synthesize_holes
+
+
+def test_precondition_constant_synthesis():
+    """``x>0 => z<0`` is satisfiable by a constant; backend should find one."""
+    src = "def test(x:{k:Int | k > 0}) : {z:Int | z < 0} = ?r"
+    _, _, mapping = _synthesize(src)
+    (term,) = mapping.values()
+    assert term is not None
+
+
+def test_graceful_failure_non_smt_type():
+    """A hole of a non-SMT (inductive) type is outside the subset."""
+    src = "inductive P\n| mk (v:Int | 0 < v && v < 10 ) : P\n\ndef fun : P = ?hole"
+    with pytest.raises(SynthesisNotSuccessful):
+        _synthesize(src)
+
+
+def test_translation_emits_sygus_if():
+    """The translation phase should produce well-formed SyGuS-IF text."""
+    src = "def f(x:{k:Int | k > 0}) : {z:Int | z == x + 1} = ?h"
+    core, ctx, _, _ = check_and_return_core(src)
+    targets = incomplete_functions_and_holes(ctx, core)
+    holes = get_holes_info(ctx, core, top, targets, refined_types=True)
+    (fn, hs) = targets[0]
+    ty, tyctx = holes[hs[0]]
+    problem = build_sygus_problem(tyctx, ty, fun_name=fn.name)
+    assert problem is not None
+    text = problem_to_sl(problem)
+    assert "(synth-fun f" in text
+    assert "(check-synth)" in text
+    assert "(=>" in text  # precondition implication
+    assert "(declare-var" in text
+
+
+def test_translation_rejects_non_refined_type():
+    """A plain (unrefined) type has no spec and is not handled here."""
+    src = "def n : Int = ?hole"
+    core, ctx, _, _ = check_and_return_core(src)
+    targets = incomplete_functions_and_holes(ctx, core)
+    holes = get_holes_info(ctx, core, top, targets, refined_types=True)
+    (fn, hs) = targets[0]
+    ty, tyctx = holes[hs[0]]
+    assert build_sygus_problem(tyctx, ty, fun_name=fn.name) is None
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def eval_int_program(source: str, term) -> int:
+    """Substitute ``term`` for the hole and evaluate the defined value."""
+    core, ctx, ectx, _ = check_and_return_core(source)
+    targets = incomplete_functions_and_holes(ctx, core)
+    (_, hs) = targets[0]
+    hole_name = hs[0]
+    # Replace the hole, then point ``main`` at the synthesised definition.
+    filled = substitution(core, term, hole_name)
+    def_name = targets[0][0]
+    program = substitution(filled, Var(def_name), Name("main", 0))
+    return aeon_eval(program, ectx)


### PR DESCRIPTION
Closes #49.

Adds a `sygus` synthesizer backend (`-s sygus`) that solves a valid subset of synthesis problems by reduction to **SyGuS**, solved with the **cvc5 Python API**.

## The three phases

1. **Translate Aeon-core → SyGuS** (`translation.py`). A hole of refined base type `{v:T | φ}` with `T ∈ {Int, Bool, Float}` becomes a SyGuS problem: SMT-typed context variables become the synth-fun's inputs, their refinements become preconditions, and `φ` is the goal. Holes outside the subset (polymorphism, non-SMT types, non-native operators) **fail gracefully** (`build_sygus_problem` returns `None`).

2. **Solve with cvc5** (`solver.py`). The problem is built and solved directly through the cvc5 SyGuS Python API — `synthFun` / `declareSygusVar` / `addSygusConstraint` / `checkSynth` / `getSynthSolution`. No SyGuS-IF text is shipped to a subprocess. cvc5 is imported **lazily and only inside this backend**; the rest of the project never touches the API, and a missing cvc5 becomes a clean `SynthesisNotSuccessful` instead of an import-time crash.

3. **Translate the solution back** (`solver.py`). The returned cvc5 `Term` (a `LAMBDA` for n-ary functions, or the body directly for constants) is walked into a well-typed Aeon-core `Term` and validated through the typechecker before being returned.

`problem_to_sl` still renders the problem as SyGuS-IF `.sl` text — used for logging/debugging and asserted in tests.

## Results (all via cvc5)

| Spec | Synthesized |
|---|---|
| `{x:Int \| x == 35}` | `35` |
| `{n:Int \| n + 4 == 7}` | `3` |
| `{n:Int \| n * n == 4}` | `1 + 1` |
| `x>0 ⇒ {z:Int \| z < 0}` | `0 - 1` |
| `{z:Int \| z == x + 1}` | `x + 1` |
| `{x:Float \| x * 2.0 == 5.0}` | `2.5` |

## Other changes
- Register `sygus` in `synthesizerfactory`; document it in the CLI `--synthesizer` help.
- Add `cvc5 >= 1.1` to dependencies.
- New tests (`tests/sygus_synthesis_test.py`), `importorskip`-guarded so they skip cleanly where cvc5 is unavailable.

## Notes
- Scope is intentionally the SyGuS-supported subset (no polymorphism, native operators only), matching the issue.
- cvc5 is used **only** in `aeon/synthesis/modules/sygus/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)