### PR TITLE
fix(synthesis): don't crash grammar generation on library refinement types

### DIFF
--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -590,9 +590,7 @@ def create_var_apps_node(name: Name, ty: AbstractionType, type_info: dict[Type, 
 
 def create_var_nodes(vars: list[Tuple[Name, Type]], type_info: dict[Type, TypingType]) -> list[TypingType]:
     """Creates a list of python types for all variables in context."""
-    var_nodes = [
-        create_var_node(var_name, ty, _get(type_info, ty)) for (var_name, ty) in vars if _has(type_info, ty)
-    ]
+    var_nodes = [create_var_node(var_name, ty, _get(type_info, ty)) for (var_name, ty) in vars if _has(type_info, ty)]
     app_nodes = [
         create_var_apps_node(var_name, ty, type_info)
         for (var_name, ty) in vars

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -549,7 +549,7 @@ def create_var_node(name: Name, ty: Type, python_ty: TypingType) -> TypingType:
     return dc
 
 
-def create_var_apps_node(name: Name, ty: AbstractionType, type_info: dict[Type, TypingType]) -> TypingType:
+def create_var_apps_node(name: Name, ty: AbstractionType, type_info: dict[Type, TypingType]) -> Optional[TypingType]:
     """Creates a python type for a given variable in context that is a function."""
 
     # Collect arguments
@@ -563,6 +563,12 @@ def create_var_apps_node(name: Name, ty: AbstractionType, type_info: dict[Type, 
     # matching the storage convention used by `extract_all_types`.
     for aname, _ in args:
         rtype = substitution_in_type(rtype, Var(Name("__self__", 0)), aname)
+    # Skip functions whose argument or return types cannot be represented as
+    # grammar nodes (e.g. a dependent refinement mentioning a sibling binder,
+    # such as ``clamp``'s ``hi: {v:Int | v >= lo}``). Such a function simply
+    # does not become a synthesis building block, instead of crashing.
+    if not _has(type_info, rtype) or any(not _has(type_info, aty) for (_, aty) in args):
+        return None
     python_ty = _get(type_info, rtype)
 
     vname = mangle_var(name)
@@ -584,17 +590,25 @@ def create_var_apps_node(name: Name, ty: AbstractionType, type_info: dict[Type, 
 
 def create_var_nodes(vars: list[Tuple[Name, Type]], type_info: dict[Type, TypingType]) -> list[TypingType]:
     """Creates a list of python types for all variables in context."""
-    return [create_var_node(var_name, ty, _get(type_info, ty)) for (var_name, ty) in vars if _has(type_info, ty)] + [
+    var_nodes = [
+        create_var_node(var_name, ty, _get(type_info, ty)) for (var_name, ty) in vars if _has(type_info, ty)
+    ]
+    app_nodes = [
         create_var_apps_node(var_name, ty, type_info)
         for (var_name, ty) in vars
         if _has(type_info, ty) and isinstance(ty, AbstractionType)
     ]
+    return var_nodes + [n for n in app_nodes if n is not None]
 
 
-def create_abstraction_node(ty: AbstractionType, type_info: dict[Type, TypingType]) -> TypingType:
+def create_abstraction_node(ty: AbstractionType, type_info: dict[Type, TypingType]) -> Optional[TypingType]:
     """Creates a dataclass to represent an abstraction (\\_0 -> x) of type sth_arrow_X."""
     vname = f"lambda_{mangle_type(ty)}"
     return_type = substitution_in_type(ty.type, Var(Name("__self__", 0)), ty.var_name)
+    # Skip arrow types whose own or body representation is unavailable (e.g. the
+    # function arguments of abstract-refinement-polymorphic library functions).
+    if not _has(type_info, ty) or not _has(type_info, return_type):
+        return None
     dc = make_dataclass(vname, [("body", _get(type_info, return_type))], bases=(_get(type_info, ty),))
 
     def get_core(_self):
@@ -621,18 +635,23 @@ def collect_all_abstractions(t: Type) -> Generator[AbstractionType]:
 
 
 def create_abstraction_nodes(type_info: dict[Type, TypingType]) -> list[TypingType]:
-    return [
+    nodes = [
         create_abstraction_node(ity, type_info)
         for ty in type_info
         for ity in collect_all_abstractions(ty)
         if isinstance(ity, AbstractionType)
     ]
+    return [n for n in nodes if n is not None]
 
 
-def create_application_node(ty: AbstractionType, type_info: dict[Type, TypingType]) -> TypingType:
+def create_application_node(ty: AbstractionType, type_info: dict[Type, TypingType]) -> Optional[TypingType]:
     """Creates a dataclass to represent an abstraction (\\_0 -> x) of type sth_arrow_X."""
     vname = f"app_{mangle_type(ty)}"
     return_type = substitution_in_type(ty.type, Var(Name("__self__", 0)), ty.var_name)
+    # Skip applications whose function, argument, or result type cannot be
+    # represented as grammar nodes.
+    if not all(_has(type_info, t) for t in (ty, ty.var_type, return_type)):
+        return None
     dc = make_dataclass(
         vname,
         [("fun", _get(type_info, ty)), ("arg", _get(type_info, ty.var_type))],
@@ -650,7 +669,8 @@ def create_application_node(ty: AbstractionType, type_info: dict[Type, TypingTyp
 
 
 def create_application_nodes(type_info: dict[Type, TypingType]) -> list[TypingType]:
-    return [create_application_node(ty, type_info) for ty in type_info if isinstance(ty, AbstractionType)]
+    nodes = [create_application_node(ty, type_info) for ty in type_info if isinstance(ty, AbstractionType)]
+    return [n for n in nodes if n is not None]
 
 
 def create_if_node(ty: Type, type_info: dict[Type, TypingType]) -> TypingType:

--- a/aeon/synthesis/grammar/refinements.py
+++ b/aeon/synthesis/grammar/refinements.py
@@ -83,7 +83,11 @@ def interval_to_metahandler(interval: Any, base_type: Type) -> MetaHandlerGenera
             metahandler_instance = aeon_to_gengy_metahandlers[base_type](min_range, max_range)
             return Annotated[python_type, metahandler_instance]
         case _:
-            raise NotImplementedError()
+            # Other sympy set shapes (e.g. a ``Union`` produced by a ``!= c``
+            # refinement) have no single-range metahandler. Skip them rather
+            # than crashing; ``intervals_to_metahandlers`` filters out ``None``,
+            # so the refined type simply gets no dedicated value generator.
+            return None
 
 
 def intervals_to_metahandlers(intervals_list: list, base_type: Type) -> list[MetaHandlerGenerator]:
@@ -92,8 +96,12 @@ def intervals_to_metahandlers(intervals_list: list, base_type: Type) -> list[Met
 
 def get_metahandler_union(
     metahandler_list: list[MetaHandlerGenerator],
-) -> MetaHandlerGenerator | Union[MetaHandlerGenerator]:
-    if len(metahandler_list) == 1:
+) -> MetaHandlerGenerator | Union[MetaHandlerGenerator] | None:
+    if len(metahandler_list) == 0:
+        # No representable range for this refinement (e.g. every interval was
+        # skipped). Callers treat ``None`` as "no dedicated value generator".
+        return None
+    elif len(metahandler_list) == 1:
         return metahandler_list[0]
     else:
         return Union[tuple(metahandler_list)]

--- a/tests/synthesis/grammar_library_import_test.py
+++ b/tests/synthesis/grammar_library_import_test.py
@@ -1,0 +1,80 @@
+"""Regression test: building the synthesis grammar for a hole whose context
+contains library functions with dependent or abstract refinements must not
+crash.
+
+Importing a library (e.g. ``Math``, ``Array``) into a file with a hole brings
+shapes the grammar generator could not represent into the hole's typing context:
+
+* ``Math.clamp`` -- ``hi: {v:Int | v >= lo}``, a refinement mentioning a
+  *sibling* binder (``create_var_apps_node``);
+* the abstract-refinement higher-order ``Array.map`` / ``reduce`` -- function
+  arguments like ``(x:{v:a | p v}) -> {w:b | q w}``
+  (``create_abstraction_node`` / ``create_application_node``);
+* ``Array.get`` -- ``i: {n:Int | n < size arr}``; and
+* ``!= 0`` refinements (``Math.fmod``'s divisor) whose interval is a sympy
+  ``Union`` with no single-range metahandler (``refinements.py``).
+
+``create_grammar`` used to abort with ``KeyError`` / ``NotImplementedError`` /
+``TypeError`` on these; it now skips the types it cannot represent and builds a
+grammar from the rest.
+"""
+
+from aeon.core.types import top
+from aeon.synthesis.grammar.grammar_generation import create_grammar
+from aeon.synthesis.identification import get_holes_info
+from aeon.utils.name import Name
+from tests.driver import check_and_return_core
+
+
+def _grammar_for_hole(code: str):
+    term, ctx, _ectx, _metadata = check_and_return_core(code)
+    holes = get_holes_info(ctx, term, top, [], refined_types=True)
+    assert holes, "expected the program to contain a hole"
+    _hole_name, (ty, hole_ctx) = next(iter(holes.items()))
+    # Must not raise (previously KeyError / NotImplementedError / TypeError).
+    return create_grammar(hole_ctx, ty, Name("synth", 0), {})
+
+
+def test_inline_dependent_refinement_on_sibling_binder_does_not_crash():
+    # ``hi``'s refinement mentions the sibling binder ``lo`` (mirrors Math.clamp).
+    code = """
+def clampish (x: Int) (lo: Int) (hi: {v:Int | v >= lo}) : Int = lo;
+
+def synth (n: Int) : Int = ?hole;
+"""
+    assert _grammar_for_hole(code) is not None
+
+
+def test_inline_nonzero_refinement_does_not_crash():
+    # ``!= 0`` yields a sympy Union with no single-range metahandler.
+    code = """
+def recip_guard (x: {v:Int | v != 0}) : Int = x;
+
+def synth (n: Int) : Int = ?hole;
+"""
+    assert _grammar_for_hole(code) is not None
+
+
+def test_open_math_library_does_not_crash():
+    # Brings clamp (sibling-binder refinement), refined-arrow helpers, and
+    # ``!= 0`` divisor refinements into scope.
+    code = """open Math
+
+def synth (x: Float) : Float = ?hole;
+"""
+    assert _grammar_for_hole(code) is not None
+
+
+def test_higher_order_library_use_does_not_crash():
+    # A helper that *uses* the abstract-refinement higher-order ``Array.reduce``
+    # together with ``Math.absf`` monomorphizes their refined-arrow types into
+    # the hole's context, exercising the abstraction/application node builders.
+    code = """open Array
+open Math
+
+def total_error (f: (a0:Float) -> Float) (xs: (Array Float)) : Float =
+    Array.reduce (\\v -> \\acc -> Math.absf (f v) + acc) 0.0 xs;
+
+def synth (x: Float) : Float = ?hole;
+"""
+    assert _grammar_for_hole(code) is not None


### PR DESCRIPTION
## Problem

Importing a standard library (e.g. `Math`, `Array`) into a file that contains a synthesis hole crashes the **whole synthesis run** during grammar generation. The libraries' functions bring refinement shapes the grammar generator can't represent, and it aborts with an exception instead of skipping them. This makes `open Math` / `open Array` (and selective imports) unusable in synthesis files.

Minimal repro (crashes on `master`, works on this branch):
```aeon
open Math
def synth (x: Float) : Float = ?hole;
```
```
uv run python -m aeon --no-main --budget 5 -s gp file.ae
# KeyError: { __c0__:Int | (__c0__ >= lo) }
```

## Crash sites fixed

| Site | Triggering shape | Symptom |
|---|---|---|
| `create_var_apps_node` | dependent refinement mentioning a **sibling binder** — `Math.clamp`'s `hi: {v:Int \| v >= lo}` | `KeyError` |
| `create_abstraction_node` / `create_application_node` | refined-arrow **function arguments** of abstract-refinement-polymorphic functions (`Array.map` / `reduce`) | `KeyError` |
| `refinements.interval_to_metahandler` | a sympy `Union` from a `!= 0` refinement (e.g. a nonzero divisor) | `NotImplementedError` |
| `refinements.get_metahandler_union` | empty metahandler list (every interval skipped) | `TypeError: Cannot take a Union of no types` |

## Fix

Each builder now **skips** the types/refinements it cannot represent (returns `None`, and the list builders filter it out) instead of crashing. A function with an unrepresentable argument/return type simply doesn't become a synthesis building block — which is the correct degradation. This is conservative: the fallbacks only affect inputs that previously **crashed**, so existing (passing) synthesis behaviour is unchanged.

## Tests

Adds `tests/synthesis/grammar_library_import_test.py` with four cases covering every site above (inline `clamp`-like sibling-binder refinement, `!= 0` refinement, `open Math`, and a higher-order `Array.reduce` + `Math.absf` helper). **Each test fails on `master`** and passes here.

Full suite: **1430 passed, 9 skipped**. `ruff` clean; no new `mypy` errors (pre-existing missing-stub/`no_implicit_optional` warnings only).

## Context

This is the synthesis-engine prerequisite identified while reviewing #352 (the SRBench examples): expressing the example fitness with the `Array`/`Math` libraries instead of an embedded `native` expression was blocked by these crashes. Kept as a separate, focused PR per request.

> Note: importing *heavy* `Math` functions (e.g. `factorial`, `exp`) can still make individual candidates slow enough to hit the per-candidate evaluation timeout; that timeout is handled separately from grammar generation and is out of scope here.

https://claude.ai/code/session_016q15mvQqLWxLN3sb3NH2hY

---
_Generated by [Claude Code](https://claude.ai/code/session_016q15mvQqLWxLN3sb3NH2hY)_