### PR TITLE
Add OS and Subprocess standard-library bindings with refinements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -405,6 +405,8 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess).
+
 ## Libraries
 
 There are a few libraries available, but unstable as they are under development:
@@ -414,6 +416,7 @@ There are a few libraries available, but unstable as they are under development:
 - List.ae
 - Map.ae
 - Math.ae
+- OS.ae
 - Plot.ae
 - PropTesting.ae
 - PSB2.ae
@@ -421,6 +424,7 @@ There are a few libraries available, but unstable as they are under development:
 - Set.ae
 - Statistics.ae
 - String.ae
+- Subprocess.ae
 - Table.ae
 - Testing.ae
 - Tuple.ae

--- a/docs/os-subprocess.md
+++ b/docs/os-subprocess.md
@@ -1,0 +1,185 @@
+# `OS` and `Subprocess`: typed bindings for error-prone system calls
+
+Two of the most bug-prone corners of the Python standard library are `os` and
+`subprocess`. Their failure modes are not exotic — they are the everyday
+mistakes that ship to production: reading an environment variable that isn't
+set, ignoring a non-zero exit code, building a shell command out of string
+concatenation. Aeon's [Liquid Types](index.md) are a natural fit here: the
+preconditions that *should* hold before each call can be written into the type,
+and the SMT solver checks them at compile time instead of letting them surface
+as a runtime `KeyError`, `CalledProcessError`, or — worse — a shell injection.
+
+This page covers the two bindings, the specific error classes they rule out,
+and how to use them. For the general mechanics of writing such a binding (`native`,
+`native_import`, opaque types, uninterpreted measures), see
+[Writing FFI bindings for a Python package](ffi).
+
+- Source: [`libraries/OS.ae`](https://github.com/alcides/aeon/blob/master/libraries/OS.ae),
+  [`libraries/Subprocess.ae`](https://github.com/alcides/aeon/blob/master/libraries/Subprocess.ae)
+- Examples: [`examples/imports/os_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/os_example.ae),
+  [`examples/imports/subprocess_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/subprocess_example.ae)
+
+---
+
+## `OS` — partial operations made total
+
+The `os` module is full of calls that look innocent but raise on a bad input.
+`OS.ae` attaches refinements so the obvious mistakes don't typecheck.
+
+### Environment access without `KeyError`
+
+`os.environ[k]` raises `KeyError` when `k` is unset — the single most common
+`os` bug. `OS.ae` models environment membership with an **uninterpreted
+predicate** and gates the unchecked lookup behind it:
+
+```aeon
+def envSet : (name: String) -> Bool := uninterpreted
+
+# Runtime witness: in the `then` branch the solver learns `envSet name`.
+def hasEnv (name: {s:String | s != ""}) : {b:Bool | b = envSet name} :=
+    native "name in os.environ"
+
+# Unchecked lookup — its precondition makes a KeyError unrepresentable.
+def getEnv (name: {s:String | s != "" && envSet s}) : String :=
+    native "os.environ[name]"
+```
+
+`getEnv` is only well-typed where the solver already knows `envSet name`, which
+is exactly the refinement that the `then` branch of `if hasEnv name then …`
+introduces (the same pattern `Path.ae` uses for `exists`/`read_text`):
+
+```aeon
+def homeDir : String :=
+    if OS.hasEnv "HOME" then
+        OS.getEnv "HOME"      # OK: branch refines `envSet "HOME"`
+    else
+        "/"
+```
+
+Drop the guard and the program is rejected at compile time:
+
+```aeon
+def bad : String := OS.getEnv "HOME"
+```
+
+```
+>>> Type error: Failed to prove ... ((vs != "") && OS_envSet(vs))
+```
+
+When you'd rather not branch, `getEnvOr name fallback` is total and always safe.
+
+### Exit codes that fit in a byte
+
+`os._exit` truncates its argument to one byte, so `os._exit(256)` silently
+becomes `0` — a "success" exit that wasn't. The refinement pins the value to
+the portable range:
+
+```aeon
+def exitNow (code: {x:Int | x >= 0 && x <= 255}) : Unit := native "os._exit(code)"
+```
+
+### Other guarded calls
+
+| Function | Refinement | Bug it prevents |
+|---|---|---|
+| `getPid`, `getParentPid` | result `> 0` | downstream "is this a real PID?" checks |
+| `cpuCount` | returns `Maybe Int` | dividing by a `None` CPU count |
+| `getCwd` | result `!= ""` | empty-path propagation |
+| `fileSize` | result `>= 0` | treating an error sentinel as a size |
+| `kill pid sig` | `pid > 0 && sig > 0` | signalling PID 0 (the whole process group) |
+
+---
+
+## `Subprocess` — no shell, no ignored failures
+
+`subprocess` is dangerous in two independent ways. `Subprocess.ae` closes both.
+
+### 1. No shell injection — argv only
+
+The classic vulnerability is `subprocess.run("rm " + name, shell=True)`: a
+hostile `name` like `"; rm -rf /"` is handed straight to `/bin/sh`. The fix is
+to pass an **argument vector** and never invoke a shell — then there is no shell
+grammar to inject into. This binding exposes *only* the argv form. Every entry
+point takes a non-empty `Array String` (the first element is the program), and
+there is deliberately no `shell=True` escape hatch:
+
+```aeon
+def run (argv: {a: (Array String) | Array.size a >= 1}) : CompletedProcess :=
+    native "subprocess.run(argv, capture_output=True, text=True)"
+```
+
+An `Array String` is a Python `list[str]` at runtime, so it flows directly into
+`subprocess.run`. The non-empty refinement is discharged for free by `append`'s
+`Array.size` postconditions:
+
+```aeon
+def echoArgs : {a: (Array String) | Array.size a >= 1} :=
+    Array.append (Array.append (Array.new[String]) "echo") "hello"
+```
+
+An empty argv — which would raise `IndexError` inside `subprocess` — is a type
+error:
+
+```aeon
+def bad : CompletedProcess := Subprocess.run (Array.new[String])
+```
+
+```
+>>> Type error: Failed to prove (Array_size(arr) >= 1)
+```
+
+### 2. Exit codes you can't forget
+
+`subprocess.run` does not raise on failure, so it's easy to read the `stdout`
+of a command that never succeeded. The binding reflects the return code into an
+uninterpreted `exitCode` measure and ties `succeeded` to it:
+
+```aeon
+def exitCode : (p: CompletedProcess) -> Int := uninterpreted
+
+def succeeded (p: CompletedProcess) : {b:Bool | b = (exitCode p = 0)} :=
+    native "p.returncode == 0"
+```
+
+```aeon
+def main (_:Int) : Unit :=
+    p : CompletedProcess := Subprocess.run echoArgs;
+    if Subprocess.succeeded p then
+        print (Subprocess.stdout p)
+    else
+        print (Subprocess.stderr p)
+```
+
+If you want failure to be *impossible to ignore*, use `checkRun`, which raises
+`CalledProcessError` on a non-zero exit. Because control only returns on
+success, its result carries the postcondition `exitCode p = 0` — downstream code
+can rely on success at the type level:
+
+```aeon
+def checkRun (argv: {a: (Array String) | Array.size a >= 1})
+    : {p: CompletedProcess | exitCode p = 0} :=
+    native "subprocess.run(argv, capture_output=True, text=True, check=True)"
+```
+
+### Quick reference
+
+| Function | Notes |
+|---|---|
+| `run argv` | argv-only, captures stdout/stderr |
+| `runWithInput argv stdin` | feeds `stdin` to the child |
+| `runWithTimeout argv seconds` | `seconds > 0`; raises `TimeoutExpired` |
+| `checkRun argv` | result refined `exitCode p = 0` |
+| `checkOutput argv` | success required; returns `stdout` only |
+| `getExitCode p`, `succeeded p`, `stdout p`, `stderr p` | inspect a result |
+
+---
+
+## A note on the trust boundary
+
+As always with FFI, refinements over `native` are **promises the wrapper author
+makes**, not facts the compiler verifies against the Python implementation (see
+[the FFI guide](ffi#mental-model)). `getEnv`'s precondition is honest because
+`os.environ[name]` really does raise iff `name` is unset; `checkRun`'s
+postcondition is honest because `check=True` really does raise on a non-zero
+exit. If you extend these modules, keep the refinement layer faithful to what
+the Python call actually does.

--- a/examples/imports/os_example.ae
+++ b/examples/imports/os_example.ae
@@ -1,0 +1,19 @@
+open OS
+
+# KeyError-safe environment access. `getEnv` carries the precondition
+# `envSet name`, so it is only well-typed inside the branch where `hasEnv`
+# has proven the variable is set. Calling `OS.getEnv "HOME"` directly —
+# without the guard — is a *compile* error, not a runtime KeyError.
+
+def homeDir : String :=
+    if OS.hasEnv "HOME" then
+        OS.getEnv "HOME"      # OK: this branch refines `envSet "HOME"`
+    else
+        "/"
+
+# When you don't care to branch, the total `getEnvOr` always has a value.
+def editor : String := OS.getEnvOr "EDITOR" "vi"
+
+def main (_:Int) : Unit :=
+    _ : Unit := print homeDir;
+    print editor

--- a/examples/imports/subprocess_example.ae
+++ b/examples/imports/subprocess_example.ae
@@ -1,0 +1,18 @@
+open Subprocess
+open Array
+
+# Build an argument vector — never a shell string, so there is nothing to
+# inject — and run it. `run` requires a non-empty `Array String`; the
+# `Array.size` postconditions of `append` discharge that automatically.
+
+def echoArgs : {a: (Array String) | Array.size a >= 1} :=
+    Array.append (Array.append (Array.new[String]) "echo") "hello"
+
+# Inspect the exit code before trusting the output. `succeeded` ties the
+# boolean to the `exitCode` measure, so the branch reads cleanly.
+def main (_:Int) : Unit :=
+    p : CompletedProcess := Subprocess.run echoArgs;
+    if Subprocess.succeeded p then
+        print (Subprocess.stdout p)
+    else
+        print (Subprocess.stderr p)

--- a/libraries/OS.ae
+++ b/libraries/OS.ae
@@ -1,0 +1,118 @@
+# Safe-by-construction bindings around Python's ``os`` module.
+#
+# ``os`` is full of *partial* operations — calls that look innocent but blow
+# up at runtime on a bad input:
+#
+#   * ``os.environ[k]``      raises ``KeyError`` when ``k`` is unset;
+#   * ``os._exit(code)``     silently truncates ``code`` to a single byte;
+#   * ``os.kill(pid, sig)``  needs a live PID and a real signal number;
+#   * ``os.path.getsize(p)`` raises ``OSError`` on a missing path.
+#
+# This library attaches Liquid Types so the common mistakes become *compile*
+# errors instead of runtime crashes. The headline is environment access:
+# ``getEnv`` is only callable once the solver knows — via ``hasEnv`` — that
+# the variable is set, mirroring the ``exists``/``read_text`` pattern in
+# ``Path.ae``.
+#
+# See ``Sys.ae`` for the ``sys``-module companion (argv, stdin/stdout, the
+# cleanup-running ``sys.exit``).
+
+open Array
+open Map
+open Maybe
+
+def os : Unit := native_import "os"
+
+# ── Environment variables (KeyError-safe) ──────────────────────────────
+#
+# ``envSet name`` is an uninterpreted predicate meaning "name is bound in the
+# current environment". The solver never computes it; it is only threaded
+# from the runtime witness ``hasEnv`` into the precondition of the unchecked
+# lookup ``getEnv``.
+
+def envSet : (name: String) -> Bool := uninterpreted
+
+# Runtime witness: lifts environment membership into the type system. In the
+# ``then`` branch of ``if hasEnv name then ...`` the solver learns
+# ``envSet name``, which is exactly what ``getEnv`` requires.
+def hasEnv (name: {s:String | s != ""}) : {b:Bool | b = envSet name} :=
+    native "name in os.environ"
+
+# Unchecked lookup. The precondition ``envSet name`` makes a ``KeyError``
+# unrepresentable — you can only reach this call after testing ``hasEnv``.
+def getEnv (name: {s:String | s != "" && envSet s}) : String :=
+    native "os.environ[name]"
+
+# Total lookup with an explicit fallback; always safe to call.
+def getEnvOr (name: {s:String | s != ""}) (fallback: String) : String :=
+    native "os.environ.get(name, fallback)"
+
+# Sets a variable and hands the value back so it can be threaded.
+def setEnv (name: {s:String | s != ""}) (value: String) : String :=
+    native "(os.environ.__setitem__(name, value), value)[1]"
+
+# Removes a variable if present; a no-op when it is unset (so, KeyError-safe).
+def unsetEnv (name: {s:String | s != ""}) : Unit :=
+    native "(os.environ.pop(name, None), None)[1]"
+
+# A snapshot of the whole environment as a Map.
+def environ (_: Unit) : (Map String String) := native "dict(os.environ)"
+
+# ── Process identity ───────────────────────────────────────────────────
+
+# The current process id. Always positive.
+def getPid (_: Unit) : {p:Int | p > 0} := native "os.getpid()"
+
+# The parent process id. Positive on every supported platform.
+def getParentPid (_: Unit) : {p:Int | p > 0} := native "os.getppid()"
+
+# ── CPU / scheduling ───────────────────────────────────────────────────
+
+# Number of CPUs in the system, if the OS can report it. ``os.cpu_count()``
+# may return ``None``, so the result is a ``Maybe`` rather than a bare ``Int``
+# — forcing callers to handle the unknown case instead of dividing by it.
+def cpuCount (_: Unit) : (Maybe Int) :=
+    native "(('Maybe_none',) if os.cpu_count() is None else ('Maybe_just', os.cpu_count()))"
+
+# ── Working directory ──────────────────────────────────────────────────
+
+# The current working directory. Always non-empty.
+def getCwd (_: Unit) : {s:String | s != ""} := native "os.getcwd()"
+
+# Changes the working directory. The path must be non-empty; raises if it
+# does not exist or is not a directory.
+def chdir (path: {s:String | s != ""}) : Unit :=
+    native "(os.chdir(path), None)[1]"
+
+# ── Filesystem queries ─────────────────────────────────────────────────
+
+# True if ``path`` refers to something that exists.
+def pathExists (path: {s:String | s != ""}) : Bool := native "os.path.exists(path)"
+
+# True if ``path`` is an existing regular file.
+def isFile (path: {s:String | s != ""}) : Bool := native "os.path.isfile(path)"
+
+# True if ``path`` is an existing directory.
+def isDir (path: {s:String | s != ""}) : Bool := native "os.path.isdir(path)"
+
+# Size of a file in bytes. Non-negative. Raises if the path is missing.
+def fileSize (path: {s:String | s != ""}) : {n:Int | n >= 0} :=
+    native "os.path.getsize(path)"
+
+# ── Signals ────────────────────────────────────────────────────────────
+
+# Sends signal ``sig`` to process ``pid``. ``pid`` must be positive and
+# ``sig`` a positive signal number. Raises if the process does not exist or
+# you lack permission.
+def kill (pid: {p:Int | p > 0}) (sig: {s:Int | s > 0}) : Unit :=
+    native "(os.kill(pid, sig), None)[1]"
+
+# ── Exit ───────────────────────────────────────────────────────────────
+
+# Immediately terminates the process with a status byte, skipping cleanup
+# handlers (the right call after ``fork()``). The portable status range is
+# 0..255; values outside it wrap around at the OS level, so the refinement
+# keeps the exit code honest. For a normal shutdown that runs ``atexit``
+# handlers, use ``Sys.exit`` instead.
+def exitNow (code: {x:Int | x >= 0 && x <= 255}) : Unit :=
+    native "os._exit(code)"

--- a/libraries/Subprocess.ae
+++ b/libraries/Subprocess.ae
@@ -1,0 +1,81 @@
+# Safe-by-construction bindings around Python's ``subprocess`` module.
+#
+# ``subprocess`` is one of the most error-prone corners of the standard
+# library, in two distinct ways:
+#
+#   1. **Shell injection.** ``subprocess.run("rm " + name, shell=True)`` hands
+#      an attacker-controlled string to ``/bin/sh``. The fix is to pass an
+#      *argument vector* (a list) and never invoke a shell — so there is no
+#      shell grammar to inject into. This binding exposes *only* the argv form:
+#      every entry point takes an ``Array String`` and runs it directly. There
+#      is deliberately no ``shell=True`` escape hatch.
+#
+#   2. **Ignored exit codes.** ``subprocess.run`` does not raise on failure;
+#      callers routinely read ``stdout`` of a command that never ran. Here the
+#      return code is reflected into an uninterpreted ``exitCode`` measure, and
+#      ``checkRun`` carries the postcondition ``exitCode p = 0`` so downstream
+#      code can rely — at the type level — on the command having succeeded.
+#
+# An ``Array String`` is backed by a Python ``list[str]`` at runtime, so it
+# flows straight into ``subprocess.run`` with no marshalling.
+
+open Array
+
+type CompletedProcess
+
+def subprocess : Unit := native_import "subprocess"
+
+# ── Measures ───────────────────────────────────────────────────────────
+
+# The process exit status. Uninterpreted: the solver only relates it across
+# calls (e.g. a ``checkRun`` result is pinned to 0), it never computes it.
+# On POSIX a negative value means the process was killed by ``-exitCode``.
+def exitCode : (p: CompletedProcess) -> Int := uninterpreted
+
+# ── Running a command ──────────────────────────────────────────────────
+
+# Runs ``argv`` and captures its output. ``argv`` must be non-empty — its
+# first element is the program to execute. No shell is involved.
+def run (argv: {a: (Array String) | Array.size a >= 1}) : CompletedProcess :=
+    native "subprocess.run(argv, capture_output=True, text=True)"
+
+# Runs ``argv``, feeding ``stdin`` to the child's standard input.
+def runWithInput (argv: {a: (Array String) | Array.size a >= 1}) (stdin: String)
+    : CompletedProcess :=
+    native "subprocess.run(argv, capture_output=True, text=True, input=stdin)"
+
+# Runs ``argv`` but aborts the child after ``seconds``. Raises
+# ``TimeoutExpired`` if the deadline passes; ``seconds`` must be positive.
+def runWithTimeout (argv: {a: (Array String) | Array.size a >= 1})
+                   (seconds: {s:Float | s > 0.0}) : CompletedProcess :=
+    native "subprocess.run(argv, capture_output=True, text=True, timeout=seconds)"
+
+# Runs ``argv`` and raises ``CalledProcessError`` on a non-zero exit. Because
+# control only returns here on success, the result is statically known to have
+# ``exitCode p = 0`` — callers can read ``stdout`` without re-checking.
+def checkRun (argv: {a: (Array String) | Array.size a >= 1})
+    : {p: CompletedProcess | exitCode p = 0} :=
+    native "subprocess.run(argv, capture_output=True, text=True, check=True)"
+
+# Convenience: run ``argv``, require success, and return only ``stdout``.
+def checkOutput (argv: {a: (Array String) | Array.size a >= 1}) : String :=
+    native "subprocess.run(argv, capture_output=True, text=True, check=True).stdout"
+
+# ── Inspecting the result ──────────────────────────────────────────────
+
+# The exit code as a value, pinned to the ``exitCode`` measure so it can be
+# threaded into later refinements.
+def getExitCode (p: CompletedProcess) : {n:Int | n = exitCode p} :=
+    native "p.returncode"
+
+# True exactly when the command succeeded (exit code 0). The result is tied to
+# the ``exitCode`` measure, so the ``then`` branch of a test on it can satisfy
+# preconditions phrased as ``exitCode p = 0``.
+def succeeded (p: CompletedProcess) : {b:Bool | b = (exitCode p = 0)} :=
+    native "p.returncode == 0"
+
+# Captured standard output (decoded text).
+def stdout (p: CompletedProcess) : String := native "p.stdout"
+
+# Captured standard error (decoded text).
+def stderr (p: CompletedProcess) : String := native "p.stderr"


### PR DESCRIPTION
## What

Two new Liquid-Type bindings around Python's most bug-prone stdlib modules, chosen because their failure modes are exactly what refinement types are good at ruling out. Each ships with a runnable example and documentation.

### `libraries/OS.ae` — partial `os` operations made total
- **KeyError-safe environment access.** `getEnv` carries the precondition `envSet name` (an uninterpreted predicate); it is only well-typed inside the branch where the runtime witness `hasEnv` has proven the variable is set — the same `exists`/`read_text` pattern as `Path.ae`. `getEnvOr` stays total.
- **Exit codes** constrained to the portable `0..255` byte (`os._exit` otherwise truncates silently).
- **PIDs / signals positive**, `fileSize` non-negative, `getCwd` non-empty, `cpuCount` returns `Maybe Int` (forcing callers to handle the unknown case instead of dividing by it).

### `libraries/Subprocess.ae` — no shell, no ignored failures
- **No shell injection.** Only the argv form is exposed: every entry point takes a non-empty `Array String` (backed by a Python `list[str]`), and there is deliberately no `shell=True` escape hatch — so there is no shell grammar to inject into.
- **Exit codes you can't forget.** The return code is reflected into an uninterpreted `exitCode` measure; `checkRun` carries the postcondition `exitCode p = 0`, so downstream code can rely on success at the type level.

## Why these two

Asked which error-prone Python libraries would benefit most from Liquid Types, `os` + `subprocess` stood out: `KeyError` on missing env vars, exit codes ignored or truncated, and shell injection are everyday production bugs that map cleanly onto preconditions/postconditions and the existing `uninterpreted` + `native` patterns.

## Verification

The refinements were checked to **bite**, not just compile:

- ✅ `examples/imports/os_example.ae` and `examples/imports/subprocess_example.ae` typecheck and run (these run in CI via `run_examples.sh`).
- ✅ Unguarded `OS.getEnv "HOME"` (no `hasEnv`) is **rejected**: `Failed to prove ((vs != "") && OS_envSet(vs))`.
- ✅ `Subprocess.run (Array.new[String])` (empty argv) is **rejected**: `Failed to prove (Array_size(arr) >= 1)`.
- ✅ `--doc` generates clean HTML for both modules; `scripts/build_stdlib_docs.py` auto-discovers them via its `libraries/*.ae` glob.

## Docs

- New page `docs/os-subprocess.md`, a worked case study of the two modules and the bug classes they prevent.
- Linked from `docs/index.md` (FFI section) and both modules added to the library list.

## Notes

No Python binding module was needed — both wrappers are inline `native` one-liners, consistent with the sibling `Sys.ae` / `Path.ae` system bindings. As always with FFI, the refinements are author-checked promises about what the underlying Python call does (`os.environ[name]` raises iff unset; `check=True` raises on non-zero) — see the trust-boundary note in the docs.

https://claude.ai/code/session_014LDN2TZ3z5WcwRYmj2WnZL

---
_Generated by [Claude Code](https://claude.ai/code/session_014LDN2TZ3z5WcwRYmj2WnZL)_