### PR TITLE
feat(libraries): Testing library for unit + property-based testing

### DIFF
--- a/aeon/bindings/image.py
+++ b/aeon/bindings/image.py
@@ -141,7 +141,10 @@ def Image_diff(im1, im2):
 def Image_diff_mse(im1, im2):
     im1 = np.array(im1)
     im2 = np.array(im2)
-    return mse(im1, im2)
+    # Cast to a native float: skimage returns a numpy scalar, which would leak a
+    # numpy type into Aeon's Float (so e.g. `diff a b <= eps` yields numpy.bool_,
+    # which the --test runner rejects as "not a Bool"). Mirror the fitness_* fns.
+    return float(mse(im1, im2))
 
 
 _HUGE = 1e30

--- a/docs/index.md
+++ b/docs/index.md
@@ -397,6 +397,7 @@ There are a few libraries available, but unstable as they are under development:
 - Statistics.ae
 - String.ae
 - Table.ae
+- Testing.ae
 - Tuple.ae
 
 The full HTML reference for every standard-library module — generated from the
@@ -512,6 +513,50 @@ Property-based tests use the related `@property` decorator: it marks a
 `Bool`-returning function whose arguments are universally quantified and checked
 on random inputs generated from their (refinement-constrained) types under
 `--test`.
+
+### Unit testing (`Testing` library)
+
+A `@property` with **no arguments** is just a unit test: one concrete case the
+runner evaluates once (use `@property(1)` so it runs a single time). The
+`Testing` library gives this a readable vocabulary — every assertion returns a
+plain `Bool`, so unit tests and property tests share the same combinators and
+the same `--test` runner:
+
+```aeon
+open Testing
+open Image
+
+# Unit test — one concrete case.
+@property(1)
+def test_invert_black_is_white : Bool =
+    black = Image.mk 4 4 (Color.mk 0 0 0);
+    assertEqual (Image.get_pixel (Image.invert black) 0 0) (Color.mk 255 255 255);
+
+# Property — the colour channels are generated; the assertion must hold for all.
+@property
+def prop_solid_pixel_is_fill
+    (r : {v : Int | v >= 0 && v < 256})
+    (g : {v : Int | v >= 0 && v < 256})
+    (b : {v : Int | v >= 0 && v < 256}) : Bool =
+    col = Color.mk r g b;
+    assertEqual (Image.get_pixel (Image.mk 8 8 col) 0 0) col;
+```
+
+Dimensions are checked here with `Image.get_width` / `Image.get_height`, the
+runtime accessors whose return type is refined to equal the static `width` /
+`height` measures — so the same number the type system proves is the one you
+read back at runtime.
+
+Available assertions: `assertTrue` / `assertThat`, `assertFalse`, `assertEqual`,
+`assertNotEqual`, the ordering family `assertLess` / `assertLessEqual` /
+`assertGreater` / `assertGreaterEqual`, `assertClose` (floating-point tolerance),
+and the combinators `both` / `allOf3` / `allOf4` / `allOf5` for grouping several
+checks into a single test. See `examples/testing/image_tests.ae` for a full
+suite that tests the Image library.
+
+```bash
+aeon --test examples/testing/image_tests.ae
+```
 
 ### Synthesis control decorators
 

--- a/examples/testing/image_tests.ae
+++ b/examples/testing/image_tests.ae
@@ -1,0 +1,235 @@
+# Testing the Image library with the Testing vocabulary and `--test`.
+#
+# This file shows both kinds of test the `--test` runner understands, written
+# with the assertion combinators from the `Testing` library:
+#
+#   * Unit tests     — a zero-argument `@property(1)` function: one concrete
+#                      case, evaluated exactly once.
+#   * Property tests — a `@property` function with arguments: the runner
+#                      generates the arguments (here pixel coordinates and
+#                      colour channels) from their refinement types and checks
+#                      the assertion holds for every generated input.
+#
+# The image *dimensions* are also guaranteed statically: in Aeon `width` /
+# `height` are uninterpreted measures the type system uses to prove the size
+# contracts (`mk w h c` has type `{i:Image | width i == w && height i == h}`,
+# `crop`/`resize` produce exactly the requested size, `rotate`/`flip`/`invert`
+# preserve it, ...). This file would not typecheck if those guarantees were
+# wrong. The runtime accessors `get_width` / `get_height` read those same
+# dimensions back (their return type is refined to equal the measure), so the
+# tests below double-check them dynamically too. The remaining tests cover what
+# the types do *not* capture: the actual pixel content produced by each
+# operation, observed through `get_pixel` and the whole-image `diff`
+# (mean-squared error).
+#
+# Run with:  aeon --test examples/testing/image_tests.ae
+
+open Testing
+open Image
+
+# ── Unit tests: dimensions (via the runtime accessors) ───────────────────────
+
+# `mk w h c` produces an image of exactly that size.
+@property(1)
+def test_mk_dimensions : Bool =
+    img = Image.mk 4 3 (Color.mk 255 0 0);
+    both (assertEqual (Image.get_width img) 4)
+         (assertEqual (Image.get_height img) 3);
+
+# `crop` returns an image of the requested size.
+@property(1)
+def test_crop_dimensions : Bool =
+    cropped = Image.crop (Image.mk 10 10 (Color.mk 0 0 0)) 2 2 5 4;
+    both (assertEqual (Image.get_width cropped) 5)
+         (assertEqual (Image.get_height cropped) 4);
+
+# `resize` resamples to an exact width and height.
+@property(1)
+def test_resize_dimensions : Bool =
+    resized = Image.resize (Image.mk 8 8 (Color.mk 0 0 0)) 32 16;
+    both (assertEqual (Image.get_width resized) 32)
+         (assertEqual (Image.get_height resized) 16);
+
+# `flip` and `invert` preserve dimensions.
+@property(1)
+def test_transforms_preserve_size : Bool =
+    img = Image.mk 6 4 (Color.mk 7 7 7);
+    flipped = Image.flip_horizontal img;
+    inverted = Image.invert img;
+    allOf4 (assertEqual (Image.get_width flipped) 6)
+           (assertEqual (Image.get_height flipped) 4)
+           (assertEqual (Image.get_width inverted) 6)
+           (assertEqual (Image.get_height inverted) 4);
+
+# ── Unit tests: pixel content ────────────────────────────────────────────────
+
+# A freshly-made solid image has the fill colour at every pixel.
+@property(1)
+def test_mk_is_solid : Bool =
+    img = Image.mk 4 4 (Color.mk 10 20 30);
+    both (assertEqual (Image.get_pixel img 0 0) (Color.mk 10 20 30))
+         (assertEqual (Image.get_pixel img 3 3) (Color.mk 10 20 30));
+
+# `copy` is content-preserving: an exact copy differs from the original by 0.
+@property(1)
+def test_copy_is_identical : Bool =
+    img = Image.mk 8 8 (Color.mk 1 2 3);
+    assertClose (Image.diff (Image.copy img) img) 0.0 0.0001;
+
+# `put_pixel` writes the pixel you asked for and leaves the rest alone.
+@property(1)
+def test_put_pixel_writes_and_isolates : Bool =
+    img = Image.mk 4 4 (Color.mk 0 0 0);
+    painted = Image.put_pixel img 1 2 (Color.mk 9 8 7);
+    allOf3 (assertEqual (Image.get_pixel painted 1 2) (Color.mk 9 8 7))
+           (assertEqual (Image.get_pixel painted 0 0) (Color.mk 0 0 0))
+           (assertEqual (Image.get_pixel painted 3 3) (Color.mk 0 0 0));
+
+# `crop` returns the requested sub-region's content at the new origin.
+@property(1)
+def test_crop_content : Bool =
+    base = Image.mk 4 4 (Color.mk 0 0 0);
+    img = Image.put_pixel base 2 2 (Color.mk 1 2 3);
+    cropped = Image.crop img 2 2 2 2;
+    assertEqual (Image.get_pixel cropped 0 0) (Color.mk 1 2 3);
+
+# Resampling a solid image leaves it the same solid colour.
+@property(1)
+def test_resize_solid_keeps_colour : Bool =
+    red = Image.mk 8 8 (Color.mk 200 10 10);
+    small = Image.resize red 4 4;
+    assertEqual (Image.get_pixel small 0 0) (Color.mk 200 10 10);
+
+# Rotating a full turn is the identity.
+@property(1)
+def test_rotate_full_turn_identity : Bool =
+    base = Image.mk 4 4 (Color.mk 0 0 0);
+    img = Image.put_pixel base 0 0 (Color.mk 255 255 255);
+    assertClose (Image.diff (Image.rotate img 360.0) img) 0.0 0.0001;
+
+# Flipping horizontally moves a pixel from column 0 to the last column, and is
+# its own inverse.
+@property(1)
+def test_flip_horizontal_swaps_and_involution : Bool =
+    base = Image.mk 4 4 (Color.mk 0 0 0);
+    img = Image.put_pixel base 0 1 (Color.mk 255 255 255);
+    flipped = Image.flip_horizontal img;
+    twice = Image.flip_horizontal flipped;
+    allOf3 (assertEqual (Image.get_pixel flipped 3 1) (Color.mk 255 255 255))
+           (assertEqual (Image.get_pixel flipped 0 1) (Color.mk 0 0 0))
+           (assertClose (Image.diff twice img) 0.0 0.0001);
+
+# Flipping vertically twice is the identity.
+@property(1)
+def test_flip_vertical_involution : Bool =
+    base = Image.mk 4 4 (Color.mk 0 0 0);
+    img = Image.put_pixel base 1 0 (Color.mk 255 255 255);
+    twice = Image.flip_vertical (Image.flip_vertical img);
+    assertClose (Image.diff twice img) 0.0 0.0001;
+
+# Inverting black yields white, and inverting white yields black.
+@property(1)
+def test_invert_endpoints : Bool =
+    black = Image.mk 4 4 (Color.mk 0 0 0);
+    white = Image.mk 4 4 (Color.mk 255 255 255);
+    both (assertEqual (Image.get_pixel (Image.invert black) 0 0) (Color.mk 255 255 255))
+         (assertEqual (Image.get_pixel (Image.invert white) 0 0) (Color.mk 0 0 0));
+
+# Inverting twice is the identity.
+@property(1)
+def test_invert_involution : Bool =
+    img = Image.mk 4 4 (Color.mk 30 90 200);
+    twice = Image.invert (Image.invert img);
+    assertClose (Image.diff twice img) 0.0 0.0001;
+
+# Grayscaling an already-grey image (R = G = B) leaves it (essentially) unchanged.
+@property(1)
+def test_grayscale_of_grey_is_stable : Bool =
+    grey = Image.mk 8 8 (Color.mk 100 100 100);
+    assertClose (Image.diff (Image.grayscale grey) grey) 0.0 4.0;
+
+# `diff` is zero for equal images and strictly positive for different ones.
+@property(1)
+def test_diff_detects_difference : Bool =
+    black = Image.mk 8 8 (Color.mk 0 0 0);
+    white = Image.mk 8 8 (Color.mk 255 255 255);
+    both (assertClose (Image.diff black black) 0.0 0.0001)
+         (assertGreater (Image.diff black white) 0.0);
+
+# `paste` drops the source at the given origin and keeps the rest of the
+# destination intact.
+@property(1)
+def test_paste_places_source : Bool =
+    dest = Image.mk 8 8 (Color.mk 0 0 0);
+    src = Image.mk 4 4 (Color.mk 255 255 255);
+    pasted = Image.paste dest src 0 0;
+    both (assertEqual (Image.get_pixel pasted 0 0) (Color.mk 255 255 255))
+         (assertEqual (Image.get_pixel pasted 7 7) (Color.mk 0 0 0));
+
+# ── Property-based tests ─────────────────────────────────────────────────────
+# The coordinates and colour channels are generated from their refinement types,
+# so each property is checked across many valid inputs rather than a single case.
+
+# `mk` honours the requested width and height for any positive dimensions.
+@property
+def prop_mk_dimensions
+    (w : {v : Int | v > 0 && v < 64})
+    (h : {v : Int | v > 0 && v < 64}) :
+    Bool =
+    img = Image.mk w h (Color.mk 0 0 0);
+    both (assertEqual (Image.get_width img) w)
+         (assertEqual (Image.get_height img) h);
+
+# `resize` always produces exactly the requested size.
+@property
+def prop_resize_dimensions
+    (w : {v : Int | v > 0 && v < 64})
+    (h : {v : Int | v > 0 && v < 64}) :
+    Bool =
+    resized = Image.resize (Image.mk 8 8 (Color.mk 1 2 3)) w h;
+    both (assertEqual (Image.get_width resized) w)
+         (assertEqual (Image.get_height resized) h);
+
+# A solid image reads back its fill colour at the origin, whatever the colour.
+@property
+def prop_solid_pixel_is_fill
+    (r : {v : Int | v >= 0 && v < 256})
+    (g : {v : Int | v >= 0 && v < 256})
+    (b : {v : Int | v >= 0 && v < 256}) :
+    Bool =
+    col = Color.mk r g b;
+    assertEqual (Image.get_pixel (Image.mk 8 8 col) 0 0) col;
+
+# put_pixel / get_pixel round-trip: whatever colour you write at an in-bounds
+# coordinate, you read the same colour back.
+@property
+def prop_put_get_roundtrip
+    (x : {v : Int | v >= 0 && v < 16})
+    (y : {v : Int | v >= 0 && v < 16})
+    (r : {v : Int | v >= 0 && v < 256})
+    (g : {v : Int | v >= 0 && v < 256})
+    (b : {v : Int | v >= 0 && v < 256}) :
+    Bool =
+    col = Color.mk r g b;
+    painted = Image.put_pixel (Image.mk 16 16 (Color.mk 0 0 0)) x y col;
+    assertEqual (Image.get_pixel painted x y) col;
+
+# Invert is its own inverse for any fill colour.
+@property
+def prop_invert_involution
+    (r : {v : Int | v >= 0 && v < 256})
+    (g : {v : Int | v >= 0 && v < 256})
+    (b : {v : Int | v >= 0 && v < 256}) :
+    Bool =
+    img = Image.mk 6 6 (Color.mk r g b);
+    assertClose (Image.diff (Image.invert (Image.invert img)) img) 0.0 0.0001;
+
+# Every image is identical to itself: diff with self is always zero.
+@property
+def prop_diff_self_is_zero
+    (r : {v : Int | v >= 0 && v < 256})
+    (g : {v : Int | v >= 0 && v < 256})
+    (b : {v : Int | v >= 0 && v < 256}) :
+    Bool =
+    img = Image.mk 8 8 (Color.mk r g b);
+    assertClose (Image.diff img img) 0.0 0.0001;

--- a/libraries/Image.ae
+++ b/libraries/Image.ae
@@ -2,11 +2,23 @@ open Color
 
 type Image
 
-# Returns the height of the image in pixels.
+# The image's height in pixels, as an uninterpreted measure. It carries the
+# size contracts of every operation (`mk`, `crop`, `resize`, ...) through the
+# type system but has no runtime value; use `get_height` to read it at runtime.
 def height : (im:Image) -> Int = uninterpreted
 
-# Returns the width of the image in pixels.
+# The image's width in pixels, as an uninterpreted measure (see `height`). Use
+# `get_width` to read it at runtime.
 def width : (im:Image) -> Int = uninterpreted
+
+# Reads the width at runtime. The return type is refined to equal the `width`
+# measure, so the value is provably the same width the type system reasons about
+# (e.g. `get_width (mk w h c)` has type `{r:Int | r == w}`).
+def get_width (im:Image) : {r:Int | r == width im} = native "im.width"
+
+# Reads the height at runtime; refined to equal the `height` measure (see
+# `get_width`).
+def get_height (im:Image) : {r:Int | r == height im} = native "im.height"
 
 # Creates a new image of given width, height, and color.
 # w: image width (>0)

--- a/libraries/Testing.ae
+++ b/libraries/Testing.ae
@@ -1,0 +1,101 @@
+# Testing — a small unit-testing vocabulary for Aeon.
+#
+# In Aeon a *test* is just a `Bool`-returning function marked with `@property`:
+# the `--test` runner evaluates it and a `True` result is a pass. A function
+# with arguments is a *property* (inputs are generated automatically from the
+# argument types); a function with no arguments is a *unit test* (one concrete
+# case). This library provides readable assertion combinators — every one
+# returns `Bool` — so unit tests and property-based tests share the same
+# vocabulary and the same runner.
+#
+#     open Testing
+#     open Image
+#
+#     # Unit test: one concrete case. `@property(1)` evaluates it exactly once.
+#     @property(1)
+#     def test_mk_dimensions : Bool =
+#         img = Image.mk 4 3 (Color.mk 255 0 0);
+#         assertEqual (Image.width img) 4;
+#
+#     # Property: dimensions are generated; the assertion must hold for all of them.
+#     @property
+#     def prop_mk_width (w : {v:Int | v > 0 && v < 64}) : Bool =
+#         assertEqual (Image.width (Image.mk w 8 (Color.mk 0 0 0))) w;
+#
+# Run with:  aeon --test yourfile.ae
+#
+# Notes
+# -----
+# * Assertions are plain `Bool` values, so you compose them with the built-in
+#   `&&` / `||` / `!`, or with the `allOf*` helpers below to group several
+#   checks into one test.
+# * Because an assertion is just a `Bool`, the same helpers work inside the
+#   `@example(...)` decorator (machine-checked documentation) as well.
+
+open Math
+
+# ── Boolean assertions ───────────────────────────────────────────────────
+
+# Passes when the condition holds. Use it to wrap any boolean expression that
+# this library has no dedicated assertion for (e.g. `assertThat (mem x s)`).
+def assertThat (condition : Bool) : Bool = condition;
+
+# Passes when the condition holds (alias of `assertThat`, reads well on a raw
+# boolean: `assertTrue (isEmpty xs)`).
+def assertTrue (condition : Bool) : Bool = condition;
+
+# Passes when the condition is false.
+def assertFalse (condition : Bool) : Bool = !condition;
+
+# ── Equality assertions (any base type, including ADTs like Color) ─────────
+
+# Passes when `actual` equals `expected`.
+def assertEqual (actual : a) (expected : a) : Bool = actual == expected;
+
+# Passes when `actual` differs from `expected`.
+def assertNotEqual (actual : a) (expected : a) : Bool = actual != expected;
+
+# ── Ordering assertions (Int, Float, String — any orderable type) ──────────
+# Calling these at a non-orderable type is rejected at the call site, mirroring
+# the language's own restriction on `<` / `<=` / `>` / `>=`.
+
+# Passes when `actual < bound`.
+def assertLess (actual : a) (bound : a) : Bool = actual < bound;
+
+# Passes when `actual <= bound`.
+def assertLessEqual (actual : a) (bound : a) : Bool = actual <= bound;
+
+# Passes when `actual > bound`.
+def assertGreater (actual : a) (bound : a) : Bool = actual > bound;
+
+# Passes when `actual >= bound`.
+def assertGreaterEqual (actual : a) (bound : a) : Bool = actual >= bound;
+
+# ── Approximate equality (floating point) ──────────────────────────────────
+
+# Passes when `actual` and `expected` are within `eps` of each other. Use this
+# instead of `assertEqual` for any value produced by floating-point arithmetic.
+def assertClose
+    (actual : Float)
+    (expected : Float)
+    (eps : {v:Float | v >= 0.0}) :
+    Bool =
+    absf (actual - expected) <= eps;
+
+# ── Combinators: group several checks into a single test ───────────────────
+# A test is one `Bool`, so to assert several things at once combine them. These
+# are short-circuiting (they reuse `&&`), so the first failing check stops the
+# rest.
+
+# Passes when both checks pass.
+def both (a : Bool) (b : Bool) : Bool = a && b;
+
+# Passes when all three checks pass.
+def allOf3 (a : Bool) (b : Bool) (c : Bool) : Bool = a && b && c;
+
+# Passes when all four checks pass.
+def allOf4 (a : Bool) (b : Bool) (c : Bool) (d : Bool) : Bool = a && b && c && d;
+
+# Passes when all five checks pass.
+def allOf5 (a : Bool) (b : Bool) (c : Bool) (d : Bool) (e : Bool) : Bool =
+    a && b && c && d && e;

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -50,9 +50,10 @@ if [ "$status" -ne 0 ]; then
     exit 111
 fi
 
-# Property-based testing examples (issue #37) and @example assertions: run with
-# --test; every property and example must pass (exit code 0).
-for entry in examples/pbt/props_*.ae examples/pbt/examples_*.ae
+# Property-based testing examples (issue #37), @example assertions, and the
+# Testing-library unit/property suites: run with --test; every property and
+# example must pass (exit code 0).
+for entry in examples/pbt/props_*.ae examples/pbt/examples_*.ae examples/testing/*.ae
 do
     printf "Running (pbt) %s ..." "$entry"
     if uv run python -m aeon --test "$entry" > /dev/null 2>&1; then

--- a/tests/testing_lib_test.py
+++ b/tests/testing_lib_test.py
@@ -1,0 +1,116 @@
+"""Tests for the Testing library (libraries/Testing.ae) and its integration
+with the ``--test`` property/unit-test runner.
+
+A *unit test* in Aeon is a zero-argument ``@property`` returning ``Bool``; a
+*property test* is a ``@property`` with arguments whose inputs are generated.
+The Testing library only adds readable ``Bool``-valued assertion combinators on
+top, so we drive everything through the same ``run_properties`` runner used by
+the rest of the PBT framework and assert on the results.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.pbt import run_properties
+from aeon.synthesis.uis.api import SynthesisUI
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+IMAGE_TESTS = REPO_ROOT / "examples" / "testing" / "image_tests.ae"
+
+# A self-contained program exercising every assertion combinator: passing and
+# failing instances of each, so we can assert the runner classifies both.
+SOURCE = """
+open Testing
+
+@property(1)
+def t_assertTrue_pass : Bool = assertTrue (1 < 2);
+@property(1)
+def t_assertTrue_fail : Bool = assertTrue (2 < 1);
+
+@property(1)
+def t_assertFalse_pass : Bool = assertFalse (2 < 1);
+
+@property(1)
+def t_assertEqual_pass : Bool = assertEqual (3 * 4) 12;
+@property(1)
+def t_assertEqual_fail : Bool = assertEqual (3 * 4) 13;
+
+@property(1)
+def t_assertNotEqual_pass : Bool = assertNotEqual 1 2;
+
+@property(1)
+def t_assertLess_pass : Bool = assertLess 1 2;
+@property(1)
+def t_assertGreaterEqual_pass : Bool = assertGreaterEqual 2 2;
+
+@property(1)
+def t_assertClose_pass : Bool = assertClose (0.1 + 0.2) 0.3 0.0001;
+@property(1)
+def t_assertClose_fail : Bool = assertClose 1.0 2.0 0.1;
+
+@property(1)
+def t_both_pass : Bool = both (assertEqual 1 1) (assertLess 1 2);
+@property(1)
+def t_allOf3_pass : Bool = allOf3 (assertTrue true) (assertEqual 2 2) (assertFalse false);
+@property(1)
+def t_allOf3_fail : Bool = allOf3 (assertTrue true) (assertEqual 2 3) (assertFalse false);
+
+# A genuine property (generated input) phrased with the assertion vocabulary.
+@property
+def prop_abs_nonneg (x : Int) : Bool = assertGreaterEqual (x * x) 0;
+"""
+
+
+@pytest.fixture(scope="module")
+def results():
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SynthesisUI(), synthesis_budget=10, no_main=False)
+    driver = AeonDriver(cfg)
+    errors = driver.parse(aeon_code=SOURCE)
+    assert errors == [], errors
+    rs = run_properties(driver.typing_ctx, driver.evaluation_ctx, driver.core, driver.metadata, seed=0)
+    return {r.name.name: r for r in rs}
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "t_assertTrue_pass",
+        "t_assertFalse_pass",
+        "t_assertEqual_pass",
+        "t_assertNotEqual_pass",
+        "t_assertLess_pass",
+        "t_assertGreaterEqual_pass",
+        "t_assertClose_pass",
+        "t_both_pass",
+        "t_allOf3_pass",
+        "prop_abs_nonneg",
+    ],
+)
+def test_assertions_that_should_pass(results, name):
+    assert results[name].passed, results[name].summary()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "t_assertTrue_fail",
+        "t_assertEqual_fail",
+        "t_assertClose_fail",
+        "t_allOf3_fail",
+    ],
+)
+def test_assertions_that_should_fail(results, name):
+    assert not results[name].passed, results[name].summary()
+
+
+def test_image_example_suite_all_pass():
+    """The shipped Image test suite must pass end-to-end (also guards the
+    Image_diff_mse native float cast)."""
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SynthesisUI(), synthesis_budget=10, no_main=False)
+    driver = AeonDriver(cfg)
+    errors = driver.parse(str(IMAGE_TESTS))
+    assert errors == [], errors
+    failures = driver.run_tests(seed=0)
+    assert failures == [], [f.summary() for f in failures]


### PR DESCRIPTION
## Summary

Adds **`libraries/Testing.ae`**, a unit-testing vocabulary that builds on the existing `--test` / `@property` framework. The key idea: **a unit test is just a zero-argument `@property(1)` returning `Bool`**, so unit tests and property-based tests share one set of assertion combinators and one runner — no engine changes.

Assertions (all return `Bool`, so they compose with `&&`/`||` and slot into `@property` / `@example`):
`assertTrue`/`assertThat`, `assertFalse`, `assertEqual`, `assertNotEqual`, `assertLess`/`assertLessEqual`/`assertGreater`/`assertGreaterEqual`, `assertClose` (float tolerance), and `both`/`allOf3`/`allOf4`/`allOf5`.

## Image module integration (worked example)

- **Runtime dimension accessors** `Image.get_width` / `Image.get_height`. `width`/`height` are uninterpreted measures (used in every refinement) with no runtime value, so the accessors are `native` with a return type **refined to equal the measure** — `def get_width (im:Image) : {r:Int | r == width im} = native "im.width"`. The number you read at runtime is provably the one the type system proves. (Making `width` itself `native` is not possible — a `native` symbol in a refinement crashes the typechecker.)
- **Bug fix surfaced by testing**: `Image_diff_mse` returned a numpy float, so `diff a b <= eps` produced a `numpy.bool_` the `--test` runner rejected as *"not a Bool"*. Now cast to `float()`, matching the `fitness_*` bindings.

## Files

- `libraries/Testing.ae` — the assertion library
- `libraries/Image.ae` — `get_width` / `get_height`
- `aeon/bindings/image.py` — `Image_diff_mse` native-float fix
- `examples/testing/image_tests.ae` — 23 unit + property tests of the Image library
- `tests/testing_lib_test.py` — pytest coverage (every combinator, pass + fail; end-to-end Image suite)
- `run_examples.sh` — runs `examples/testing/*.ae` under `--test` in CI
- `docs/index.md` — documents the Testing library and accessors

## Testing

```
$ aeon --test examples/testing/image_tests.ae
23 passed, 0 failed, 23 total

$ uv run pytest tests/testing_lib_test.py
15 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)