### PR TITLE
test(libraries): Testing suites for core data-structure libraries (+ Set.ae fix)

### DIFF
--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from z3 import Function
 from z3 import Int
+from z3 import Length
 from z3 import IntVal
 from z3 import Real
 from z3 import RealVal
@@ -135,6 +136,12 @@ base_functions: dict[str, Any] = {
     "%": lambda x, y: x % y,
     "-->": lambda x, y: Implies(x, y),
     "ite": lambda c, t, e: If(c, t, e),
+    # String.len -> Z3's native string-length, so refinements over string length
+    # (e.g. the `len i` preconditions of String.slice/replace/split) connect to
+    # Z3's string theory. Without this, `String_len` would be an uninterpreted
+    # symbol and `len "hello"` could not be shown to equal 5, so length-refined
+    # operations were undischargeable on string literals.
+    "String_len": lambda s: Length(s),
     # SMT Set operations
     "Set_empty": EmptySet(IntSort()),
     "Set_sng": lambda x: SetAdd(EmptySet(IntSort()), x),

--- a/examples/testing/array_tests.ae
+++ b/examples/testing/array_tests.ae
@@ -1,0 +1,80 @@
+# Tests for the Array library (flat, native-backed sequence). Arrays are opaque
+# (no constructors to generate), so property tests generate the Int *elements*
+# and build arrays from `new` / `append`.
+#
+# Run with:  aeon --test examples/testing/array_tests.ae
+
+open Testing
+open Array
+
+# ── Unit tests ───────────────────────────────────────────────────────────────
+
+@property(1)
+def test_new_is_empty : Bool =
+    both (assertTrue (empty new))
+         (assertEqual (length new) 0);
+
+@property(1)
+def test_append_grows : Bool =
+    arr = append (append new 5) 9;
+    both (assertEqual (length arr) 2)
+         (assertEqual (sum arr) 14);
+
+@property(1)
+def test_get : Bool =
+    arr = append (append new 5) 9;
+    both (assertEqual (get arr 0) 5)
+         (assertEqual (get arr 1) 9);
+
+@property(1)
+def test_cons_prepends : Bool =
+    arr = cons (append new 9) 5;
+    both (assertEqual (get arr 0) 5)
+         (assertEqual (get arr 1) 9);
+
+@property(1)
+def test_head : Bool = assertEqual (head (cons (append new 9) 5)) 5;
+
+@property(1)
+def test_set_preserves_length : Bool =
+    arr = set (append (append new 5) 9) 0 7;
+    both (assertEqual (length arr) 2)
+         (assertEqual (get arr 0) 7);
+
+@property(1)
+def test_reversed : Bool =
+    arr = reversed (append (append new 5) 9);
+    both (assertEqual (get arr 0) 9)
+         (assertEqual (get arr 1) 5);
+
+@property(1)
+def test_map : Bool =
+    arr = map (fun x => x + 1) (append (append new 5) 9);
+    assertEqual (sum arr) 16;
+
+@property(1)
+def test_sum : Bool = assertEqual (sum (append (append new 2) 3)) 5;
+
+# ── Property-based tests (Int elements generated) ─────────────────────────────
+
+# A one-element array reads its element back.
+@property
+def prop_singleton_get (x : Int) : Bool =
+    assertEqual (get (append new x) 0) x;
+
+# append adds exactly one element.
+@property
+def prop_append_length (x : Int) (y : Int) : Bool =
+    assertEqual (length (append (append new x) y)) 2;
+
+# set overwrites the targeted slot and keeps the length.
+@property
+def prop_set_overwrites (x : Int) (y : Int) : Bool =
+    arr = set (append new x) 0 y;
+    both (assertEqual (get arr 0) y)
+         (assertEqual (length arr) 1);
+
+# sum of a two-element array is the sum of its elements.
+@property
+def prop_sum_two (x : Int) (y : Int) : Bool =
+    assertEqual (sum (append (append new x) y)) (x + y);

--- a/examples/testing/list_tests.ae
+++ b/examples/testing/list_tests.ae
@@ -1,0 +1,78 @@
+# Tests for the List library (inductive linked list), written with the Testing
+# vocabulary. Unit tests use concrete lists; property tests have the runner
+# generate `(List Int)` values as constructor trees.
+#
+# Run with:  aeon --test examples/testing/list_tests.ae
+
+open Testing
+open List
+
+# ── Unit tests ───────────────────────────────────────────────────────────────
+
+@property(1)
+def test_length : Bool = assertEqual (length (cons 1 (cons 2 (cons 3 nil)))) 3;
+
+@property(1)
+def test_empty : Bool =
+    both (assertTrue (empty nil))
+         (assertFalse (empty (cons 1 nil)));
+
+@property(1)
+def test_sum : Bool = assertEqual (sum (cons 1 (cons 2 (cons 3 nil)))) 6;
+
+@property(1)
+def test_append : Bool =
+    xs = append (cons 1 (cons 2 nil)) (cons 3 nil);
+    both (assertEqual (length xs) 3)
+         (assertEqual (sum xs) 6);
+
+@property(1)
+def test_reversed : Bool =
+    assertEqual (reversed (cons 1 (cons 2 (cons 3 nil))))
+                (cons 3 (cons 2 (cons 1 nil)));
+
+@property(1)
+def test_snoc : Bool =
+    assertEqual (snoc (cons 1 nil) 2) (cons 1 (cons 2 nil));
+
+@property(1)
+def test_map : Bool =
+    doubled = map (fun x => x * 2) (cons 1 (cons 2 (cons 3 nil)));
+    assertEqual (sum doubled) 12;
+
+@property(1)
+def test_foldr : Bool =
+    assertEqual (foldr (fun x => fun acc => x + acc) 0 (cons 1 (cons 2 (cons 3 nil)))) 6;
+
+# ── Property-based tests (inputs generated as List Int) ───────────────────────
+
+# Reversing preserves length.
+@property(40)
+def prop_reverse_preserves_length (l : (List Int)) : Bool =
+    assertEqual (length (reversed l)) (length l);
+
+# Reversing preserves the sum of elements.
+@property(40)
+def prop_reverse_preserves_sum (l : (List Int)) : Bool =
+    assertEqual (sum (reversed l)) (sum l);
+
+# Length of a concatenation is the sum of the lengths.
+@property(40)
+def prop_append_length_additive (xs : (List Int)) (ys : (List Int)) : Bool =
+    assertEqual (length (append xs ys)) (length xs + length ys);
+
+# Sum of a concatenation is the sum of the sums.
+@property(40)
+def prop_append_sum_additive (xs : (List Int)) (ys : (List Int)) : Bool =
+    assertEqual (sum (append xs ys)) (sum xs + sum ys);
+
+# Length is never negative, and is zero exactly when the list is empty.
+@property(40)
+def prop_length_nonneg_and_empty (l : (List Int)) : Bool =
+    both (assertGreaterEqual (length l) 0)
+         (assertEqual (empty l) (length l == 0));
+
+# snoc increases the length by exactly one.
+@property(40)
+def prop_snoc_increments_length (l : (List Int)) (x : Int) : Bool =
+    assertEqual (length (snoc l x)) (length l + 1);

--- a/examples/testing/map_tests.ae
+++ b/examples/testing/map_tests.ae
@@ -1,0 +1,63 @@
+# Tests for the Map library (immutable key/value map). `size` is an
+# uninterpreted measure (no runtime value), so tests observe behaviour through
+# `get` / `has` / `delete`.
+#
+# Run with:  aeon --test examples/testing/map_tests.ae
+
+open Testing
+open Map
+
+# ── Unit tests ───────────────────────────────────────────────────────────────
+
+@property(1)
+def test_get_after_set : Bool = assertEqual (get (set new 1 100) 1) 100;
+
+@property(1)
+def test_has : Bool =
+    m = set new 1 100;
+    both (assertTrue (has m 1))
+         (assertFalse (has m 2));
+
+@property(1)
+def test_overwrite : Bool =
+    m = set (set new 1 100) 1 200;
+    assertEqual (get m 1) 200;
+
+@property(1)
+def test_two_keys : Bool =
+    m = set (set new 1 10) 2 20;
+    both (assertEqual (get m 1) 10)
+         (assertEqual (get m 2) 20);
+
+@property(1)
+def test_delete : Bool =
+    m = delete (set new 1 100) 1;
+    assertFalse (has m 1);
+
+@property(1)
+def test_delete_keeps_others : Bool =
+    m = delete (set (set new 1 10) 2 20) 1;
+    both (assertFalse (has m 1))
+         (assertTrue (has m 2));
+
+# ── Property-based tests (Int keys and values generated) ──────────────────────
+
+# Whatever value you set for a key, you get it back.
+@property
+def prop_set_get_roundtrip (k : Int) (v : Int) : Bool =
+    assertEqual (get (set new k v) k) v;
+
+# A key is present right after being set.
+@property
+def prop_set_then_has (k : Int) (v : Int) : Bool =
+    assertTrue (has (set new k v) k);
+
+# A key is absent right after being deleted.
+@property
+def prop_delete_then_absent (k : Int) (v : Int) : Bool =
+    assertFalse (has (delete (set new k v) k) k);
+
+# The last write wins.
+@property
+def prop_last_write_wins (k : Int) (v1 : Int) (v2 : Int) : Bool =
+    assertEqual (get (set (set new k v1) k v2) k) v2;

--- a/examples/testing/maybe_tests.ae
+++ b/examples/testing/maybe_tests.ae
@@ -1,0 +1,40 @@
+# Tests for the Maybe library (optional values).
+#
+# Run with:  aeon --test examples/testing/maybe_tests.ae
+
+open Testing
+open Maybe
+
+# A typed `none` so its element type is fixed for `isNone` / `isJust`.
+def noneInt : (Maybe Int) = none;
+
+# ── Unit tests ───────────────────────────────────────────────────────────────
+
+@property(1)
+def test_isJust : Bool =
+    both (assertTrue (isJust (just 5)))
+         (assertFalse (isJust noneInt));
+
+@property(1)
+def test_isNone : Bool =
+    both (assertTrue (isNone noneInt))
+         (assertFalse (isNone (just 5)));
+
+@property(1)
+def test_withDefault_just : Bool = assertEqual (withDefault 0 (just 7)) 7;
+
+@property(1)
+def test_withDefault_none : Bool = assertEqual (withDefault 0 noneInt) 0;
+
+# ── Property-based tests ─────────────────────────────────────────────────────
+
+# `just x` is always present and unwraps to `x`.
+@property
+def prop_just_is_present (x : Int) : Bool =
+    both (assertTrue (isJust (just x)))
+         (assertEqual (withDefault 0 (just x)) x);
+
+# withDefault on a present value ignores the default.
+@property
+def prop_withDefault_ignores_default (x : Int) (d : Int) : Bool =
+    assertEqual (withDefault d (just x)) x;

--- a/examples/testing/pair_tests.ae
+++ b/examples/testing/pair_tests.ae
@@ -1,0 +1,35 @@
+# Tests for the Pair library (polymorphic product type). Pair has no projection
+# functions — its single `mk` constructor is eliminated with `match` — so we
+# define small projections to observe the components.
+#
+# Run with:  aeon --test examples/testing/pair_tests.ae
+
+open Testing
+open Pair
+
+def pfst (p : (Pair Int Int)) : Int = match p with | mk a b => a;
+def psnd (p : (Pair Int Int)) : Int = match p with | mk a b => b;
+
+# ── Unit tests ───────────────────────────────────────────────────────────────
+
+@property(1)
+def test_fst : Bool = assertEqual (pfst (mk 3 4)) 3;
+
+@property(1)
+def test_snd : Bool = assertEqual (psnd (mk 3 4)) 4;
+
+@property(1)
+def test_both_components : Bool =
+    p = mk 10 20;
+    both (assertEqual (pfst p) 10)
+         (assertEqual (psnd p) 20);
+
+# ── Property-based tests ─────────────────────────────────────────────────────
+
+# The first projection returns the first component, whatever it is.
+@property
+def prop_fst (a : Int) (b : Int) : Bool = assertEqual (pfst (mk a b)) a;
+
+# The second projection returns the second component.
+@property
+def prop_snd (a : Int) (b : Int) : Bool = assertEqual (psnd (mk a b)) b;

--- a/examples/testing/set_tests.ae
+++ b/examples/testing/set_tests.ae
@@ -1,0 +1,60 @@
+# Tests for the Set library (immutable set). `size` / `contains` are
+# uninterpreted measures, so tests observe membership through `has`.
+#
+# Run with:  aeon --test examples/testing/set_tests.ae
+
+open Testing
+open Set
+
+# ── Unit tests ───────────────────────────────────────────────────────────────
+
+@property(1)
+def test_empty_has_nothing : Bool = assertFalse (has new 5);
+
+@property(1)
+def test_add_then_has : Bool = assertTrue (has (add new 5) 5);
+
+@property(1)
+def test_remove : Bool = assertFalse (has (remove (add new 5) 5) 5);
+
+@property(1)
+def test_remove_absent_is_noop : Bool =
+    s = remove (add new 5) 9;
+    assertTrue (has s 5);
+
+@property(1)
+def test_union : Bool =
+    s = union (add new 1) (add new 2);
+    both (assertTrue (has s 1))
+         (assertTrue (has s 2));
+
+@property(1)
+def test_intersection : Bool =
+    s = intersection (add (add new 1) 2) (add new 2);
+    both (assertTrue (has s 2))
+         (assertFalse (has s 1));
+
+@property(1)
+def test_difference : Bool =
+    s = difference (add (add new 1) 2) (add new 2);
+    both (assertTrue (has s 1))
+         (assertFalse (has s 2));
+
+# ── Property-based tests (Int elements generated) ─────────────────────────────
+
+# An element is present right after being added.
+@property
+def prop_add_then_has (x : Int) : Bool =
+    assertTrue (has (add new x) x);
+
+# An element is absent right after being removed.
+@property
+def prop_remove_then_absent (x : Int) : Bool =
+    assertFalse (has (remove (add new x) x) x);
+
+# Every element of either set is in their union.
+@property
+def prop_union_contains_both (x : Int) (y : Int) : Bool =
+    s = union (add new x) (add new y);
+    both (assertTrue (has s x))
+         (assertTrue (has s y));

--- a/examples/testing/string_tests.ae
+++ b/examples/testing/string_tests.ae
@@ -1,0 +1,83 @@
+# Tests for the String library.
+#
+# These are all unit tests (zero-argument `@property(1)`). Property-based testing
+# over generated `String` arguments is intentionally avoided here: the input
+# generator does not terminate well for the unbounded `String` type, so string
+# properties are better expressed as concrete cases.
+#
+# Functions with length-refined preconditions (`slice`, `replace`, `split`) are
+# also not covered: their refinements mention `len`, which is opaque to the SMT
+# solver, so they cannot be discharged for string *literals* (the solver cannot
+# compute `len "hello"`). They remain usable where the length is carried in a
+# refinement-typed variable.
+#
+# Run with:  aeon --test examples/testing/string_tests.ae
+
+open Testing
+open String
+
+@property(1)
+def test_len : Bool = assertEqual (len "hello") 5;
+
+@property(1)
+def test_len_empty : Bool = assertEqual (len "") 0;
+
+@property(1)
+def test_intToString : Bool = assertEqual (intToString 42) "42";
+
+@property(1)
+def test_equal : Bool =
+    both (assertTrue (equal "abc" "abc"))
+         (assertFalse (equal "abc" "abd"));
+
+@property(1)
+def test_upper : Bool = assertEqual (upper "abc") "ABC";
+
+@property(1)
+def test_lower : Bool = assertEqual (lower "ABC") "abc";
+
+@property(1)
+def test_concat : Bool = assertEqual (concat "foo" "bar") "foobar";
+
+@property(1)
+def test_startsWith : Bool =
+    both (assertTrue (startsWith "hello" "he"))
+         (assertFalse (startsWith "hello" "lo"));
+
+@property(1)
+def test_endsWith : Bool =
+    both (assertTrue (endsWith "hello" "lo"))
+         (assertFalse (endsWith "hello" "he"));
+
+@property(1)
+def test_contains : Bool =
+    both (assertTrue (contains "hello" "ell"))
+         (assertFalse (contains "hello" "xyz"));
+
+@property(1)
+def test_indexOf : Bool =
+    both (assertEqual (indexOf "hello" "l") 2)
+         (assertEqual (indexOf "hello" "z") (0 - 1));
+
+@property(1)
+def test_lastIndexOf : Bool = assertEqual (lastIndexOf "hello" "l") 3;
+
+@property(1)
+def test_trim : Bool = assertEqual (trim "  hi  ") "hi";
+
+@property(1)
+def test_trimLeft : Bool = assertEqual (trimLeft "  hi") "hi";
+
+@property(1)
+def test_trimRight : Bool = assertEqual (trimRight "hi  ") "hi";
+
+@property(1)
+def test_repeat : Bool = assertEqual (repeat "ab" 3) "ababab";
+
+@property(1)
+def test_repeat_zero : Bool = assertEqual (repeat "ab" 0) "";
+
+@property(1)
+def test_isEmpty : Bool =
+    both (assertTrue (isEmpty ""))
+         (assertFalse (isEmpty "x"));

--- a/examples/testing/string_tests.ae
+++ b/examples/testing/string_tests.ae
@@ -6,15 +6,14 @@
 # properties are better expressed as concrete cases.
 #
 # Functions with length-refined preconditions (`slice`, `replace`, `split`) are
-# also not covered: their refinements mention `len`, which is opaque to the SMT
-# solver, so they cannot be discharged for string *literals* (the solver cannot
-# compute `len "hello"`). They remain usable where the length is carried in a
-# refinement-typed variable.
+# covered too: `len` is translated to Z3's native string length, so the solver
+# computes `len "hello" == 5` and discharges those preconditions on literals.
 #
 # Run with:  aeon --test examples/testing/string_tests.ae
 
 open Testing
 open String
+import Array;
 
 @property(1)
 def test_len : Bool = assertEqual (len "hello") 5;
@@ -81,3 +80,26 @@ def test_repeat_zero : Bool = assertEqual (repeat "ab" 0) "";
 def test_isEmpty : Bool =
     both (assertTrue (isEmpty ""))
          (assertFalse (isEmpty "x"));
+
+# ── Length-refined operations (preconditions discharged via Z3 string length) ──
+
+@property(1)
+def test_slice_prefix : Bool = assertEqual (slice "hello" 0 3) "hel";
+
+@property(1)
+def test_slice_suffix : Bool = assertEqual (slice "hello" 1 5) "ello";
+
+@property(1)
+def test_slice_full : Bool = assertEqual (slice "hello" 0 5) "hello";
+
+@property(1)
+def test_replace : Bool = assertEqual (replace "hello" "l" "L") "heLLo";
+
+@property(1)
+def test_replace_word : Bool = assertEqual (replace "foofoo" "foo" "bar") "barbar";
+
+@property(1)
+def test_split : Bool =
+    parts = split "a,b,c" ",";
+    both (assertEqual (Array.length parts) 3)
+         (assertEqual (Array.get parts 0) "a");

--- a/examples/testing/tuple_tests.ae
+++ b/examples/testing/tuple_tests.ae
@@ -1,0 +1,60 @@
+# Tests for the Tuple library (native 2-tuples).
+#
+# Run with:  aeon --test examples/testing/tuple_tests.ae
+
+open Testing
+open Tuple
+
+# ── Unit tests ───────────────────────────────────────────────────────────────
+
+@property(1)
+def test_fst : Bool = assertEqual (fst (new 1 2)) 1;
+
+@property(1)
+def test_snd : Bool = assertEqual (snd (new 1 2)) 2;
+
+@property(1)
+def test_length : Bool = assertEqual (length (new 1 2)) 2;
+
+@property(1)
+def test_eq : Bool =
+    both (assertTrue (eq (new 1 2) (new 1 2)))
+         (assertFalse (eq (new 1 2) (new 2 1)));
+
+@property(1)
+def test_swap : Bool =
+    s = swap (new 1 2);
+    both (assertEqual (fst s) 2)
+         (assertEqual (snd s) 1);
+
+@property(1)
+def test_map_fst : Bool =
+    t = map_fst (fun x => x + 10) (new 1 2);
+    both (assertEqual (fst t) 11)
+         (assertEqual (snd t) 2);
+
+@property(1)
+def test_map_snd : Bool =
+    t = map_snd (fun x => x + 10) (new 1 2);
+    both (assertEqual (fst t) 1)
+         (assertEqual (snd t) 12);
+
+# ── Property-based tests ─────────────────────────────────────────────────────
+
+# Projections return the components they were built from.
+@property
+def prop_fst_snd (a : Int) (b : Int) : Bool =
+    both (assertEqual (fst (new a b)) a)
+         (assertEqual (snd (new a b)) b);
+
+# Swapping exchanges the two components.
+@property
+def prop_swap (a : Int) (b : Int) : Bool =
+    s = swap (new a b);
+    both (assertEqual (fst s) b)
+         (assertEqual (snd s) a);
+
+# Swapping twice is the identity.
+@property
+def prop_swap_involution (a : Int) (b : Int) : Bool =
+    assertTrue (eq (swap (swap (new a b))) (new a b));

--- a/libraries/Set.ae
+++ b/libraries/Set.ae
@@ -1,51 +1,46 @@
+open Array
+
+# Immutable set of elements, backed by a Python ``set``. Every operation
+# returns a new set rather than mutating in place.
 type Set a
 
-# Returns the size (number of elements) of the set.
-def size: (s:(Set a)) -> Int = uninterpreted
+# Number of elements, as an uninterpreted measure (no runtime value).
+def size : (s:(Set a)) -> Int = uninterpreted
 
-# Returns whether the set contains an element.
-def contains: (s:(Set a)) -> (x:a) -> Bool = uninterpreted
+# Whether the set contains an element, as an uninterpreted predicate usable in
+# refinements. Use ``has`` to test membership at runtime.
+def contains : (s:(Set a)) -> (x:a) -> Bool = uninterpreted
 
 # Creates a new empty set.
-def new : {s:(Set a) | size s == 0} = native "set()";
+def new : {s:(Set a) | size s == 0} = native "set()"
 
-# Adds an element to the set.
+# Adds an element, returning a new set (never smaller than the original).
 # s: set
 # x: element to add
-# returns: new set with element added
-def add: (s:(Set a)) -> (x:a) -> {s2:(Set a) | size s2 >= size s} = native "set.add(x)";
+# returns: new set containing x
+def add (s:(Set a)) (x:a) : {s2:(Set a) | size s2 >= size s} = native "s | {x}"
 
-# Checks if the set contains an element.
+# Checks if the set contains an element at runtime.
 # s: set
 # x: element to check
-# returns: true if element is in set
-def has: (s:(Set a)) -> (x:a) -> Bool = native "x in s"
+# returns: true if x is in s
+def has (s:(Set a)) (x:a) : Bool = native "x in s"
 
-# Removes an element from the set.
+# Removes an element, returning a new set. Removing an absent element is a
+# no-op (unlike Python's ``set.remove``).
 # s: set
 # x: element to remove
-# returns: new set with element removed
-def remove: (s:(Set a)) -> (x: {el: a | contains s el}) -> (Set a) = native "set.remove(x)"
+# returns: new set without x
+def remove (s:(Set a)) (x:a) : (Set a) = native "s - {x}"
 
 # Returns the union of two sets.
-# s1: set
-# s2: set
-# returns: union of s1 and s2
-def union: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 | s2"
+def union (s1:(Set a)) (s2:(Set a)) : (Set a) = native "s1 | s2"
 
 # Returns the intersection of two sets.
-# s1: set
-# s2: set
-# returns: intersection of s1 and s2
-def intersection: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 & s2"
+def intersection (s1:(Set a)) (s2:(Set a)) : (Set a) = native "s1 & s2"
 
-# Returns the difference of two sets.
-# s1: set
-# s2: set
-# returns: elements in s1 but not in s2
-def difference: (s1:(Set a)) -> (s2:(Set a)) -> (Set a) = native "s1 - s2"
+# Returns the difference of two sets (elements in s1 but not in s2).
+def difference (s1:(Set a)) (s2:(Set a)) : (Set a) = native "s1 - s2"
 
-# Returns the list of elements in the set.
-# s: set
-# returns: list of elements
-def toList: (s:(Set a)) -> (Array a) = native "list(s)"
+# Returns the elements of the set as an array.
+def toList (s:(Set a)) : (Array a) = native "list(s)"

--- a/tests/testing_lib_test.py
+++ b/tests/testing_lib_test.py
@@ -17,7 +17,8 @@ from aeon.synthesis.pbt import run_properties
 from aeon.synthesis.uis.api import SynthesisUI
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-IMAGE_TESTS = REPO_ROOT / "examples" / "testing" / "image_tests.ae"
+TESTING_EXAMPLES_DIR = REPO_ROOT / "examples" / "testing"
+EXAMPLE_SUITES = sorted(TESTING_EXAMPLES_DIR.glob("*.ae"))
 
 # A self-contained program exercising every assertion combinator: passing and
 # failing instances of each, so we can assert the runner classifies both.
@@ -105,12 +106,20 @@ def test_assertions_that_should_fail(results, name):
     assert not results[name].passed, results[name].summary()
 
 
-def test_image_example_suite_all_pass():
-    """The shipped Image test suite must pass end-to-end (also guards the
-    Image_diff_mse native float cast)."""
+@pytest.mark.parametrize("suite", EXAMPLE_SUITES, ids=lambda p: p.stem)
+def test_example_suites_all_pass(suite):
+    """Every shipped suite under examples/testing/ must pass end-to-end. This
+    also guards the libraries those suites exercise (e.g. the Image_diff_mse
+    native float cast and the Set.ae rewrite)."""
     cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SynthesisUI(), synthesis_budget=10, no_main=False)
     driver = AeonDriver(cfg)
-    errors = driver.parse(str(IMAGE_TESTS))
+    errors = driver.parse(str(suite))
     assert errors == [], errors
     failures = driver.run_tests(seed=0)
     assert failures == [], [f.summary() for f in failures]
+
+
+def test_example_suites_discovered():
+    """Guard against the glob silently finding nothing (which would make the
+    parametrized test vacuously pass)."""
+    assert len(EXAMPLE_SUITES) >= 9

--- a/tests/testing_lib_test.py
+++ b/tests/testing_lib_test.py
@@ -123,3 +123,23 @@ def test_example_suites_discovered():
     """Guard against the glob silently finding nothing (which would make the
     parametrized test vacuously pass)."""
     assert len(EXAMPLE_SUITES) >= 9
+
+
+def _parse_errors(source: str):
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SynthesisUI(), synthesis_budget=10, no_main=False)
+    return AeonDriver(cfg).parse(aeon_code=source)
+
+
+def test_string_length_refinement_discharged_on_literal():
+    """`String.len` is wired to Z3's native string length, so a slice whose
+    bounds are valid for the literal typechecks (the `l <= len i` precondition
+    is discharged because Z3 computes `len "hello" == 5`)."""
+    src = 'open String\ndef ok (_:Int) : String = slice "hello" 0 5;\n'
+    assert _parse_errors(src) == []
+
+
+def test_string_length_refinement_rejects_out_of_bounds_literal():
+    """Soundness: an out-of-bounds slice on a literal is still rejected — the
+    Z3 string length makes `99 <= len "hello"` provably false, not unknown."""
+    src = 'open String\ndef bad (_:Int) : String = slice "hello" 0 99;\n'
+    assert _parse_errors(src) != []


### PR DESCRIPTION
## Summary

Adds `--test` suites for the core data-structure libraries, built with the `Testing` library (from #364). Each suite mixes **unit tests** (zero-arg `@property(1)`) and **property-based tests** (generated `Int`/ADT inputs):

| Suite | Library | Checks |
|---|---|---|
| `list_tests.ae` | List | 14 |
| `array_tests.ae` | Array | 13 |
| `map_tests.ae` | Map | 10 |
| `set_tests.ae` | Set | 10 |
| `pair_tests.ae` | Pair | 5 |
| `tuple_tests.ae` | Tuple | 10 |
| `maybe_tests.ae` | Maybe | 6 |
| `string_tests.ae` | String | 24 |

`tests/testing_lib_test.py` now parametrizes over **every** suite in `examples/testing/`, and `run_examples.sh` already runs that glob under `--test` in CI.

## Bug fix surfaced by testing: `libraries/Set.ae`

The Set library **did not compile or run** — writing tests is what exposed it:

- **Typecheck**: `add`/`remove`/… used the `def f : (args) -> ret = native` colon-arrow form with a *refined polymorphic* return, which the typechecker rejects with a `"bare kind"` error. So *any* `open Set` failed. Rewritten in the `def f (args) : ret` form (matching `Array.ae`).
- **Runtime**: the native bodies for `add`/`remove` referenced Python's builtin `set` (`set.add(x)` / `set.remove(x)`) rather than the set argument, and mutated in place. They now return new sets (`s | {x}` / `s - {x}`); `remove` of an absent element is a harmless no-op.

(No other code depended on the old Set API.)

## Verifier improvement: `String.len` → Z3 native string length

`String.len` appears in the refinement preconditions of `slice`/`replace`/`split` (e.g. `l <= len i`), but was lowered to an **uninterpreted** `String_len` symbol disconnected from Z3's string theory — so `len "hello"` was unconstrained and those preconditions couldn't be discharged for string *literals*. Now `String_len` maps to Z3's `Length` (`aeon/verification/smt.py`), so:

- valid length-refined ops typecheck on literals (`slice "hello" 0 5`), and
- **soundly**, out-of-bounds ones are still rejected (`slice "hello" 0 99` → provably false, not unknown).

The String suite now covers `slice`/`replace`/`split`, with accept/reject regression tests.

## Remaining notes

- **String** still has no property tests — generation over the unbounded `String` type doesn't terminate well, so string properties are concrete cases.
- **unsafeList** is not covered — it crashes the typechecker (`Top` in substitution); it's an explicitly "unsafe" low-level module.

## Testing

```
$ uv run pytest tests/testing_lib_test.py      # 26 passed
$ uv run pytest tests -k "smt or verif or liquid or string or refine"   # 177 passed, no regressions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)