### PR TITLE
feat(libraries): encode Silva-thesis per-line axioms with the `axiom` keyword

### DIFF
--- a/examples/ml/temporal_leakage_proof.ae
+++ b/examples/ml/temporal_leakage_proof.ae
@@ -1,0 +1,55 @@
+# Worked proofs over the per-line model in ``libraries/LearningLines.ae``,
+# showing how the thesis's Appendix-A axioms — declared there with the
+# ``axiom`` keyword — are *instantiated* to discharge a refinement.
+#
+# Each function below carries its hypotheses as the refinement of an
+# ``Int`` parameter ``h`` and states its conclusion as the refinement of
+# the return type. The proof is the ``let inst = <axiom> <args> in h``
+# line: instantiating the axiom adds its fact to the context, which lets
+# the SMT solver discharge the conclusion. Remove that line and the
+# function no longer type-checks (see ``tests/learning_axioms_test.py``).
+
+open LearningLines
+
+
+# Time-series law (A.1). In a chronologically-ordered dataset with more
+# than one line, if ``earlier`` precedes ``later`` then ``later`` causally
+# depends on ``earlier``. This is the heart of temporal leakage: shuffling
+# a time series before the split can put a test instance chronologically
+# *earlier* than a training instance, so the model trains on a row that
+# depends on a future (test) row.
+def causal_from_precedence
+    (d: LDataset) (earlier: Line) (later: Line)
+    (h: {x: Int | line_count d > 1 && is_ts d && earlier != later && prec earlier later d}) :
+    {r: Int | causality earlier later} =
+    let inst = LearningLines.ax_timeseries earlier later d in
+    h ;
+
+
+# Precedence is transitive (A.5), instantiated for one triple.
+def precedence_is_transitive
+    (d: LDataset) (a: Line) (b: Line) (c: Line)
+    (h: {x: Int | a != b && b != c && a != c && prec a b d && prec b c d}) :
+    {r: Int | prec a c d} =
+    let inst = LearningLines.ax_prec_trans a b c d in
+    h ;
+
+
+# Causality is antisymmetric (A.4): mutual causal dependence is
+# impossible, so the hypotheses are contradictory and anything follows.
+def no_mutual_causality
+    (a: Line) (b: Line)
+    (h: {x: Int | causality a b && causality b a}) :
+    {r: Int | false} =
+    let inst = LearningLines.ax_causality_antisym a b in
+    h ;
+
+
+# A clone causally depends on its original (A.3) — duplicating a row (e.g.
+# random oversampling) before the split creates a train/test dependency.
+def clone_implies_dependency
+    (a: Line) (b: Line)
+    (h: {x: Int | clone a b}) :
+    {r: Int | causality a b} =
+    let inst = LearningLines.ax_clone_causality a b in
+    h ;

--- a/libraries/LearningLines.ae
+++ b/libraries/LearningLines.ae
@@ -1,0 +1,101 @@
+# Per-line (instance-level) model from Pedro Silva's MSc thesis
+# *"Static Analysis for Detection of Defects in Machine Learning
+# Pipelines"* (ULisboa 2024), Appendix A — with the relational axioms
+# stated using the Lean-style ``axiom`` keyword.
+#
+# ─── Axioms ─────────────────────────────────────────────────────────────
+#
+# ``axiom name : <type> ;`` introduces a constant of the given (dependent,
+# refined) type without a proof; its refinements are assumed (trusted).
+# Aeon's liquid refinements are quantifier-free, so there is no global
+# quantifier: an axiom is brought into a proof by **instantiating** it —
+# applying it to concrete arguments adds its fact to the context
+# (ghost-lemma style, as in F*/Dafny/Lean's ``exact``). Each axiom below
+# states one Appendix-A law, parameterised over the lines / dataset it
+# quantifies over; instantiate the ones a proof needs (see
+# ``examples/ml/temporal_leakage_proof.ae``).
+#
+# This is the finer-grained counterpart to the dataset-level summary flags
+# in ``Learning.ae``: those are *determined* by component post-conditions
+# so they need no instantiation, whereas these per-line relations are
+# genuinely relational (transitivity, antisymmetry, the time-series law)
+# and cannot be made determined — so they are stated as axioms here.
+#
+# CAUTION: an axiom is only as sound as the fact it states. A false
+# refinement becomes a false axiom and unsoundens everything downstream —
+# these must be read as the trusted core, exactly like the thesis loads
+# its axioms into the solver unconditionally.
+
+# ─── Sorts ──────────────────────────────────────────────────────────────
+
+type Line
+type LDataset
+
+# ─── Uninterpreted per-line predicates (thesis §6.3.3) ──────────────────
+
+# ``l`` is one of the instances of dataset ``d``.
+def line_in : (l: Line) -> (d: LDataset) -> Bool = uninterpreted
+# ``a`` precedes ``b`` in dataset ``d`` (chronological / positional order).
+def prec : (a: Line) -> (b: Line) -> (d: LDataset) -> Bool = uninterpreted
+# ``causality a b`` ≡ ``b`` causally depends on ``a`` (thesis lineCausality).
+def causality : (a: Line) -> (b: Line) -> Bool = uninterpreted
+# ``b`` is a clone of ``a`` (same column values).
+def clone : (a: Line) -> (b: Line) -> Bool = uninterpreted
+# ``l`` was synthesised (e.g. by SMOTE), not a real-world record.
+def synth : (l: Line) -> Bool = uninterpreted
+# ``d`` holds chronologically-ordered (time-stamped) data.
+def is_ts : (d: LDataset) -> Bool = uninterpreted
+def line_count : (d: LDataset) -> Int = uninterpreted
+
+# ─── Appendix A.4 — Causality ───────────────────────────────────────────
+
+# A line never causally depends on itself.
+axiom ax_causality_irreflexive :
+    (l: Line) -> {u: Unit | causality l l == false} ;
+
+# Causality is antisymmetric.
+axiom ax_causality_antisym :
+    (a: Line) -> (b: Line) -> {u: Unit | causality a b --> (causality b a == false)} ;
+
+# Causality is transitive (over distinct lines).
+axiom ax_causality_trans :
+    (a: Line) -> (b: Line) -> (c: Line)
+    -> {u: Unit | (a != b && b != c && a != c && causality a b && causality b c)
+                  --> causality a c} ;
+
+# ─── Appendix A.5 — Precedence ──────────────────────────────────────────
+
+# Precedence relates lines that are both in the dataset.
+axiom ax_prec_membership :
+    (a: Line) -> (b: Line) -> (d: LDataset)
+    -> {u: Unit | prec a b d --> (line_in a d && line_in b d)} ;
+
+# A line never precedes itself.
+axiom ax_prec_irreflexive :
+    (l: Line) -> (d: LDataset) -> {u: Unit | prec l l d == false} ;
+
+# Precedence is transitive (over distinct lines).
+axiom ax_prec_trans :
+    (a: Line) -> (b: Line) -> (c: Line) -> (d: LDataset)
+    -> {u: Unit | (a != b && b != c && a != c && prec a b d && prec b c d)
+                  --> prec a c d} ;
+
+# ─── Appendix A.3 — Line clone ──────────────────────────────────────────
+
+# A clone causally depends on its original.
+axiom ax_clone_causality :
+    (a: Line) -> (b: Line) -> {u: Unit | clone a b --> causality a b} ;
+
+# A clone shares the synthesised flag of its original.
+axiom ax_clone_synth :
+    (a: Line) -> (b: Line) -> {u: Unit | clone a b --> (synth a == synth b)} ;
+
+# ─── Appendix A.1 — Time-series law ─────────────────────────────────────
+
+# In a chronologically-ordered dataset with more than one line, a later
+# line causally depends on an earlier one: if ``a`` precedes ``b`` then
+# ``b`` causally depends on ``a``.
+axiom ax_timeseries :
+    (a: Line) -> (b: Line) -> (d: LDataset)
+    -> {u: Unit | (line_count d > 1 && is_ts d && a != b && prec a b d)
+                  --> causality a b} ;

--- a/tests/learning_axioms_test.py
+++ b/tests/learning_axioms_test.py
@@ -1,0 +1,86 @@
+"""Axioms via ``def`` + ``native`` in the ``LearningLines`` library.
+
+A ``native`` body is trusted (not checked against its declared
+refinement), so ``def ax (...) : {u: Unit | P} = native "()"`` asserts
+``P`` as an axiom. Because Aeon refinements are quantifier-free, the
+axiom is brought into a proof by *instantiating* it — calling it with the
+relevant arguments. These tests check that each Appendix-A axiom in
+``libraries/LearningLines.ae`` is **load-bearing**: the proof type-checks
+when the axiom is instantiated and is rejected when it is not.
+"""
+
+from __future__ import annotations
+
+from aeon.facade.driver import AeonDriver, AeonConfig
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _typechecks(source: str) -> bool:
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=True,
+    )
+    driver = AeonDriver(cfg)
+    errors = driver.parse(aeon_code=source)
+    return not errors
+
+
+# Each case is a (proof-with-instantiation, proof-without-instantiation)
+# pair sharing the same signature; only the ``let inst = ...`` line differs.
+
+_TIMESERIES = """
+open LearningLines
+def thm
+    (d: LDataset) (earlier: Line) (later: Line)
+    (h: {{x: Int | line_count d > 1 && is_ts d && earlier != later && prec earlier later d}}) :
+    {{r: Int | causality earlier later}} =
+    {body} ;
+"""
+
+_PREC_TRANS = """
+open LearningLines
+def thm
+    (d: LDataset) (a: Line) (b: Line) (c: Line)
+    (h: {{x: Int | a != b && b != c && a != c && prec a b d && prec b c d}}) :
+    {{r: Int | prec a c d}} =
+    {body} ;
+"""
+
+_ANTISYM = """
+open LearningLines
+def thm
+    (a: Line) (b: Line)
+    (h: {{x: Int | causality a b && causality b a}}) :
+    {{r: Int | false}} =
+    {body} ;
+"""
+
+_CLONE = """
+open LearningLines
+def thm
+    (a: Line) (b: Line)
+    (h: {{x: Int | clone a b}}) :
+    {{r: Int | causality a b}} =
+    {body} ;
+"""
+
+CASES = {
+    "timeseries": (_TIMESERIES, "let inst = LearningLines.ax_timeseries earlier later d in h"),
+    "prec_trans": (_PREC_TRANS, "let inst = LearningLines.ax_prec_trans a b c d in h"),
+    "antisym": (_ANTISYM, "let inst = LearningLines.ax_causality_antisym a b in h"),
+    "clone": (_CLONE, "let inst = LearningLines.ax_clone_causality a b in h"),
+}
+
+
+def test_axioms_discharge_when_instantiated():
+    for name, (template, instantiated) in CASES.items():
+        assert _typechecks(template.format(body=instantiated)), f"{name}: should type-check with the axiom instantiated"
+
+
+def test_proofs_fail_without_the_axiom():
+    # Same signature, but the conclusion is asserted with no axiom in
+    # scope — the uninterpreted relations leave it unprovable.
+    for name, (template, _instantiated) in CASES.items():
+        assert not _typechecks(template.format(body="h")), f"{name}: should be rejected without the axiom"


### PR DESCRIPTION
## Summary

Expresses the **per-line** (instance-level) relational laws from Pedro Silva's MSc thesis [*"Static Analysis for Detection of Defects in Machine Learning Pipelines"*](https://repositorio.ulisboa.pt/server/api/core/bitstreams/43faca47-b46e-4b1e-a8d3-e4cef959f351/content) (ULisboa 2024), Appendix A, using Aeon's **`axiom` keyword** (added in #361).

It is the finer-grained, instantiation-based counterpart to #359's *dataset-level* determined summary flags: those are made determined by component post-conditions (no instantiation), whereas these relations are genuinely relational (transitivity, antisymmetry, the time-series law) and cannot be made determined — so they are stated as axioms. Purely additive (no existing file is touched).

## Mechanism

`axiom name : <type> ;` asserts a constant of the given dependent, refined type without proof. Aeon's refinements are quantifier-free, so each law is parameterised over the lines/dataset it quantifies over and brought into a proof by **instantiating** it — applying it to concrete arguments (ghost-lemma style, the analogue of Lean's `exact`):

```aeon
let inst = LearningLines.ax_timeseries earlier later d in
h        -- the conclusion `causality earlier later` now discharges
```

## Changes

- **`libraries/LearningLines.ae`** — the per-line vocabulary (`Line` / `LDataset` sorts; `line_in`, `prec`, `causality`, `clone`, `synth`, `is_ts`, `line_count`) and the Appendix-A laws as `axiom` declarations: causality irreflexivity / antisymmetry / transitivity (A.4), precedence membership / irreflexivity / transitivity (A.5), clone ⇒ causality and clone-preserves-synth (A.3), and the time-series law (A.1).
- **`examples/ml/temporal_leakage_proof.ae`** — worked proofs instantiating each axiom, including the time-series law deriving a train/test causal dependency (the essence of temporal leakage) and an antisymmetry-based contradiction.
- **`tests/learning_axioms_test.py`** — each axiom is **load-bearing**: the proof type-checks when the axiom is instantiated and is rejected without it.

## Test plan

- `uv run pytest tests/learning_axioms_test.py` → **2 passed** (4 axioms × accepted-with / rejected-without).
- `uv run python -m aeon --no-main libraries/LearningLines.ae` and `… examples/ml/temporal_leakage_proof.ae` both type-check.

## Caveat

An axiom is only as sound as the fact it states (same trust basis as any `native`); these are the trusted core, exactly as the thesis loads its Appendix-A axioms into the solver unconditionally.

Builds on #361 (the `axiom` keyword) and complements #359 (dataset-level flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)