### PR TITLE
Tests for Args/Socket libraries + fix memoized socket constructors

### DIFF
--- a/examples/ffi/socket_linear.ae
+++ b/examples/ffi/socket_linear.ae
@@ -2,7 +2,7 @@ open Socket
 
 # Linear (QTT) socket lifecycle.
 #
-# `stream_socket` returns a fresh `StreamSocket` value. Binding it to a
+# `stream_socket unit` returns a fresh `StreamSocket` value. Binding it to a
 # `1`-multiplicity binder makes the type checker enforce that this socket
 # is consumed *exactly once* in its scope. Each socket-consuming operation
 # (`stream_bind`, `stream_listen`, ..., `stream_close`) takes its socket
@@ -20,7 +20,7 @@ open Socket
 # typechecker) can exercise the linearity discipline without actually
 # opening a socket at module load.
 def lifecycle (port: { p: Int | (p >= 0) && (p <= 65535) }) : Unit =
-    let 1 s0 = stream_socket in
+    let 1 s0 = stream_socket unit in
     let 1 s1 = stream_bind (ipv4_addr "127.0.0.1" port) s0 in
     let 1 s2 = stream_listen 5 s1 in
     stream_close s2;

--- a/examples/pbt/props_args.ae
+++ b/examples/pbt/props_args.ae
@@ -1,0 +1,124 @@
+# Property-based tests and machine-checked examples for the Args library
+# (argparse via FFI). See libraries/Args.ae.
+#
+# Two kinds of checks:
+#
+#   * @property — universally quantified over generated Int/Float inputs (drawn
+#     from the synthesis grammar). The robust round-trip properties feed a value
+#     as an option *default*, which argparse stores verbatim without re-parsing
+#     it, so any generated value survives intact. prop_int_positional_roundtrips
+#     additionally exercises the real argv parse path (the value is rendered to
+#     a string and parsed back). Strings are covered by the @example tests
+#     instead — random String generation is not supported as a property input.
+#
+#   * @example — concrete unit tests for the argv-parsing paths (flags,
+#     options, choices, positionals, and string values) where a hand-picked
+#     input keeps argparse away from its CLI edge cases (a leading '-' looks
+#     like an option, etc.).
+#
+# Run with:  aeon --test examples/pbt/props_args.ae
+
+open Args
+open Array
+open String
+
+# ── argv constants (argparse consumes a list of strings) ─────────────────
+
+def argvEmpty : (Array String) = native "[]"
+def argvAlice : (Array String) = native "['alice']"
+def argv42 : (Array String) = native "['42']"
+def argvRatio : (Array String) = native "['1.5']"
+def argvVerbose : (Array String) = native "['--verbose']"
+def argvOutFile : (Array String) = native "['--out', 'file.txt']"
+def argvNum99 : (Array String) = native "['--num', '99']"
+def argvModeSlow : (Array String) = native "['--mode', 'slow']"
+
+# Built via Array.append so its size (2 > 0) is provable — addChoice requires
+# a statically non-empty list of options.
+def choicesModes : {l : (Array String) | Array.size l > 0} =
+    Array.append (Array.append Array.new "fast") "slow"
+
+def singleton (x : String) : (Array String) = native "[x]"
+
+# ── Properties: option defaults round-trip through argparse ───────────────
+# An option's default is stored as-is, so for ANY generated value, building a
+# parser with that default and parsing an empty argv must read it back equal.
+
+@property
+def prop_int_option_default_roundtrips (d : Int) : Bool =
+    p : Parser = Args.addIntOption (Args.newParser "t") "num" d "";
+    a : ParsedArgs = Args.parseList p argvEmpty;
+    Args.getInt a "num" == d;
+
+@property
+def prop_float_option_default_roundtrips (d : Float) : Bool =
+    p : Parser = Args.addFloatOption (Args.newParser "t") "x" d "";
+    a : ParsedArgs = Args.parseList p argvEmpty;
+    Args.getFloat a "x" == d;
+
+# (String inputs are exercised by the @example unit tests below rather than a
+# @property: random String generation is not supported as a quantified input.)
+
+# Full argv parse path: a non-negative int rendered to a string and parsed
+# back as a positional must equal the original (non-negative avoids the
+# leading-'-' argparse ambiguity).
+@property
+def prop_int_positional_roundtrips (d : {v : Int | v >= 0}) : Bool =
+    p : Parser = Args.addIntArg (Args.newParser "t") "count" "";
+    a : ParsedArgs = Args.parseList p (singleton (String.intToString d));
+    Args.getInt a "count" == d;
+
+# ── Unit tests: argv parsing for each accessor / argument kind ────────────
+
+# Required string positional.
+@example(getName argvAlice)
+def getName (argv : (Array String)) : Bool =
+    p : Parser = Args.addArg (Args.newParser "t") "name" "";
+    a : ParsedArgs = Args.parseList p argv;
+    String.equal (Args.getString a "name") "alice";
+
+# Required int positional.
+@example(getCount argv42 == 42)
+def getCount (argv : (Array String)) : Int =
+    p : Parser = Args.addIntArg (Args.newParser "t") "count" "";
+    a : ParsedArgs = Args.parseList p argv;
+    Args.getInt a "count";
+
+# Required float positional.
+@example(getRatio argvRatio == 1.5)
+def getRatio (argv : (Array String)) : Float =
+    p : Parser = Args.addFloatArg (Args.newParser "t") "ratio" "";
+    a : ParsedArgs = Args.parseList p argv;
+    Args.getFloat a "ratio";
+
+# Boolean flag: true when present, false (the default) when absent.
+@example(getVerbose argvVerbose == true)
+@example(getVerbose argvEmpty == false)
+def getVerbose (argv : (Array String)) : Bool =
+    p : Parser = Args.addFlag (Args.newParser "t") "verbose" "";
+    a : ParsedArgs = Args.parseList p argv;
+    Args.getBool a "verbose";
+
+# String option: default when absent, supplied value when present.
+@example(String.equal (getOut argvEmpty) "stdout")
+@example(String.equal (getOut argvOutFile) "file.txt")
+def getOut (argv : (Array String)) : String =
+    p : Parser = Args.addOption (Args.newParser "t") "out" "stdout" "";
+    a : ParsedArgs = Args.parseList p argv;
+    Args.getString a "out";
+
+# Int option: default when absent, supplied value when present.
+@example(getNum argvEmpty == 10)
+@example(getNum argvNum99 == 99)
+def getNum (argv : (Array String)) : Int =
+    p : Parser = Args.addIntOption (Args.newParser "t") "num" 10 "";
+    a : ParsedArgs = Args.parseList p argv;
+    Args.getInt a "num";
+
+# Choice option restricted to a fixed set: default and a valid override.
+@example(String.equal (getMode argvEmpty) "fast")
+@example(String.equal (getMode argvModeSlow) "slow")
+def getMode (argv : (Array String)) : String =
+    p : Parser = Args.addChoice (Args.newParser "t") "mode" choicesModes "fast" "";
+    a : ParsedArgs = Args.parseList p argv;
+    Args.getString a "mode";

--- a/examples/pbt/props_socket.ae
+++ b/examples/pbt/props_socket.ae
@@ -1,0 +1,86 @@
+# Property-based tests and machine-checked examples for the Socket library
+# (linear/QTT TCP+UDP sockets via FFI). See libraries/Socket.ae.
+#
+# What can be tested at runtime, and what cannot:
+#
+#   * Socket values are opaque and linear (multiplicity 1), so they cannot be
+#     *generated* the way Int/Float/String are — there is no constructor for
+#     the synthesis grammar to sample. The logical state predicates
+#     (`stream_bound`, `payload_len`, ...) are `uninterpreted`: SMT-only, with
+#     no runtime, so they cannot appear in a runtime assertion either.
+#
+#   * The send/recv/connect/accept operations need a live peer and a
+#     `SocketPayload`, and the library exposes no payload constructor, so they
+#     are not exercisable from a self-contained test.
+#
+#   * What we *can* drive is the real server-side syscall lifecycle:
+#     open → bind → listen → close. Each test binds to the loopback address on
+#     port 0, so the OS hands out a free ephemeral port and the tests never
+#     collide with each other or with ports already in use.
+#
+# That every test also type-checks is itself a check of the library's
+# linear/refinement contract: each socket is threaded through `let 1` binders
+# and consumed exactly once, advancing the bound/connected state machine.
+#
+# Run with:  aeon --test examples/pbt/props_socket.ae
+
+open Socket
+
+def loopback : {a : SockAddr | ipv4_sock_addr a == true} = ipv4_addr "127.0.0.1" 0
+
+# ── TCP lifecycle unit tests ─────────────────────────────────────────────
+
+# Open then close.
+@example(tcpOpenClose == true)
+def tcpOpenClose : Bool =
+    let 1 s = stream_socket unit in
+    let done = stream_close s in
+    true;
+
+# Open, bind to an ephemeral loopback port, close.
+@example(tcpBindClose == true)
+def tcpBindClose : Bool =
+    let 1 s0 = stream_socket unit in
+    let 1 s1 = stream_bind loopback s0 in
+    let done = stream_close s1 in
+    true;
+
+# Full server-side setup: open, bind, listen, close.
+@example(tcpServerSetup == true)
+def tcpServerSetup : Bool =
+    let 1 s0 = stream_socket unit in
+    let 1 s1 = stream_bind loopback s0 in
+    let 1 s2 = stream_listen 5 s1 in
+    let done = stream_close s2 in
+    true;
+
+# ── UDP lifecycle unit tests ─────────────────────────────────────────────
+
+# Open then close.
+@example(udpOpenClose == true)
+def udpOpenClose : Bool =
+    let 1 s = dgram_socket unit in
+    let done = dgram_close s in
+    true;
+
+# Open, bind to an ephemeral loopback port, close.
+@example(udpBindClose == true)
+def udpBindClose : Bool =
+    let 1 s0 = dgram_socket unit in
+    let 1 s1 = dgram_bind loopback s0 in
+    let done = dgram_close s1 in
+    true;
+
+# ── Property: the TCP server lifecycle works for any valid backlog ────────
+# `stream_listen` requires backlog > 0; we cap it well under the usual
+# SOMAXCONN so the syscall always succeeds. Each trial builds its own socket
+# (the constructors yield a fresh handle per use), so port 0 keeps every trial
+# on a distinct ephemeral port.
+
+@property(20)
+def prop_tcp_listen_any_backlog (backlog : {n : Int | n > 0 && n < 64}) : Bool =
+    let 1 s0 = stream_socket unit in
+    let 1 s1 = stream_bind loopback s0 in
+    let 1 s2 = stream_listen backlog s1 in
+    let done = stream_close s2 in
+    true;

--- a/libraries/Socket.ae
+++ b/libraries/Socket.ae
@@ -2,7 +2,7 @@
 #
 # Every socket-consuming operation takes its socket parameter at
 # multiplicity 1 (``(1 s: ...)``), so the type checker enforces the
-# resource discipline at the binder. A ``let 1 s = stream_socket in
+# resource discipline at the binder. A ``let 1 s = stream_socket unit in
 # body`` *must* consume ``s`` exactly once: passing it to ``stream_bind``,
 # ``stream_close``, etc. discharges the linear obligation. Forgetting to
 # close any handle, or using one after consumption, is rejected at
@@ -56,13 +56,19 @@ def ipv4_addr (host: String) (port: { p: Int | (p >= 0) && (p <= 65535) }) :
     native "(host, port)"
 
 # ── Constructors — return a *fresh* socket the user must bind to a
-# linear binder (``let 1 s = stream_socket in ...``) ────────────────────
+# linear binder (``let 1 s = stream_socket unit in ...``) ───────────────
+#
+# They take a ``Unit`` argument so that opening a socket is an *applied*
+# action: each ``stream_socket unit`` re-runs the native and yields a new
+# handle. A nullary ``def`` would be a value, which the evaluator memoizes —
+# every use would then alias the same Python socket, so a second
+# ``let 1 s = stream_socket`` would reuse an already-closed descriptor.
 
-def stream_socket :
+def stream_socket (_ : Unit) :
     { s: StreamSocket | (stream_bound s == false) && (stream_connected s == false) } =
     native "socket.socket(socket.AF_INET, socket.SOCK_STREAM)"
 
-def dgram_socket :
+def dgram_socket (_ : Unit) :
     { s: DatagramSocket | (dgram_bound s == false) && (dgram_connected s == false) } =
     native "socket.socket(socket.AF_INET, socket.SOCK_DGRAM)"
 

--- a/tests/socket_fresh_test.py
+++ b/tests/socket_fresh_test.py
@@ -1,0 +1,95 @@
+"""Regression: opening a socket must yield a fresh handle on every use within a
+single evaluation.
+
+``stream_socket`` / ``dgram_socket`` take a ``Unit`` argument so that each
+``stream_socket unit`` is an *application* that re-runs the native constructor.
+They used to be nullary ``def``s (``def stream_socket : ... = native "..."``),
+which the evaluator memoizes — so every ``let 1 s = stream_socket`` in one
+evaluation aliased the SAME Python socket, and the second server's ``bind()``
+ran on the first, already-closed, socket → ``OSError: [Errno 9] Bad file
+descriptor``. The linear type system assumes each use is a fresh resource; the
+runtime must match.
+
+These tests open two sockets in a single evaluation and require the program to
+run to completion. They do a real (loopback, ephemeral-port) bind, so they
+exercise the actual syscall path the memoization broke.
+"""
+
+from __future__ import annotations
+
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _run(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=False)
+    driver = AeonDriver(cfg)
+    errors = list(driver.parse(aeon_code=source))
+    assert errors == [], errors
+    return driver.run()
+
+
+def test_two_tcp_servers_in_one_evaluation_get_fresh_sockets():
+    src = """
+open Socket
+
+def loopback : {a : SockAddr | ipv4_sock_addr a == true} = ipv4_addr "127.0.0.1" 0
+
+def two_servers (u : Int) : Bool =
+    let 1 a0 = stream_socket unit in
+    let 1 a1 = stream_bind loopback a0 in
+    let done_a = stream_close a1 in
+    let 1 b0 = stream_socket unit in
+    let 1 b1 = stream_bind loopback b0 in
+    let done_b = stream_close b1 in
+    true;
+
+def main (i : Int) : Bool = two_servers i;
+"""
+    # Before the fix this raised OSError (bad file descriptor) on b0's bind.
+    assert _run(src) is True
+
+
+def test_repeated_calls_each_open_a_fresh_socket():
+    # The same constructor used across several independent calls in one
+    # evaluation must hand back a different live socket each time.
+    src = """
+open Socket
+
+def loopback : {a : SockAddr | ipv4_sock_addr a == true} = ipv4_addr "127.0.0.1" 0
+
+def bind_close (u : Int) : Bool =
+    let 1 s0 = stream_socket unit in
+    let 1 s1 = stream_bind loopback s0 in
+    let done = stream_close s1 in
+    true;
+
+def main (i : Int) : Bool =
+    let a = bind_close i in
+    let b = bind_close i in
+    let c = bind_close i in
+    a && b && c;
+"""
+    assert _run(src) is True
+
+
+def test_two_udp_sockets_in_one_evaluation_get_fresh_sockets():
+    src = """
+open Socket
+
+def loopback : {a : SockAddr | ipv4_sock_addr a == true} = ipv4_addr "127.0.0.1" 0
+
+def two_dgram (u : Int) : Bool =
+    let 1 a0 = dgram_socket unit in
+    let 1 a1 = dgram_bind loopback a0 in
+    let done_a = dgram_close a1 in
+    let 1 b0 = dgram_socket unit in
+    let 1 b1 = dgram_bind loopback b0 in
+    let done_b = dgram_close b1 in
+    true;
+
+def main (i : Int) : Bool = two_dgram i;
+"""
+    assert _run(src) is True

--- a/tests/socket_qtt_test.py
+++ b/tests/socket_qtt_test.py
@@ -44,7 +44,7 @@ def test_socket_open_bind_listen_close_ok():
 open Socket
 
 def lifecycle (port: { p: Int | (p >= 0) && (p <= 65535) }) : Unit =
-    let 1 s0 = stream_socket in
+    let 1 s0 = stream_socket unit in
     let 1 s1 = stream_bind (ipv4_addr "127.0.0.1" port) s0 in
     let 1 s2 = stream_listen 5 s1 in
     stream_close s2;
@@ -66,7 +66,7 @@ def test_socket_unclosed_errors():
 open Socket
 
 def leak (args: Int) : Unit =
-    let 1 s = stream_socket in
+    let 1 s = stream_socket unit in
     print "ignored s";
 
 def main (args: Int) : Unit = print "ok";
@@ -87,7 +87,7 @@ def test_socket_double_close_errors():
 open Socket
 
 def double_close (args: Int) : Unit =
-    let 1 s = stream_socket in
+    let 1 s = stream_socket unit in
     let _ = stream_close s in
     stream_close s;
 
@@ -110,7 +110,7 @@ def test_socket_use_after_consume_errors():
 open Socket
 
 def stale (port: { p: Int | (p >= 0) && (p <= 65535) }) : Unit =
-    let 1 s0 = stream_socket in
+    let 1 s0 = stream_socket unit in
     let 1 s1 = stream_bind (ipv4_addr "127.0.0.1" port) s0 in
     let 1 s2 = stream_listen 5 s1 in
     let _ = stream_close s2 in
@@ -134,7 +134,7 @@ def test_socket_alias_then_double_close_errors():
 open Socket
 
 def alias_double (args: Int) : Unit =
-    let 1 s = stream_socket in
+    let 1 s = stream_socket unit in
     let g = s in
     let _ = stream_close s in
     stream_close g;


### PR DESCRIPTION
## What

Adds property-based / `@example` tests for the **Args** and **Socket** standard-library modules (runnable with `aeon --test`), and fixes a latent runtime bug those tests surfaced.

### Tests
- **`examples/pbt/props_args.ae`** — 3 `@property` round-trip tests (int/float option defaults; non-negative int positional through the real argv parse path) + 11 `@example` unit tests covering every accessor (`getString/getInt/getFloat/getBool`) and argument kind (positionals, flags, options, choices). Strings are covered via `@example` because random `String` generation isn't supported as a property input (it hangs).
- **`examples/pbt/props_socket.ae`** — `@example` unit tests for the TCP/UDP `open → bind → listen → close` lifecycle + a `@property` over the listen backlog. Everything binds loopback **port 0** (ephemeral) so trials never collide.

Both files match the `props_*.ae` glob already run under `--test` in `run_examples.sh`.

### Fix: socket constructors must yield fresh handles
Writing the socket tests surfaced a real bug. `stream_socket` / `dgram_socket` were **nullary `native` bindings**, which the evaluator memoizes — so every `let 1 s = stream_socket` within one evaluation aliased the **same** Python socket. A second `bind()` then ran on an already-closed fd:

```
OSError: [Errno 9] Bad file descriptor
```

The linear type system assumes each use is a fresh resource; the runtime didn't deliver one.

**Fix (library-level):** the constructors now take a `Unit` argument, so each `stream_socket unit` is an *application* that re-runs the native and produces a fresh handle:

```aeon
def stream_socket (_ : Unit) : { s: StreamSocket | ... } =
    native "socket.socket(socket.AF_INET, socket.SOCK_STREAM)"
```

Call sites become `let 1 s = stream_socket unit in ...`.

#### Why not fix the evaluator instead?
I prototyped an evaluator-level fix (re-evaluate `native` bindings on each reference). It fixed the sockets but broke `tests/linearity_test.py::test_omega_let_val_is_evaluated`, which requires an **unused** `let ghost = native "1/0"` to still evaluate and raise `ZeroDivisionError`. Strict-`let` evaluation is intentional, so the right move is to make the effect explicit in the *type* (a function), not change evaluator semantics.

## Changes
- `libraries/Socket.ae` — `stream_socket` / `dgram_socket` take `(_ : Unit)`.
- `examples/ffi/socket_linear.ae`, `tests/socket_qtt_test.py` — call sites updated to `stream_socket unit`.
- `tests/socket_fresh_test.py` (new) — regression: opens two sockets in one evaluation (two TCP servers, repeated calls, two UDP sockets) and requires the program to run to completion.
- `examples/pbt/props_args.ae`, `examples/pbt/props_socket.ae` (new) — the test suites.

## Validation
- Full `pytest`: **1480 passed, 11 skipped** (incl. the restored `test_omega_let_val_is_evaluated` and the new `socket_fresh_test.py`).
- `bash run_examples.sh`: all examples pass, including `socket_linear`, `props_args`, `props_socket` under `--test`.

## Notes for reviewers
- The Socket constructor signature change is a small **API change**: callers must now write `stream_socket unit` instead of `stream_socket`. Docs/comments in `Socket.ae` and `socket_linear.ae` were updated accordingly.
- `String`-typed `@property` arguments hang (grammar generation doesn't terminate); strings are tested via `@example` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)