### PR TITLE
feat(typecheck): reject division and modulo by a zero divisor

### DIFF
--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -252,15 +252,28 @@ def type_infer_liquid(
                 of a TypeConstructor, the return type ``a`` would never
                 be bound to the concrete type at the call site.
                 """
+
+                def _is_numeric(ty: Type) -> bool:
+                    return isinstance(ty, TypeConstructor) and ty.name.name in ("Int", "Float")
+
                 match (actual, expected):
                     case (_, TypeVar(name)):
                         resolved = resolve_type(actual) if isinstance(actual, (TypeConstructor, TypeVar)) else actual
                         if name in equalities:
-                            if resolve_type(TypeVar(name)) != resolved:
-                                raise LiquidTypeCheckException(
-                                    f"Argument {arg} in {liq} is expected to be of type "
-                                    f"{exp_t} ({equalities[name]}), but {k} was found instead."
-                                )
+                            bound = resolve_type(TypeVar(name))
+                            if bound != resolved:
+                                # An integer literal (typed ``Int``) may stand in
+                                # for a ``Float`` operand: Z3 coerces numerals
+                                # across the Int/Real tower, so e.g. the divisor
+                                # refinement ``{v:a | v != 0}`` instantiated at
+                                # ``Float`` still discharges. Widen to ``Float``.
+                                if _is_numeric(bound) and _is_numeric(resolved):
+                                    equalities[name] = t_float
+                                else:
+                                    raise LiquidTypeCheckException(
+                                        f"Argument {arg} in {liq} is expected to be of type "
+                                        f"{exp_t} ({equalities[name]}), but {k} was found instead."
+                                    )
                         else:
                             assert isinstance(resolved, (TypeConstructor, TypeVar))
                             # Skip a self-referential binding ``a := a``: it is
@@ -275,6 +288,9 @@ def type_infer_liquid(
                     ):
                         for a_in, e_in in zip(a_args, e_args):
                             _unify(a_in, e_in)
+                    case (TypeConstructor(_), TypeConstructor(_)) if _is_numeric(actual) and _is_numeric(expected):
+                        # Int/Float mismatch: tolerated as numeric coercion (see above).
+                        pass
                     case (TypeConstructor(t), TypeConstructor(e)):
                         raise LiquidTypeCheckException(
                             f"Argument {arg} in {liq} is expected to be of type {exp_t}, but {k} was found instead."

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -269,11 +269,38 @@ def prim_litstring(t: str) -> RefinedType:
     )
 
 
-def make_binary_app_type(t: Name, ity: TypeConstructor | TypeVar, oty: TypeConstructor | TypeVar) -> Type:
-    """Creates the type of a binary operator"""
+def nonzero_refined(ty: TypeConstructor | TypeVar) -> RefinedType:
+    """Wraps ``ty`` in the refinement ``{v : ty | v != 0}``.
+
+    Used for the divisor parameter of ``/`` and ``%`` so that division by a
+    statically-zero value is rejected at typechecking. The literal ``0`` is an
+    ``Int``; when ``ty`` is ``Float`` (or a base type variable instantiated to
+    it) Z3 coerces the numeral into its sort, so the same refinement discharges
+    for both ``Int`` and ``Float`` divisors (see the Int/Float coercion in
+    ``aeon.typechecking.liquid._unify``)."""
+    vname = Name("v", fresh_counter.fresh())
+    return RefinedType(
+        vname,
+        ty,
+        LiquidApp(Name("!=", 0), [LiquidVar(vname), LiquidLiteralInt(0)]),
+    )
+
+
+def make_binary_app_type(
+    t: Name,
+    ity: TypeConstructor | TypeVar,
+    oty: TypeConstructor | TypeVar,
+    nonzero_divisor: bool = False,
+) -> Type:
+    """Creates the type of a binary operator.
+
+    When ``nonzero_divisor`` is set, the second parameter (the divisor) carries
+    a ``v != 0`` refinement so division/modulo by a statically-zero value is
+    rejected."""
     xname = Name("x", fresh_counter.fresh())
     yname = Name("y", fresh_counter.fresh())
     zname = Name("z", fresh_counter.fresh())
+    yty: Type = nonzero_refined(ity) if nonzero_divisor else ity
     output = RefinedType(
         zname,
         oty,
@@ -288,7 +315,7 @@ def make_binary_app_type(t: Name, ity: TypeConstructor | TypeVar, oty: TypeConst
             ],
         ),
     )
-    appt2 = AbstractionType(yname, ity, output)
+    appt2 = AbstractionType(yname, yty, output)
     appt1 = AbstractionType(xname, ity, appt2)
     return appt1
 
@@ -296,10 +323,14 @@ def make_binary_app_type(t: Name, ity: TypeConstructor | TypeVar, oty: TypeConst
 def prim_op(t: Name) -> Type:
     match t.name:
         case "%":
-            return make_binary_app_type(t, t_int, t_int)
+            return make_binary_app_type(t, t_int, t_int, nonzero_divisor=True)
         case "+" | "-" | "*" | "/":
             name_a = Name("a", fresh_counter.fresh())
-            return TypePolymorphism(name_a, Kind.BASE, make_binary_app_type(t, TypeVar(name_a), TypeVar(name_a)))
+            return TypePolymorphism(
+                name_a,
+                Kind.BASE,
+                make_binary_app_type(t, TypeVar(name_a), TypeVar(name_a), nonzero_divisor=t.name == "/"),
+            )
         case "==" | "!=" | ">" | ">=" | "<" | "<=":
             name_a = Name("a", fresh_counter.fresh())
             return TypePolymorphism(name_a, Kind.BASE, make_binary_app_type(t, TypeVar(name_a), t_bool))

--- a/examples/PSB2/solved/bouncing_balls.ae
+++ b/examples/PSB2/solved/bouncing_balls.ae
@@ -5,14 +5,14 @@ def calculate_distance_helper (b_index: Float) (h: Float) (n: Int) (distance: Fl
 if isZero n then
     distance
 else
-    a: Float = h / b_index;
+    a: Float = if b_index != 0.0 then h / b_index else 0.0;
     n1: Int = n - 1;
     d1: Float = (distance + h) + a;
     calculate_distance_helper b_index a n1 d1
 
 
 def bouncing_balls (s_height: Float) (b_height:Float) (b:Int) : Float=
-    bounciness_index : Float = s_height / b_height;
+    bounciness_index : Float = if b_height != 0.0 then s_height / b_height else 0.0;
     calculate_distance_helper bounciness_index s_height b 0.0
 
 

--- a/examples/PSB2/solved/dice_game.ae
+++ b/examples/PSB2/solved/dice_game.ae
@@ -7,7 +7,7 @@ def peter_wins (n:Int) (m:Int) : Int = if m == 0 then 0 else Math_max 0 (n - m) 
 
 def dice_game (n:Int | 1 <= n && n <= 10000) (m:Int | 1 <= m && m <= 10000) : Float = a : Float = Math_toFloat (peter_wins n m);
      b : Float = Math_toFloat (n * m);
-     c : Float = a / b;
+     c : Float = if b != 0.0 then a / b else 0.0;
      c;
 
 

--- a/tests/division_by_zero_test.py
+++ b/tests/division_by_zero_test.py
@@ -1,0 +1,141 @@
+"""Division and modulo by a statically-zero divisor must be rejected.
+
+The divisor parameter of ``/`` and ``%`` carries a ``{v | v != 0}`` refinement
+(synthesised in ``aeon.typechecking.typeinfer.prim_op``), so the typechecker
+demands a proof that the divisor is non-zero. A guard or a refinement that
+bounds the divisor away from zero discharges the obligation.
+"""
+
+from aeon.facade.api import LiquidTypeCheckingFailedRelation
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SynthesisUI
+
+setup_logger()
+
+
+def _run(source: str):
+    cfg = AeonConfig(synthesizer="none", synthesis_ui=SynthesisUI(), synthesis_budget=0)
+    driver = AeonDriver(cfg)
+    errors = list(driver.parse(aeon_code=source))
+    assert not errors, errors
+    return driver.run()
+
+
+def _errors(source: str):
+    cfg = AeonConfig(synthesizer="none", synthesis_ui=SynthesisUI(), synthesis_budget=0)
+    driver = AeonDriver(cfg)
+    return list(driver.parse(aeon_code=source))
+
+
+def _rejected(source: str) -> bool:
+    return any(isinstance(e, LiquidTypeCheckingFailedRelation) for e in _errors(source))
+
+
+# --- accepted: the divisor is statically known to be non-zero ----------------
+
+
+def test_int_division_by_literal_ok():
+    assert _run("def main (args : Int) : Int = 10 / 2;") == 5
+
+
+def test_int_modulo_by_literal_ok():
+    assert _run("def main (args : Int) : Int = 10 % 3;") == 1
+
+
+def test_float_division_by_literal_ok():
+    assert _run("def main (args : Int) : Int = if 10.0 / 2.0 >= 1.0 then 0 else 1;") == 0
+
+
+def test_int_division_guarded_ok():
+    source = r"""
+    def f (x : Int) (y : Int) : Int = if y != 0 then x / y else 0;
+    def main (args : Int) : Int = f 10 0;
+    """
+    assert _run(source) == 0
+
+
+def test_int_modulo_guarded_ok():
+    source = r"""
+    def f (x : Int) (y : Int) : Int = if y != 0 then x % y else 0;
+    def main (args : Int) : Int = f 10 0;
+    """
+    assert _run(source) == 0
+
+
+def test_float_division_guarded_ok():
+    source = r"""
+    def f (x : Float) (y : Float) : Float = if y != 0.0 then x / y else 0.0;
+    def main (args : Int) : Int = if f 10.0 2.0 >= 1.0 then 0 else 1;
+    """
+    assert _run(source) == 0
+
+
+def test_int_division_refinement_bounded_ok():
+    source = r"""
+    def f (x : Int) (y : {v : Int | v >= 1}) : Int = x / y;
+    def main (args : Int) : Int = f 10 2;
+    """
+    assert _run(source) == 5
+
+
+def test_float_division_refinement_bounded_ok():
+    # A divisor refined away from zero (as in PSB2/bouncing_balls).
+    source = r"""
+    def f (x : Float) (y : {v : Float | 1.0 <= v && v <= 100.0}) : Float = x / y;
+    def main (args : Int) : Int = if f 10.0 2.0 >= 1.0 then 0 else 1;
+    """
+    assert _run(source) == 0
+
+
+# --- rejected: the divisor is not provably non-zero --------------------------
+
+
+def test_int_division_unconstrained_divisor_rejected():
+    source = r"""
+    def f (x : Int) (y : Int) : Int = x / y;
+    def main (args : Int) : Int = f 10 3;
+    """
+    assert _rejected(source)
+
+
+def test_int_modulo_unconstrained_divisor_rejected():
+    source = r"""
+    def f (x : Int) (y : Int) : Int = x % y;
+    def main (args : Int) : Int = f 10 3;
+    """
+    assert _rejected(source)
+
+
+def test_float_division_unconstrained_divisor_rejected():
+    source = r"""
+    def f (x : Float) (y : Float) : Float = x / y;
+    def main (args : Int) : Int = 0;
+    """
+    assert _rejected(source)
+
+
+def test_int_division_by_literal_zero_rejected():
+    source = r"""
+    def f (x : Int) : Int = x / 0;
+    def main (args : Int) : Int = f 5;
+    """
+    assert _rejected(source)
+
+
+def test_int_modulo_by_literal_zero_rejected():
+    source = r"""
+    def f (x : Int) : Int = x % 0;
+    def main (args : Int) : Int = f 5;
+    """
+    assert _rejected(source)
+
+
+def test_both_operands_literal_division_rejected():
+    # Both operands constant: the constant ``5 / 0`` reaches the SMT layer and
+    # is caught rather than silently skipped (smt.smt_valid ZeroDivisionError).
+    assert _rejected("def main (args : Int) : Int = 5 / 0;")
+
+
+def test_both_operands_literal_modulo_rejected():
+    assert _rejected("def main (args : Int) : Int = 5 % 0;")


### PR DESCRIPTION
## What

`/` and `%` now require a statically-provable **non-zero divisor**. Division/modulo where the divisor cannot be proven `!= 0` is a type error.

```aeon
def f (x: Int) (y: Int) : Int = x / y            // rejected: y not provably != 0
def g (x: Int) (y: Int) : Int =
    if y != 0 then x / y else 0                  // ok: guard discharges it
def h : Int = 5 / 0                              // rejected
```

## How

- **`typeinfer.py`** — operators are special-cased in the core typechecker (`prim_op`), which synthesises their types and ignores the prelude signatures. `make_binary_app_type` gained a `nonzero_divisor` flag that refines the divisor parameter with `{v | v != 0}`; `prim_op` sets it for `%` and for `/` (inside its polymorphic `forall a:B`).
- **`liquid.py`** — the divisor literal `0` is an `Int`, but `/` also instantiates at `Float`, so `_unify` now tolerates Int/Float numeric coercion (widening to `Float`). z3 already coerces numerals across the Int/Real tower, so the single refinement discharges for both `Int` and `Float` divisors.

> Note: constant divide-by-zero (`5 / 0`, `5 % 0`) was independently fixed on `master` (the `smt_valid` `ZeroDivisionError` path now reports the obligation invalid instead of silently skipping it). This branch is rebased on top of that, so those cases are covered too — see the tests below.

## Behaviour

| Case | Result |
|---|---|
| `x / y`, `x % y` (unconstrained) | rejected |
| `x / 0`, `5 / 0`, `5 % 0` | rejected |
| `if y != 0 then x / y` (guarded) | accepted — path-sensitive |
| `{v:Float \| 1.0 <= v}` divisor | accepted — refinement proves non-zero |
| `10 / 2`, `10 % 3`, `10.0 / 2.0` | accepted |

## Blast radius

Two reference solutions divided by unconstrained `Float`s — `examples/PSB2/solved/bouncing_balls.ae` and `dice_game.ae` — and now correctly fail. Both gained `if d != 0.0 then x/d else 0.0` guards; the guards never trigger and the outputs are unchanged (`20.954`, `0.5`).

## Tests

- New `tests/division_by_zero_test.py` (15 cases): valid div/mod accepted; unconstrained, literal-zero, and both-literal-constant divisors rejected; guarded and refinement-bounded divisors accepted; Float covered.
- Full suite (rebased on latest master): **1560 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)