### PR TITLE
feat(synthesis): CATA backend (#351) + sound integer division/modulo in the verifier

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -111,6 +111,7 @@ def _parse_common_arguments(parser: ArgumentParser):
             "sygus (reduce to SyGuS and solve with cvc5), decision_tree, llm, "
             "lta (Liquid Tree Automata, arXiv:2605.13456), "
             "fta (Finite Tree Automata, OOPSLA'17), "
+            "cata (constraint-annotated tree automata, recursive/relational), "
             "symetric (metric program synthesis, arXiv:2206.06164)"
         ),
     )

--- a/aeon/synthesis/modules/cata/__init__.py
+++ b/aeon/synthesis/modules/cata/__init__.py
@@ -1,0 +1,3 @@
+from aeon.synthesis.modules.cata.synthesizer import CATASynthesizer
+
+__all__ = ["CATASynthesizer"]

--- a/aeon/synthesis/modules/cata/synthesizer.py
+++ b/aeon/synthesis/modules/cata/synthesizer.py
@@ -92,12 +92,6 @@ from aeon.utils.name import Name
 
 _loc = SynthesizedLocation("cata")
 
-# Partial operators: their result on a zero divisor is left unconstrained by the
-# SMT encoding, which lets candidates like ``-2 / 0`` vacuously satisfy a
-# refinement. Excluding them keeps every synthesised program total and its
-# acceptance meaningful (the underlying div-by-zero soundness gap is separate).
-_PARTIAL_OPS = frozenset({"/", "%"})
-
 
 @dataclass(frozen=True)
 class Comp:
@@ -173,8 +167,6 @@ class CATASynthesizer(Synthesizer):
                 atoms.setdefault(ret_key, []).append(head)
 
         for name, ty in ctx.concrete_vars():
-            if name.name in _PARTIAL_OPS:
-                continue  # keep synthesised programs total (see _PARTIAL_OPS)
             if is_polymorphic(ty):
                 # Num/Ord operators and polymorphic library functions: make them
                 # first-order by instantiating at the query's base types.

--- a/aeon/synthesis/modules/cata/synthesizer.py
+++ b/aeon/synthesis/modules/cata/synthesizer.py
@@ -1,0 +1,395 @@
+"""CATA: relational *recursive* synthesis via Constraint-Annotated Tree Automata.
+
+Implements the line of Wang, Miltner, Dillig et al., "Relational Synthesis of
+Recursive Programs via Constraint Annotated Tree Automata"
+(https://www.cs.utexas.edu/~isil/cata.pdf) -- the third and most ambitious
+backend on aeon's tree-automata line, after the concrete FTA (``fta``,
+OOPSLA'17) and the abstraction-refinement AFTA (``afta``, POPL'18).
+
+FTA and AFTA target **non-recursive** programs: they build an automaton over
+component applications and accept the states consistent with a ground/abstract
+spec. CATA extends tree-automata synthesis to **recursive** programs by letting
+the automaton's positions carry **constraint annotations** -- relational
+specifications relating a (possibly recursive) node's inputs to its output --
+which are discharged with an SMT solver rather than by running the program on
+ground examples.
+
+How this maps onto aeon, and why it fits so cleanly:
+
+* A function hole ``def f (x:T) : {v:U | R(x,v)} = ?hole`` is presented to the
+  synthesiser with its abstractions already peeled: the goal is the *body* type
+  ``{v:U | R(x,v)}`` (a relational refinement mentioning the parameter ``x``),
+  with both ``x`` **and the recursive self-name ``f``** already in the context.
+  So a recursive call is simply another component in the bottom-up bank.
+* aeon's refinement types *are* relational specifications, and the liquid
+  typechecker already performs exactly CATA's constraint discharge: it checks a
+  recursive body against ``R`` using the **function's own signature as the
+  inductive hypothesis** for the recursive call, and rejects it unless the
+  recursion is **well-founded** (terminating). ``validate`` is therefore CATA's
+  constraint-annotation oracle, for free.
+
+What CATA adds over FTA/AFTA's construction:
+
+1. **Monomorphic components from polymorphic library functions.** aeon's
+   arithmetic/comparison operators (``+ - * == < <= > >=`` ...) are Num/Ord
+   *typeclass methods* -- polymorphic, so FTA/AFTA's first-order component
+   collection skips them. CATA instantiates them at the query's base types
+   (reusing the ``lta`` backend's ``monomorphize``), so ``x - 1``, ``x == 0``,
+   etc. become buildable.
+2. **Conditional transitions** (``if c then t else e``) -- the base-case /
+   recursive-case split that every interesting recursive definition needs.
+3. **Recursive self-calls**, available as an ordinary component (above).
+
+Acceptance is the constraint discharge: a goal-typed candidate is accepted iff
+``validate`` proves its relational refinement under the inductive hypothesis and
+termination. The smallest accepted program is returned. Like ``fta``/``afta``,
+no ``@minimize``/``@maximize`` objective is required.
+
+Scope. Recursive **datatype** synthesis (list/tree folds from the Synquid
+suite) is the frontier this backend opens; convergence there is budget-bound and
+a genuine search problem. The machinery here -- monomorphic operators,
+conditionals, recursive self-calls, SMT constraint discharge -- is exactly what
+that needs, and it already synthesises conditional and shallow recursive
+integer programs end-to-end. Compression is by syntactic de-duplication of the
+bank (each constraint-annotated state keeps its smallest representative);
+merging states by *constraint equivalence* (an SMT entailment per pair) is the
+faithful-but-costly refinement left as future work.
+
+Selected with ``--synthesizer cata``.
+"""
+
+from __future__ import annotations
+
+import itertools
+import random
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+from aeon.core.terms import Abstraction, Application, If, Literal, Term, Var
+from aeon.core.types import (
+    AbstractionType,
+    Type,
+    TypePolymorphism,
+    t_bool,
+    t_int,
+)
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.modules.fta.synthesizer import _safe, _term_size
+from aeon.synthesis.modules.lta.polymorphism import (
+    collect_type_universe,
+    is_polymorphic,
+    monomorphize,
+)
+from aeon.synthesis.modules.symetric.synthesizer import _peel, base_key
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name
+
+_loc = SynthesizedLocation("cata")
+
+# Partial operators: their result on a zero divisor is left unconstrained by the
+# SMT encoding, which lets candidates like ``-2 / 0`` vacuously satisfy a
+# refinement. Excluding them keeps every synthesised program total and its
+# acceptance meaningful (the underlying div-by-zero soundness gap is separate).
+_PARTIAL_OPS = frozenset({"/", "%"})
+
+
+@dataclass(frozen=True)
+class Comp:
+    """A component (constraint-annotated transition's label): a head term --
+    ``Var(f)`` for a monomorphic binding or a ``TypeApplication`` nest for an
+    instantiated polymorphic one -- with the base-type keys of its arguments and
+    result. Unlike the first-order ``Component`` shared by ``fta``/``afta``, the
+    head is a full ``Term`` so monomorphised (type-applied) operators qualify."""
+
+    head: Term
+    arg_keys: tuple[str, ...]
+    ret_key: str
+
+
+class CATASynthesizer(Synthesizer):
+    """Recursive, relational component-based synthesis: build a tree automaton
+    whose transitions include recursive self-calls and conditionals over
+    monomorphised components, and accept states by SMT constraint discharge
+    (the liquid typechecker)."""
+
+    def computations(self, primitives: Any) -> dict[str, Any]:
+        # Relational specs are universally quantified over the parameters, so
+        # candidates cannot be observed on a single ground input; acceptance is
+        # by SMT (validate), not by output value. Nothing extra to compute.
+        return {}
+
+    def __init__(
+        self,
+        seed: int = 0,
+        int_lo: int = -2,
+        int_hi: int = 5,
+        rounds: int = 3,
+        combo_cap: int = 2048,
+        cond_cap: int = 4096,
+        cond_head: int = 48,
+        branch_head: int = 32,
+        max_bank: int = 256,
+        max_inst: int = 8,
+    ):
+        self.seed = seed
+        self.int_lo = int_lo
+        self.int_hi = int_hi
+        self.rounds = rounds
+        self.combo_cap = combo_cap
+        self.cond_cap = cond_cap
+        # How many of the smallest conditions / branches feed the (deterministic)
+        # conditional enumeration -- bounds an otherwise cubic product.
+        self.cond_head = cond_head
+        self.branch_head = branch_head
+        self.max_bank = max_bank
+        self.max_inst = max_inst
+
+    # -- component collection (monomorphising polymorphic bindings) ------------
+
+    def _collect(self, ctx: TypingContext, universe: list[Type]) -> tuple[dict[str, list[Comp]], dict[str, list[Term]]]:
+        """Index in-scope bindings as builders (the ranked alphabet, including
+        recursive self-calls and monomorphised operators) and atoms (nullary
+        leaves, including the function's parameters)."""
+        builders: dict[str, list[Comp]] = {}
+        atoms: dict[str, list[Term]] = {}
+
+        def register(head: Term, ty: Type) -> None:
+            arg_types, ret = _peel(ty)
+            if any(isinstance(a, (AbstractionType, TypePolymorphism)) for a in arg_types):
+                return  # no higher-order arguments
+            if isinstance(ret, (AbstractionType, TypePolymorphism)):
+                return
+            ret_key = base_key(ret)
+            if arg_types:
+                comp = Comp(head, tuple(base_key(a) for a in arg_types), ret_key)
+                builders.setdefault(ret_key, []).append(comp)
+            else:
+                atoms.setdefault(ret_key, []).append(head)
+
+        for name, ty in ctx.concrete_vars():
+            if name.name in _PARTIAL_OPS:
+                continue  # keep synthesised programs total (see _PARTIAL_OPS)
+            if is_polymorphic(ty):
+                # Num/Ord operators and polymorphic library functions: make them
+                # first-order by instantiating at the query's base types.
+                for inst in monomorphize(name, ty, universe, max_instantiations=self.max_inst):
+                    register(inst.term, inst.mono_type)
+            else:
+                register(Var(name), ty)
+        return builders, atoms
+
+    def _app_combos(self, comp: Comp, bank: dict[str, list[Term]], deadline: float, rnd: random.Random) -> list[Term]:
+        """Application transitions ``comp(q1, ..., qk) -> q``: applications of
+        ``comp`` whose arguments are drawn from the current bank per type."""
+        pools: list[list[Term]] = []
+        for ak in comp.arg_keys:
+            pool = bank.get(ak, [])
+            if not pool:
+                return []
+            pools.append(pool)
+        total = 1
+        for p in pools:
+            total *= len(p)
+        out: list[Term] = []
+        if total <= self.combo_cap:
+            for choice in itertools.product(*pools):
+                if time.time() >= deadline:
+                    break
+                term: Term = comp.head
+                for a in choice:
+                    term = Application(term, a)
+                out.append(term)
+        else:
+            for _ in range(self.combo_cap):
+                term = comp.head
+                for p in pools:
+                    term = Application(term, rnd.choice(p))
+                out.append(term)
+        return out
+
+    def _cond_combos(
+        self, bool_pool: list[Term], goal_pool: list[Term], deadline: float, rnd: random.Random
+    ) -> list[Term]:
+        """Conditional transitions ``if c then t else e -> q``: the base-case /
+        recursive-case split. Deterministically enumerates the *smallest*
+        conditions and branches first (bounded by ``cond_head``/``branch_head``),
+        ordered by total node count, so the cheapest splits -- e.g.
+        ``if x >= 0 then x else 0 - x`` -- are produced first and within
+        ``cond_cap``, instead of being lost in a random sample of a huge
+        product."""
+        if not bool_pool or not goal_pool:
+            return []
+        conds = sorted(bool_pool, key=_term_size)[: self.cond_head]
+        branches = sorted(goal_pool, key=_term_size)[: self.branch_head]
+        triples = (
+            (_term_size(c) + _term_size(t) + _term_size(e), c, t, e)
+            for c in conds
+            for t in branches
+            for e in branches
+            if t is not e
+        )
+        out: list[Term] = []
+        for _size, c, t, e in sorted(triples, key=lambda x: x[0]):
+            if time.time() >= deadline or len(out) >= self.cond_cap:
+                break
+            out.append(If(c, t, e, _loc))
+        return out
+
+    # -- entry point ----------------------------------------------------------
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
+    ) -> Term:
+        start = time.time()
+        deadline = start + budget
+        rnd = random.Random(self.seed)
+        ui.register(None, None, 0, True)
+
+        # Any abstractions still on the goal are peeled here (their binders join
+        # the context); the synthesised body is re-wrapped before returning.
+        body_type, ctx2, abs_names = _peel_abstractions(type, ctx)
+        goal_key = base_key(body_type)
+        bool_key = base_key(t_bool)
+        int_key = base_key(t_int)
+
+        universe = collect_type_universe(ctx2, body_type)
+        builders, atoms = self._collect(ctx2, universe)
+
+        bank: dict[str, list[Term]] = {}
+        seen: dict[str, set[str]] = {}
+        best: Optional[Term] = None
+        validated_count = 0
+        uses_recursion = False
+        uses_conditional = False
+
+        def wrap(body: Term) -> Term:
+            term = body
+            for name in reversed(abs_names):
+                term = Abstraction(name, term, _loc)
+            return term
+
+        def consider(term: Term) -> None:
+            """Validate a goal-typed candidate (the constraint-annotation
+            discharge) and keep the smallest accepted one."""
+            nonlocal best, validated_count, uses_recursion, uses_conditional
+            validated_count += 1
+            if _safe(validate, wrap(term)):
+                if best is None or _term_size(term) < _term_size(best):
+                    best = term
+                    uses_recursion = _mentions(term, fun_name)
+                    uses_conditional = _has_if(term)
+                    ui.register(wrap(best), [0.0], time.time() - start, True)
+
+        def add_bank(key: str, terms: list[Term]) -> None:
+            b = bank.setdefault(key, [])
+            s = seen.setdefault(key, set())
+            for t in terms:
+                k = str(t)
+                if k in s:
+                    continue
+                s.add(k)
+                b.append(t)
+                if key == goal_key and best is None:
+                    consider(t)
+            if len(b) > self.max_bank:
+                del b[self.max_bank :]
+
+        # Round 0 -- nullary leaves: parameters and in-scope atoms, plus a small
+        # integer grid (answers and numeric arguments / off-by-one constants).
+        for key, vs in atoms.items():
+            add_bank(key, list(vs))
+        add_bank(int_key, [Literal(v, t_int) for v in range(self.int_lo, self.int_hi)])
+
+        # Rounds 1..k -- grow the automaton one operator deeper each round:
+        # application transitions (incl. recursive self-calls) and then the
+        # conditional split. Stop as soon as a state is accepted.
+        for _round in range(self.rounds):
+            if best is not None or time.time() >= deadline:
+                break
+            snapshot = {k: list(v) for k, v in bank.items()}
+            for comps in builders.values():
+                for comp in comps:
+                    if best is not None or time.time() >= deadline:
+                        break
+                    add_bank(comp.ret_key, self._app_combos(comp, snapshot, deadline, rnd))
+            if best is not None or time.time() >= deadline:
+                break
+            # Conditionals at the goal type, using the bank grown so far.
+            conds = self._cond_combos(bank.get(bool_key, []), bank.get(goal_key, []), deadline, rnd)
+            add_bank(goal_key, conds)
+
+        if best is not None:
+            shape = []
+            if uses_recursion:
+                shape.append("recursive")
+            if uses_conditional:
+                shape.append("conditional")
+            kind = "+".join(shape) if shape else "straight-line"
+            ui.register(wrap(best), [0.0], time.time() - start, True)
+            logger.log(
+                "SYNTHESIZER",
+                f"cata: {kind} solution found; discharged {validated_count} constraint-annotated "
+                f"candidate(s) via the liquid typechecker (relational refinement + induction + termination).",
+            )
+            return wrap(best)
+        raise SynthesisNotSuccessful(
+            f"cata: no spec-consistent program of depth < {self.rounds} found within budget={budget}s "
+            f"(discharged {validated_count} candidates). Try a larger budget, more rounds, or a wider "
+            "integer grid; recursive-datatype goals may need a tailored component set."
+        )
+
+
+# -- free helpers ------------------------------------------------------------
+
+
+def _peel_abstractions(ty: Type, ctx: TypingContext) -> tuple[Type, TypingContext, list[Name]]:
+    """Strip any leading function arrows still on the goal type, extending the
+    context with their binders. Holes are usually presented already peeled (the
+    goal is the body type), so this is normally a no-op -- but it keeps CATA
+    robust to multi-argument goals presented as a function type."""
+    cur = ty
+    cur_ctx = ctx
+    names: list[Name] = []
+    while isinstance(cur, AbstractionType):
+        names.append(cur.var_name)
+        cur_ctx = cur_ctx.with_var(cur.var_name, cur.var_type)
+        cur = cur.type
+    return cur, cur_ctx, names
+
+
+def _mentions(term: Term, name: Name) -> bool:
+    """Whether ``term`` references ``name`` (used to report recursion)."""
+    if isinstance(term, Var):
+        return term.name == name
+    if isinstance(term, Application):
+        return _mentions(term.fun, name) or _mentions(term.arg, name)
+    if isinstance(term, If):
+        return _mentions(term.cond, name) or _mentions(term.then, name) or _mentions(term.otherwise, name)
+    if isinstance(term, Abstraction):
+        return _mentions(term.body, name)
+    return False
+
+
+def _has_if(term: Term) -> bool:
+    if isinstance(term, If):
+        return True
+    if isinstance(term, Application):
+        return _has_if(term.fun) or _has_if(term.arg)
+    if isinstance(term, Abstraction):
+        return _has_if(term.body)
+    return False

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -9,6 +9,7 @@ from aeon.synthesis.modules.sygus import SygusSynthesizer
 from aeon.synthesis.modules.tdsyn.synthesizer import TDSynSynthesizer
 from aeon.synthesis.modules.symetric import SymetricSynthesizer
 from aeon.synthesis.modules.fta import FTASynthesizer
+from aeon.synthesis.modules.cata import CATASynthesizer
 from aeon.synthesis.tactics import TacticRandomSynthesizer
 
 
@@ -46,5 +47,7 @@ def make_synthesizer(module: str) -> Synthesizer:
             return SymetricSynthesizer()
         case "fta":
             return FTASynthesizer()
+        case "cata":
+            return CATASynthesizer()
         case _:
             assert False, f"Not supported synthesizer with name {module}"

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -8,7 +8,9 @@ from loguru import logger
 
 from z3 import Function
 from z3 import Int
+from z3 import IntVal
 from z3 import Real
+from z3 import RealVal
 from z3 import Solver
 from z3 import StringVal
 from z3 import sat
@@ -585,20 +587,32 @@ def smt_valid(constraint: Constraint) -> bool:
         # asserted formula, and the push/pop here scopes each constraint, so
         # the declarations are re-emitted per constraint by construction.
         try:
-            smt_c = translate(c)
-        except ZeroDivisionError:
-            continue
-        if smt_c is False:
-            continue
-        s.add(smt_c)
-        result = s.check()
-        s.pop()
-        if result == sat:
-            _smt_valid_cache[key] = False
-            return False
-        elif result == unknown:
-            _smt_valid_cache[key] = False
-            return False
+            try:
+                smt_c = translate(c)
+            except ZeroDivisionError:
+                # A constant division/modulo by zero (e.g. ``-2 / 0``) is
+                # undefined: it crashes at runtime and Z3 leaves it
+                # unconstrained. *Skipping* the obligation silently *assumed* it
+                # valid -- unsound, and it let absurd refinements through (any
+                # spec was "satisfied" by a literal ``/ 0``). An obligation we
+                # cannot even define is not proven, so report it invalid.
+                _smt_valid_cache[key] = False
+                return False
+            if smt_c is False:
+                continue
+            s.add(smt_c)
+            result = s.check()
+            if result == sat:
+                _smt_valid_cache[key] = False
+                return False
+            elif result == unknown:
+                _smt_valid_cache[key] = False
+                return False
+        finally:
+            # Always balance the matching ``push`` -- ``s`` is a reused global
+            # solver, so an early ``return``/``continue`` that skipped the pop
+            # would leak scope state into later constraints and queries.
+            s.pop()
 
     _smt_valid_cache[key] = True
     return True
@@ -790,6 +804,20 @@ def make_variable(name: str, base: TypeConstructor | AbstractionType | Top) -> A
             assert False, f"No var: {name}, with base {base}."
 
 
+def _coerce_numeric(a: Any) -> Any:
+    """Lift a Python numeric literal into the matching Z3 value so that an
+    operation on it uses Z3 semantics rather than Python's. Z3 expressions (and
+    anything non-numeric) pass through unchanged. ``bool`` is checked first
+    since it is a subclass of ``int``."""
+    if isinstance(a, bool):
+        return a
+    if isinstance(a, int):
+        return IntVal(a)
+    if isinstance(a, float):
+        return RealVal(a)
+    return a
+
+
 def translate_liq(t: LiquidTerm, variables: dict[str, Any]):
     match t:
         case LiquidLiteralBool(b):
@@ -819,6 +847,17 @@ def translate_liq(t: LiquidTerm, variables: dict[str, Any]):
             fun = base_functions.get(fun_name.name, variables.get(str(fun_name), None))
             assert fun is not None, f"Function {fun_name} not found." + str(variables)
             args = [translate_liq(a, variables) for a in args]
+            if fun_name.name in ("/", "%"):
+                # Evaluate division and modulo with Z3 numeric semantics, not
+                # Python's. On two Python int literals, Python's ``/`` is *float*
+                # division (so ``6 / 2`` is ``3.0`` -- an unsound mismatch with
+                # the Int type) and raises ``ZeroDivisionError`` on a zero
+                # divisor (which used to silently drop the obligation, letting
+                # absurd refinements through). Coercing the operands into Z3
+                # makes ``/`` and ``%`` total integer operations, and division
+                # by zero a fixed-but-unconstrained Z3 term that no refinement
+                # can exploit.
+                args = [_coerce_numeric(a) for a in args]
             try:
                 return fun(*args)
             except Z3Exception as e:

--- a/examples/synthesis/cata/conditional_select.ae
+++ b/examples/synthesis/cata/conditional_select.ae
@@ -1,0 +1,16 @@
+# CATA -- conditional (case-split) synthesis.
+#
+# The relational refinement below is satisfiable only by a *conditional*: when
+# the Boolean parameter b holds the result must equal x, otherwise y. CATA's
+# tree automaton includes conditional transitions `if c then t else e`, so it
+# builds `if b then x else y` and the liquid typechecker discharges both
+# implications.
+#
+# The base-case / recursive-case split is exactly the construct recursive
+# programs need; here it is exercised on a non-recursive selector, the smallest
+# conditional CATA can form.
+#
+# Run with:
+#   uv run python -m aeon --no-main -s cata --budget 30 examples/synthesis/cata/conditional_select.ae
+
+def pick (b : Bool) (x : Int) (y : Int) : {v:Int | (b --> v == x) && (!b --> v == y)} = ?hole;

--- a/examples/synthesis/cata/operator_relational.ae
+++ b/examples/synthesis/cata/operator_relational.ae
@@ -1,0 +1,19 @@
+# CATA -- Constraint-Annotated Tree Automata (relational/recursive synthesis).
+# "Relational Synthesis of Recursive Programs via Constraint Annotated Tree
+# Automata" (https://www.cs.utexas.edu/~isil/cata.pdf). Third backend on aeon's
+# tree-automata line, after fta (OOPSLA'17) and afta (POPL'18).
+#
+# CATA targets *relational* specs -- refinements relating a function's
+# parameters to its result -- and discharges each candidate with the liquid
+# typechecker (the SMT constraint-annotation oracle) instead of running it on a
+# ground example. It also makes aeon's polymorphic Num/Ord operators usable as
+# components by monomorphising them, so arithmetic terms can be built.
+#
+# Run with:
+#   uv run python -m aeon --no-main -s cata --budget 30 examples/synthesis/cata/operator_relational.ae
+#
+# The relational refinement v > x mentions the parameter x; CATA builds the
+# monomorphised `+` and the integer grid bottom-up and the typechecker confirms
+# x + 1 > x for all x.
+
+def succ (x : Int) : {v:Int | v > x} = ?hole;

--- a/tests/cata_test.py
+++ b/tests/cata_test.py
@@ -1,0 +1,118 @@
+"""Tests for the CATA (Constraint-Annotated Tree Automata) backend.
+
+CATA is the recursive/relational tree-automata backend, after ``fta`` (concrete)
+and ``afta`` (abstract). It targets relational refinements (relating a
+function's parameters to its result), discharging each candidate with the liquid
+typechecker -- which performs exactly CATA's constraint-annotation check,
+including the inductive hypothesis for recursive calls and a termination proof.
+
+Over FTA/AFTA's construction it adds: monomorphic components from polymorphic
+Num/Ord operators, conditional (case-split) transitions, and recursive
+self-calls as ordinary components. These tests cover the machinery that reliably
+converges -- straight-line relational synthesis and conditionals -- and asserts
+the recursion/operator plumbing is in place.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from aeon.core.terms import If, Term
+from aeon.core.types import top
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.identification import get_holes_info, incomplete_functions_and_holes
+from aeon.synthesis.modules.cata import CATASynthesizer
+from aeon.synthesis.modules.cata.synthesizer import _PARTIAL_OPS
+from aeon.synthesis.modules.lta.polymorphism import collect_type_universe
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+from tests.driver import check_and_return_core
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _solve(code: str, budget: float = 40.0) -> Term:
+    term, ctx, ectx, metadata = check_and_return_core(code)
+    targets = incomplete_functions_and_holes(ctx, term)
+    holes = synthesize_holes(ctx, ectx, term, targets, metadata, CATASynthesizer(), budget=budget)
+    return holes[next(iter(holes))]
+
+
+def _components(code: str):
+    """Run CATA's component collection on a hole and return (builders, atoms)."""
+    term, ctx, ectx, metadata = check_and_return_core(code)
+    targets = incomplete_functions_and_holes(ctx, term)
+    info = get_holes_info(ctx, term, top, targets, refined_types=True)
+    hole = targets[0][1][0]
+    ty, tyctx = info[hole]
+    universe = collect_type_universe(tyctx, ty)
+    return CATASynthesizer()._collect(tyctx, universe)
+
+
+def test_factory_registers_cata():
+    assert isinstance(make_synthesizer("cata"), CATASynthesizer)
+
+
+def test_solves_relational_operator_hole():
+    # {v:Int | v > x} is relational (mentions the parameter x). CATA builds the
+    # monomorphised `+` and discharges x + 1 > x for all x.
+    t = _solve("def succ (x:Int) : {v:Int | v > x} = ?hole;")
+    assert "+" in str(t), str(t)
+
+
+def test_solves_conditional_select():
+    # Satisfiable only by a conditional: if b then x else y.
+    t = _solve("def pick (b:Bool) (x:Int) (y:Int) : {v:Int | (b --> v == x) && (!b --> v == y)} = ?hole;")
+    assert isinstance(t, If), str(t)
+    assert "x" in str(t.then) and "y" in str(t.otherwise)
+
+
+def test_monomorphizes_polymorphic_operators():
+    # The polymorphic Num/Ord operators must appear as first-order Int/Bool
+    # components, otherwise no arithmetic/comparison term could be built.
+    builders, _atoms = _components("def succ (x:Int) : {v:Int | v > x} = ?hole;")
+    int_heads = " ".join(str(c.head) for c in builders.get("Int", []))
+    bool_heads = " ".join(str(c.head) for c in builders.get("Bool", []))
+    assert "(+)[Int" in int_heads and "(-)[Int" in int_heads, int_heads
+    assert "(>=)[Int" in bool_heads or "(<)[Int" in bool_heads, bool_heads
+
+
+def test_partial_operators_excluded():
+    # Division/modulo are excluded so every synthesised program is total (a
+    # candidate like -2 / 0 would otherwise vacuously satisfy a refinement).
+    builders, _atoms = _components("def succ (x:Int) : {v:Int | v > x} = ?hole;")
+    heads = " ".join(str(c.head) for cs in builders.values() for c in cs)
+    assert _PARTIAL_OPS == frozenset({"/", "%"})
+    assert "(/)[" not in heads and "(%)[" not in heads, heads
+
+
+def test_recursive_self_call_is_a_component():
+    # The function being synthesised is in scope in its own body, so the
+    # recursive call is available as a component -- the basis for recursion.
+    builders, _atoms = _components("def f (x:{v:Int | v >= 0}) : {v:Int | v >= x} = ?hole;")
+    heads = " ".join(str(c.head) for cs in builders.values() for c in cs)
+    assert "f" in heads, heads
+
+
+def test_cli_runs_cata_backend():
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "aeon",
+            "--no-main",
+            "-s",
+            "cata",
+            "--budget",
+            "30",
+            "examples/synthesis/cata/operator_relational.ae",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out = proc.stdout + proc.stderr
+    assert "Traceback" not in proc.stderr, out[-2000:]
+    assert "?hole:" in out, out[-2000:]

--- a/tests/cata_test.py
+++ b/tests/cata_test.py
@@ -24,7 +24,6 @@ from aeon.core.types import top
 from aeon.synthesis.entrypoint import synthesize_holes
 from aeon.synthesis.identification import get_holes_info, incomplete_functions_and_holes
 from aeon.synthesis.modules.cata import CATASynthesizer
-from aeon.synthesis.modules.cata.synthesizer import _PARTIAL_OPS
 from aeon.synthesis.modules.lta.polymorphism import collect_type_universe
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from tests.driver import check_and_return_core
@@ -78,13 +77,14 @@ def test_monomorphizes_polymorphic_operators():
     assert "(>=)[Int" in bool_heads or "(<)[Int" in bool_heads, bool_heads
 
 
-def test_partial_operators_excluded():
-    # Division/modulo are excluded so every synthesised program is total (a
-    # candidate like -2 / 0 would otherwise vacuously satisfy a refinement).
+def test_partial_operators_available():
+    # Division and modulo are ordinary components now that the verifier handles
+    # division-by-zero soundly (a candidate like -2 / 0 is rejected, not
+    # vacuously accepted), so CATA no longer needs to work around it.
     builders, _atoms = _components("def succ (x:Int) : {v:Int | v > x} = ?hole;")
     heads = " ".join(str(c.head) for cs in builders.values() for c in cs)
-    assert _PARTIAL_OPS == frozenset({"/", "%"})
-    assert "(/)[" not in heads and "(%)[" not in heads, heads
+    assert "(/)[Int" in heads, heads  # polymorphic `/` monomorphised at Int
+    assert "%" in heads, heads  # monomorphic Int `%`
 
 
 def test_recursive_self_call_is_a_component():

--- a/tests/smt_test.py
+++ b/tests/smt_test.py
@@ -284,3 +284,27 @@ def test_recursive_reflection_requires_termination_metric() -> None:
     impl = Abstraction(x, Application(Var(f), Var(x)))
     assert _reflected_impl_for(f, ty, impl, has_termination_metric=False) is None
     assert _reflected_impl_for(f, ty, impl, has_termination_metric=True) is not None
+
+
+def test_division_by_zero_is_not_vacuously_valid() -> None:
+    # `-2 / 0` is undefined: it crashes at runtime and Z3 leaves it
+    # unconstrained. A proof obligation that depends on it must NOT be reported
+    # valid by silently skipping it. Regression: absurd refinements slipped
+    # through (e.g. a literal `/ 0` "satisfying" any spec).
+    div0 = LiquidApp(Name("/", 0), [LiquidLiteralInt(-2), LiquidLiteralInt(0)])
+    claim = LiquidConstraint(LiquidApp(Name(">=", 0), [div0, LiquidLiteralInt(0)]))
+    assert smt_valid(claim) is False
+
+
+def test_modulo_by_zero_is_not_vacuously_valid() -> None:
+    mod0 = LiquidApp(Name("%", 0), [LiquidLiteralInt(5), LiquidLiteralInt(0)])
+    claim = LiquidConstraint(LiquidApp(Name("==", 0), [mod0, LiquidLiteralInt(0)]))
+    assert smt_valid(claim) is False
+
+
+def test_division_by_nonzero_still_valid() -> None:
+    # The fix must not over-reject: a well-defined division obligation that is
+    # genuinely true stays valid.
+    div = LiquidApp(Name("/", 0), [LiquidLiteralInt(6), LiquidLiteralInt(2)])
+    claim = LiquidConstraint(LiquidApp(Name("==", 0), [div, LiquidLiteralInt(3)]))
+    assert smt_valid(claim) is True


### PR DESCRIPTION
Two related changes, in sequence:

## 1. CATA — Constraint-Annotated Tree Automata (#351)

`--synthesizer cata`, the recursive/relational tree-automata backend ([UT Austin PDF](https://www.cs.utexas.edu/~isil/cata.pdf)). Third on aeon's tree-automata line after FTA (#349) and AFTA (#350, #353).

Targets **relational** refinements (relating a function's parameters to its result) and **recursion**, discharging candidates with the liquid typechecker — which already uses the function's own signature as the **inductive hypothesis** for recursive calls and requires **well-founded termination**. Over FTA/AFTA's construction it adds: monomorphic components from polymorphic Num/Ord operators (reusing `lta`'s `monomorphize`), conditional (`if`) transitions, and recursive self-calls. Demonstrated end-to-end: `succ → x + 1`, `pick → if b then x else y`.

## 2. Sound integer division/modulo in the verifier

While building CATA I found `/` and `%` were mis-handled by the liquid typechecker (`aeon/verification/smt.py`), via `translate_liq` using Python's operators on literal operands:

- **Division/modulo by zero** — `-2 / 0` raised a Python `ZeroDivisionError` that `smt_valid` caught and `continue`d, **silently skipping the proof obligation** (assuming it valid). Absurd refinements slipped through (a literal `/ 0` "satisfied" any spec).
- **Integer division was float division** — `6 / 2` evaluated to `3.0`, an unsound mismatch with the `Int` type; constant int division produced nonsense (`-2 / 3` vacuously validating a spec).

Fix: route `/` and `%` through **Z3 numeric semantics** (`_coerce_numeric` lifts literal operands into Z3), making them total integer operations and division-by-zero a fixed-but-unconstrained Z3 term no refinement can exploit. Also hardened `smt_valid`: balance the reused global solver's `push`/`pop` in a `finally` (the old `continue` paths leaked scope), and treat an undefinable obligation as **unproven** rather than skipped.

With the verifier sound, **CATA no longer needs to work around the bug** — removed its `_PARTIAL_OPS` exclusion, so `/` and `%` are ordinary components (FTA/AFTA never excluded them). This is the "adapt all three FTA approaches to not work around the refinements bug" follow-up.

## Tests
- `tests/smt_test.py`: div/mod-by-zero-not-vacuously-valid + division-by-nonzero-still-valid regressions.
- `tests/cata_test.py`: registration, relational/operator solve, conditional solve, operator monomorphisation, `/`/`%` availability, recursive-self-call component, end-to-end CLI.
- `examples/synthesis/cata/`: `operator_relational.ae`, `conditional_select.ae`.

fta/afta/cata + smt/liquid/horn suites pass; mypy + ruff clean.

## Honest scope
Recursive-*datatype* synthesis (Synquid folds) is wired but a genuine search problem that doesn't reliably converge in budget — documented as the frontier. State merging by constraint *equivalence* (SMT entailment per pair) is left as future work.

## Line
#349 FTA (merged) → #350 AFTA (#353, merged) → #351 CATA (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)