### PR TITLE
feat(synthesis): FTA backend + DACE data-completion examples (FTA paper)

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -97,6 +97,7 @@ def _parse_common_arguments(parser: ArgumentParser):
             "random_search, enumerative (grammar enumeration), hc, 1p1, smt, "
             "sygus (reduce to SyGuS and solve with cvc5), decision_tree, llm, "
             "lta (Liquid Tree Automata, arXiv:2605.13456), "
+            "fta (Finite Tree Automata, OOPSLA'17), "
             "symetric (metric program synthesis, arXiv:2206.06164)"
         ),
     )

--- a/aeon/synthesis/modules/fta/__init__.py
+++ b/aeon/synthesis/modules/fta/__init__.py
@@ -1,0 +1,5 @@
+"""Finite Tree Automata (FTA) program-synthesis backend, registered as ``fta``."""
+
+from aeon.synthesis.modules.fta.synthesizer import FTASynthesizer
+
+__all__ = ["FTASynthesizer"]

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -1,0 +1,295 @@
+"""FTA: spec-guided program synthesis via Finite Tree Automata.
+
+Implements the core construction of Wang, Dillig & Singh, "Synthesis of Data
+Completion Scripts using Finite Tree Automata" (OOPSLA 2017). Bottom-up over the
+DSL's components, it builds a finite tree automaton whose
+
+* **states** ``q`` are observational-equivalence classes of sub-programs -- in
+  the paper, the concrete value a sub-program produces on the input example;
+  here, a candidate's concrete output as exposed by aeon's ``output_value``,
+* **alphabet** are the in-scope components (inductive constructors / library
+  functions), each a ranked transition ``f(q1, ..., qk) -> q``,
+* **accepting states** are those consistent with the specification.
+
+The defining feature of the FTA is *compression by observational equivalence*:
+many syntactically distinct programs collapse into one state per distinct
+output, so the automaton compactly represents the whole version space of
+spec-consistent programs, and a single (minimal) program is extracted from it.
+The pay-off is that the spec is checked **once per state**, not once per program.
+
+How the paper maps onto aeon. The paper accepts a program iff it reproduces a
+concrete output *example*; aeon specifies a hole by a *refinement type*, so this
+backend's acceptance oracle is ``validate`` (the liquid typechecker), and it
+materialises the automaton's value-states at the hole's type, where aeon exposes
+a candidate's concrete output via ``output_value``. Because output is observable
+only at the hole type, observational-equivalence merging -- and the resulting
+once-per-class validation -- happens there; structured arguments are drawn from
+the bottom-up bank, exactly as in FTA construction, but are not separately
+observed. Requiring no objective/metric, this is the backend of choice for the
+refinement holes that the metric synthesiser (``symetric``) rejects.
+
+The repo's ``lta`` backend (Liquid Tree Automata, arXiv:2605.13456) is the
+refinement-typed descendant of this line of work; abstraction-refinement FTAs
+(``afta``, Wang/Dillig/Singh POPL'18) and constraint-annotated tree automata
+(``cata``) sit between this concrete FTA and LTA, and are tracked as follow-ups.
+
+Selected with ``--synthesizer fta``.
+"""
+
+from __future__ import annotations
+
+import itertools
+import random
+import time
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+from aeon.core.terms import Application, Literal, Term, Var
+from aeon.core.types import (
+    AbstractionType,
+    Type,
+    TypePolymorphism,
+    t_int,
+)
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.modules.symetric.synthesizer import (
+    Component,
+    _decompose,
+    _peel,
+    base_key,
+)
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+
+# An automaton state: ("val", frozen-output) for an observed value, or
+# ("term", str) for a sub-program whose output aeon cannot observe (kept
+# distinct so unobservable candidates are never wrongly merged).
+StateKey = tuple[str, Any]
+
+
+class FTASynthesizer(Synthesizer):
+    """Component-based synthesis by building a finite tree automaton bottom-up
+    and extracting the smallest spec-consistent program from it."""
+
+    def computations(self, primitives: Any) -> dict[str, Any]:
+        # The automaton keys states by each candidate's concrete *output*; the
+        # pool computes it (a ``@cluster`` featuriser, else the candidate value).
+        return {"output": primitives.feature}
+
+    def __init__(
+        self,
+        seed: int = 0,
+        int_lo: int = -8,
+        int_hi: int = 33,
+        rounds: int = 3,
+        combo_cap: int = 4096,
+        max_bank: int = 512,
+    ):
+        self.seed = seed
+        self.int_lo = int_lo
+        self.int_hi = int_hi
+        self.rounds = rounds
+        self.combo_cap = combo_cap
+        self.max_bank = max_bank
+
+    # -- components -----------------------------------------------------------
+
+    def _collect(self, ctx: TypingContext) -> tuple[dict[str, list[Component]], dict[str, list[Var]]]:
+        """Index the in-scope bindings as builders (functions/constructors, the
+        automaton's ranked alphabet) and atoms (nullary leaves)."""
+        builders: dict[str, list[Component]] = {}
+        atoms: dict[str, list[Var]] = {}
+        for name, ty in ctx.concrete_vars():
+            if isinstance(ty, TypePolymorphism):
+                continue  # recursors / polymorphic library functions
+            arg_types, ret = _peel(ty)
+            if any(isinstance(a, (AbstractionType, TypePolymorphism)) for a in arg_types):
+                continue  # no higher-order arguments
+            if isinstance(ret, (AbstractionType, TypePolymorphism)):
+                continue
+            ret_key = base_key(ret)
+            if arg_types:
+                comp = Component(name, tuple(base_key(a) for a in arg_types), ret_key)
+                builders.setdefault(ret_key, []).append(comp)
+            else:
+                atoms.setdefault(ret_key, []).append(Var(name))
+        return builders, atoms
+
+    def _combos(self, comp: Component, bank: dict[str, list[Term]], deadline: float, rnd: random.Random) -> list[Term]:
+        """Transitions ``comp(q1, ..., qk) -> q``: applications of ``comp`` whose
+        arguments are drawn from the current bank (per argument type). Enumerates
+        the full product when small, else samples ``combo_cap`` of it."""
+        pools: list[list[Term]] = []
+        for ak in comp.arg_keys:
+            pool = bank.get(ak, [])
+            if not pool:
+                return []
+            pools.append(pool)
+        total = 1
+        for p in pools:
+            total *= len(p)
+        out: list[Term] = []
+        if total <= self.combo_cap:
+            for choice in itertools.product(*pools):
+                if time.time() >= deadline:
+                    break
+                term: Term = Var(comp.name)
+                for a in choice:
+                    term = Application(term, a)
+                out.append(term)
+        else:
+            for _ in range(self.combo_cap):
+                term = Var(comp.name)
+                for p in pools:
+                    term = Application(term, rnd.choice(p))
+                out.append(term)
+        return out
+
+    # -- entry point ----------------------------------------------------------
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
+    ) -> Term:
+        start = time.time()
+        deadline = start + budget
+        rnd = random.Random(self.seed)
+        ui.register(None, None, 0, True)
+
+        builders, atoms = self._collect(ctx)
+        goal_key = base_key(type)
+        int_key = base_key(t_int)
+
+        # The automaton, materialised at the goal type: each observational state
+        # keeps its smallest representative; the spec is checked once per state.
+        rep: dict[StateKey, Term] = {}
+        validated: dict[StateKey, bool] = {}
+        transitions = 0
+        best: Optional[Term] = None
+
+        def obs(term: Term) -> StateKey:
+            """The observational state of a goal-typed term -- its concrete
+            output. Falls back to a literal's syntactic value, and otherwise
+            keeps the term distinct (no unsound merge)."""
+            if output_value is not None:
+                try:
+                    v = output_value(term)
+                except Exception:
+                    v = None
+                if v is not None:
+                    try:
+                        return ("val", _freeze(v))
+                    except TypeError:
+                        return ("val", repr(v))
+            if isinstance(term, Literal):
+                return ("val", term.value)
+            return ("term", str(term))
+
+        def insert_goal(term: Term) -> None:
+            """Add a goal-typed term to the automaton: merge by observational
+            equivalence (keep the smallest representative) and validate the
+            state's representative once."""
+            nonlocal best
+            st = obs(term)
+            cur = rep.get(st)
+            if cur is None or _term_size(term) < _term_size(cur):
+                rep[st] = term
+            if st not in validated:
+                validated[st] = _safe(validate, rep[st])
+            if validated[st]:
+                cand = rep[st]
+                if best is None or _term_size(cand) < _term_size(best):
+                    best = cand
+                    ui.register(best, [0.0], time.time() - start, True)
+
+        bank: dict[str, list[Term]] = {}
+        seen: dict[str, set[str]] = {}
+
+        def add_bank(key: str, terms: list[Term]) -> None:
+            b = bank.setdefault(key, [])
+            s = seen.setdefault(key, set())
+            for t in terms:
+                k = str(t)
+                if k in s:
+                    continue
+                s.add(k)
+                b.append(t)
+                if key == goal_key:
+                    insert_goal(t)
+            if len(b) > self.max_bank:
+                del b[self.max_bank :]
+
+        # Round 0 -- nullary leaves: the in-scope atoms, plus the integer range
+        # (available both as candidate answers and as numeric arguments).
+        for key, vs in atoms.items():
+            add_bank(key, list(vs))
+        add_bank(int_key, [Literal(v, t_int) for v in range(self.int_lo, self.int_hi)])
+
+        # Rounds 1..k -- apply every transition to the bank built so far, growing
+        # programs one operator deeper. Stop as soon as an accepting state is
+        # found: bottom-up construction reaches the smallest programs first.
+        for _round in range(self.rounds):
+            if best is not None or time.time() >= deadline:
+                break
+            snapshot = {k: list(v) for k, v in bank.items()}
+            for comps in builders.values():
+                for comp in comps:
+                    if best is not None or time.time() >= deadline:
+                        break
+                    new_terms = self._combos(comp, snapshot, deadline, rnd)
+                    transitions += len(new_terms)
+                    add_bank(comp.ret_key, new_terms)
+
+        states = len(rep)
+        if best is not None:
+            logger.log(
+                "SYNTHESIZER",
+                f"fta: solution found; automaton had {states} states / {transitions} transitions "
+                f"at the goal type (version space compressed by observational equivalence)",
+            )
+            ui.register(best, [0.0], time.time() - start, True)
+            return best
+        raise SynthesisNotSuccessful(
+            f"fta: no spec-consistent program of depth < {self.rounds} found within budget={budget}s "
+            f"(explored {states} observational states / {transitions} transitions). Try a larger budget, "
+            "more rounds, or a backend that abstracts states (afta/lta)."
+        )
+
+
+# -- free helpers ------------------------------------------------------------
+
+
+def _term_size(term: Term) -> int:
+    """Node count of a term -- the size measure minimised during extraction."""
+    _head, args = _decompose(term)
+    return 1 + sum(_term_size(a) for a in args)
+
+
+def _freeze(v: object) -> Any:
+    """A hashable, order-stable view of a candidate's output, so that equal
+    outputs map to the same automaton state regardless of container type."""
+    if isinstance(v, (list, tuple)):
+        return tuple(_freeze(x) for x in v)
+    if isinstance(v, (set, frozenset)):
+        return frozenset(_freeze(x) for x in v)
+    if isinstance(v, dict):
+        return tuple(sorted((k, _freeze(x)) for k, x in v.items()))
+    return v
+
+
+def _safe(validate: Callable[[Term], bool], term: Term) -> bool:
+    try:
+        return validate(term)
+    except Exception:
+        return False

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -8,6 +8,7 @@ from aeon.synthesis.modules.smt_synthesizer import SMTSynthesizer
 from aeon.synthesis.modules.sygus import SygusSynthesizer
 from aeon.synthesis.modules.tdsyn.synthesizer import TDSynSynthesizer
 from aeon.synthesis.modules.symetric import SymetricSynthesizer
+from aeon.synthesis.modules.fta import FTASynthesizer
 from aeon.synthesis.tactics import TacticRandomSynthesizer
 
 
@@ -43,5 +44,7 @@ def make_synthesizer(module: str) -> Synthesizer:
             return LTASynthesizer()
         case "symetric":
             return SymetricSynthesizer()
+        case "fta":
+            return FTASynthesizer()
         case _:
             assert False, f"Not supported synthesizer with name {module}"

--- a/examples/synthesis/dace/README.md
+++ b/examples/synthesis/dace/README.md
@@ -1,0 +1,80 @@
+# DACE — data-completion examples (FTA paper)
+
+Aeon renderings of the data-completion tasks from **Wang, Dillig & Singh,
+"Synthesis of Data Completion Scripts using Finite Tree Automata"** (OOPSLA 2017;
+tool **DACE**, [arXiv:1707.01469](https://arxiv.org/abs/1707.01469)). The paper
+synthesises spreadsheet data-completion scripts from input/output **examples**
+over a DSL that combines *spatial* (cell/range) and *relational* (table)
+reasoning, using finite tree automata as a compact version space.
+
+## How the paper maps onto Aeon
+
+Two honest gaps shape this port:
+
+1. **The benchmark suite is not reproducible verbatim.** DACE's 84 benchmarks
+   are spreadsheets scraped from online help forums (a supplementary artifact,
+   not listed in the paper). These files instead cover the **operation
+   categories** the paper describes, one runnable task each.
+2. **Spec mechanism.** DACE is programming-by-**example**; Aeon specifies by
+   **refinement type**. So the two halves of this directory take the two
+   faithful routes:
+
+   * **Worked pipelines** (top level) — the DACE DSL applied to a concrete input
+     table, computing the completed result. These execute end-to-end and are the
+     faithful rendering of the *DSL and its operators*.
+   * **Synthesised completions** (`synth/`) — per-cell data completion run by the
+     new **FTA backend** (`--synthesizer fta`): the output cell is a `?hole`
+     whose refinement is the completion formula over the (constant) input cells.
+     This is the faithful rendering of *FTA synthesis* itself.
+
+The DSL lives in [`libraries/Table.ae`](../../../libraries/Table.ae): the
+relational core (`select`, `filter`, `map_column`, `group_by`, `pivot`/`spread`,
+`melt`/`gather`, `summary`) was already present; this work added the spatial and
+aggregate operators DACE needs — `mutate`, `cell`, `nrow`/`ncol`, `sum_col`/
+`mean_col`/`max_col`/`min_col`/`count`, `arrange`, `head`, `cumsum` (running
+total), and `join` — and fixed a broken module path in `group_by`/`pivot`/`melt`.
+
+## Worked pipelines (run directly)
+
+```bash
+uv run python -m aeon examples/synthesis/dace/<file>.ae
+```
+
+| File | DACE category | Operators | Result |
+|---|---|---|--:|
+| `column_formula.ae` | column arithmetic | `mutate`, `sum_col` | 33 |
+| `aggregate_sum.ae` | aggregate (SUM) | `sum_col` | 35 |
+| `group_average.ae` | group-by aggregate | `filter`, `mean_col` | 15 |
+| `running_balance.ae` | running/cumulative total | `cumsum`, `cell` | 12 |
+| `pivot_wide.ae` | reshape long→wide | `pivot`, `cell` | 7 |
+| `melt_long.ae` | reshape wide→long | `melt`, `cell` | 8 |
+| `filter_aggregate.ae` | conditional aggregate (SUMIF) | `filter`, `sum_col` | 15 |
+| `join_lookup.ae` | relational join (VLOOKUP) | `join`, `mutate`, `sum_col` | 41 |
+
+## Synthesised completions (run with the FTA backend)
+
+```bash
+uv run python -m aeon --no-main -s fta --budget 10 examples/synthesis/dace/synth/<file>.ae
+```
+
+| File | Completion | Synthesised cell |
+|---|---|--:|
+| `synth/complete_total.ae` | sum of two cells | `?hole: 15` |
+| `synth/complete_average.ae` | mean of three cells | `?hole: 10` |
+| `synth/complete_max.ae` | max of two cells | `?hole: 8` |
+
+The FTA backend enumerates candidate cells bottom-up, keys each by its value
+(observational equivalence), checks the refinement once per value, and extracts
+the smallest accepted cell.
+
+## Scope / faithfulness
+
+- The worked pipelines are *executed*, not synthesised — they demonstrate the
+  DSL exactly. Synthesising a full table-transformation **script** from I/O
+  examples would need example-based (PBE) acceptance over opaque table values,
+  which the current FTA backend (refinement/`validate` acceptance) does not do;
+  the `synth/` tasks therefore complete at the **cell** level, where the spec is
+  SMT-decidable. Adding example-based acceptance to the FTA backend (so it can
+  synthesise whole pipelines over `Table`) is a natural follow-up.
+- Run on demand; not swept by `run_examples.sh`. A subset is covered by
+  `tests/dace_test.py`.

--- a/examples/synthesis/dace/aggregate_sum.ae
+++ b/examples/synthesis/dace/aggregate_sum.ae
@@ -1,0 +1,8 @@
+# DACE category: aggregate (SUM over a column) -- the grand-total completion.
+open Table
+
+def t : Table = native "[{'amount':10},{'amount':20},{'amount':5}]";
+
+def total : Int = Table.sum_col t "amount";  # 35
+
+def main (x:Int) : Unit = print total;

--- a/examples/synthesis/dace/column_formula.ae
+++ b/examples/synthesis/dace/column_formula.ae
@@ -1,0 +1,14 @@
+# DACE category: column arithmetic (mutate) -- fill a derived column with a
+# per-row formula. Here `total = qty * price`, the canonical data-completion
+# task (Wang, Dillig & Singh, OOPSLA'17).
+open Table
+
+def orders : Table =
+    native "[{'item':'a','qty':2,'price':3},{'item':'b','qty':5,'price':4},{'item':'c','qty':1,'price':7}]";
+
+def completed : Table = Table.mutate orders "total" (\row -> native "row['qty'] * row['price']");
+
+# 2*3 + 5*4 + 1*7 = 33
+def grand_total : Int = Table.sum_col completed "total";
+
+def main (x:Int) : Unit = print grand_total;

--- a/examples/synthesis/dace/filter_aggregate.ae
+++ b/examples/synthesis/dace/filter_aggregate.ae
@@ -1,0 +1,10 @@
+# DACE category: conditional aggregate -- filter rows, then SUM (SUMIF).
+open Table
+
+def t : Table = native "[{'ok':1,'v':10},{'ok':0,'v':20},{'ok':1,'v':5}]";
+
+def kept : Table = Table.filter t (\row -> native "row['ok'] == 1");
+
+def total : Int = Table.sum_col kept "v";  # 10 + 5 = 15
+
+def main (x:Int) : Unit = print total;

--- a/examples/synthesis/dace/group_average.ae
+++ b/examples/synthesis/dace/group_average.ae
@@ -1,0 +1,13 @@
+# DACE category: group-by aggregate -- the average within a group. `group_by`
+# returns one sub-table per group; here we aggregate a single group via
+# filter + mean (the per-group average a completion would fill in).
+open Table
+
+def sales : Table =
+    native "[{'region':'N','v':10},{'region':'N','v':20},{'region':'S','v':6}]";
+
+def north : Table = Table.filter sales (\row -> native "row['region'] == 'N'");
+
+def north_avg : Int = Table.mean_col north "v";  # (10 + 20) / 2 = 15
+
+def main (x:Int) : Unit = print north_avg;

--- a/examples/synthesis/dace/join_lookup.ae
+++ b/examples/synthesis/dace/join_lookup.ae
@@ -1,0 +1,13 @@
+# DACE category: relational join (VLOOKUP) -- pull `price` from a lookup table
+# by key, then complete `cost = qty * price`.
+open Table
+
+def orders : Table = native "[{'item':1,'qty':2},{'item':2,'qty':3}]";
+def prices : Table = native "[{'item':1,'price':10},{'item':2,'price':7}]";
+
+def joined    : Table = Table.join orders prices "item";
+def with_cost : Table = Table.mutate joined "cost" (\row -> native "row['qty'] * row['price']");
+
+def total_cost : Int = Table.sum_col with_cost "cost";  # 2*10 + 3*7 = 41
+
+def main (x:Int) : Unit = print total_cost;

--- a/examples/synthesis/dace/melt_long.ae
+++ b/examples/synthesis/dace/melt_long.ae
@@ -1,0 +1,13 @@
+# DACE category: reshape wide -> long (melt / gather).
+open Table
+
+def wide : Table = native "[{'id':1,'x':7,'y':8}]";
+
+def ids  : (Array String) = native "['id']";
+def vals : (Array String) = native "['x','y']";
+
+def long : Table = Table.melt wide ids vals "k" "v";
+
+def v1 : Int = Table.cell long 1 "v";  # second melted row (y) -> 8
+
+def main (x:Int) : Unit = print v1;

--- a/examples/synthesis/dace/pivot_wide.ae
+++ b/examples/synthesis/dace/pivot_wide.ae
@@ -1,0 +1,11 @@
+# DACE category: reshape long -> wide (pivot / spread).
+open Table
+
+def long : Table =
+    native "[{'id':1,'k':'x','v':7},{'id':1,'k':'y','v':8},{'id':2,'k':'x','v':9}]";
+
+def wide : Table = Table.pivot long "id" "k" "v";
+
+def cell_x0 : Int = Table.cell wide 0 "x";  # row id=1, column x -> 7
+
+def main (x:Int) : Unit = print cell_x0;

--- a/examples/synthesis/dace/running_balance.ae
+++ b/examples/synthesis/dace/running_balance.ae
@@ -1,0 +1,11 @@
+# DACE category: running (cumulative) total -- a spatial scan down a column,
+# e.g. an account balance. `cumsum` fills `balance` with the running sum.
+open Table
+
+def tx : Table = native "[{'d':1,'amt':10},{'d':2,'amt':-3},{'d':3,'amt':5}]";
+
+def withbal : Table = Table.cumsum tx "amt" "balance";
+
+def final_balance : Int = Table.cell withbal 2 "balance";  # 10 - 3 + 5 = 12
+
+def main (x:Int) : Unit = print final_balance;

--- a/examples/synthesis/dace/synth/complete_average.ae
+++ b/examples/synthesis/dace/synth/complete_average.ae
@@ -1,0 +1,9 @@
+# DACE per-cell completion (average), synthesised by the FTA backend.
+#
+# Three input cells 6, 9, 15; complete the cell holding their mean. Written as
+# 3*v == 6+9+15 so the refinement is linear-integer (SMT-decidable).
+#
+#   uv run python -m aeon --no-main -s fta --budget 10 examples/synthesis/dace/synth/complete_average.ae
+#
+# Expected: ?hole: 10
+def average_cell : {v:Int | 3 * v == 6 + 9 + 15} = ?hole;

--- a/examples/synthesis/dace/synth/complete_max.ae
+++ b/examples/synthesis/dace/synth/complete_max.ae
@@ -1,0 +1,9 @@
+# DACE per-cell completion (maximum), synthesised by the FTA backend.
+#
+# Two input cells 8 and 7; complete the cell holding their maximum: it is >= both
+# and equal to one of them.
+#
+#   uv run python -m aeon --no-main -s fta --budget 10 examples/synthesis/dace/synth/complete_max.ae
+#
+# Expected: ?hole: 8
+def max_cell : {v:Int | v >= 8 && v >= 7 && (v == 8 || v == 7)} = ?hole;

--- a/examples/synthesis/dace/synth/complete_total.ae
+++ b/examples/synthesis/dace/synth/complete_total.ae
@@ -1,0 +1,10 @@
+# DACE per-cell completion, synthesised by the FTA backend.
+#
+# The input column holds a = 8 and b = 7; complete the total cell so that
+# total == a + b. The fta backend enumerates integer cells, keys each by its
+# value (observational equivalence), and accepts the one the refinement admits.
+#
+#   uv run python -m aeon --no-main -s fta --budget 10 examples/synthesis/dace/synth/complete_total.ae
+#
+# Expected: ?hole: 15
+def total_cell : {v:Int | v == 8 + 7} = ?hole;

--- a/examples/synthesis/fta/arithmetic_refinement.ae
+++ b/examples/synthesis/fta/arithmetic_refinement.ae
@@ -1,0 +1,17 @@
+# Finite Tree Automata (FTA) synthesis -- Wang, Dillig & Singh, "Synthesis of
+# Data Completion Scripts using Finite Tree Automata" (OOPSLA 2017).
+#
+# The FTA backend builds a finite tree automaton bottom-up over the in-scope
+# components, keying states by each candidate's concrete output (observational
+# equivalence) and accepting the states whose representative satisfies the
+# refinement-typed specification -- so the spec is checked once per state, and
+# the smallest accepted program is extracted.
+#
+# Unlike `symetric`, FTA needs no @minimize/@maximize objective: a pure
+# refinement hole is enough. Run with:
+#
+#   uv run python -m aeon --no-main -s fta --budget 10 examples/synthesis/fta/arithmetic_refinement.ae
+#
+# The hole below is solved by the integer whose value satisfies the refinement.
+
+def answer : {v:Int | v + 4 == 7 && v * 2 == 6} = ?hole;

--- a/libraries/Table.ae
+++ b/libraries/Table.ae
@@ -67,7 +67,7 @@ def summary(table: Table) (column: String) (f: (a: (Array Int)) -> b): b =
 # column: column to group by
 # returns: list of tables, each corresponding to a group
 def group_by(table: Table) (column: String): (Array Table) =
-    native "__import__('aeon.aeon.bindings.table').aeon.aeon.bindings.table.group_by(table, column)"
+    native "__import__('aeon.bindings.table').bindings.table.group_by(table, column)"
 
 
 # Pivots a table: turns unique values from one column into new columns.
@@ -80,7 +80,7 @@ def group_by(table: Table) (column: String): (Array Table) =
 # values: column to fill values from
 # returns: reshaped table (list of dicts)
 def pivot(table: Table) (index: String) (columns: String) (values: String): Table =
-    native "__import__('aeon.aeon.bindings.table').aeon.aeon.bindings.table.pivot(table, index, columns, values)"
+    native "__import__('aeon.bindings.table').bindings.table.pivot(table, index, columns, values)"
 
 
 # Melts a table: turns columns into rows (unpivot).
@@ -93,4 +93,86 @@ def pivot(table: Table) (index: String) (columns: String) (values: String): Tabl
 # value_name: name for the new value column
 # returns: reshaped table (list of dicts)
 def melt(table: Table) (id_vars: (Array String)) (value_vars: (Array String)) (var_name: String) (value_name: String): Table =
-    native "__import__('aeon.aeon.bindings.table').aeon.aeon.bindings.table.melt(table, id_vars, value_vars, var_name, value_name)"
+    native "__import__('aeon.bindings.table').bindings.table.melt(table, id_vars, value_vars, var_name, value_name)"
+
+
+# ============================================================================
+# Data-completion operators (Wang, Dillig & Singh, "Synthesis of Data
+# Completion Scripts using Finite Tree Automata", OOPSLA 2017 -- the DACE DSL).
+#
+# These extend the relational core above (select / filter / map_column /
+# group_by / pivot / melt) with the spatial and aggregate constructs the paper's
+# data-completion tasks rely on: deriving a column from a per-row formula
+# (mutate), cell/shape access, column aggregates, sorting, slicing, running
+# (cumulative) totals, and relational joins. Together they cover the spatial +
+# relational reasoning DACE combines.
+# ============================================================================
+
+# --- shape / spatial access -------------------------------------------------
+
+# Number of rows in the table.
+def nrow(table: Table): Int = native "len(table)"
+
+# Number of columns in the table.
+def ncol(table: Table): Int = native "(len(table[0]) if len(table) > 0 else 0)"
+
+# The integer cell at row `r` (0-based) of column `col` -- DACE's spatial
+# cell reference.
+def cell(table: Table) (r: Int) (col: String): Int = native "table[r][col]"
+
+# --- deriving a column (mutate) ---------------------------------------------
+
+# Add a new column `newcol` whose value in each row is `f` applied to that row.
+# This is the workhorse of data completion: filling a column with a formula
+# over the other columns (e.g. `mutate t "total" (\row -> ...)`).
+def mutate(table: Table) (newcol: String) (f: (row: Row) -> Int): Table =
+    native "[dict(row, **{newcol: f(row)}) for row in table]"
+
+# --- column aggregates ------------------------------------------------------
+
+# Sum of the integer column `column`.
+def sum_col(table: Table) (column: String): Int = native "sum(row[column] for row in table)"
+
+# Integer mean (floor) of the column `column`.
+def mean_col(table: Table) (column: String): Int =
+    native "(sum(row[column] for row in table) // len(table) if len(table) > 0 else 0)"
+
+# Maximum of the integer column `column`.
+def max_col(table: Table) (column: String): Int = native "max(row[column] for row in table)"
+
+# Minimum of the integer column `column`.
+def min_col(table: Table) (column: String): Int = native "min(row[column] for row in table)"
+
+# Number of rows (COUNT).
+def count(table: Table): Int = native "len(table)"
+
+# --- ordering and slicing ---------------------------------------------------
+
+# Sort the rows in ascending order of `column` (arrange).
+def arrange(table: Table) (column: String): Table = native "sorted(table, key=lambda r: r[column])"
+
+# The first `n` rows (head / take).
+def head(table: Table) (n: Int): Table = native "table[:n]"
+
+# --- running (cumulative) total: a spatial scan ----------------------------
+
+# Add a column `newcol` holding the running sum of `column` down the rows --
+# the cumulative-total completion pattern (e.g. a balance column).
+def cumsum(table: Table) (column: String) (newcol: String): Table =
+    native "[dict(table[i], **{newcol: t}) for i, t in enumerate(__import__('itertools').accumulate(rw[column] for rw in table))]"
+
+# --- relational join --------------------------------------------------------
+
+# Inner-join `left` and `right` on equal values of key column `on`.
+def join(left: Table) (right: Table) (on: String): Table =
+    native "[dict(l, **{k: v for k, v in r.items() if k != on}) for l in left for r in right if l[on] == r[on]]"
+
+# --- tidyverse-style aliases for reshape (DACE naming) ---------------------
+
+# `spread` is `pivot`: long -> wide.
+def spread(table: Table) (index: String) (columns: String) (values: String): Table =
+    native "__import__('aeon.bindings.table').bindings.table.pivot(table, index, columns, values)"
+
+# `gather` is `melt`: wide -> long.
+def gather(table: Table) (id_vars: (Array String)) (value_vars: (Array String)) (var_name: String) (value_name: String): Table =
+    native "__import__('aeon.bindings.table').bindings.table.melt(table, id_vars, value_vars, var_name, value_name)"

--- a/tests/dace_test.py
+++ b/tests/dace_test.py
@@ -1,0 +1,60 @@
+"""Tests for the DACE data-completion examples (FTA paper, OOPSLA'17).
+
+Covers (a) the Table DSL worked pipelines -- including the reshape operators
+whose binding module path this work fixed -- and (b) a per-cell completion run
+by the FTA backend.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run(args: list[str]) -> str:
+    proc = subprocess.run(
+        [sys.executable, "-m", "aeon", *args],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+    assert "Traceback" not in proc.stderr, out[-2000:]
+    return out
+
+
+@pytest.mark.parametrize(
+    "example,expected",
+    [
+        ("column_formula", "33"),  # mutate + sum_col
+        ("aggregate_sum", "35"),  # sum_col
+        ("group_average", "15"),  # filter + mean_col
+        ("running_balance", "12"),  # cumsum + cell
+        ("pivot_wide", "7"),  # pivot + cell (binding-path fix)
+        ("melt_long", "8"),  # melt + cell (binding-path fix)
+        ("filter_aggregate", "15"),  # filter + sum_col
+        ("join_lookup", "41"),  # join + mutate + sum_col
+    ],
+)
+def test_table_pipeline_runs(example: str, expected: str):
+    out = _run([f"examples/synthesis/dace/{example}.ae"])
+    assert expected in out.split(), out[-1500:]
+
+
+@pytest.mark.parametrize(
+    "example,value",
+    [
+        ("complete_total", "15"),
+        ("complete_average", "10"),
+        ("complete_max", "8"),
+    ],
+)
+def test_fta_completes_cell(example: str, value: str):
+    out = _run(["--no-main", "-s", "fta", "--budget", "10", f"examples/synthesis/dace/synth/{example}.ae"])
+    assert f"?hole: {value}" in out, out[-1500:]

--- a/tests/fta_test.py
+++ b/tests/fta_test.py
@@ -1,0 +1,71 @@
+"""Tests for the FTA (Finite Tree Automata) synthesis backend.
+
+FTA builds a finite tree automaton bottom-up, keying states by a candidate's
+concrete output (observational equivalence) and accepting the states consistent
+with the refinement-typed spec (so the spec is checked once per state). Unlike
+the metric backend (``symetric``), it needs no objective: a pure refinement hole
+is enough, and it extracts the smallest accepted program.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from aeon.core.terms import Literal
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.modules.fta import FTASynthesizer
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+from tests.driver import check_and_return_core
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _solve(code: str, budget: float = 15.0):
+    term, ctx, ectx, metadata = check_and_return_core(code)
+    targets = incomplete_functions_and_holes(ctx, term)
+    holes = synthesize_holes(ctx, ectx, term, targets, metadata, FTASynthesizer(), budget=budget)
+    return holes[next(iter(holes))]
+
+
+def test_factory_registers_fta():
+    assert isinstance(make_synthesizer("fta"), FTASynthesizer)
+
+
+def test_solves_linear_refinement():
+    # The accepting state is the integer satisfying v + 4 == 7.
+    t = _solve("def n : {v:Int | v + 4 == 7} = ?hole;")
+    assert isinstance(t, Literal) and t.value == 3
+
+
+def test_solves_conjoined_refinement():
+    # Two constraints pin a single value; FTA validates one rep per output value.
+    t = _solve("def m : {v:Int | v * 2 == 10 && v - 1 == 4} = ?hole;")
+    assert isinstance(t, Literal) and t.value == 5
+
+
+def test_cli_runs_fta_backend():
+    # End-to-end through the real driver: the hole is filled with the value that
+    # satisfies the refinement, with no objective decorator required.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "aeon",
+            "--no-main",
+            "-s",
+            "fta",
+            "--budget",
+            "10",
+            "examples/synthesis/fta/arithmetic_refinement.ae",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+    assert "Traceback" not in proc.stderr, out[-2000:]
+    assert "?hole: 3" in out, out[-2000:]


### PR DESCRIPTION
## Summary

Implements the **Finite Tree Automata** line of work — Wang, Dillig & Singh, *"Synthesis of Data Completion Scripts using Finite Tree Automata"* (OOPSLA 2017) — in two parts:

1. a new **`--synthesizer fta`** backend, and
2. the paper's **data-completion examples** (tool: DACE), with the standard-library Table DSL extended to support them.

AFTA (POPL'18, #350) and CATA (#351) remain filed as follow-up issues.

## Part 1 — the FTA backend

Bottom-up over the in-scope components (constructors / library functions as a ranked alphabet), it builds a finite tree automaton whose **states** are observational-equivalence classes (a candidate's concrete output via `output_value`), **transitions** are component applications `f(q1,…,qk) → q`, and **accepting states** are those whose representative satisfies the spec. Equal-output programs collapse to one state, so the spec is checked **once per state** and the **smallest** accepted program is extracted.

The paper accepts a program iff it reproduces a concrete output **example**; aeon specifies a hole by a **refinement type**, so the acceptance oracle here is `validate` (the liquid typechecker), and value-states are materialised at the hole type. Needs **no `@minimize`/`@maximize` objective** — the backend for refinement holes that `symetric` rejects.

- `aeon/synthesis/modules/fta/` — backend; reuses `symetric`'s `Component`/`_peel`/`base_key`/`_decompose`.
- Registered in `synthesizerfactory.py` and the `--synthesizer` CLI help.
- `tests/fta_test.py` — registration, two refinement holes, end-to-end CLI. mypy + ruff clean.

## Part 2 — DACE data-completion examples + Table DSL

`examples/synthesis/dace/` renders the paper's task categories in two faithful halves (full rationale in its README):

- **Worked DSL pipelines** (8 files, executed end-to-end): column arithmetic (`mutate`), aggregate (SUM), group-by average, running/cumulative total (`cumsum`), reshape long↔wide (`pivot`/`melt`), conditional aggregate (filter+SUM), relational join (VLOOKUP).
- **Synthesised per-cell completions** (`synth/`, 3 files): the output cell is a `?hole` whose refinement is the completion formula, solved by `--synthesizer fta` → `15`, `10`, `8`.

**Standard library** (`libraries/Table.ae`): the relational core already existed (`select`/`filter`/`map_column`/`group_by`/`pivot`/`melt`/`summary`); this adds the spatial+aggregate operators DACE needs — `mutate`, `cell`, `nrow`/`ncol`, `sum_col`/`mean_col`/`max_col`/`min_col`/`count`, `arrange`, `head`, `cumsum`, `join`, and `spread`/`gather` aliases — and **fixes a pre-existing bug**: `group_by`/`pivot`/`melt` imported `aeon.aeon.bindings.table` (doubled package), crashing at runtime; corrected to `aeon.bindings.table`.

`tests/dace_test.py` covers all eight pipelines (incl. the now-fixed `pivot`/`melt`) and the three FTA completions.

### Honest scope notes
- The paper's 84 benchmarks are forum-scraped spreadsheets (artifact unavailable); these examples cover the **operation categories** the paper describes, one task each.
- Synthesising a full table-transformation *script* from I/O examples needs example-based (PBE) acceptance over opaque table values, which the FTA backend (refinement/`validate` acceptance) doesn't do; the `synth/` tasks therefore complete at the **cell** level, where the spec is SMT-decidable. Example-based acceptance in the FTA backend is a natural follow-up.
- The DACE suite runs on demand (not swept by `run_examples.sh`); a subset is covered by the pytest suite.

## Follow-ups
- **#350** — AFTA, abstraction-refinement FTA (POPL'18)
- **#351** — CATA, constraint-annotated tree automata (relational/recursive synthesis)

https://claude.ai/code/session_01HLPufK3ESWM9RwQ143WndW