### PR TITLE
feat(lsp): refinement-type-aware completion, hover, inlay hints and navigation

### DIFF
--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -54,6 +54,12 @@ class AeonDriver:
         if aeon_code is None:
             aeon_code = read_file(filename)
 
+        # Clear any core/context retained from a previous parse so a parse or
+        # elaboration error on this input cannot leave tooling reading stale
+        # state (these are repopulated below once core generation succeeds).
+        self.core = None
+        self.typing_ctx = None
+
         with RecordTime("ParseSugar"):
             clear_instance_registry()
             prog: Program = parse_main_program(aeon_code, filename=filename)
@@ -82,6 +88,14 @@ class AeonDriver:
             typing_ctx = lower_to_core_context(desugared.elabcontext)
             core_ast = lower_to_core(sterm)
             typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+
+        # Expose the core program and its top-level typing context as soon as
+        # they exist — before type checking — so tooling (the LSP's hover,
+        # completion and type-index features) can still introspect a program
+        # that elaborates but fails to type check. The later assignments on the
+        # success path overwrite these with identical values.
+        self.core = core_ast
+        self.typing_ctx = typing_ctx
 
         with RecordTime("TypeChecking"):
             type_errors = check_type_errors(typing_ctx, core_ast, top)

--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -51,6 +51,48 @@ class ParseResult:
     holes: List[HolePosition] = field(default_factory=list)
 
 
+# Last-good per-document analysis state, used by the type-aware features (hover,
+# completion, inlay hints, navigation). Kept separate from the parse cache and
+# only overwritten on a parse that reaches core generation, so these survive
+# transient errors while the user is mid-edit — exactly when completion is most
+# wanted. Values are plain objects to avoid importing core types here.
+_type_index_cache: "Dict[URI, object]" = {}
+_typing_ctx_cache: "Dict[URI, object]" = {}
+_core_cache: "Dict[URI, object]" = {}
+
+
+def get_type_index(uri: URI):
+    """The last successfully-built ``TypeIndex`` for ``uri`` (or ``None``)."""
+    return _type_index_cache.get(uri)
+
+
+def get_typing_ctx(uri: URI):
+    """The last successful top-level typing context for ``uri`` (or ``None``)."""
+    return _typing_ctx_cache.get(uri)
+
+
+def get_core(uri: URI):
+    """The last successfully-generated core program for ``uri`` (or ``None``)."""
+    return _core_cache.get(uri)
+
+
+def _refresh_analysis(driver: AeonDriver, uri: URI) -> None:
+    """After a parse, rebuild and cache the position→type index for ``uri`` if
+    core generation succeeded. On failure the previous caches are left intact."""
+    core = getattr(driver, "core", None)
+    typing_ctx = getattr(driver, "typing_ctx", None)
+    if core is None or typing_ctx is None:
+        return
+    try:
+        from aeon.lsp.typeindex import build_type_index
+
+        _type_index_cache[uri] = build_type_index(typing_ctx, core)
+        _typing_ctx_cache[uri] = typing_ctx
+        _core_cache[uri] = core
+    except Exception:
+        logger.exception("Failed to build type index for %s", uri)
+
+
 def find_holes_in_source(source: str) -> List[HolePosition]:
     """Find all ?identifier holes in source text and return their LSP ranges (0-indexed)."""
     holes = []
@@ -119,6 +161,10 @@ async def _parse(
     try:
         content = fp.read()
         errors = driver.parse(filename=uri, aeon_code=content)
+
+        # Refresh the type-aware analysis caches (kept even when `errors` is
+        # non-empty, as long as the program reached core generation).
+        _refresh_analysis(driver, uri)
 
         holes = find_holes_in_source(content)
 

--- a/aeon/lsp/completion.py
+++ b/aeon/lsp/completion.py
@@ -1,0 +1,531 @@
+"""Refinement-type-aware completion for the Aeon LSP.
+
+This module is deliberately free of any ``lsprotocol`` import so the logic is
+unit-testable in isolation; the server maps :class:`Completion` records to LSP
+``CompletionItem``s.
+
+Three tiers, increasing in sophistication (issue #27 gave the language the
+``receiver.method`` dot syntax this targets):
+
+* **Tier 1** — ``receiver.`` where the receiver is a literal (``1.``, ``"x".``)
+  or a name in scope: list the methods defined on the receiver's base type. A
+  method on type ``T`` is any in-scope binder named ``T.method`` (dotted
+  definition) or ``T_method`` (a member imported from module ``T``); this is the
+  exact convention ``ElaborationTypingContext.resolve_method`` dispatches on.
+* **Tier 2** — the receiver is an arbitrary expression ``(f x).``; its type is
+  recovered from the :class:`~aeon.lsp.typeindex.TypeIndex` by source range.
+* **Tier 3** — *refinement-aware*: for each candidate whose receiver parameter
+  is refined, an SMT subtyping check decides whether the receiver's known
+  refinement satisfies the method's precondition. Infeasible candidates are
+  de-ranked and annotated rather than hidden, and the precondition is surfaced.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from aeon.core.liquid import LiquidLiteralBool, LiquidVar
+from aeon.core.substitutions import substitution_in_liquid
+from aeon.core.types import (
+    AbstractionType,
+    ExistentialType,
+    RefinedType,
+    RefinementPolymorphism,
+    Top,
+    Type,
+    TypeConstructor,
+    TypePolymorphism,
+    TypeVar,
+)
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+
+# --------------------------------------------------------------------------- #
+# Completion records
+# --------------------------------------------------------------------------- #
+
+KIND_VARIABLE = "variable"
+KIND_FUNCTION = "function"
+KIND_METHOD = "method"
+
+
+@dataclass(frozen=True)
+class Completion:
+    label: str
+    detail: str
+    kind: str
+    insert_text: str
+    sort_text: Optional[str] = None
+    feasible: bool = True
+    documentation: Optional[str] = None
+
+
+# --------------------------------------------------------------------------- #
+# Type formatting
+# --------------------------------------------------------------------------- #
+
+_CLEAN_BINDER = Name("ν", 0)
+
+
+def format_type(t: Type) -> str:
+    """A readable, refinement-preserving rendering of a core type.
+
+    Trivial (``True``) refinements are dropped; a non-trivial refinement's bound
+    variable is normalised to ``ν`` so the user sees ``{ν:Int | ν > 0}`` rather
+    than the checker's internal ``v⁴⁴⁸``. Falls back to ``str`` for shapes the
+    structural printer does not special-case."""
+    try:
+        return _fmt(t)
+    except Exception:
+        return str(t)
+
+
+def _fmt(t: Type) -> str:
+    match t:
+        case Top():
+            return "⊤"
+        case TypeVar(name):
+            return name.pretty()
+        case TypeConstructor(name, args):
+            if not args:
+                return name.pretty()
+            return f"{name.pretty()} " + " ".join(_fmt_atom(a) for a in args)
+        case RefinedType(name, base, ref):
+            if ref == LiquidLiteralBool(True):
+                return _fmt(base)
+            clean = substitution_in_liquid(ref, LiquidVar(_CLEAN_BINDER), name)
+            return f"{{{_CLEAN_BINDER.pretty()}:{_fmt(base)} | {clean}}}"
+        case AbstractionType(var_name, var_type, rtype):
+            dom = _fmt(var_type)
+            cod = _fmt(rtype)
+            if _name_used_in(rtype, var_name):
+                return f"({var_name.pretty()}:{dom}) -> {cod}"
+            return f"{dom} -> {cod}"
+        case TypePolymorphism(name, _, body):
+            return f"∀{name.pretty()}. {_fmt(body)}"
+        case RefinementPolymorphism(name, sort, body):
+            return f"∀<{name.pretty()}:{_fmt(sort)}>. {_fmt(body)}"
+        case ExistentialType(_, body):
+            return _fmt(body)
+        case _:
+            return str(t)
+
+
+def _fmt_atom(t: Type) -> str:
+    """Like :func:`_fmt` but parenthesises compound types used as arguments."""
+    inner = _fmt(t)
+    if isinstance(t, (AbstractionType, TypeConstructor)) and " " in inner:
+        return f"({inner})"
+    return inner
+
+
+def _name_used_in(t: Type, name: Name) -> bool:
+    from aeon.core.types import type_free_term_vars
+
+    try:
+        return name in type_free_term_vars(t)
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Base-type extraction
+# --------------------------------------------------------------------------- #
+
+
+def base_type_name(t: Type) -> Optional[str]:
+    """The name of ``t``'s underlying type constructor / variable — the
+    namespace its methods live in — peeling refinements and existentials."""
+    match t:
+        case RefinedType(_, base, _):
+            return base_type_name(base)
+        case ExistentialType(_, body):
+            return base_type_name(body)
+        case TypeConstructor(name, _):
+            return name.pretty()
+        case TypeVar(name):
+            return name.pretty()
+        case _:
+            return None
+
+
+# --------------------------------------------------------------------------- #
+# Receiver detection (textual)
+# --------------------------------------------------------------------------- #
+
+_WORD_RE = re.compile(r"[A-Za-z0-9_]")
+_INT_RE = re.compile(r"^-?\d+$")
+_FLOAT_RE = re.compile(r"^-?\d+\.\d+$")
+_STRING_RE = re.compile(r'^".*"$')
+
+
+@dataclass(frozen=True)
+class DotContext:
+    receiver_text: str
+    receiver_start: int  # 0-indexed column where the receiver begins
+    receiver_end: int  # 0-indexed column just past the receiver (the '.')
+    prefix: str  # the partial method name already typed after the dot
+
+
+def _is_word(c: str) -> bool:
+    return bool(_WORD_RE.match(c))
+
+
+def _scan_receiver_left(line: str, dot: int) -> Optional[int]:
+    """Given the index of a ``.``, return the start column of the receiver
+    expression immediately to its left, or ``None`` if there is none."""
+    if dot <= 0:
+        return None
+    i = dot - 1
+    c = line[i]
+    if c == ")":
+        depth = 0
+        while i >= 0:
+            if line[i] == ")":
+                depth += 1
+            elif line[i] == "(":
+                depth -= 1
+                if depth == 0:
+                    return i
+            i -= 1
+        return None
+    if c == '"':
+        i -= 1
+        while i >= 0:
+            if line[i] == '"':
+                return i
+            i -= 1
+        return None
+    if _is_word(c) or c == ".":
+        # A run of identifier characters and dots (covers `n`, `n.double`,
+        # `Int`, `1`, `1.5`). Stop at whitespace or an operator/paren.
+        while i >= 0 and (_is_word(line[i]) or line[i] == "."):
+            i -= 1
+        return i + 1
+    return None
+
+
+def parse_dot_context(line: str, character: int) -> Optional[DotContext]:
+    """If the 0-indexed cursor sits in a ``receiver.<prefix>`` position, return
+    its :class:`DotContext`; otherwise ``None``."""
+    if character > len(line):
+        character = len(line)
+    j = character
+    while j > 0 and _is_word(line[j - 1]):
+        j -= 1
+    prefix = line[j:character]
+    if j == 0 or line[j - 1] != ".":
+        return None
+    dot = j - 1
+    start = _scan_receiver_left(line, dot)
+    if start is None or start == dot:
+        return None
+    return DotContext(
+        receiver_text=line[start:dot],
+        receiver_start=start,
+        receiver_end=dot,
+        prefix=prefix,
+    )
+
+
+def literal_base_type(text: str) -> Optional[str]:
+    """The base type of a literal receiver, or ``None`` if ``text`` is not a
+    recognised literal."""
+    text = text.strip()
+    if _FLOAT_RE.match(text):
+        return "Float"
+    if _INT_RE.match(text):
+        return "Int"
+    if _STRING_RE.match(text):
+        return "String"
+    if text in ("true", "false"):
+        return "Bool"
+    return None
+
+
+def _is_simple_identifier(text: str) -> bool:
+    return bool(text) and "." not in text and "(" not in text and not literal_base_type(text)
+
+
+# --------------------------------------------------------------------------- #
+# Method-type inspection (for Tier 3 receiver-parameter analysis)
+# --------------------------------------------------------------------------- #
+
+
+def method_receiver_param_type(method_type: Type, type_name: str) -> Optional[Type]:
+    """The declared type of the parameter a ``receiver.method`` call fills.
+
+    Mirrors elaboration's receiver placement: walk the arrow spine (skipping
+    type-/refinement-polymorphism binders) and return the first explicit
+    parameter whose base type matches ``type_name``. Instance-dictionary
+    parameters carry a class type whose name will not match, so they are skipped
+    naturally."""
+    ty = method_type
+    while True:
+        match ty:
+            case TypePolymorphism(_, _, body) | RefinementPolymorphism(_, _, body):
+                ty = body
+            case AbstractionType(_, var_type, rtype):
+                if base_type_name(var_type) == type_name:
+                    return var_type
+                ty = rtype
+            case _:
+                return None
+
+
+def _has_nontrivial_refinement(t: Type) -> bool:
+    return isinstance(t, RefinedType) and t.refinement != LiquidLiteralBool(True)
+
+
+def receiver_satisfies(ctx: TypingContext, receiver_type: Type, param_type: Type, loc) -> Optional[bool]:
+    """Whether ``receiver_type`` is a subtype of the method's receiver parameter
+    ``param_type`` (i.e. the receiver meets the method's precondition).
+
+    Returns ``True``/``False`` when SMT decides it, or ``None`` when the question
+    is not crisply decidable here (generic parameter, solver error) — callers
+    treat ``None`` as "do not penalise"."""
+    if not _has_nontrivial_refinement(param_type):
+        return True
+    try:
+        from aeon.typechecking.entailment import entailment
+        from aeon.verification.sub import sub
+        from aeon.verification.vcs import LiquidConstraint
+
+        constraint = sub(ctx, receiver_type, param_type, loc)
+        if constraint == LiquidConstraint(LiquidLiteralBool(False)):
+            return False
+        return bool(entailment(ctx, constraint))
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Candidate enumeration
+# --------------------------------------------------------------------------- #
+
+
+def _dedup_latest(vars_: list[tuple[Name, Type]]) -> list[tuple[Name, Type]]:
+    """Keep the innermost binding per surface name (``with_var`` appends, so the
+    last occurrence shadows earlier ones)."""
+    latest: dict[str, tuple[Name, Type]] = {}
+    for name, ty in vars_:
+        latest[name.pretty()] = (name, ty)
+    return list(latest.values())
+
+
+def _post_receiver_signature(method_type: Type, type_name: str) -> str:
+    """The method's type with its receiver parameter removed — what the user
+    still has to supply after ``receiver.method``."""
+    removed = False
+    parts: list[str] = []
+    ty = method_type
+    while isinstance(ty, (TypePolymorphism, RefinementPolymorphism)):
+        ty = ty.body
+    while isinstance(ty, AbstractionType):
+        if not removed and base_type_name(ty.var_type) == type_name:
+            removed = True
+        else:
+            parts.append(_fmt_atom(ty.var_type))
+        ty = ty.type
+    parts.append(format_type(ty))
+    return " -> ".join(parts)
+
+
+def method_completions(
+    type_name: str,
+    scope_vars: list[tuple[Name, Type]],
+    *,
+    receiver_obs=None,
+    enable_feasibility: bool = True,
+) -> list[Completion]:
+    """All methods defined on ``type_name``, as completion records.
+
+    When ``receiver_obs`` (a :class:`~aeon.lsp.typeindex.TypeObservation`) is
+    given and ``enable_feasibility`` is set, each candidate is checked against
+    the receiver's known refinement (Tier 3) and infeasible ones are de-ranked
+    and annotated."""
+    seen: set[str] = set()
+    out: list[Completion] = []
+    prefixes = (f"{type_name}.", f"{type_name}_")
+    for name, ty in _dedup_latest(scope_vars):
+        nm = name.name
+        method: Optional[str] = None
+        for p in prefixes:
+            if nm.startswith(p) and len(nm) > len(p):
+                method = nm[len(p) :]
+                break
+        if method is None or method in seen:
+            continue
+        seen.add(method)
+
+        feasible = True
+        documentation = format_type(ty)
+        if enable_feasibility and receiver_obs is not None:
+            param_type = method_receiver_param_type(ty, type_name)
+            if param_type is not None and _has_nontrivial_refinement(param_type):
+                verdict = receiver_satisfies(receiver_obs.ctx, receiver_obs.type, param_type, receiver_obs.loc)
+                if verdict is False:
+                    feasible = False
+                    documentation = (
+                        f"⚠ receiver may not satisfy precondition `{format_type(param_type)}`\n\n{documentation}"
+                    )
+                elif verdict is True:
+                    documentation = f"✓ receiver satisfies `{format_type(param_type)}`\n\n{documentation}"
+
+        # Feasible methods sort before infeasible ones; alphabetical within each.
+        sort_rank = "1" if not feasible else "0"
+        out.append(
+            Completion(
+                label=method,
+                detail=_post_receiver_signature(ty, type_name),
+                kind=KIND_METHOD,
+                insert_text=method,
+                sort_text=f"{sort_rank}{method}",
+                feasible=feasible,
+                documentation=documentation,
+            )
+        )
+    return sorted(out, key=lambda c: c.sort_text or c.label)
+
+
+def identifier_completions(scope_vars: list[tuple[Name, Type]]) -> list[Completion]:
+    """Plain identifiers in scope (locals and globals), excluding the dotted
+    method names that belong to dot completion."""
+    out: list[Completion] = []
+    for name, ty in _dedup_latest(scope_vars):
+        label = name.pretty()
+        if "." in name.name:
+            continue
+        kind = KIND_FUNCTION if isinstance(_strip_foralls(ty), AbstractionType) else KIND_VARIABLE
+        out.append(
+            Completion(
+                label=label,
+                detail=format_type(ty),
+                kind=kind,
+                insert_text=label,
+                sort_text=label,
+                documentation=format_type(ty),
+            )
+        )
+    return sorted(out, key=lambda c: c.label)
+
+
+def _strip_foralls(t: Type) -> Type:
+    while isinstance(t, (TypePolymorphism, RefinementPolymorphism)):
+        t = t.body
+    return t
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def _literal_observation(text: str, ctx: TypingContext):
+    """A synthetic :class:`TypeObservation` for a literal receiver, so Tier-3
+    feasibility works for ``1.foo`` just as it does for variables."""
+    from aeon.lsp.typeindex import TypeObservation
+    from aeon.typechecking.typeinfer import (
+        prim_litbool,
+        prim_litfloat,
+        prim_litint,
+        prim_litstring,
+    )
+    from aeon.utils.location import SynthesizedLocation
+
+    text = text.strip()
+    try:
+        if _FLOAT_RE.match(text):
+            ty: Type = prim_litfloat(float(text))
+        elif _INT_RE.match(text):
+            ty = prim_litint(int(text))
+        elif _STRING_RE.match(text):
+            ty = prim_litstring(text[1:-1])
+        elif text in ("true", "false"):
+            ty = prim_litbool(text == "true")
+        else:
+            return None
+    except Exception:
+        return None
+    # SynthesizedLocation is acceptable here: feasibility only reads the type and
+    # context, and ``sub`` uses ``loc`` purely for error provenance.
+    return TypeObservation(SynthesizedLocation("literal-receiver"), ctx, ty)  # type: ignore[arg-type]
+
+
+def _resolve_receiver(dot: DotContext, line: int, typing_ctx, type_index, scope_ctx, scope_vars):
+    """Resolve the receiver to ``(base_type_name, receiver_observation)``.
+
+    ``receiver_observation`` may be ``None`` when the type is known but no
+    refinement context is available (then Tier-3 feasibility is skipped)."""
+    text = dot.receiver_text
+    lit = literal_base_type(text)
+    if lit is not None:
+        obs = _literal_observation(text, typing_ctx) if typing_ctx is not None else None
+        return lit, obs
+    if type_index is not None:
+        obs = type_index.obs_covering(line, dot.receiver_start, dot.receiver_end)
+        if obs is not None:
+            bn = base_type_name(obs.type)
+            if bn is not None:
+                return bn, obs
+    if _is_simple_identifier(text):
+        # The receiver is a plain name the position index didn't cover (often
+        # because the live, half-typed buffer no longer matches the last good
+        # parse). Look the name up by string and synthesise an observation from
+        # its declared type so Tier-3 feasibility still applies.
+        from aeon.lsp.typeindex import TypeObservation
+        from aeon.utils.location import SynthesizedLocation
+
+        for name, ty in _dedup_latest(scope_vars):
+            if name.pretty() == text:
+                bn = base_type_name(ty)
+                if bn is not None:
+                    ctx = scope_ctx if scope_ctx is not None else typing_ctx
+                    obs = (
+                        TypeObservation(SynthesizedLocation("receiver-var"), ctx, ty)  # type: ignore[arg-type]
+                        if ctx is not None
+                        else None
+                    )
+                    return bn, obs
+    return None, None
+
+
+def compute_completions(
+    source: str,
+    line: int,
+    character: int,
+    typing_ctx: Optional[TypingContext],
+    type_index=None,
+    *,
+    enable_feasibility: bool = True,
+) -> list[Completion]:
+    """Top-level entry: completions for the 0-indexed cursor in ``source``.
+
+    ``type_index`` is the last successfully-built
+    :class:`~aeon.lsp.typeindex.TypeIndex` for the document (used for locals and
+    receiver types); ``typing_ctx`` is the global fallback context."""
+    lines = source.splitlines()
+    line_text = lines[line] if 0 <= line < len(lines) else ""
+
+    scope_ctx = None
+    if type_index is not None:
+        scope_ctx = type_index.scope_at(line, character)
+    if scope_ctx is None:
+        scope_ctx = typing_ctx
+    scope_vars = scope_ctx.vars() if scope_ctx is not None else []
+
+    dot = parse_dot_context(line_text, character)
+    if dot is None:
+        return identifier_completions(scope_vars)
+
+    type_name, receiver_obs = _resolve_receiver(dot, line, typing_ctx, type_index, scope_ctx, scope_vars)
+    if type_name is None:
+        return []
+    return method_completions(
+        type_name,
+        scope_vars,
+        receiver_obs=receiver_obs,
+        enable_feasibility=enable_feasibility,
+    )

--- a/aeon/lsp/navigation.py
+++ b/aeon/lsp/navigation.py
@@ -1,0 +1,216 @@
+"""Structural LSP features over the core AST: document symbols, go-to-definition
+and inlay hints.
+
+All of these walk the elaborated core program (``driver.core``) once. Core node
+ranges are 1-indexed; the plain dataclasses returned here keep that convention,
+and the server converts to 0-indexed LSP positions in one place.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+from aeon.core.terms import Abstraction, Let, Rec, Term, TypeAbstraction, Var
+from aeon.core.types import AbstractionType, RefinementPolymorphism, Type, TypePolymorphism
+from aeon.utils.location import FileLocation
+from aeon.utils.name import Name
+
+# A core range, 1-indexed, end-exclusive: (start_line, start_col, end_line, end_col)
+Span = tuple[int, int, int, int]
+
+
+def _span(loc) -> Optional[Span]:
+    if not isinstance(loc, FileLocation):
+        return None
+    (sl, sc), (el, ec) = loc.get_start(), loc.get_end()
+    return (sl, sc, el, ec)
+
+
+def iter_terms(t: Term) -> Iterator[Term]:
+    """Yield ``t`` and every ``Term`` reachable from it (pre-order)."""
+    import dataclasses
+    from typing import Any, cast
+
+    yield t
+    if not dataclasses.is_dataclass(t):
+        return
+    for f in dataclasses.fields(cast(Any, t)):
+        v = getattr(t, f.name)
+        if isinstance(v, Term):
+            yield from iter_terms(v)
+        elif isinstance(v, (list, tuple)):
+            for it in v:
+                if isinstance(it, Term):
+                    yield from iter_terms(it)
+
+
+def _is_function_type(t: Type) -> bool:
+    while isinstance(t, (TypePolymorphism, RefinementPolymorphism)):
+        t = t.body
+    return isinstance(t, AbstractionType)
+
+
+def _name_range_after(source_lines: list[str], start_line: int, start_col: int, name: str) -> Optional[Span]:
+    """Locate ``name`` as a whole word at/after the 1-indexed ``(start_line,
+    start_col)`` and return its 1-indexed span. Used to point selection ranges
+    and definitions at the bound identifier rather than the whole binding."""
+    if not name:
+        return None
+    pattern = re.compile(r"(?<![A-Za-z0-9_.])" + re.escape(name) + r"(?![A-Za-z0-9_.])")
+    li = start_line - 1
+    col = start_col - 1
+    # Search at most a handful of lines forward (binder names are near the keyword).
+    for line_idx in range(li, min(li + 3, len(source_lines))):
+        text = source_lines[line_idx]
+        from_col = col if line_idx == li else 0
+        m = pattern.search(text, from_col)
+        if m:
+            return (line_idx + 1, m.start() + 1, line_idx + 1, m.end() + 1)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Document symbols
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class SymbolInfo:
+    name: str
+    detail: str
+    is_function: bool
+    full_range: Span
+    selection_range: Span
+
+
+def document_symbols(core: Term, source: str) -> list[SymbolInfo]:
+    """Top-level definitions, in source order. Every ``def`` lowers to a ``Rec``
+    on the outer spine whose ``body`` is the next definition; we walk that spine
+    until the trailing expression (``main``)."""
+    from aeon.lsp.completion import format_type
+
+    lines = source.splitlines()
+    out: list[SymbolInfo] = []
+    cur: Term = core
+    while isinstance(cur, Rec):
+        full = _span(cur.loc)
+        if full is not None:
+            sel = _name_range_after(lines, full[0], full[1], cur.var_name.name) or full
+            out.append(
+                SymbolInfo(
+                    name=cur.var_name.name,
+                    detail=format_type(cur.var_type),
+                    is_function=_is_function_type(cur.var_type),
+                    full_range=full,
+                    selection_range=sel,
+                )
+            )
+        cur = cur.body
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Go-to-definition
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class DefIndex:
+    """Maps every variable *use* range to the *definition* range of its binder."""
+
+    uses: list[tuple[Span, Name]]
+    defs: dict[Name, Span]
+
+    def definition_at(self, line0: int, char0: int) -> Optional[Span]:
+        """The binder span for the use under the 0-indexed cursor, or ``None``."""
+        pos = (line0 + 1, char0 + 1)
+        best: Optional[tuple[Span, Name]] = None
+        for span, name in self.uses:
+            sl, sc, el, ec = span
+            if (sl, sc) <= pos < (el, ec):
+                if best is None or _span_size(span) <= _span_size(best[0]):
+                    best = (span, name)
+        if best is None:
+            return None
+        return self.defs.get(best[1])
+
+
+def _span_size(s: Span) -> tuple[int, int]:
+    return (s[2] - s[0], s[3] - s[1])
+
+
+def build_def_index(core: Term, source: str) -> DefIndex:
+    lines = source.splitlines()
+    uses: list[tuple[Span, Name]] = []
+    defs: dict[Name, Span] = {}
+    for t in iter_terms(core):
+        if isinstance(t, Var):
+            sp = _span(t.loc)
+            if sp is not None:
+                uses.append((sp, t.name))
+        elif isinstance(t, (Rec, Let)):
+            sp = _span(t.loc)
+            if sp is not None and t.var_name not in defs:
+                defs[t.var_name] = _name_range_after(lines, sp[0], sp[1], t.var_name.name) or sp
+        elif isinstance(t, Abstraction):
+            sp = _span(t.loc)
+            if sp is not None and t.var_name not in defs:
+                # Parameter binder; point at the name if we can find it nearby.
+                defs[t.var_name] = _name_range_after(lines, sp[0], sp[1], t.var_name.name) or sp
+        elif isinstance(t, TypeAbstraction):
+            sp = _span(t.loc)
+            if sp is not None and t.name not in defs:
+                defs[t.name] = sp
+    return DefIndex(uses, defs)
+
+
+# --------------------------------------------------------------------------- #
+# Inlay hints (inferred types on un-annotated let bindings)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class InlayInfo:
+    line: int  # 1-indexed, position to place the hint
+    character: int  # 1-indexed
+    label: str
+
+
+def inlay_hints(core: Term, source: str, type_index) -> list[InlayInfo]:
+    """Inferred-type hints for un-annotated ``let`` bindings.
+
+    An annotated ``let x : T = …`` lowers to a ``Rec`` (the user already sees
+    ``T``); only un-annotated bindings lower to ``Let``, and those are exactly
+    where showing the inferred (refined) type is worth the screen space — e.g.
+    ``let x = 41`` gets ``: {ν:Int | ν == 41}``."""
+    from aeon.lsp.completion import format_type
+
+    if type_index is None:
+        return []
+    lines = source.splitlines()
+    out: list[InlayInfo] = []
+    for t in iter_terms(core):
+        if not isinstance(t, Let):
+            continue
+        binder = _span(t.loc)
+        if binder is None:
+            continue
+        name_span = _name_range_after(lines, binder[0], binder[1], t.var_name.name)
+        if name_span is None:
+            continue
+        vspan = _span(t.var_value.loc)
+        if vspan is None:
+            continue
+        obs = type_index.obs_covering(vspan[0] - 1, vspan[1] - 1, vspan[3] - 1)
+        if obs is None:
+            continue
+        out.append(
+            InlayInfo(
+                line=name_span[2],
+                character=name_span[3],
+                label=f": {format_type(obs.type)}",
+            )
+        )
+    return out

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -4,9 +4,12 @@ from typing import List, Optional, AsyncIterable
 from lsprotocol.types import (
     TEXT_DOCUMENT_CODE_ACTION,
     TEXT_DOCUMENT_COMPLETION,
+    TEXT_DOCUMENT_DEFINITION,
     TEXT_DOCUMENT_DID_OPEN,
     TEXT_DOCUMENT_DID_CHANGE,
+    TEXT_DOCUMENT_DOCUMENT_SYMBOL,
     TEXT_DOCUMENT_HOVER,
+    TEXT_DOCUMENT_INLAY_HINT,
     WORKSPACE_DID_CHANGE_WATCHED_FILES,
     ApplyWorkspaceEditParams,
     CodeAction,
@@ -15,20 +18,31 @@ from lsprotocol.types import (
     CodeActionParams,
     Command,
     CompletionItem,
+    CompletionItemKind,
+    CompletionItemTag,
     CompletionOptions,
     CompletionParams,
+    DefinitionParams,
     DidChangeTextDocumentParams,
     DidChangeWatchedFilesParams,
     DidOpenTextDocumentParams,
     Diagnostic,
+    DocumentSymbol,
+    DocumentSymbolParams,
     Hover,
     HoverParams,
+    InlayHint,
+    InlayHintKind,
+    InlayHintParams,
+    Location,
     MarkupContent,
     MarkupKind,
     MessageType,
+    Position,
     PublishDiagnosticsParams,
     ShowMessageParams,
     Range,
+    SymbolKind,
     TextEdit,
     WorkspaceEdit,
 )
@@ -127,33 +141,142 @@ class AeonLanguageServer(LanguageServer):
             ls: AeonLanguageServer,
             params: HoverParams,
         ) -> Optional[Hover]:
-            await asyncio.sleep(ls.debounce_delay)
+            from . import aeon_adapter
+            from aeon.lsp.completion import format_type
+
             document = ls.workspace.get_text_document(params.text_document.uri)
             source = document.source
-            word = _get_word_at_position(source, params.position.line, params.position.character)
+            line, character = params.position.line, params.position.character
+            word = _get_word_at_position(source, line, character)
+
+            # Position-accurate hover: the inferred (refined) type of the
+            # expression under the cursor, from the type index.
+            index = aeon_adapter.get_type_index(params.text_document.uri)
+            if index is not None:
+                result = index.type_at(line, character)
+                if result is not None:
+                    ty, loc = result
+                    lhs = f"{word} : " if word else ""
+                    return Hover(
+                        contents=MarkupContent(
+                            kind=MarkupKind.Markdown,
+                            value=f"```aeon\n{lhs}{format_type(ty)}\n```",
+                        ),
+                        range=_loc_to_range(loc),
+                    )
+
+            # Fallback: top-level name match (e.g. hovering a definition's name,
+            # which is a binder and has no synthesized-expression observation).
             if not word:
                 return None
-            try:
-                typing_ctx = ls.aeon_driver.typing_ctx
-            except AttributeError:
+            typing_ctx = aeon_adapter.get_typing_ctx(params.text_document.uri) or getattr(
+                ls.aeon_driver, "typing_ctx", None
+            )
+            if typing_ctx is None:
                 return None
             for name, type_ in typing_ctx.vars():
                 if name.pretty() == word:
                     return Hover(
                         contents=MarkupContent(
                             kind=MarkupKind.Markdown,
-                            value=f"```\n{word} : {type_}\n```",
+                            value=f"```aeon\n{word} : {format_type(type_)}\n```",
                         )
                     )
             return None
 
-        @self.feature(TEXT_DOCUMENT_COMPLETION, CompletionOptions(trigger_characters=["= "]))
+        @self.feature(TEXT_DOCUMENT_COMPLETION, CompletionOptions(trigger_characters=["."]))
         async def lsp_completion(
             ls: AeonLanguageServer,
             params: CompletionParams,
         ) -> Optional[List[CompletionItem]]:
-            await asyncio.sleep(ls.debounce_delay)
-            return []
+            from . import aeon_adapter
+            from aeon.lsp.completion import compute_completions
+
+            document = ls.workspace.get_text_document(params.text_document.uri)
+            source = document.source
+            index = aeon_adapter.get_type_index(params.text_document.uri)
+            typing_ctx = aeon_adapter.get_typing_ctx(params.text_document.uri) or getattr(
+                ls.aeon_driver, "typing_ctx", None
+            )
+            try:
+                completions = compute_completions(
+                    source, params.position.line, params.position.character, typing_ctx, index
+                )
+            except Exception:
+                return []
+            return [_to_completion_item(c) for c in completions]
+
+        @self.feature(TEXT_DOCUMENT_INLAY_HINT)
+        async def inlay_hint(
+            ls: AeonLanguageServer,
+            params: InlayHintParams,
+        ) -> Optional[List[InlayHint]]:
+            from . import aeon_adapter
+            from aeon.lsp.navigation import inlay_hints
+
+            uri = params.text_document.uri
+            core = aeon_adapter.get_core(uri)
+            index = aeon_adapter.get_type_index(uri)
+            if core is None or index is None:
+                return []
+            document = ls.workspace.get_text_document(uri)
+            hints = []
+            for h in inlay_hints(core, document.source, index):
+                # 1-indexed core positions -> 0-indexed LSP.
+                hints.append(
+                    InlayHint(
+                        position=Position(line=h.line - 1, character=h.character - 1),
+                        label=h.label,
+                        kind=InlayHintKind.Type,
+                        padding_left=True,
+                    )
+                )
+            return hints
+
+        @self.feature(TEXT_DOCUMENT_DEFINITION)
+        async def definition(
+            ls: AeonLanguageServer,
+            params: DefinitionParams,
+        ) -> Optional[Location]:
+            from . import aeon_adapter
+            from aeon.lsp.navigation import build_def_index
+
+            uri = params.text_document.uri
+            core = aeon_adapter.get_core(uri)
+            if core is None:
+                return None
+            document = ls.workspace.get_text_document(uri)
+            def_index = build_def_index(core, document.source)
+            span = def_index.definition_at(params.position.line, params.position.character)
+            if span is None:
+                return None
+            return Location(uri=uri, range=_span_to_range(span))
+
+        @self.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)
+        async def document_symbol(
+            ls: AeonLanguageServer,
+            params: DocumentSymbolParams,
+        ) -> Optional[List[DocumentSymbol]]:
+            from . import aeon_adapter
+            from aeon.lsp.navigation import document_symbols
+
+            uri = params.text_document.uri
+            core = aeon_adapter.get_core(uri)
+            if core is None:
+                return []
+            document = ls.workspace.get_text_document(uri)
+            out = []
+            for s in document_symbols(core, document.source):
+                out.append(
+                    DocumentSymbol(
+                        name=s.name,
+                        detail=s.detail,
+                        kind=SymbolKind.Function if s.is_function else SymbolKind.Variable,
+                        range=_span_to_range(s.full_range),
+                        selection_range=_span_to_range(s.selection_range),
+                    )
+                )
+            return out
 
         @self.feature(
             TEXT_DOCUMENT_CODE_ACTION,
@@ -216,6 +339,50 @@ class AeonLanguageServer(LanguageServer):
             ls.window_show_message(
                 ShowMessageParams(type=MessageType.Info, message=f"Synthesized ?{hole_name_str} = {synthesized_str}")
             )
+
+
+_COMPLETION_KIND_MAP = {
+    "method": CompletionItemKind.Method,
+    "function": CompletionItemKind.Function,
+    "variable": CompletionItemKind.Variable,
+}
+
+
+def _loc_to_range(loc) -> Range:
+    """Convert a 1-indexed core ``FileLocation`` to a 0-indexed LSP ``Range``."""
+    (sl, sc), (el, ec) = loc.get_start(), loc.get_end()
+    return Range(
+        start=Position(line=max(sl - 1, 0), character=max(sc - 1, 0)),
+        end=Position(line=max(el - 1, 0), character=max(ec - 1, 0)),
+    )
+
+
+def _span_to_range(span) -> Range:
+    """Convert a 1-indexed ``(sl, sc, el, ec)`` span to a 0-indexed LSP ``Range``."""
+    sl, sc, el, ec = span
+    return Range(
+        start=Position(line=max(sl - 1, 0), character=max(sc - 1, 0)),
+        end=Position(line=max(el - 1, 0), character=max(ec - 1, 0)),
+    )
+
+
+def _to_completion_item(c) -> CompletionItem:
+    """Map a :class:`aeon.lsp.completion.Completion` to an LSP ``CompletionItem``.
+
+    Tier-3-infeasible candidates are tagged ``Deprecated`` so editors render them
+    struck-through, and their ``sortText`` already sinks them below feasible
+    ones."""
+    tags = [CompletionItemTag.Deprecated] if not c.feasible else None
+    documentation = MarkupContent(kind=MarkupKind.Markdown, value=c.documentation) if c.documentation else None
+    return CompletionItem(
+        label=c.label,
+        kind=_COMPLETION_KIND_MAP.get(c.kind, CompletionItemKind.Text),
+        detail=c.detail,
+        documentation=documentation,
+        insert_text=c.insert_text,
+        sort_text=c.sort_text,
+        tags=tags,
+    )
 
 
 def _get_word_at_position(source: str, line: int, character: int) -> Optional[str]:

--- a/aeon/lsp/typeindex.py
+++ b/aeon/lsp/typeindex.py
@@ -1,0 +1,147 @@
+"""Position → type / scope index for the LSP.
+
+The Aeon type checker has no typed AST: ``check_type_errors`` produces only
+pass/fail plus verification conditions, and the driver exposes just the final
+*top-level* typing context. That is enough to list globals, but not to answer
+"what is the type of the expression under the cursor?" or "what is in scope
+*here* (including ``let``/lambda locals)?" — the questions every good hover and
+completion needs.
+
+This module recovers that information without re-implementing the (subtle)
+bidirectional context threading. The bidirectional checker's
+``synth(ctx, term) -> (constraint, type)`` already computes the type of every
+sub-expression with exactly the right context. We temporarily wrap ``synth`` so
+that each call records ``(location, context, synthesized_type)``, run a checking
+pass over the elaborated core program, and index the observations by source
+range. The checker threads contexts correctly, so locals and shadowing fall out
+for free; no SMT solving happens in ``synth``/``check`` (that is deferred to
+entailment), so the extra pass is cheap.
+
+Source ranges from core nodes are **1-indexed** (Lark ``meta.line``/``column``);
+LSP positions are **0-indexed**. All public query methods take 0-indexed
+``(line, character)`` and convert internally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from aeon.core.types import Type
+from aeon.typechecking.context import TypingContext
+from aeon.utils.location import FileLocation, Location
+
+
+@dataclass(frozen=True)
+class TypeObservation:
+    """One node's synthesized type and the context it was synthesized in."""
+
+    loc: FileLocation
+    ctx: TypingContext
+    type: Type
+
+    def start(self) -> tuple[int, int]:
+        return self.loc.get_start()
+
+    def end(self) -> tuple[int, int]:
+        return self.loc.get_end()
+
+    def span(self) -> tuple[int, int]:
+        """A comparable size of the range: (line span, column span). Smaller is
+        tighter, so the most specific enclosing node wins ties of containment."""
+        (sl, sc), (el, ec) = self.start(), self.end()
+        return (el - sl, ec - sc)
+
+
+def _contains(obs: TypeObservation, line1: int, col1: int) -> bool:
+    """Whether the (1-indexed) position ``(line1, col1)`` lies within ``obs``'s
+    half-open range ``[start, end)`` under lexicographic ordering."""
+    return obs.start() <= (line1, col1) < obs.end()
+
+
+@dataclass
+class TypeIndex:
+    """Queryable index of per-node types and scopes for a single document."""
+
+    observations: list[TypeObservation] = field(default_factory=list)
+
+    def _tightest(self, line: int, character: int) -> Optional[TypeObservation]:
+        """The smallest observation whose range contains the 0-indexed cursor.
+
+        Ties (identical ranges, e.g. a variable synthesized more than once) are
+        broken in favour of the *last* recorded observation, which carries the
+        more refined "selfified" type the checker produces for variable uses."""
+        line1, col1 = line + 1, character + 1
+        best: Optional[TypeObservation] = None
+        for obs in self.observations:
+            if not _contains(obs, line1, col1):
+                continue
+            if best is None or obs.span() <= best.span():
+                best = obs
+        return best
+
+    def type_at(self, line: int, character: int) -> Optional[tuple[Type, FileLocation]]:
+        """The inferred type (and its source range) of the tightest expression
+        containing the 0-indexed cursor, or ``None``."""
+        obs = self._tightest(line, character)
+        if obs is None:
+            return None
+        return (obs.type, obs.loc)
+
+    def scope_at(self, line: int, character: int) -> Optional[TypingContext]:
+        """The typing context (locals included) at the cursor, or ``None``."""
+        obs = self._tightest(line, character)
+        return obs.ctx if obs is not None else None
+
+    def obs_covering(self, line: int, start_char: int, end_char: int) -> Optional[TypeObservation]:
+        """The outermost observation fully contained in the 0-indexed span
+        ``[start_char, end_char)`` on ``line`` — i.e. the type of the whole
+        sub-expression occupying that span (a receiver before a ``.``). Returns
+        the *largest* such observation so a parenthesised or chained receiver
+        resolves to the type of the entire expression, not an inner fragment."""
+        s = (line + 1, start_char + 1)
+        e = (line + 1, end_char + 1)
+        best: Optional[TypeObservation] = None
+        for obs in self.observations:
+            if obs.start() >= s and obs.end() <= e:
+                if best is None or obs.span() >= best.span():
+                    best = obs
+        return best
+
+
+def build_type_index(typing_ctx: TypingContext, core, expected: Optional[Type] = None) -> TypeIndex:
+    """Build a :class:`TypeIndex` for ``core`` checked under ``typing_ctx``.
+
+    Wraps ``aeon.typechecking.typeinfer.synth`` for the duration of one checking
+    pass so every synthesized node is recorded. The wrapper delegates to the
+    original ``synth`` (so recursion still flows through the wrapped global and
+    every node is captured), and is always restored afterwards. A checking
+    failure on an ill-typed program is swallowed — whatever was observed before
+    the failure is still useful for tooling."""
+    import aeon.typechecking.typeinfer as ti
+    from aeon.core.types import top
+
+    if expected is None:
+        expected = top
+
+    observations: list[TypeObservation] = []
+    original_synth = ti.synth
+
+    def recording_synth(ctx: TypingContext, t):
+        result = original_synth(ctx, t)
+        loc: Location = getattr(t, "loc", None)
+        if isinstance(loc, FileLocation):
+            observations.append(TypeObservation(loc, ctx, result[1]))
+        return result
+
+    ti.synth = recording_synth
+    try:
+        try:
+            ti.check(typing_ctx, core, expected)
+        except Exception:
+            # Ill-typed (or partially typed) program: keep partial observations.
+            pass
+    finally:
+        ti.synth = original_synth
+
+    return TypeIndex(observations)

--- a/tests/lsp_features_test.py
+++ b/tests/lsp_features_test.py
@@ -1,0 +1,346 @@
+"""Tests for the type-aware LSP features: position→type index, refinement-aware
+completion (Tiers 1–3), inferred-type inlay hints, document symbols and
+go-to-definition."""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.lsp import completion as C
+from aeon.lsp import navigation as N
+from aeon.lsp.typeindex import build_type_index
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def analyse(src: str):
+    """Parse ``src`` and return ``(driver, type_index, errors)``. The type index
+    is built whenever core generation succeeded, even if type checking failed."""
+    cfg = AeonConfig(synthesizer="gp", synthesis_ui=SilentSynthesisUI(), synthesis_budget=1)
+    d = AeonDriver(cfg)
+    errors = list(d.parse(filename="file:///t.ae", aeon_code=src))
+    index = build_type_index(d.typing_ctx, d.core) if getattr(d, "core", None) is not None else None
+    return d, index, errors
+
+
+def labels(comps):
+    return [c.label for c in comps]
+
+
+def by_label(comps, label):
+    return next(c for c in comps if c.label == label)
+
+
+def col_after(src, line0, needle):
+    """0-indexed column just past ``needle`` on (0-indexed) ``line0``."""
+    text = src.splitlines()[line0]
+    return text.index(needle) + len(needle)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers: receiver detection, base types, formatting
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_dot_context_simple_identifier():
+    line = "    n.dou"
+    ctx = C.parse_dot_context(line, len(line))
+    assert ctx is not None
+    assert ctx.receiver_text == "n"
+    assert ctx.prefix == "dou"
+
+
+def test_parse_dot_context_literal():
+    ctx = C.parse_dot_context("1.", 2)
+    assert ctx is not None
+    assert ctx.receiver_text == "1"
+    assert ctx.prefix == ""
+
+
+def test_parse_dot_context_parenthesised_receiver():
+    line = "(1.plus 2)."
+    ctx = C.parse_dot_context(line, len(line))
+    assert ctx is not None
+    assert ctx.receiver_text == "(1.plus 2)"
+
+
+def test_parse_dot_context_none_without_dot():
+    assert C.parse_dot_context("let n = 3", 9) is None
+
+
+def test_literal_base_type():
+    assert C.literal_base_type("1") == "Int"
+    assert C.literal_base_type("1.5") == "Float"
+    assert C.literal_base_type('"hi"') == "String"
+    assert C.literal_base_type("true") == "Bool"
+    assert C.literal_base_type("n") is None
+
+
+def test_format_type_normalises_refinement_binder():
+    # The internal binder (e.g. v⁴⁴) is normalised to ν and trivial refinements
+    # are dropped.
+    _, index, _ = analyse("def main (u:Int) : Int =\n    let x = 7 in\n    x;\n")
+    r = index.type_at(1, col_after("def main (u:Int) : Int =\n    let x = 7 in\n    x;\n", 1, "7") - 1)
+    assert r is not None
+    s = C.format_type(r[0])
+    assert s.startswith("{ν:Int |") and "== 7" in s
+
+
+# --------------------------------------------------------------------------- #
+# Type index keystone
+# --------------------------------------------------------------------------- #
+
+
+def test_type_index_recovers_refined_literal_type():
+    src = "def main (u:Int) : Int =\n    let x = 41 in\n    x;\n"
+    _, index, errs = analyse(src)
+    assert errs == []
+    # cursor on the '1' of '41' (line 1, the literal starts after 'let x = ')
+    c = src.splitlines()[1].index("41")
+    r = index.type_at(1, c)
+    assert r is not None
+    assert "41" in str(r[0])
+
+
+def test_type_index_includes_locals_in_scope():
+    src = "def main (u:Int) : Int =\n    let x = 41 in\n    x;\n"
+    _, index, _ = analyse(src)
+    c = src.splitlines()[2].index("x")
+    scope = index.scope_at(2, c)
+    assert scope is not None
+    assert any(n.name == "x" for n, _ in scope.vars())
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1 & 2 completion
+# --------------------------------------------------------------------------- #
+
+METHODS_SRC = (
+    'def Int.toString (n:Int) : String = native "str(n)";\n'
+    "def Int.double (n:Int) : Int = n + n;\n"
+    "def main (u:Int) : Int =\n"
+    "    let n = 4 in\n"
+    "    n.double;\n"
+)
+
+
+def test_tier1_literal_receiver_lists_methods():
+    d, index, errs = analyse(METHODS_SRC)
+    assert errs == []
+    # Probe inside main's body where the Int methods are in scope: replace the
+    # receiver position with a literal dot. Use the real 'n.double' line.
+    line0 = 4
+    col = col_after(METHODS_SRC, line0, "n.")
+    comps = C.compute_completions(METHODS_SRC, line0, col, d.typing_ctx, index)
+    assert "double" in labels(comps)
+    assert "toString" in labels(comps)
+
+
+def test_tier2_variable_receiver_post_receiver_signature():
+    d, index, _ = analyse(METHODS_SRC)
+    line0 = 4
+    col = col_after(METHODS_SRC, line0, "n.")
+    comps = C.compute_completions(METHODS_SRC, line0, col, d.typing_ctx, index)
+    double = by_label(comps, "double")
+    # `Int.double : Int -> Int`; after the receiver is consumed, nothing remains
+    # but the return type.
+    assert double.detail == "Int"
+
+
+def test_identifier_completion_without_dot():
+    d, index, _ = analyse(METHODS_SRC)
+    line0 = 4
+    # cursor right after 'n' (no dot) -> identifier completion includes 'n'
+    col = col_after(METHODS_SRC, line0, "    n")
+    comps = C.compute_completions(METHODS_SRC, line0, col - 1, d.typing_ctx, index)
+    assert "n" in labels(comps)
+
+
+# --------------------------------------------------------------------------- #
+# Tier 3: refinement-aware feasibility
+# --------------------------------------------------------------------------- #
+
+REFINED_SRC = (
+    "def Int.half (x:{v:Int | v % 2 == 0}) : Int = x / 2;\n"
+    "def main (u:Int) : Int =\n"
+    "    let a : {v:Int | v == 4} = 4 in\n"
+    "    let b : {v:Int | v == 5} = 5 in\n"
+    "    a.half;\n"
+)
+
+
+def _half_for_receiver(varname):
+    d, index, _ = analyse(REFINED_SRC)
+    line0 = 4
+    col = col_after(REFINED_SRC, line0, "a.")
+    scope = index.scope_at(line0, col)
+    scope_vars = scope.vars()
+    from aeon.lsp.typeindex import TypeObservation
+    from aeon.utils.location import SynthesizedLocation
+
+    ty = next(t for n, t in scope_vars if n.name == varname)
+    obs = TypeObservation(SynthesizedLocation("x"), scope, ty)
+    comps = C.method_completions("Int", scope_vars, receiver_obs=obs, enable_feasibility=True)
+    return by_label(comps, "half")
+
+
+def test_tier3_even_receiver_is_feasible():
+    half = _half_for_receiver("a")  # a == 4, even
+    assert half.feasible is True
+    assert half.sort_text.startswith("0")
+    assert "satisfies" in half.documentation
+
+
+def test_tier3_odd_receiver_is_infeasible():
+    half = _half_for_receiver("b")  # b == 5, odd -> violates v % 2 == 0
+    assert half.feasible is False
+    assert half.sort_text.startswith("1")  # de-ranked below feasible methods
+    assert "precondition" in half.documentation
+
+
+def test_tier3_receiver_satisfies_decides_subtyping():
+    from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidVar
+    from aeon.core.types import RefinedType, t_int
+    from aeon.typechecking.context import TypingContext
+    from aeon.utils.location import SynthesizedLocation
+    from aeon.utils.name import Name
+
+    def eq(n, val):
+        v = Name(n, 1)
+        return RefinedType(v, t_int, LiquidApp(Name("==", 0), [LiquidVar(v), LiquidLiteralInt(val)]))
+
+    def even(n):
+        v = Name(n, 1)
+        ref = LiquidApp(
+            Name("==", 0),
+            [LiquidApp(Name("%", 0), [LiquidVar(v), LiquidLiteralInt(2)]), LiquidLiteralInt(0)],
+        )
+        return RefinedType(v, t_int, ref)
+
+    ctx = TypingContext()
+    loc = SynthesizedLocation("t")
+    assert C.receiver_satisfies(ctx, eq("a", 4), even("x"), loc) is True
+    assert C.receiver_satisfies(ctx, eq("b", 5), even("x"), loc) is False
+
+
+# --------------------------------------------------------------------------- #
+# Navigation: symbols, definition, inlay hints
+# --------------------------------------------------------------------------- #
+
+NAV_SRC = "def inc (n:Int) : Int = n + 1;\ndef main (u:Int) : Int =\n    let x = 41 in\n    let y = inc x in\n    y;\n"
+
+
+def test_document_symbols_lists_top_level_defs():
+    d, _, _ = analyse(NAV_SRC)
+    syms = N.document_symbols(d.core, NAV_SRC)
+    names = [s.name for s in syms]
+    assert names == ["inc", "main"]
+    assert all(s.is_function for s in syms)
+
+
+def test_go_to_definition_resolves_function_use():
+    d, _, _ = analyse(NAV_SRC)
+    di = N.build_def_index(d.core, NAV_SRC)
+    # 'inc' used on line 3 (0-indexed) "    let y = inc x in"
+    col = NAV_SRC.splitlines()[3].index("inc") + 1
+    span = di.definition_at(3, col)
+    assert span is not None
+    assert span[0] == 1  # defined on source line 1 (1-indexed)
+
+
+def test_go_to_definition_resolves_let_binding():
+    d, _, _ = analyse(NAV_SRC)
+    di = N.build_def_index(d.core, NAV_SRC)
+    # 'x' used in 'inc x' on line 3
+    col = NAV_SRC.splitlines()[3].rindex("x")
+    span = di.definition_at(3, col)
+    assert span is not None
+    assert span[0] == 3  # 'let x' on source line 3 (1-indexed)
+
+
+def test_inlay_hints_show_inferred_refinement():
+    d, index, _ = analyse(NAV_SRC)
+    hints = N.inlay_hints(d.core, NAV_SRC, index)
+    by_line = {h.line: h.label for h in hints}
+    # `let x = 41` -> inferred refined Int singleton
+    assert 3 in by_line
+    assert "Int" in by_line[3] and "41" in by_line[3]
+    # `let y = inc x` -> Int
+    assert 4 in by_line
+    assert "Int" in by_line[4]
+
+
+# --------------------------------------------------------------------------- #
+# Driver: core/context retained even when type checking fails
+# --------------------------------------------------------------------------- #
+
+
+def test_core_retained_on_type_error():
+    # Ill-typed: assigning 5 to {v:Int | v == 4}. Type checking fails, but the
+    # program elaborates, so tooling state must still be available.
+    src = "def main (u:Int) : Int =\n    let a : {v:Int | v == 4} = 5 in\n    a;\n"
+    d, index, errs = analyse(src)
+    assert errs, "expected a type error"
+    assert d.core is not None
+    assert d.typing_ctx is not None
+    assert index is not None
+
+
+def test_core_cleared_on_parse_error():
+    src = "def main (u:Int) : Int = !!! not valid"
+    d, index, errs = analyse(src)
+    assert errs
+    assert d.core is None
+    assert index is None
+
+
+# --------------------------------------------------------------------------- #
+# Adapter integration: parse populates the caches the server handlers read
+# --------------------------------------------------------------------------- #
+
+
+class _MockDocument:
+    def __init__(self, source: str):
+        self.source = source
+
+
+class _MockWorkspace:
+    def __init__(self, source: str):
+        self._source = source
+
+    def get_text_document(self, uri: str) -> _MockDocument:
+        return _MockDocument(self._source)
+
+
+class _MockLS:
+    def __init__(self, source: str):
+        cfg = AeonConfig(synthesizer="gp", synthesis_ui=SilentSynthesisUI(), synthesis_budget=1)
+        self.aeon_driver = AeonDriver(cfg)
+        self.workspace = _MockWorkspace(source)
+
+
+def test_adapter_parse_populates_type_index_and_drives_completion():
+    import asyncio
+
+    from aeon.lsp import aeon_adapter
+
+    uri = "file:///integration.ae"
+    ls = _MockLS(METHODS_SRC)
+    asyncio.run(aeon_adapter.parse(ls, uri))
+
+    index = aeon_adapter.get_type_index(uri)
+    typing_ctx = aeon_adapter.get_typing_ctx(uri)
+    assert index is not None and typing_ctx is not None
+
+    col = col_after(METHODS_SRC, 4, "n.")
+    comps = C.compute_completions(METHODS_SRC, 4, col, typing_ctx, index)
+    assert "double" in labels(comps)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Builds a type-aware layer on top of the basic LSP (which had diagnostics, synthesis code-actions, a string-match hover and an empty completion stub), culminating in **refinement-aware dot completion** for the issue-#27 `receiver.method` syntax.

## The keystone — `aeon/lsp/typeindex.py`

Aeon has no typed AST (`check_type_errors` yields only pass/fail + VCs, and the driver exposes just the final top-level context). To recover per-subexpression types, this temporarily wraps the bidirectional checker's `synth` — a module global, so recursive calls flow through the wrapper — and records `(location, context, type)` for every node during one checking pass. No SMT solving happens in `synth`/`check` (deferred to entailment), so the extra pass is cheap. Queries map the tightest enclosing source range to a type and an in-scope context (**locals included**).

## Completion — `aeon/lsp/completion.py` (lsprotocol-free, unit-testable)

- **Tier 1** — literal/identifier receivers (`1.`, `n.`) list the methods on the receiver's base type, using the exact `T.method` / `T_method` convention `ElaborationTypingContext.resolve_method` dispatches on.
- **Tier 2** — arbitrary receivers (`(f x).`); the receiver type is recovered from the index by source range.
- **Tier 3 (refinement-aware)** — when a candidate's receiver parameter is *refined*, an SMT subtyping check (`verification.sub` + `entailment`) decides whether the receiver's known refinement meets the precondition. Infeasible candidates are **de-ranked and annotated** (`CompletionItemTag.Deprecated` → struck-through) rather than hidden, and the precondition is surfaced. E.g. against `def Int.half (x:{v:Int | v % 2 == 0})`, receiver `a≡4` passes (✓, ranked first) while `b≡5` is flagged infeasible (⚠, ranked last).

## Everything else

- **Real hover** — position-accurate inferred (refined) type under the cursor.
- **Inlay hints** — un-annotated `let`s show their inferred refinement, e.g. `let x = 41` → `: {ν:Int | ν == 41}`.
- **Go-to-definition & document symbols** — `aeon/lsp/navigation.py`.
- Fixed the completion trigger character (`"= "` → `"."`).

## Supporting changes

- `AeonDriver.parse` now exposes `core`/`typing_ctx` even when type-checking *fails* (so completion keeps working mid-edit) and nulls them on parse errors so no stale state leaks.
- The adapter keeps last-good per-URI analysis caches (`_refresh_analysis`).

## Notes / gotchas

- Core `FileLocation` is 1-indexed (Lark `meta.line`/`column`); LSP is 0-indexed — converted in one place.
- `def Type.method` dotted defs lower to nested `Rec`s, so they live in the *local* scope at a use site, not the global `typing_ctx`; completion reads `scope_at(pos)`.

## Tests

`tests/lsp_features_test.py` — 21 tests covering the keystone, all three tiers, navigation, inlay hints, the type-error/parse-error driver paths, and the full adapter → completion integration. Existing `lsp_test.py` (61) and `method_call_test.py` still pass; mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)