### PR TITLE
fix(synthesis): correct eval-sandbox timeout cleanup; seed stochastic backends via AEON_SEED

### DIFF
--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -119,9 +119,13 @@ def make_evaluator(
         eval_process.start()
         eval_process.join(timeout=timeout)
         if eval_process.is_alive():
-            eval_process.close()
+            # Order matters: ``Process.close()`` raises
+            # ``ValueError: Cannot close a process while it is still running``
+            # unless the process has already exited. Terminate and join first,
+            # then release its resources.
             eval_process.terminate()
             eval_process.join()
+            eval_process.close()
             raise TimeoutInEvaluationException()
         kind, payload = result_queue.get()
         if kind == "ok":

--- a/aeon/synthesis/grammar/ge_synthesis.py
+++ b/aeon/synthesis/grammar/ge_synthesis.py
@@ -8,7 +8,7 @@ from aeon.utils.name import Name
 
 
 from aeon.synthesis.uis.api import SynthesisUI
-from aeon.synthesis.api import InvalidIndividualException, Synthesizer
+from aeon.synthesis.api import InvalidIndividualException, Synthesizer, TimeoutInEvaluationException
 
 from aeon.decorators.api import Metadata
 
@@ -91,10 +91,11 @@ def create_problem(
                 raise InvalidFitnessException()
             try:
                 return evaluate(p)
-            except InvalidIndividualException:
-                # Translate the backend-neutral exception raised by the
-                # Aeon evaluator into geneticengine's own "drop this
-                # candidate" sentinel.
+            except (InvalidIndividualException, TimeoutInEvaluationException):
+                # Translate the backend-neutral exceptions raised by the Aeon
+                # evaluator into geneticengine's own "drop this candidate"
+                # sentinel. A candidate whose evaluation times out is dropped
+                # like an invalid one, rather than aborting the whole search.
                 raise InvalidFitnessException()
 
         return MultiObjectiveProblem(fitness_function=fitness_fun, minimize=minimize_list)

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -1,3 +1,5 @@
+import os
+
 from aeon.synthesis.api import Synthesizer
 from aeon.synthesis.grammar.ge_synthesis import GESynthesizer
 from aeon.synthesis.modules.lta import LTASynthesizer
@@ -10,17 +12,21 @@ from aeon.synthesis.tactics import TacticRandomSynthesizer
 
 
 def make_synthesizer(module: str) -> Synthesizer:
+    # The random seed for stochastic backends is taken from the AEON_SEED
+    # environment variable (default 0), so experiments can vary it across runs
+    # (e.g. multi-seed benchmarks) without a dedicated CLI flag.
+    seed = int(os.environ.get("AEON_SEED", "0"))
     match module:
         case "random_search":
-            return GESynthesizer(method="random_search")
+            return GESynthesizer(seed=seed, method="random_search")
         case "enumerative":
-            return GESynthesizer(method="enumerative")
+            return GESynthesizer(seed=seed, method="enumerative")
         case "gp":
-            return GESynthesizer(method="genetic_programming")
+            return GESynthesizer(seed=seed, method="genetic_programming")
         case "1p1":
-            return GESynthesizer(method="one_plus_one")
+            return GESynthesizer(seed=seed, method="one_plus_one")
         case "hc":
-            return GESynthesizer(method="hill_climbing")
+            return GESynthesizer(seed=seed, method="hill_climbing")
         case "synquid":
             return SynquidSynthesizer()
         case "llm":
@@ -30,11 +36,11 @@ def make_synthesizer(module: str) -> Synthesizer:
         case "smt":
             return SMTSynthesizer()
         case "tdsyn" | "tdsyn_enumerative":
-            return TDSynSynthesizer(mode="enumerative")
+            return TDSynSynthesizer(mode="enumerative", seed=seed)
         case "tdsyn_random":
-            return TDSynSynthesizer(mode="random")
+            return TDSynSynthesizer(mode="random", seed=seed)
         case "tactics":
-            return TacticRandomSynthesizer()
+            return TacticRandomSynthesizer(seed=seed)
         case "lta":
             return LTASynthesizer()
         case _:

--- a/aeon/synthesis/modules/tdsyn/synthesizer.py
+++ b/aeon/synthesis/modules/tdsyn/synthesizer.py
@@ -74,10 +74,11 @@ class TDSynSynthesizer(Synthesizer):
     order on each iteration to explore different term structures.
     """
 
-    def __init__(self, mode: str = "enumerative"):
+    def __init__(self, mode: str = "enumerative", seed: int = 0):
         assert mode in ("enumerative", "random")
         self.mode = mode
-        self._rng = random.Random(42)
+        self.seed = seed
+        self._rng = random.Random(seed)
         self._iteration = 0
 
     def synthesize(
@@ -272,7 +273,7 @@ class TDSynSynthesizer(Synthesizer):
         best: tuple[list[float], Term | None],
     ) -> tuple[list[float], Term | None]:
         """Random exploration search."""
-        rng = random.Random(42)
+        rng = random.Random(self.seed)
 
         while _get_elapsed_time(start_time) < budget:
             # Start fresh from initial each time for random search

--- a/tests/synthesizer_seed_test.py
+++ b/tests/synthesizer_seed_test.py
@@ -1,0 +1,35 @@
+"""The AEON_SEED environment variable seeds the stochastic synthesizers.
+
+`make_synthesizer` reads AEON_SEED (default 0) so multi-seed experiments can
+vary the random seed of the stochastic backends without a dedicated CLI flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+
+SEEDED_BACKENDS = [
+    "random_search",
+    "enumerative",
+    "gp",
+    "1p1",
+    "hc",
+    "tdsyn",
+    "tdsyn_enumerative",
+    "tdsyn_random",
+    "tactics",
+]
+
+
+@pytest.mark.parametrize("backend", SEEDED_BACKENDS)
+def test_aeon_seed_is_threaded(monkeypatch, backend):
+    monkeypatch.setenv("AEON_SEED", "123")
+    assert make_synthesizer(backend).seed == 123
+
+
+@pytest.mark.parametrize("backend", SEEDED_BACKENDS)
+def test_seed_defaults_to_zero(monkeypatch, backend):
+    monkeypatch.delenv("AEON_SEED", raising=False)
+    assert make_synthesizer(backend).seed == 0


### PR DESCRIPTION
Two small, independent synthesis fixes (one bug fix, one reproducibility feature), each in its own commit.

## 1. `fix`: terminate before close in the evaluation sandbox

Every candidate evaluation runs in a per-candidate `multiprocess.Process` (the sandbox in `make_evaluator`). On a per-eval **timeout**, the cleanup called `Process.close()` *before* `terminate()`/`join()`:

```python
if eval_process.is_alive():
    eval_process.close()       # raises: Cannot close a process while it is still running
    eval_process.terminate()
    eval_process.join()
```

`multiprocess.Process.close()` raises `ValueError: Cannot close a process while it is still running` unless the process has already exited. Corrected to `terminate()` → `join()` → `close()` (matching the order already used in `make_output_evaluator`).

**Impact:** this fired whenever a candidate's native evaluation exceeded the per-eval timeout. The `ValueError` escaped the fitness function and crashed the geneticengine-based backends (`gp`, `hc`, `1p1`, `random_search`, `enumerative`) with a spurious non-zero exit — observed on ~30% of runs in a heavy inverse-CSG sweep. Backends that wrap `evaluate()` in their own `try/except` (e.g. the metric backend) were unaffected because they scored such candidates as invalid.

## 2. `feat`: seed stochastic backends from `AEON_SEED`

There was no way to vary a synthesizer's random seed from the outside — every backend was constructed with its default seed `0`, so repeated runs were identical. `make_synthesizer` now reads the `AEON_SEED` environment variable (default `0`) and threads it into the stochastic backends (GE methods, TDSyn, tactics). `TDSynSynthesizer` gained a `seed` parameter (previously a hardcoded `random.Random(42)` in two places).

This enables multi-seed benchmarking (`AEON_SEED=<n> python -m aeon -s <backend> ...`) without a dedicated CLI flag. Added `tests/synthesizer_seed_test.py` covering both the threading and the default.

## Testing
- `pytest tests/synthesizer_seed_test.py` — 18 passed
- pre-commit (mypy, ruff, ruff format) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)