### PR TITLE
feat(libraries): detect ML-pipeline defects in Learning.ae (Silva 2024)

### DIFF
--- a/aeon/bindings/learning.py
+++ b/aeon/bindings/learning.py
@@ -99,25 +99,66 @@ def Learning_read_csv(path):
 
 
 @curried
-def Learning_target(df, column):
-    """Designate ``column`` as the target; return the ``(X, y)`` Dataset."""
+def Learning_target(df, column, temporal, missing):
+    """Designate ``column`` as the target; return the ``(X, y)`` Dataset.
+
+    ``temporal`` / ``missing`` are modelling facts consumed only by the
+    static analyser (they carry the chronological-order and
+    missing-value flags into the refinement); the runtime ignores them.
+    """
     y = df[column].tolist()
     X = df.drop(columns=[column]).values.tolist()
     return _xy(X, y)
 
 
 @curried
-def Learning_target_at(df, index):
+def Learning_target_at(df, index, temporal, missing):
     """Designate the column at ``index`` (0-based) as the target."""
     column = df.columns[index]
-    return Learning_target(df, column)
+    return Learning_target(df, column, temporal, missing)
 
 
 @curried
-def Learning_load(path):
+def Learning_load(path, temporal, missing):
     """Convenience: read a CSV and use the *last* column as the target."""
     df = pd.read_csv(path)
-    return Learning_target_at(df, len(df.columns) - 1)
+    return Learning_target_at(df, len(df.columns) - 1, temporal, missing)
+
+
+@curried
+def Learning_create_dataset(rows, features, balanced, temporal, missing):
+    """Build a synthetic Dataset with a declared shape and balance.
+
+    Used for thesis-style static modelling of pipelines: the concrete
+    row/feature counts make shape-dependent refinements (minimum data,
+    metric suitability) statically decidable. ``temporal`` / ``missing``
+    are modelling-only and do not change the generated data.
+    """
+    n = int(rows)
+    f = max(int(features), 1)
+    X = np.random.rand(n, f).tolist()
+    if balanced:
+        y = [i % 2 for i in range(n)]
+    else:
+        # Skew toward the majority class so the result is imbalanced.
+        cutoff = max(n - n // 5, 0)
+        y = [0 if i < cutoff else 1 for i in range(n)]
+    return _xy(X, y)
+
+
+@curried
+def Learning_require_enough_data(ds):
+    """Trusted cast: assert ``rows > features * 10`` and return ``ds``.
+
+    Lets the CSV path discharge a trainer's minimum-data precondition,
+    where the static counts are unknown. Raises if the assertion fails.
+    """
+    X, _ = _as_xy(ds)
+    nrows = len(X)
+    ncols = len(X[0]) if nrows else 0
+    if not (nrows > ncols * 10):
+        raise ValueError(f"require_enough_data: {nrows} rows is not > 10 * {ncols} features")
+    return ds
 
 
 @curried
@@ -167,21 +208,25 @@ def Learning_class_counts(ds):
 
 
 @curried
-def Learning_split(ds, fraction):
-    """Split into (training, testing). ``fraction`` is the training share."""
+def Learning_split(ds, fraction, shuffle):
+    """Split into (training, testing). ``fraction`` is the training share.
+
+    ``shuffle`` randomises the rows before partitioning; pass ``False``
+    to keep chronological order for time-series data.
+    """
     X, y = _as_xy(ds)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=1 - fraction)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=1 - fraction, shuffle=shuffle)
     return (_xy(X_train, y_train), _xy(X_test, y_test))
 
 
 @curried
 def Learning_split_training(ds, fraction):
-    return Learning_split(ds, fraction)[0]
+    return Learning_split(ds, fraction, True)[0]
 
 
 @curried
 def Learning_split_testing(ds, fraction):
-    return Learning_split(ds, fraction)[1]
+    return Learning_split(ds, fraction, True)[1]
 
 
 # ─── Resampling / balancing ─────────────────────────────────────────────

--- a/examples/demos/3_dataset.ae
+++ b/examples/demos/3_dataset.ae
@@ -1,16 +1,17 @@
 # Multinomial Naive Bayes pipeline.
 # https://people.csail.mit.edu/jrennie/papers/icml03-nb.pdf
+#
+# SMOTE is applied to the training half only, after the split, so the
+# held-out test set is never contaminated.
 
 open Learning
 
 
 def train_multinomial (path: String) (target_col: String) : Classifier =
     let 1 df = Learning.read_csv path in
-    let ds = Learning.target df target_col in
-    if Learning.is_multiclass ds then
-        let bds = Learning.smote ds in
-        let parts = Learning.split bds 0.7 in
-        Learning.multinomial_nb (Learning.train_of parts)
-    else
-        let parts = Learning.split ds 0.7 in
-        Learning.multinomial_nb (Learning.train_of parts) ;
+    let ds0 = Learning.target df target_col false false in
+    let ds = Learning.require_enough_data ds0 in
+    let parts = Learning.split ds 0.7 true in
+    let train0 = Learning.train_of parts in
+    let train = if Learning.is_multiclass train0 then Learning.smote train0 else train0 in
+    Learning.multinomial_nb train ;

--- a/examples/ml/balanced_dataset.ae
+++ b/examples/ml/balanced_dataset.ae
@@ -1,27 +1,26 @@
-# Train a random-forest classifier on a balanced dataset.
+# Train a random-forest classifier, balancing the training set with SMOTE.
 #
-# The source dataframe is bound linearly, the split returns a refined
-# ``Pair Dataset Dataset`` whose halves preserve the source's feature /
-# class / balance invariants, and the ``train_of`` / ``test_of`` runtime
-# accessors propagate those invariants to the let-bound halves.
+# SMOTE runs on the training half *after* the split, so the held-out test
+# set stays untouched (no synthetic instances leak into evaluation). The
+# split's minimum-data precondition is discharged with
+# ``require_enough_data`` on the CSV path.
 
 open Learning
 
 
 def generate_model_smote (path: String) (target_col: String) : Classifier =
     let 1 df = Learning.read_csv path in
-    let ds = Learning.target df target_col in
-    if Learning.is_multiclass ds then
-        let bds = Learning.smote ds in
-        let parts = Learning.split bds 0.7 in
-        Learning.random_forest_classifier (Learning.train_of parts)
-    else
-        let parts = Learning.split ds 0.7 in
-        Learning.random_forest_classifier (Learning.train_of parts) ;
+    let ds0 = Learning.target df target_col false false in
+    let ds = Learning.require_enough_data ds0 in
+    let parts = Learning.split ds 0.7 true in
+    let train0 = Learning.train_of parts in
+    let train = if Learning.is_multiclass train0 then Learning.smote train0 else train0 in
+    Learning.random_forest_classifier train ;
 
 
 def generate_model_plain (path: String) (target_col: String) : Classifier =
     let 1 df = Learning.read_csv path in
-    let ds = Learning.target df target_col in
-    let parts = Learning.split ds 0.7 in
+    let ds0 = Learning.target df target_col false false in
+    let ds = Learning.require_enough_data ds0 in
+    let parts = Learning.split ds 0.7 true in
     Learning.random_forest_classifier (Learning.train_of parts) ;

--- a/examples/ml/classification_pipeline.ae
+++ b/examples/ml/classification_pipeline.ae
@@ -1,42 +1,43 @@
 # End-to-end classification pipeline showcasing the Learning library.
 #
-# ``Learning.split`` returns a ``Pair Dataset Dataset`` with refinements
-# that link both halves' shape to the source dataset. The ``train_of`` /
-# ``test_of`` accessors propagate that link, so when we
-# ``Learning.accuracy model test_part`` the precondition
-# ``clf_features model == ds_features test_part`` is discharged
-# automatically (the model's ``clf_features`` matches ``ds_features
-# train_part``, which equals ``ds_features ds``, which equals
-# ``ds_features test_part``).
+# This pipeline is *leakage-free* by construction, and the refinements
+# enforce it (see ``libraries/Learning.ae``):
+#
+#   * ``require_enough_data`` discharges the minimum-data precondition of
+#     ``split`` on the CSV path, where the row count is statically unknown.
+#   * The train/test ``split`` happens **before** any cross-row transform.
+#     SMOTE is applied to the *training half only*, after the split — doing
+#     it earlier would taint the test set (``coupled`` source) and
+#     ``Learning.accuracy`` / ``f1`` would no longer type-check.
+#   * The metric is chosen by an inline ``balanced`` check: ``accuracy``
+#     (balance-sensitive) only when the test set is balanced, otherwise the
+#     balance-insensitive ``f1``.
 
 open Learning
 
 
 def pipeline (path: String) (target_col: String) : Float =
     let 1 df = Learning.read_csv path in
-    let ds = Learning.target df target_col in
-    if Learning.is_multiclass ds then
-        let bds = Learning.smote ds in
-        let scaled = Learning.standard_scale bds in
-        let parts = Learning.split scaled 0.8 in
-        let train_part = Learning.train_of parts in
-        let test_part = Learning.test_of parts in
-        let model = Learning.random_forest_classifier train_part in
-        Learning.accuracy model test_part
+    # ``false false`` = not a time series, no missing values.
+    let ds0 = Learning.target df target_col false false in
+    let ds = Learning.require_enough_data ds0 in
+    let parts = Learning.split ds 0.8 true in
+    let train0 = Learning.train_of parts in
+    let test = Learning.test_of parts in
+    # Balance the *training* half only, after the split.
+    let train = if Learning.is_multiclass train0 then Learning.smote train0 else train0 in
+    let model = Learning.random_forest_classifier train in
+    if Learning.balanced test then
+        Learning.accuracy model test
     else
-        let scaled = Learning.standard_scale ds in
-        let parts = Learning.split scaled 0.8 in
-        let train_part = Learning.train_of parts in
-        let test_part = Learning.test_of parts in
-        let model = Learning.random_forest_classifier train_part in
-        Learning.accuracy model test_part ;
+        Learning.f1 model test ;
 
 
 # ComplementNB requires imbalanced data — discharged via an inline
 # ``balanced`` runtime check.
 def cnb_pipeline (path: String) (target_col: String) : Classifier =
     let 1 df = Learning.read_csv path in
-    let ds = Learning.target df target_col in
+    let ds = Learning.target df target_col false false in
     if Learning.balanced ds then
         Learning.multinomial_nb ds
     else

--- a/examples/ml/regression_pipeline.ae
+++ b/examples/ml/regression_pipeline.ae
@@ -1,29 +1,31 @@
 # End-to-end regression pipeline.
 #
-# The ``Pair``-based split combined with ``train_of`` / ``test_of`` lets
-# the regressor's ``reg_features`` flow from training through scoring,
-# so ``Learning.r2 model test_part`` discharges its
-# ``reg_features model == ds_features test_part`` precondition.
+# The source has missing values (``target ... true``), so each split is
+# imputed **separately, after the split** — imputing the whole dataset
+# beforehand would fit the imputer on the test rows too (``coupled``
+# source) and ``Learning.r2`` would reject the test set. Scaling, when
+# used, follows the same rule.
 
 open Learning
 
 
-def train_ridge (path: String) (target_col: String) : Regressor =
-    let 1 df = Learning.read_csv path in
-    let ds = Learning.target df target_col in
-    let imputed = Learning.fill_median ds in
-    let scaled = Learning.standard_scale imputed in
-    let parts = Learning.split scaled 0.8 in
-    Learning.ridge_alpha 0.5 (Learning.train_of parts) ;
-
-
 def score_ridge (path: String) (target_col: String) : Float =
     let 1 df = Learning.read_csv path in
-    let ds = Learning.target df target_col in
-    let imputed = Learning.fill_median ds in
-    let scaled = Learning.standard_scale imputed in
-    let parts = Learning.split scaled 0.8 in
-    let train_part = Learning.train_of parts in
-    let test_part = Learning.test_of parts in
-    let model = Learning.ridge train_part in
-    Learning.r2 model test_part ;
+    # not a time series, but has missing values.
+    let ds0 = Learning.target df target_col false true in
+    let ds = Learning.require_enough_data ds0 in
+    let parts = Learning.split ds 0.8 true in
+    # Impute (and could scale) each half independently — no leakage.
+    let train = Learning.fill_median (Learning.train_of parts) in
+    let test = Learning.fill_median (Learning.test_of parts) in
+    let model = Learning.ridge_alpha 0.5 train in
+    Learning.r2 model test ;
+
+
+def train_ridge (path: String) (target_col: String) : Regressor =
+    let 1 df = Learning.read_csv path in
+    let ds0 = Learning.target df target_col false true in
+    let ds = Learning.require_enough_data ds0 in
+    let parts = Learning.split ds 0.8 true in
+    let train = Learning.fill_median (Learning.train_of parts) in
+    Learning.ridge train ;

--- a/libraries/Learning.ae
+++ b/libraries/Learning.ae
@@ -13,27 +13,55 @@
 #     so callers who bind their source with ``let 1 df = ...`` get a
 #     type error if they keep using the pre-transformed dataset.
 #   * Refinements carry shape and class invariants. Common ML bugs are
-#     rejected at compile time:
+#     rejected at compile time.
 #
-#       - ``target`` and ``target_at`` link the resulting dataset's
-#         row/feature counts to the source ``DataFrame``.
-#       - Training functions stamp the resulting model with
-#         ``clf_features`` / ``clf_classes`` / ``reg_features``.
-#       - Scaling, imputation and oversampling preserve the feature
-#         count and class count; scaling/imputation preserve balance.
-#       - ``random_undersample`` only ever shrinks the row count;
-#         oversamplers only grow it.
-#       - ``smote`` / ``random_oversample`` / ``random_undersample``
-#         require ``ds_classes ds >= 2``; ``knn_classifier_k`` requires
-#         ``k <= ds_rows ds``; ``complement_nb`` requires an imbalanced
-#         dataset (its actual design intent).
-#       - Probabilities are refined to ``[0, 1]``; error metrics to
-#         ``>= 0.0``.
+# ─── Pipeline-defect detection (Silva 2024) ─────────────────────────────
 #
-#     Runtime witnesses (``is_multiclass``, ``is_splittable``,
-#     ``is_nonempty``, ``balanced``) refine their Bool return type so
-#     they can discharge the corresponding precondition inside an
-#     ``if ... then ... else ...`` guard.
+# This library encodes the component contracts from Pedro Silva's MSc
+# thesis *"Static Analysis for Detection of Defects in Machine Learning
+# Pipelines"* (ULisboa 2024). The thesis specifies each component with
+# first-order pre/post-conditions over per-line predicates (``lineInDs``,
+# ``lineCausality``, ``synthesizedLine`` …). Aeon's liquid refinements are
+# quantifier-free, so instead of quantifying over lines we lift those
+# predicates to **dataset-level summary flags** whose values are *fully
+# determined* by each component's post-condition (biconditionals, not
+# implications). This keeps everything decidable and needs no global
+# axioms — the propagation laws live entirely in the contracts below.
+#
+# Summary flags (all uninterpreted ``Dataset -> Bool``):
+#
+#   * ``is_timeseries``  — instances are chronologically ordered.
+#   * ``has_missing``    — some feature has missing values.
+#   * ``coupled``        — a whole-dataset transform (scaling, imputation,
+#                          resampling, SMOTE) has made rows statistically
+#                          depend on one another. Splitting a *coupled*
+#                          dataset leaks information across the partition.
+#   * ``clean_test``     — this dataset is a held-out test set produced by
+#                          a *safe* split (source not coupled, and not a
+#                          shuffled time series). Only ``split`` ever sets
+#                          it true, so evaluating on anything else is a
+#                          type error.
+#   * ``independent_target`` — the target does not depend on any feature
+#                          (no proxy / leaky feature).
+#
+# Defects caught at compile time:
+#
+#   - Pre-processing (scale / impute / resample / SMOTE) **before** the
+#     train/test split  → ``coupled`` source → ``clean_test`` is false.
+#   - Temporal leakage: shuffling a time series before splitting
+#     → ``clean_test`` is false.
+#   - Evaluating on the training data / on a non-split dataset
+#     → ``clean_test`` cannot be proven true.
+#   - Feeding missing values to an estimator → ``has_missing`` precondition.
+#   - Too few instances (``ds_rows <= ds_features * 10``) → ``split``
+#     precondition (decidable for ``create_dataset``; assert it on the
+#     CSV path with ``require_enough_data`` before splitting).
+#   - A balance-sensitive metric (``accuracy`` / ``precision`` / ``recall``)
+#     on an imbalanced test set → ``is_balanced`` precondition.
+#
+# Runtime witnesses (``is_multiclass``, ``is_splittable``, ``is_nonempty``,
+# ``balanced``) refine their Bool return type so they can discharge the
+# corresponding precondition inside an ``if ... then ... else ...`` guard.
 
 open List
 open Tuple
@@ -69,6 +97,21 @@ def clf_features : (m: Classifier) -> Int = uninterpreted
 def clf_classes : (m: Classifier) -> Int = uninterpreted
 def reg_features : (m: Regressor) -> Int = uninterpreted
 
+# ─── Pipeline-defect summary predicates (see header) ───────────────────
+
+# Instances are indexed in chronological order (time-stamped data).
+def is_timeseries : (ds: Dataset) -> Bool = uninterpreted
+# Some feature still has missing values.
+def has_missing : (ds: Dataset) -> Bool = uninterpreted
+# A whole-dataset transform has coupled the rows (so a later split leaks).
+def coupled : (ds: Dataset) -> Bool = uninterpreted
+# Produced by a safe split — sound to use as a held-out test set.
+def clean_test : (ds: Dataset) -> Bool = uninterpreted
+# The target does not depend on any feature (no proxy/leaky feature).
+def independent_target : (ds: Dataset) -> Bool = uninterpreted
+# The dataset's target column has the given name.
+def ds_target : (ds: Dataset) -> (name: String) -> Bool = uninterpreted
+
 # NOTE: ``Pair_mk_fst`` and ``Pair_mk_snd`` are auto-generated by
 # ``expand_inductive_decls`` (one uninterpreted projection per named
 # field of each inductive constructor). They let the SMT solver reason
@@ -82,20 +125,64 @@ def read_csv (path: String) : {df: DataFrame | df_cols df >= 1 && df_rows df >= 
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_read_csv(path)"
 
 # Designate ``column`` as the target. Consumes the source DataFrame.
-# Row count is preserved; feature count is one less than the column
-# count of the source.
-def target (1 df: DataFrame) (column: String) :
-    {ds: Dataset | ds_rows ds == df_rows df && ds_features ds == (df_cols df) - 1} =
-    native "__import__('aeon.bindings.learning').bindings.learning.Learning_target(df, column)"
+# ``temporal`` declares whether the rows are chronologically ordered and
+# ``missing`` whether any feature still has missing values — both are
+# modelling facts the static analyser cannot infer from a CSV path.
+def target (1 df: DataFrame) (column: String) (temporal: Bool) (missing: Bool) :
+    {ds: Dataset | ds_rows ds == df_rows df
+                && ds_features ds == (df_cols df) - 1
+                && ds_target ds column == true
+                && is_timeseries ds == temporal
+                && has_missing ds == missing
+                && coupled ds == false
+                && independent_target ds == true} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_target(df, column, temporal, missing)"
 
 # Designate the column at position ``index`` (0-based) as the target.
-def target_at (1 df: DataFrame) (index: {n: Int | n >= 0 && n < df_cols df}) :
-    {ds: Dataset | ds_rows ds == df_rows df && ds_features ds == (df_cols df) - 1} =
-    native "__import__('aeon.bindings.learning').bindings.learning.Learning_target_at(df, index)"
+def target_at (1 df: DataFrame) (index: {n: Int | n >= 0 && n < df_cols df}) (temporal: Bool) (missing: Bool) :
+    {ds: Dataset | ds_rows ds == df_rows df
+                && ds_features ds == (df_cols df) - 1
+                && is_timeseries ds == temporal
+                && has_missing ds == missing
+                && coupled ds == false
+                && independent_target ds == true} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_target_at(df, index, temporal, missing)"
 
 # Convenience: read a CSV and use the *last* column as the target.
-def load (path: String) : {ds: Dataset | ds_features ds >= 0 && ds_rows ds >= 0} =
-    native "__import__('aeon.bindings.learning').bindings.learning.Learning_load(path)"
+def load (path: String) (temporal: Bool) (missing: Bool) :
+    {ds: Dataset | ds_features ds >= 0 && ds_rows ds >= 0
+                && is_timeseries ds == temporal
+                && has_missing ds == missing
+                && coupled ds == false
+                && independent_target ds == true} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_load(path, temporal, missing)"
+
+# ─── Synthetic dataset (thesis-style static modelling) ──────────────────
+# ``create_dataset`` declares concrete row/feature counts and balance,
+# so shape-dependent checks (minimum data, metric suitability) become
+# statically decidable — mirroring the thesis ``create_dataset``
+# component used throughout its evaluation pipelines.
+def create_dataset
+    (rows: {n: Int | n >= 0})
+    (features: {n: Int | n >= 0})
+    (bal: Bool) (temporal: Bool) (missing: Bool) :
+    {ds: Dataset | ds_rows ds == rows
+                && ds_features ds == features
+                && is_balanced ds == bal
+                && is_timeseries ds == temporal
+                && has_missing ds == missing
+                && coupled ds == false
+                && independent_target ds == true} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_create_dataset(rows, features, bal, temporal, missing)"
+
+# Trusted runtime assertion that a (statically unknown) dataset has at
+# least an order of magnitude more rows than features. Returns the
+# dataset unchanged but introduces the ``ds_rows > ds_features * 10``
+# fact; raises at runtime if violated. Use it to discharge a trainer's
+# minimum-data precondition on the CSV path, where counts are unknown.
+def require_enough_data (ds: Dataset) :
+    {d: Dataset | d == ds && ds_rows d > ds_features d * 10} =
+    native "__import__('aeon.bindings.learning').bindings.learning.Learning_require_enough_data(ds)"
 
 # ─── DataFrame inspection ──────────────────────────────────────────────
 
@@ -138,21 +225,39 @@ def class_counts (ds: Dataset) : List =
 # ─── Splitting ─────────────────────────────────────────────────────────
 
 # Linear split into ``(training, testing)``. Consumes the source so
-# training on the un-split dataset becomes a type error. The two halves
-# preserve the source's feature count, class count and balance flag —
-# expressed via the auto-generated ``Pair_mk_fst`` / ``Pair_mk_snd``
-# projections so the relationship survives through downstream calls.
+# training on the un-split dataset becomes a type error. ``shuffle``
+# selects whether rows are randomised before partitioning.
+#
+# The two halves preserve the source's feature/class counts and the
+# defect flags (``is_timeseries`` / ``has_missing`` / ``coupled`` /
+# ``independent_target``). Balance is preserved *only when shuffling*
+# (the thesis: an unshuffled split of class-ordered data is imbalanced).
+#
+# The testing half is stamped ``clean_test`` iff the split is sound: the
+# source is not coupled and is not a shuffled time series. That single
+# flag is what every metric below checks, so any pre-split contamination
+# or temporal leakage surfaces at evaluation time.
 def split
-    (1 ds: Dataset)
-    (fraction: {f: Float | 0.0 < f && f < 1.0}) :
+    (1 ds: {d: Dataset | ds_rows d > ds_features d * 10})
+    (fraction: {f: Float | 0.0 < f && f < 1.0})
+    (shuffle: Bool) :
     {p: (Pair Dataset Dataset)
         | ds_features (Pair_mk_fst p) == ds_features ds
        && ds_features (Pair_mk_snd p) == ds_features ds
        && ds_classes (Pair_mk_fst p) == ds_classes ds
        && ds_classes (Pair_mk_snd p) == ds_classes ds
-       && is_balanced (Pair_mk_fst p) == is_balanced ds
-       && is_balanced (Pair_mk_snd p) == is_balanced ds} =
-    native "('Pair_mk',) + __import__('aeon.bindings.learning').bindings.learning.Learning_split(ds, fraction)"
+       && is_timeseries (Pair_mk_fst p) == is_timeseries ds
+       && is_timeseries (Pair_mk_snd p) == is_timeseries ds
+       && has_missing (Pair_mk_fst p) == has_missing ds
+       && has_missing (Pair_mk_snd p) == has_missing ds
+       && coupled (Pair_mk_fst p) == coupled ds
+       && coupled (Pair_mk_snd p) == coupled ds
+       && independent_target (Pair_mk_fst p) == independent_target ds
+       && independent_target (Pair_mk_snd p) == independent_target ds
+       && (shuffle --> (is_balanced (Pair_mk_fst p) == is_balanced ds))
+       && (shuffle --> (is_balanced (Pair_mk_snd p) == is_balanced ds))
+       && clean_test (Pair_mk_snd p) == (coupled ds == false && (is_timeseries ds --> (shuffle == false)))} =
+    native "('Pair_mk',) + __import__('aeon.bindings.learning').bindings.learning.Learning_split(ds, fraction, shuffle)"
 
 # Runtime accessors for the training / testing halves, refined so the
 # returned dataset is linked to the source ``Pair`` via the auto-
@@ -167,6 +272,9 @@ def test_of (p: (Pair Dataset Dataset)) : {d: Dataset | d == Pair_mk_snd p} =
     native "p[2]"
 
 # ─── Resampling / balancing ────────────────────────────────────────────
+# Resampling couples the rows (synthetic/duplicated/removed instances are
+# derived from the rest), so applying it *before* a split leaks. Apply it
+# to the training half only, after splitting.
 
 # SMOTE oversampling; requires multi-class input (guard with
 # ``is_multiclass``). Output is balanced and preserves the feature
@@ -175,193 +283,267 @@ def smote (1 ds: {d: Dataset | ds_classes d >= 2}) :
     {out: Dataset | is_balanced out == true
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && ds_rows out >= ds_rows ds} =
+                  && ds_rows out >= ds_rows ds
+                  && coupled out == true
+                  && has_missing out == has_missing ds
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_smote(ds)"
 
 def random_oversample (1 ds: {d: Dataset | ds_classes d >= 2}) :
     {out: Dataset | is_balanced out == true
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && ds_rows out >= ds_rows ds} =
+                  && ds_rows out >= ds_rows ds
+                  && coupled out == true
+                  && has_missing out == has_missing ds
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_oversample(ds)"
 
 def random_undersample (1 ds: {d: Dataset | ds_classes d >= 2}) :
     {out: Dataset | is_balanced out == true
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && ds_rows out <= ds_rows ds} =
+                  && ds_rows out <= ds_rows ds
+                  && coupled out == true
+                  && has_missing out == has_missing ds
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_undersample(ds)"
 
 # ─── Scaling ───────────────────────────────────────────────────────────
+# Scaling fits statistics over the whole dataset, coupling the rows.
 
 def standard_scale (1 ds: Dataset) :
     {out: Dataset | ds_rows out == ds_rows ds
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && is_balanced out == is_balanced ds} =
+                  && is_balanced out == is_balanced ds
+                  && coupled out == true
+                  && has_missing out == has_missing ds
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds
+                  && clean_test out == clean_test ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_standard_scale(ds)"
 
 def minmax_scale (1 ds: Dataset) :
     {out: Dataset | ds_rows out == ds_rows ds
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && is_balanced out == is_balanced ds} =
+                  && is_balanced out == is_balanced ds
+                  && coupled out == true
+                  && has_missing out == has_missing ds
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds
+                  && clean_test out == clean_test ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_minmax_scale(ds)"
 
 def robust_scale (1 ds: Dataset) :
     {out: Dataset | ds_rows out == ds_rows ds
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && is_balanced out == is_balanced ds} =
+                  && is_balanced out == is_balanced ds
+                  && coupled out == true
+                  && has_missing out == has_missing ds
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds
+                  && clean_test out == clean_test ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_robust_scale(ds)"
 
 # ─── Missing-value imputation ──────────────────────────────────────────
+# Imputation fills from cross-row statistics (couples the rows) and
+# clears the missing-value flag.
 
 def fill_mean (1 ds: Dataset) :
     {out: Dataset | ds_rows out == ds_rows ds
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && is_balanced out == is_balanced ds} =
+                  && is_balanced out == is_balanced ds
+                  && has_missing out == false
+                  && coupled out == true
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds
+                  && clean_test out == clean_test ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_mean(ds)"
 
 def fill_median (1 ds: Dataset) :
     {out: Dataset | ds_rows out == ds_rows ds
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && is_balanced out == is_balanced ds} =
+                  && is_balanced out == is_balanced ds
+                  && has_missing out == false
+                  && coupled out == true
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds
+                  && clean_test out == clean_test ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_median(ds)"
 
 def fill_most_frequent (1 ds: Dataset) :
     {out: Dataset | ds_rows out == ds_rows ds
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && is_balanced out == is_balanced ds} =
+                  && is_balanced out == is_balanced ds
+                  && has_missing out == false
+                  && coupled out == true
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds
+                  && clean_test out == clean_test ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_most_frequent(ds)"
 
 def fill_constant (value: Float) (1 ds: Dataset) :
     {out: Dataset | ds_rows out == ds_rows ds
                   && ds_features out == ds_features ds
                   && ds_classes out == ds_classes ds
-                  && is_balanced out == is_balanced ds} =
+                  && is_balanced out == is_balanced ds
+                  && has_missing out == false
+                  && coupled out == true
+                  && is_timeseries out == is_timeseries ds
+                  && independent_target out == independent_target ds
+                  && clean_test out == clean_test ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_fill_constant(ds, value)"
 
 # ─── Classifier training ───────────────────────────────────────────────
-# Training stamps the model with the dataset's feature/class count.
+# Every trainer requires a clean training set: an independent target (no
+# proxy feature) and no missing values. The minimum-data check
+# (rows > 10x features) is enforced by ``split``. Training stamps the
+# resulting model with the dataset's feature/class count.
 
-def random_forest_classifier (ds: Dataset) :
+def random_forest_classifier
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_classifier(ds)"
 
-def random_forest_classifier_n (n: {k: Int | k > 0}) (ds: Dataset) :
+def random_forest_classifier_n (n: {k: Int | k > 0})
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_classifier_n(n, ds)"
 
-def logistic_regression (ds: Dataset) :
+def logistic_regression
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_logistic_regression(ds)"
 
-def decision_tree_classifier (ds: Dataset) :
+def decision_tree_classifier
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_decision_tree_classifier(ds)"
 
-def gradient_boosting_classifier (ds: Dataset) :
+def gradient_boosting_classifier
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_gradient_boosting_classifier(ds)"
 
-def knn_classifier (ds: Dataset) :
+def knn_classifier
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_knn_classifier(ds)"
 
 # ``k`` must be positive and not exceed the number of training rows.
 def knn_classifier_k
     (k: {n: Int | n > 0})
-    (ds: {d: Dataset | ds_rows d >= k}) :
+    (ds: {d: Dataset | ds_rows d >= k && independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_knn_classifier_k(k, ds)"
 
-def svc (ds: Dataset) :
+def svc
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_svc(ds)"
 
-def gaussian_nb (ds: Dataset) :
+def gaussian_nb
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_gaussian_nb(ds)"
 
-def multinomial_nb (ds: Dataset) :
+def multinomial_nb
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_multinomial_nb(ds)"
 
 # ComplementNB targets imbalanced data — refining out the balanced case
 # guides callers toward the right tool. Discharge with
 # ``if Learning.balanced ds then ... else Learning.complement_nb ds``.
-def complement_nb (ds: {d: Dataset | is_balanced d == false}) :
+def complement_nb
+    (ds: {d: Dataset | is_balanced d == false && independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_complement_nb(ds)"
 
-def mlp_classifier (ds: Dataset) :
+def mlp_classifier
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Classifier | clf_features m == ds_features ds && clf_classes m == ds_classes ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_mlp_classifier(ds)"
 
 # ─── Regressor training ────────────────────────────────────────────────
 
-def linear_regression (ds: Dataset) :
+def linear_regression
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_linear_regression(ds)"
 
-def ridge (ds: Dataset) :
+def ridge
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_ridge(ds)"
 
-def ridge_alpha (alpha: {a: Float | a >= 0.0}) (ds: Dataset) :
+def ridge_alpha (alpha: {a: Float | a >= 0.0})
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_ridge_alpha(alpha, ds)"
 
-def lasso (ds: Dataset) :
+def lasso
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_lasso(ds)"
 
-def lasso_alpha (alpha: {a: Float | a >= 0.0}) (ds: Dataset) :
+def lasso_alpha (alpha: {a: Float | a >= 0.0})
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_lasso_alpha(alpha, ds)"
 
-def elastic_net (ds: Dataset) :
+def elastic_net
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_elastic_net(ds)"
 
-def random_forest_regressor (ds: Dataset) :
+def random_forest_regressor
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_regressor(ds)"
 
-def random_forest_regressor_n (n: {k: Int | k > 0}) (ds: Dataset) :
+def random_forest_regressor_n (n: {k: Int | k > 0})
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_random_forest_regressor_n(n, ds)"
 
-def decision_tree_regressor (ds: Dataset) :
+def decision_tree_regressor
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_decision_tree_regressor(ds)"
 
-def gradient_boosting_regressor (ds: Dataset) :
+def gradient_boosting_regressor
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_gradient_boosting_regressor(ds)"
 
-def knn_regressor (ds: Dataset) :
+def knn_regressor
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_knn_regressor(ds)"
 
-def svr (ds: Dataset) :
+def svr
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_svr(ds)"
 
-def mlp_regressor (ds: Dataset) :
+def mlp_regressor
+    (ds: {d: Dataset | independent_target d == true && has_missing d == false}) :
     {m: Regressor | reg_features m == ds_features ds} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_mlp_regressor(ds)"
 
 # ─── Prediction ────────────────────────────────────────────────────────
-# Each call now carries a feature-count precondition: the model's
-# ``clf_features`` (or ``reg_features``) must match the dataset's
-# ``ds_features``. This is discharged automatically by the typical
-# pipeline because ``split``'s output refinement links both halves'
-# ``ds_features`` to the source's.
+# Prediction only needs the model's feature count to match the dataset's;
+# it is leakage-neutral (no held-out guarantee is consumed).
 
 def predict
     (model: Classifier)
@@ -379,73 +561,77 @@ def predict_value
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_predict(model, ds)"
 
 # ─── Classification metrics ────────────────────────────────────────────
+# Every metric requires a ``clean_test`` dataset (a sound held-out split),
+# rejecting evaluation on training/contaminated/leaky data. The
+# balance-sensitive metrics (accuracy / precision / recall) additionally
+# require a balanced test set — discharge with the ``balanced`` witness.
 
 def accuracy
     (model: Classifier)
-    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    (ds: {d: Dataset | clf_features model == ds_features d && clean_test d == true && is_balanced d == true}) :
     {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_accuracy(model, ds)"
 
 def precision
     (model: Classifier)
-    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    (ds: {d: Dataset | clf_features model == ds_features d && clean_test d == true && is_balanced d == true}) :
     {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_precision(model, ds)"
 
 def recall
     (model: Classifier)
-    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    (ds: {d: Dataset | clf_features model == ds_features d && clean_test d == true && is_balanced d == true}) :
     {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_recall(model, ds)"
 
 def f1
     (model: Classifier)
-    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    (ds: {d: Dataset | clf_features model == ds_features d && clean_test d == true}) :
     {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_f1(model, ds)"
 
 def roc_auc
     (model: Classifier)
-    (ds: {d: Dataset | clf_features model == ds_features d}) :
+    (ds: {d: Dataset | clf_features model == ds_features d && clean_test d == true}) :
     {f: Float | 0.0 <= f && f <= 1.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_roc_auc(model, ds)"
 
 def confusion_matrix
     (model: Classifier)
-    (ds: {d: Dataset | clf_features model == ds_features d}) : List =
+    (ds: {d: Dataset | clf_features model == ds_features d && clean_test d == true}) : List =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_confusion_matrix(model, ds)"
 
 def classification_report
     (model: Classifier)
-    (ds: {d: Dataset | clf_features model == ds_features d}) : String =
+    (ds: {d: Dataset | clf_features model == ds_features d && clean_test d == true}) : String =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_classification_report(model, ds)"
 
 # ─── Regression metrics ────────────────────────────────────────────────
 
 def mse
     (model: Regressor)
-    (ds: {d: Dataset | reg_features model == ds_features d}) :
+    (ds: {d: Dataset | reg_features model == ds_features d && clean_test d == true}) :
     {f: Float | f >= 0.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_mse(model, ds)"
 
 def rmse
     (model: Regressor)
-    (ds: {d: Dataset | reg_features model == ds_features d}) :
+    (ds: {d: Dataset | reg_features model == ds_features d && clean_test d == true}) :
     {f: Float | f >= 0.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_rmse(model, ds)"
 
 def mae
     (model: Regressor)
-    (ds: {d: Dataset | reg_features model == ds_features d}) :
+    (ds: {d: Dataset | reg_features model == ds_features d && clean_test d == true}) :
     {f: Float | f >= 0.0} =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_mae(model, ds)"
 
 def r2
     (model: Regressor)
-    (ds: {d: Dataset | reg_features model == ds_features d}) : Float =
+    (ds: {d: Dataset | reg_features model == ds_features d && clean_test d == true}) : Float =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_r2(model, ds)"
 
 def explained_variance
     (model: Regressor)
-    (ds: {d: Dataset | reg_features model == ds_features d}) : Float =
+    (ds: {d: Dataset | reg_features model == ds_features d && clean_test d == true}) : Float =
     native "__import__('aeon.bindings.learning').bindings.learning.Learning_explained_variance(model, ds)"

--- a/tests/learning_test.py
+++ b/tests/learning_test.py
@@ -1,0 +1,230 @@
+"""Type-level pipeline-defect detection in the ``Learning`` library.
+
+These tests exercise the contracts added to ``libraries/Learning.ae`` that
+encode the ML-pipeline defects from Pedro Silva's MSc thesis. A *clean*
+pipeline type-checks (no errors); a pipeline containing a defect is
+rejected by the liquid-type checker.
+
+We drive the full front-end via ``AeonDriver`` so that ``open Learning``
+is resolved exactly as it is on the command line, and run with
+``no_main=True`` so nothing is executed — we only assert on typing.
+"""
+
+from __future__ import annotations
+
+from aeon.facade.driver import AeonDriver, AeonConfig
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _typechecks(source: str) -> bool:
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=True,
+    )
+    driver = AeonDriver(cfg)
+    errors = driver.parse(aeon_code=source)
+    return not errors
+
+
+# ─── Clean pipelines — must type-check ──────────────────────────────────
+
+
+def test_clean_static_pipeline():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true false false in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.accuracy model (Learning.test_of parts) ;
+    """
+    assert _typechecks(src)
+
+
+def test_clean_timeseries_unshuffled_with_f1():
+    # A time series split without shuffling, scored with a
+    # balance-insensitive metric, is sound.
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true true false in
+        let parts = Learning.split ds 0.8 false in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert _typechecks(src)
+
+
+def test_clean_imbalanced_with_f1():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 false false false in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert _typechecks(src)
+
+
+def test_clean_accuracy_discharged_by_balanced_witness():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 false false false in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        let test = Learning.test_of parts in
+        if Learning.balanced test then Learning.accuracy model test
+        else Learning.f1 model test ;
+    """
+    assert _typechecks(src)
+
+
+def test_clean_regression_per_split_imputation():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true false true in
+        let parts = Learning.split ds 0.8 true in
+        let train = Learning.fill_median (Learning.train_of parts) in
+        let test = Learning.fill_median (Learning.test_of parts) in
+        let model = Learning.ridge train in
+        Learning.r2 model test ;
+    """
+    assert _typechecks(src)
+
+
+def test_clean_csv_path_with_require_enough_data():
+    src = """
+    open Learning
+    def p (path: String) (col: String) : Float =
+        let 1 df = Learning.read_csv path in
+        let ds0 = Learning.target df col false false in
+        let ds = Learning.require_enough_data ds0 in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert _typechecks(src)
+
+
+# ─── Defective pipelines — must be rejected ─────────────────────────────
+
+
+def test_defect_temporal_leakage():
+    # Shuffling a time series before splitting destroys chronological order.
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true true false in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_scale_before_split():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true false false in
+        let scaled = Learning.standard_scale ds in
+        let parts = Learning.split scaled 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_smote_before_split():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true false false in
+        let bds = Learning.smote ds in
+        let parts = Learning.split bds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_impute_before_split():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true false true in
+        let filled = Learning.fill_median ds in
+        let parts = Learning.split filled 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_evaluate_on_training_set():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true false false in
+        let parts = Learning.split ds 0.8 true in
+        let train = Learning.train_of parts in
+        let model = Learning.random_forest_classifier train in
+        Learning.f1 model train ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_missing_values_to_estimator():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 true false true in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_lack_of_data():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 20 4 true false false in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_balance_sensitive_metric_on_imbalanced():
+    src = """
+    open Learning
+    def p (a: Int) : Float =
+        let ds = Learning.create_dataset 1000 4 false false false in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.accuracy model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)
+
+
+def test_defect_csv_path_without_require_enough_data():
+    # The CSV row count is statically unknown, so the minimum-data
+    # precondition of ``split`` cannot be discharged without an assertion.
+    src = """
+    open Learning
+    def p (path: String) (col: String) : Float =
+        let 1 df = Learning.read_csv path in
+        let ds = Learning.target df col false false in
+        let parts = Learning.split ds 0.8 true in
+        let model = Learning.random_forest_classifier (Learning.train_of parts) in
+        Learning.f1 model (Learning.test_of parts) ;
+    """
+    assert not _typechecks(src)


### PR DESCRIPTION
## Summary

Extends the `Learning` standard library with the **pipeline-defect detection** primitives and refinements from Pedro Silva's MSc thesis [*"Static Analysis for Detection of Defects in Machine Learning Pipelines"*](https://repositorio.ulisboa.pt/server/api/core/bitstreams/43faca47-b46e-4b1e-a8d3-e4cef959f351/content) (ULisboa 2024, advised by Alcides Fonseca & Antónia Lopes, CAMELOT/Feedzai). Common ML-pipeline defects are now rejected at **compile time** by the liquid-type checker.

The thesis specifies each component with first-order pre/post-conditions over **per-line** predicates (`lineInDs`, `lineCausality`, `synthesizedLine`, …). Aeon's liquid refinements are **quantifier-free**, so those `∀`-over-`ZLine` specs are collapsed to **dataset-level summary flags** whose values are *fully determined* by each component's post-condition (biconditionals, not implications). This keeps everything decidable and needs **no global `axiom` construct** — the propagation laws live entirely in the contracts.

## What's new in `Learning.ae`

- **Summary flags** (uninterpreted `Dataset -> Bool`): `is_timeseries`, `has_missing`, `coupled`, `clean_test`, `independent_target`, `ds_target`.
- **`create_dataset rows features bal temporal missing`** — thesis-style static modelling; concrete counts make minimum-data / balance checks statically decidable (mirrors the thesis evaluation pipelines).
- **`require_enough_data`** — trusted cast asserting `rows > features * 10`, to discharge the minimum-data precondition on the CSV path where the row count is statically unknown.
- **`split` gains a `shuffle` parameter** and stamps the test half `clean_test` **iff** the source is not coupled and not a shuffled time series. (This also fixes a latent unsoundness: the old `split` claimed balance was preserved unconditionally.)
- Scaling / imputation / resampling set `coupled`; scalers and imputers (not resamplers) preserve `clean_test` so legitimate *per-split* preprocessing still type-checks; imputers clear `has_missing`.
- Trainers require `independent_target && !has_missing`; balance-sensitive metrics (`accuracy`/`precision`/`recall`) require `is_balanced`; every metric requires `clean_test`; `f1`/`roc_auc` stay balance-insensitive.

## Defects caught at compile time

- Pre-processing / SMOTE **before** the train/test split
- Temporal leakage (shuffling a time series before splitting)
- Evaluating on the training set / on non-split data
- Missing values fed into an estimator
- Too few instances (`rows ≤ features × 10`)
- A balance-sensitive metric on an imbalanced test set

## Changes

- `libraries/Learning.ae` — new flags, primitives, and refined component contracts.
- `aeon/bindings/learning.py` — matching signatures (`target`/`target_at`/`load` take `temporal`/`missing`; `split` takes `shuffle`) plus `Learning_create_dataset` and `Learning_require_enough_data`.
- `examples/ml/*.ae`, `examples/demos/3_dataset.ae` — rewritten **leakage-free** (the previous versions scaled/SMOTEd before splitting, which the new contracts correctly reject).
- `tests/learning_test.py` — **15 tests**: 6 clean pipelines that type-check, 9 defective ones that are rejected.

## Test plan

- `uv run pytest tests/learning_test.py` → **15 passed**.
- All four `.ae` examples type-check (`uv run python -m aeon --no-main …`).
- A clean pipeline also executes end-to-end through the FFI; the new bindings smoke-test passes (including `require_enough_data` raising on a 20-row dataset).

## Notes / limitations

- Detection is at **dataset** granularity (the quantifier-free collapse), not per-row. It covers every defect in the thesis's evaluation.
- Deliberately **out of scope** (would require core/language changes, not library changes): a first-class `axiom` form (avoided here via determined flags) and per-line precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)