### PR TITLE
feat(sugar): add Lean-style `axiom` keyword

### DIFF
--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -46,8 +46,13 @@ measure_rule : "+" ID args ":" type                        -> def_ind_cons
 // A definition name may be a plain identifier or a dotted ``Type.method`` name
 // (issue #27): ``def Int.toString : ...`` declares a method on ``Int`` that
 // ``recv.toString`` dispatches to when the receiver has type ``Int``.
+// Lean-style trusted axiom: ``axiom name : <type> ;`` introduces a constant
+// of the given (possibly dependent, refined) type without a proof. The type's
+// refinements are assumed; the body is never checked. Like Lean, axioms are
+// noncomputable (applying one yields an opaque proof token).
 def : soft_constraint "def" def_name ":" type "=" expression ";"?                  -> def_cons
     | soft_constraint "def" def_name  args ":" type decreasing_by_opt "=" expression ";"?     -> def_fun_eq
+    | "axiom" def_name ":" type ";"?                                         -> axiom_decl
     | instance_decl                                                          -> same
 
 def_name : ID                                                -> same

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -651,6 +651,50 @@ class TreeToSugar(Transformer):
     def def_fun_eq(self, meta, args):
         return self.def_fun(meta, args)
 
+    @v_args(meta=True)
+    def axiom_decl(self, meta, args):
+        # ``axiom name : <type> ;`` — Lean-style trusted declaration. The type
+        # may be a dependent, refined arrow; we peel its leading binders into a
+        # Definition's foralls / refinement-foralls / value args so that the
+        # usual lambda-wrapping makes the axiom *callable* (it is instantiated
+        # by application, ghost-lemma style). The body is a trusted ``native``
+        # token: never checked against the refinement, and — like a Lean axiom
+        # — not meant to be computed (applying it yields an opaque value).
+        name, ty = args[0], args[1]
+        loc = self._loc(meta)
+        foralls: list = []
+        rforalls: list = []
+        fn_args: list = []
+        mults: list = []
+        flags: list = []
+        while isinstance(ty, STypePolymorphism):
+            foralls.append((ty.name, ty.kind))
+            ty = ty.body
+        while isinstance(ty, SRefinementPolymorphism):
+            rforalls.append((ty.name, ty.sort))
+            ty = ty.body
+        while isinstance(ty, SAbstractionType):
+            fn_args.append((ty.var_name, ty.var_type))
+            mults.append(ty.multiplicity)
+            flags.append(ty.is_instance)
+            ty = ty.type
+        body = SApplication(
+            SVar(Name("native"), loc=loc),
+            SLiteral("()", type=st_string, loc=loc),
+            loc=loc,
+        )
+        return Definition(
+            Name(name),
+            foralls,
+            fn_args,
+            ty,
+            body,
+            rforalls=rforalls,
+            arg_multiplicities=tuple(mults),
+            instance_flags=tuple(flags),
+            loc=loc,
+        )
+
     def macros(self, args):
         return args
 

--- a/examples/syntax/axiom.ae
+++ b/examples/syntax/axiom.ae
@@ -1,0 +1,32 @@
+# Lean-style `axiom` declarations.
+#
+# `axiom name : <type> ;` introduces a constant of the given type without a
+# proof. The type may be a dependent, refined arrow; its refinements are
+# *assumed* (trusted, never checked). Like a Lean axiom it is noncomputable —
+# it carries logical content, not a runtime value.
+#
+# Because Aeon's refinements are quantifier-free, an axiom is brought into a
+# proof by *instantiating* it: applying it to concrete arguments adds its fact
+# to the context (ghost-lemma style, as in F*/Dafny/Lean's `exact`).
+
+# An uninterpreted relation we want to reason about.
+def reaches : (a: Int) -> (b: Int) -> Bool = uninterpreted
+
+# Axioms about it — no `native "()"` boilerplate, just the stated facts.
+axiom reaches_refl : (x: Int) -> {u: Unit | reaches x x} ;
+axiom reaches_trans :
+    (a: Int) -> (b: Int) -> (c: Int)
+    -> {u: Unit | (reaches a b && reaches b c) --> reaches a c} ;
+
+# A proof that uses the axioms by instantiating them at the needed points.
+def two_hops
+    (a: Int) (b: Int) (c: Int)
+    (h: {x: Int | reaches a b && reaches b c}) :
+    {r: Int | reaches a c} =
+    let step = reaches_trans a b c in
+    h ;
+
+# Reflexivity, instantiated.
+def self_reaches (a: Int) (h: Int) : {r: Int | reaches a a} =
+    let step = reaches_refl a in
+    h ;

--- a/tests/axiom_test.py
+++ b/tests/axiom_test.py
@@ -1,0 +1,87 @@
+"""The Lean-style ``axiom`` keyword.
+
+``axiom name : <type> ;`` introduces a trusted constant of the given
+(possibly dependent, refined) type. Its refinements are assumed and never
+checked. Because Aeon's refinements are quantifier-free, an axiom is used
+by *instantiating* it — applying it to concrete arguments brings its fact
+into the proof context. These tests check that an axiom is load-bearing
+(discharges an obligation only when instantiated) and that the various
+binder shapes parse and elaborate.
+"""
+
+from __future__ import annotations
+
+from aeon.facade.driver import AeonDriver, AeonConfig
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _typechecks(source: str) -> bool:
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=True,
+    )
+    driver = AeonDriver(cfg)
+    errors = driver.parse(aeon_code=source)
+    return not errors
+
+
+def test_axiom_discharges_when_instantiated():
+    src = """
+    def p : (x:Int) -> Bool = uninterpreted
+    axiom assume_p : (x:Int) -> {u:Unit | p x == true} ;
+    def needs_p (y: {z:Int | p z == true}) : Int = y ;
+    def main (a:Int) : Int =
+        let inst = assume_p 5 in
+        needs_p 5 ;
+    """
+    assert _typechecks(src)
+
+
+def test_axiom_is_load_bearing():
+    # Same program, but the axiom is never instantiated, so the fact is
+    # not in scope and the precondition cannot be discharged.
+    src = """
+    def p : (x:Int) -> Bool = uninterpreted
+    axiom assume_p : (x:Int) -> {u:Unit | p x == true} ;
+    def needs_p (y: {z:Int | p z == true}) : Int = y ;
+    def main (a:Int) : Int = needs_p 5 ;
+    """
+    assert not _typechecks(src)
+
+
+def test_relational_axiom_transitivity():
+    src = """
+    def prec : (a:Int) -> (b:Int) -> Bool = uninterpreted
+    axiom trans :
+        (a:Int) -> (b:Int) -> (c:Int) -> {u:Unit | (prec a b && prec b c) --> prec a c} ;
+    def use (a: {x:Int | prec 1 2 && prec 2 3}) : {r:Int | prec 1 3} =
+        let l = trans 1 2 3 in a ;
+    def main (a:Int) : Int = 0 ;
+    """
+    assert _typechecks(src)
+
+
+def test_polymorphic_axiom_with_forall():
+    src = """
+    def q : forall a:B, (x:a) -> Bool = uninterpreted
+    axiom q_holds : forall a:B, (x:a) -> {u:Unit | q x == true} ;
+    def needs (n: {z:Int | q z == true}) : Int = n ;
+    def main (a:Int) : Int = let i = q_holds 7 in needs 7 ;
+    """
+    assert _typechecks(src)
+
+
+def test_constant_axiom_no_arguments():
+    # An axiom need not be a function: a bare refined constant (zero binders)
+    # works too, stating a closed fact about an uninterpreted symbol.
+    src = """
+    def p : (x:Int) -> Bool = uninterpreted
+    axiom p_at_5 : {u:Unit | p 5 == true} ;
+    def needs (n: {z:Int | p 5 == true}) : Int = n ;
+    def main (a:Int) : Int =
+        let fact = p_at_5 in
+        needs 0 ;
+    """
+    assert _typechecks(src)


### PR DESCRIPTION
## Summary

Adds a first-class **`axiom`** declaration to Aeon's surface language, using Lean 4 syntax:

```aeon
axiom reaches_trans :
    (a: Int) -> (b: Int) -> (c: Int)
    -> {u: Unit | (reaches a b && reaches b c) --> reaches a c} ;
```

`axiom name : <type> ;` introduces a constant of the given (possibly dependent, refined) type **without a proof** — the type's refinements are trusted and never checked. It is the ergonomic surface for the existing `def … = native "()"` axiom pattern (used in #360), and fits Aeon's ongoing convergence on Lean conventions (operator associativity, `fun x =>`).

## Semantics

- The refinements in the declared type are **assumed**.
- Because Aeon's refinements are **quantifier-free**, an axiom is brought into a proof by **instantiating** it — applying it to concrete arguments adds its fact to the context (ghost-lemma style, the analogue of Lean's `exact ax a b`).
- Like a Lean axiom it is **noncomputable**: applying it yields an opaque token (`native "()"`), harmless if a program happens to evaluate it.

```aeon
def two_hops (a:Int) (b:Int) (c:Int)
    (h: {x:Int | reaches a b && reaches b c}) : {r:Int | reaches a c} =
    let step = reaches_trans a b c in   -- instantiate the axiom
    h ;
```

## Implementation (sugar layer only)

Deliberately minimal — no changes to elaboration, type-checking, or the runtime:

- **`aeon/sugar/aeon_sugar.lark`** — one new alternative of the `def` rule: `"axiom" def_name ":" type ";"?`.
- **`aeon/sugar/parser.py`** — an `axiom_decl` transformer that peels the type's leading binders (`forall` type-polymorphism, refinement-polymorphism, and `(x:T)->` value arrows, preserving multiplicities / instance flags) into a `Definition`, with a trusted `native "()"` body. Reusing the normal definition path means the binders become lambda wrappers, so the axiom is **callable** (instantiable) — unlike a bare `uninterpreted` symbol, which crashes if referenced in term position.

## Changes

- `examples/syntax/axiom.ae` — reflexivity / transitivity axioms instantiated in proofs (lives in the CI-run `examples/syntax/` folder).
- `tests/axiom_test.py` — 5 tests: an axiom discharges an obligation only when instantiated (**load-bearing**), is rejected when not, plus `forall`-polymorphic and zero-binder forms.

## Test plan

- `uv run pytest tests/axiom_test.py` → **5 passed**.
- Regression: `tests/end_to_end_test.py`, `native_test.py`, `polymorphic_uninterpreted_test.py`, `typeclass_test.py` → **36 passed**; every `examples/syntax/*.ae` still parses under `--no-main`.
- All pre-commit hooks green (mypy, ruff).

## Notes

- A base-type `uninterpreted` *constant* (`def big : Int = uninterpreted`) remains unsupported — that's a pre-existing limitation, unrelated to this keyword. Axioms desugar through the `native` path and are unaffected.
- An axiom is only as sound as the fact it states (same trust basis as any `native`). A future enhancement could add `--print-axioms`-style trust accounting (the genuinely Lean-like discipline); this PR adds only the keyword.

Relates to #359 / #360 — those used the `def … = native "()"` pattern by hand; this is the dedicated syntax for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)