### PR TITLE
Add Http (requests), linear Subprocess process handles, and a state-safe Database (sqlite3) binding

### DIFF
--- a/aeon/bindings/database.py
+++ b/aeon/bindings/database.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sqlite3
+
+from aeon.bindings.binding_utils import curried
+
+
+@curried
+def read_all(path, sql):
+    """Open ``path``, run a read-only ``sql`` query, and return all rows.
+
+    The connection is opened and closed entirely inside this helper, so no
+    handle escapes to Aeon — there is nothing for a caller to leak. Returns a
+    ``list`` of row tuples (``len`` is the row count).
+    """
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute(sql).fetchall()
+    finally:
+        conn.close()

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,119 @@
+# `Database`: state-safe sqlite3 with linear types and refinements
+
+`Database.ae` wraps Python's `sqlite3` so the two things that make raw database
+code error-prone — **transaction discipline** and **connection state** — are
+checked by the compiler. It is the standard library's flagship example of
+combining Aeon's two big ideas: [Liquid Types](index.md) for the *values* and
+**Quantitative Type Theory** (linear/multiplicity types, as in
+[`Socket.ae`](https://github.com/alcides/aeon/blob/master/libraries/Socket.ae))
+for the *protocol*.
+
+- Source: [`libraries/Database.ae`](https://github.com/alcides/aeon/blob/master/libraries/Database.ae)
+- Example: [`examples/imports/database_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/database_example.ae)
+
+---
+
+## The two failure modes
+
+```python
+conn = sqlite3.connect("app.db")
+conn.execute("INSERT INTO log VALUES ('x')")
+# ... forgot conn.commit() — the write silently vanishes
+conn.close()
+conn.execute("SELECT ...")   # ProgrammingError: closed database
+```
+
+1. **Transaction discipline.** A transaction must be committed *xor* rolled
+   back — **exactly once** — and the connection closed **exactly once**. Forget
+   the commit and your writes disappear; touch the connection after close and
+   you crash. These are *linear-resource* rules.
+2. **State.** `execute` only makes sense inside an open connection; `commit`
+   only inside a transaction. Doing things out of order is a state error.
+
+A `with` block guards a single scope, but it cannot express "you owe exactly one
+of commit-or-rollback on this handle, and may not touch it afterward." Linear
+types can.
+
+## Typestate: the handle's *kind* is the state
+
+`Database` exposes two opaque handle types, and the operations move between them:
+
+```aeon
+type Conn      # an open connection        (linear)
+type Txn       # a connection inside a txn  (linear)
+
+def connect  (path: {p:String | p != ""}) : Conn         # → Conn
+def begin    (1 c: Conn)                   : Txn          # Conn → Txn
+def execSql  (sql: {s:String | s != ""}) (1 t: Txn) : Txn # Txn  → Txn
+def commit   (1 t: Txn)                    : Conn         # Txn  → Conn
+def rollback (1 t: Txn)                    : Conn         # Txn  → Conn
+def close    (1 c: Conn)                   : Unit         # Conn → ∎
+```
+
+Because the states are *distinct types*, illegal orderings simply don't
+type-check: you cannot `execSql` on a `Conn` (you must `begin` first), nor
+`close` a `Txn` (you must `commit`/`rollback` first). Closing a transaction is a
+plain type error:
+
+```
+Expression has type Txn, but is expected to have type Conn
+```
+
+## Linearity: exactly once, in order
+
+The `(1 c: …)` annotation marks a parameter consumed at **multiplicity 1**, and
+results are bound with `let 1`. Each operation consumes its handle and returns
+the next state, so the whole lifecycle threads through linear binders — exactly
+like `Socket.ae`:
+
+```aeon
+def writeEntry (path: {p:String | p != ""}) : Unit :=
+    let 1 c0 := Database.connect path in
+    let 1 t0 := Database.begin c0 in
+    let 1 t1 := Database.execSql "CREATE TABLE IF NOT EXISTS log (msg TEXT)" t0 in
+    let 1 t2 := Database.execSql "INSERT INTO log VALUES ('entry')" t1 in
+    let 1 c1 := Database.commit t2 in       # MUST commit or rollback — exactly once
+    Database.close c1;                      # MUST close — c0/t0/t1 are now spent
+```
+
+The type checker now rejects every classic mistake:
+
+| Mistake | Error |
+|---|---|
+| Forget `commit`/`rollback` (writes lost) | `Linear binding t2 … is never used` (`LinearUnusedError`) |
+| Forget `close` (leaked connection) | `Linear binding c1 … is never used` |
+| `commit` twice / use a spent txn | `Linear binding t2 … is used 2 times` (`LinearUsedTooManyTimesError`) |
+| `execSql` after `commit` | the old `Txn` binder was already consumed → over-use error |
+| `close` a `Txn` | type mismatch `Txn` vs `Conn` |
+
+A correct, complete lifecycle is the *only* thing that type-checks.
+
+## Reads need no ceremony
+
+A `SELECT` that needs no transaction uses the non-linear one-shot path, which
+opens and closes the connection internally (so nothing can leak), with ordinary
+refinements on the result:
+
+```aeon
+def row_count : (r: Rows) -> Int := uninterpreted
+
+def readAll (path: {p:String | p != ""}) (sql: {s:String | s != ""}) :
+    {r: Rows | row_count r >= 0} := ...
+
+def rowCount (r: Rows) : {n:Int | n = row_count r && n >= 0} := native "len(r)"
+def isEmpty  (r: Rows) : {b:Bool | b = (row_count r = 0)} := native "len(r) == 0"
+```
+
+```aeon
+def countRows (path: {p:String | p != ""}) : Int :=
+    Database.rowCount (Database.readAll path "SELECT * FROM log");
+```
+
+## A note on the trust boundary
+
+As with any FFI binding, the refinements and the state machine are **promises
+the wrapper makes** (see [the FFI guide](ffi#mental-model)). They are honest
+here: `connect(..., isolation_level=None)` puts sqlite3 in autocommit so the
+explicit `BEGIN`/`COMMIT`/`ROLLBACK` are obeyed verbatim, and each linear
+operation maps to exactly one underlying call. Keep that correspondence intact
+if you extend the module.

--- a/docs/database.md
+++ b/docs/database.md
@@ -42,16 +42,16 @@ types can.
 type Conn      # an open connection        (linear)
 type Txn       # a connection inside a txn  (linear)
 
-def connect  (path: {p:String | p != ""}) : Conn         # → Conn
-def begin    (1 c: Conn)                   : Txn          # Conn → Txn
-def execSql  (sql: {s:String | s != ""}) (1 t: Txn) : Txn # Txn  → Txn
-def commit   (1 t: Txn)                    : Conn         # Txn  → Conn
-def rollback (1 t: Txn)                    : Conn         # Txn  → Conn
-def close    (1 c: Conn)                   : Unit         # Conn → ∎
+def connect  (path: {p:String | p != ""}) : Conn          # → Conn
+def begin    (1 c: Conn)                    : Txn          # Conn → Txn
+def execute  (sql: {s:String | s != ""}) (1 t: Txn) : Txn  # Txn  → Txn
+def commit   (1 t: Txn)                     : Conn         # Txn  → Conn
+def rollback (1 t: Txn)                     : Conn         # Txn  → Conn
+def close    (1 c: Conn)                    : Unit         # Conn → ∎
 ```
 
 Because the states are *distinct types*, illegal orderings simply don't
-type-check: you cannot `execSql` on a `Conn` (you must `begin` first), nor
+type-check: you cannot `execute` on a `Conn` (you must `begin` first), nor
 `close` a `Txn` (you must `commit`/`rollback` first). Closing a transaction is a
 plain type error:
 
@@ -70,8 +70,8 @@ like `Socket.ae`:
 def writeEntry (path: {p:String | p != ""}) : Unit :=
     let 1 c0 := Database.connect path in
     let 1 t0 := Database.begin c0 in
-    let 1 t1 := Database.execSql "CREATE TABLE IF NOT EXISTS log (msg TEXT)" t0 in
-    let 1 t2 := Database.execSql "INSERT INTO log VALUES ('entry')" t1 in
+    let 1 t1 := Database.execute "CREATE TABLE IF NOT EXISTS log (msg TEXT)" t0 in
+    let 1 t2 := Database.execute "INSERT INTO log VALUES ('entry')" t1 in
     let 1 c1 := Database.commit t2 in       # MUST commit or rollback — exactly once
     Database.close c1;                      # MUST close — c0/t0/t1 are now spent
 ```
@@ -83,7 +83,7 @@ The type checker now rejects every classic mistake:
 | Forget `commit`/`rollback` (writes lost) | `Linear binding t2 … is never used` (`LinearUnusedError`) |
 | Forget `close` (leaked connection) | `Linear binding c1 … is never used` |
 | `commit` twice / use a spent txn | `Linear binding t2 … is used 2 times` (`LinearUsedTooManyTimesError`) |
-| `execSql` after `commit` | the old `Txn` binder was already consumed → over-use error |
+| `execute` after `commit` | the old `Txn` binder was already consumed → over-use error |
 | `close` a `Txn` | type mismatch `Txn` vs `Conn` |
 
 A correct, complete lifecycle is the *only* thing that type-checks.
@@ -97,16 +97,16 @@ refinements on the result:
 ```aeon
 def row_count : (r: Rows) -> Int := uninterpreted
 
-def readAll (path: {p:String | p != ""}) (sql: {s:String | s != ""}) :
+def read_all (path: {p:String | p != ""}) (sql: {s:String | s != ""}) :
     {r: Rows | row_count r >= 0} := ...
 
-def rowCount (r: Rows) : {n:Int | n = row_count r && n >= 0} := native "len(r)"
-def isEmpty  (r: Rows) : {b:Bool | b = (row_count r = 0)} := native "len(r) == 0"
+def num_rows (r: Rows) : {n:Int | n = row_count r && n >= 0} := native "len(r)"
+def is_empty (r: Rows) : {b:Bool | b = (row_count r = 0)} := native "len(r) == 0"
 ```
 
 ```aeon
-def countRows (path: {p:String | p != ""}) : Int :=
-    Database.rowCount (Database.readAll path "SELECT * FROM log");
+def count_rows (path: {p:String | p != ""}) : Int :=
+    Database.num_rows (Database.read_all path "SELECT * FROM log");
 ```
 
 ## A note on the trust boundary

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,0 +1,109 @@
+# `Http`: typed bindings for the `requests` library
+
+The [`requests`](https://requests.readthedocs.io/) library is a pleasure to use
+and a reliable source of production incidents — almost always in the same three
+ways. `Http.ae` wraps it so each of those failure modes becomes a compile-time
+error instead of a runtime surprise. For the general mechanics of writing such a
+binding, see [Writing FFI bindings for a Python package](ffi); for two more
+worked examples in the same spirit, see
+[`os` and `subprocess`](os-subprocess).
+
+- Source: [`libraries/Http.ae`](https://github.com/alcides/aeon/blob/master/libraries/Http.ae)
+- Example: [`examples/imports/http_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/http_example.ae)
+
+---
+
+## 1. Requests can't hang forever
+
+A `requests` call with no `timeout` blocks indefinitely if the peer never
+answers — the classic "the whole service froze" outage. Every entry point in
+`Http.ae` *requires* a strictly positive timeout (in seconds), and there is no
+timeout-less overload to reach for by accident:
+
+```aeon
+def get (url: {u:String | u != ""}) (timeout: {t:Float | t > 0.0}) : Response :=
+    native "requests.get(url, timeout=timeout)"
+```
+
+A non-positive timeout — which `requests` interprets as "fail immediately" (`0`)
+or "wait forever" (`None`) — is rejected:
+
+```aeon
+def bad : Response := Http.get "http://example.com" 0.0
+```
+
+```
+>>> Type error: Failed to prove (vt == 0.0) ... t > 0.0
+```
+
+The same precondition rules out the empty URL that would otherwise raise
+`MissingSchema`.
+
+## 2. Status codes you can't ignore
+
+`requests` does not raise on a 4xx or 5xx; it is easy to parse the body of a
+request that never succeeded. The status is reflected into an **uninterpreted
+measure**, and `isSuccess` is tied to it so a test refines the response in the
+`then` branch:
+
+```aeon
+def status : (r: Response) -> Int := uninterpreted
+
+def isSuccess (r: Response) : {b:Bool | b = (status r >= 200 && status r < 300)} :=
+    native "(200 <= r.status_code) and (r.status_code < 300)"
+```
+
+```aeon
+def fetchTitle (url: {u:String | u != ""}) : String :=
+    let r : Response := Http.get url 5.0 in
+    if Http.isSuccess r then
+        Http.body r            # only read the body on a 2xx
+    else
+        "request failed";
+```
+
+When you'd rather treat any error status as fatal, `raiseForStatus` raises
+`HTTPError` on a 4xx/5xx and carries the postcondition `status r < 400` — so the
+rest of your code can trust the request succeeded, at the type level:
+
+```aeon
+def raiseForStatus (r: Response) : {x:Response | status x < 400} :=
+    native "(r.raise_for_status(), r)[1]"
+```
+
+## 3. JSON bodies are parsed, not assumed
+
+`response.json()` raises `JSONDecodeError` on a non-JSON body. `bodyJson` returns
+a [`Json`](https://github.com/alcides/aeon/blob/master/libraries/Json.ae) value,
+which you then interrogate with the runtime-typed `Json` coercions (`isObject`,
+`asString`, …) rather than assuming a dict:
+
+```aeon
+def fetchJson (url: {u:String | u != ""}) : Json :=
+    let r : Response := Http.raiseForStatus (Http.get url 5.0) in
+    Http.bodyJson r;
+```
+
+## Quick reference
+
+| Function | Notes |
+|---|---|
+| `get url timeout` | GET; `url != ""`, `timeout > 0.0` |
+| `getWithHeaders url headers timeout` | headers as a `Map String String` |
+| `post url body timeout` | POST a raw string body |
+| `postJson url payload timeout` | POST a `Json` payload (sets `Content-Type`) |
+| `put url body timeout` | PUT a raw string body |
+| `delete url timeout` | DELETE |
+| `statusCode r`, `isSuccess r`, `raiseForStatus r` | status handling |
+| `body r`, `bodyJson r`, `contentLength r` | response payload |
+| `getHeader r name default` | total header lookup (never KeyError) |
+| `finalUrl r` | URL after redirects |
+
+## A note on the trust boundary
+
+As with every FFI binding, the refinements are **promises the wrapper author
+makes**, not facts checked against `requests` itself (see
+[the FFI guide](ffi#mental-model)). They are honest here because the underlying
+calls really do behave as claimed — `raise_for_status()` raises iff the status
+is 4xx/5xx, `timeout=` really does bound the wait. Keep them honest if you extend
+the module.

--- a/docs/index.md
+++ b/docs/index.md
@@ -405,12 +405,13 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database).
 
 ## Libraries
 
 There are a few libraries available, but unstable as they are under development:
 
+- Database.ae
 - Http.ae
 - Image.ae
 - Learning.ae

--- a/docs/index.md
+++ b/docs/index.md
@@ -405,12 +405,13 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http).
 
 ## Libraries
 
 There are a few libraries available, but unstable as they are under development:
 
+- Http.ae
 - Image.ae
 - Learning.ae
 - List.ae

--- a/docs/os-subprocess.md
+++ b/docs/os-subprocess.md
@@ -161,6 +161,45 @@ def checkRun (argv: {a: (Array String) | Array.size a >= 1})
     native "subprocess.run(argv, capture_output=True, text=True, check=True)"
 ```
 
+### 3. Long-running children must be reaped — exactly once (QTT)
+
+`run`/`checkRun` spawn, wait, and capture in one call. But when you start a child
+now and reap it later (`subprocess.Popen`), a new bug class appears: forget to
+`wait` and you leak a zombie / open pipes; `wait` twice and you misuse a spent
+handle. That is a *linear-resource* discipline, so `Subprocess` also exposes a
+multiplicity-1 `Process` handle — the same Quantitative Type Theory machinery as
+[`Socket.ae`](https://github.com/alcides/aeon/blob/master/libraries/Socket.ae):
+
+```aeon
+type Process
+
+def spawn  (argv: {a: (Array String) | Array.size a >= 1}) : Process
+def wait   (1 p: Process) : Int     # blocks, reaps, returns exit code
+def waitFor (seconds: {s:Float | s > 0.0}) (1 p: Process) : Int
+def terminate (1 p: Process) : Int  # SIGTERM + wait
+def kill      (1 p: Process) : Int  # SIGKILL + wait
+```
+
+Every consumer takes the handle at multiplicity 1, so a child bound with `let 1`
+must be reaped exactly once via one of `wait` / `waitFor` / `terminate` / `kill`:
+
+```aeon
+def runDetached (argv: {a: (Array String) | Array.size a >= 1}) : Int :=
+    let 1 p := Subprocess.spawn argv in
+    Subprocess.wait p;
+```
+
+Drop the `wait` and the binder is left unconsumed:
+
+```
+>>> Linearity error: Linear binding p … is declared with multiplicity 1 but is never used.
+```
+
+— and waiting twice reports `… is used 2 times`. The leaked-process / zombie bug
+becomes a compile error. For the full transactional version of this pattern
+(commit-xor-rollback, close exactly once), see
+[`Database`](database).
+
 ### Quick reference
 
 | Function | Notes |
@@ -170,7 +209,9 @@ def checkRun (argv: {a: (Array String) | Array.size a >= 1})
 | `runWithTimeout argv seconds` | `seconds > 0`; raises `TimeoutExpired` |
 | `checkRun argv` | result refined `exitCode p = 0` |
 | `checkOutput argv` | success required; returns `stdout` only |
-| `getExitCode p`, `succeeded p`, `stdout p`, `stderr p` | inspect a result |
+| `getExitCode p`, `succeeded p`, `stdout p`, `stderr p` | inspect a `CompletedProcess` |
+| `spawn argv` → `Process` | **linear** handle; reap with one of below |
+| `wait p`, `waitFor s p`, `terminate p`, `kill p` | consume the `Process` exactly once |
 
 ---
 

--- a/examples/imports/database_example.ae
+++ b/examples/imports/database_example.ae
@@ -2,20 +2,20 @@ open Database
 
 # A linear write transaction. The type checker forces commit-XOR-rollback
 # exactly once and close exactly once, and the typestate (Conn vs Txn) forbids
-# illegal orderings — you cannot execSql before begin, nor close before commit.
+# illegal orderings — you cannot execute before begin, nor close before commit.
 #
 # Wrapped in a function so the lifecycle is fully type-checked without touching
 # a real database in CI (mirrors examples/ffi/socket_linear.ae).
 def writeEntry (path: {p:String | p != ""}) : Unit :=
     let 1 c0 := Database.connect path in
     let 1 t0 := Database.begin c0 in
-    let 1 t1 := Database.execSql "CREATE TABLE IF NOT EXISTS log (msg TEXT)" t0 in
-    let 1 t2 := Database.execSql "INSERT INTO log VALUES ('entry')" t1 in
+    let 1 t1 := Database.execute "CREATE TABLE IF NOT EXISTS log (msg TEXT)" t0 in
+    let 1 t2 := Database.execute "INSERT INTO log VALUES ('entry')" t1 in
     let 1 c1 := Database.commit t2 in
     Database.close c1;
 
 # A safe one-shot read needs no linear handle at all.
-def countRows (path: {p:String | p != ""}) : Int :=
-    Database.rowCount (Database.readAll path "SELECT * FROM log");
+def count_rows (path: {p:String | p != ""}) : Int :=
+    Database.num_rows (Database.read_all path "SELECT * FROM log");
 
 def main (args: Int) : Unit := print "ok"

--- a/examples/imports/database_example.ae
+++ b/examples/imports/database_example.ae
@@ -1,0 +1,21 @@
+open Database
+
+# A linear write transaction. The type checker forces commit-XOR-rollback
+# exactly once and close exactly once, and the typestate (Conn vs Txn) forbids
+# illegal orderings — you cannot execSql before begin, nor close before commit.
+#
+# Wrapped in a function so the lifecycle is fully type-checked without touching
+# a real database in CI (mirrors examples/ffi/socket_linear.ae).
+def writeEntry (path: {p:String | p != ""}) : Unit :=
+    let 1 c0 := Database.connect path in
+    let 1 t0 := Database.begin c0 in
+    let 1 t1 := Database.execSql "CREATE TABLE IF NOT EXISTS log (msg TEXT)" t0 in
+    let 1 t2 := Database.execSql "INSERT INTO log VALUES ('entry')" t1 in
+    let 1 c1 := Database.commit t2 in
+    Database.close c1;
+
+# A safe one-shot read needs no linear handle at all.
+def countRows (path: {p:String | p != ""}) : Int :=
+    Database.rowCount (Database.readAll path "SELECT * FROM log");
+
+def main (args: Int) : Unit := print "ok"

--- a/examples/imports/http_example.ae
+++ b/examples/imports/http_example.ae
@@ -1,0 +1,26 @@
+open Http
+open Json
+
+# Demonstrates the two compile-time guarantees of the Http binding without
+# performing a live request at module load. The body of `fetchTitle` is fully
+# type-checked — proving the API is used correctly — but `main` only prints a
+# constant, so the example stays hermetic in CI (mirroring socket_linear.ae).
+
+# `Http.get` *requires* a positive timeout: there is no way to spell a request
+# that hangs forever. `isSuccess` ties the boolean to the `status` measure, so
+# the branch reads the body only when the request actually succeeded.
+def fetchTitle (url: {u:String | u != ""}) : String :=
+    let r : Response := Http.get url 5.0 in
+    if Http.isSuccess r then
+        Http.body r
+    else
+        "request failed";
+
+# `raiseForStatus` turns a 4xx/5xx into an exception, and its result is
+# statically known to satisfy `status x < 400` — so callers downstream can
+# trust the response without re-checking.
+def fetchJson (url: {u:String | u != ""}) : Json :=
+    let r : Response := Http.raiseForStatus (Http.get url 5.0) in
+    Http.bodyJson r;
+
+def main (args: Int) : Unit := print "ok"

--- a/examples/imports/subprocess_process_example.ae
+++ b/examples/imports/subprocess_process_example.ae
@@ -1,0 +1,12 @@
+open Subprocess
+open Array
+
+# Linear process lifecycle: a spawned child MUST be reaped exactly once (here
+# via `wait`). Forgetting it — a zombie / leaked pipe — would leave the linear
+# binder unconsumed and fail to type-check; waiting twice would reuse a consumed
+# handle. Wrapped in a function so CI spawns nothing (mirrors socket_linear.ae).
+def runDetached (argv: {a: (Array String) | Array.size a >= 1}) : Int :=
+    let 1 p := Subprocess.spawn argv in
+    Subprocess.wait p;
+
+def main (args: Int) : Unit := print "ok"

--- a/libraries/Database.ae
+++ b/libraries/Database.ae
@@ -1,0 +1,89 @@
+# Linear (QTT) + refinement bindings for sqlite3 — a state-safe database API.
+#
+# Raw sqlite3 is error-prone in two ways this library closes:
+#
+#   1. **Transaction discipline (linearity).** A transaction must be committed
+#      XOR rolled back — exactly once — and the connection closed exactly once.
+#      Forget the commit and your writes silently vanish; touch the connection
+#      after close and you get ``ProgrammingError: Cannot operate on a closed
+#      database``. These are linear-resource rules, so ``Conn`` and ``Txn`` are
+#      multiplicity-1 handles: the type checker forces a complete, well-ordered
+#      lifecycle and rejects a forgotten commit (``LinearUnusedError``) or a
+#      use-after-commit / double-close (``LinearUsedTooManyTimesError``).
+#
+#   2. **State (typestate).** The *kind* of handle encodes the connection state.
+#      You cannot ``execSql`` on a plain ``Conn`` (you must ``begin`` a ``Txn``
+#      first), nor ``close`` a ``Txn`` (you must ``commit``/``rollback`` back to
+#      a ``Conn``). Illegal orderings simply do not type-check.
+#
+# Plus ordinary refinements: non-empty paths and SQL, non-negative row counts.
+#
+# The lifecycle threads a linear handle exactly like libraries/Socket.ae:
+#
+#     let 1 c0 := connect "app.db" in
+#     let 1 t0 := begin c0 in
+#     let 1 t1 := execSql "INSERT INTO log VALUES ('x')" t0 in
+#     let 1 c1 := commit t1 in        # MUST commit or rollback — exactly once
+#     close c1                        # MUST close — and t0/t1 are now unusable
+
+open Array
+
+type Conn      # an open connection            (linear)
+type Txn       # a connection inside a txn      (linear)
+type Rows      # a materialized SELECT result   (unrestricted)
+
+def sqlite3 : Unit := native_import "sqlite3"
+
+# ── One-shot reads (safe, non-linear) ──────────────────────────────────
+#
+# A read that needs no transaction: open, SELECT, close — all internal to the
+# helper, so no handle escapes and there is nothing to leak.
+
+def row_count : (r: Rows) -> Int := uninterpreted
+
+# Runs a SELECT against `path` and returns every row. Both arguments must be
+# non-empty.
+def readAll (path: {p:String | p != ""}) (sql: {s:String | s != ""}) :
+    {r: Rows | row_count r >= 0} :=
+    native "__import__('aeon.bindings.database').bindings.database.read_all(path, sql)"
+
+# Number of rows returned. Pinned to the `row_count` measure; non-negative.
+def rowCount (r: Rows) : {n:Int | n = row_count r && n >= 0} := native "len(r)"
+
+# True exactly when the result set is empty. Tied to `row_count`.
+def isEmpty (r: Rows) : {b:Bool | b = (row_count r = 0)} := native "len(r) == 0"
+
+# ── Linear write transactions (QTT) ─────────────────────────────────────
+#
+# Each operation consumes its linear handle at multiplicity 1 and returns the
+# next state, so downstream `let 1` binders enforce the same discipline. Bind
+# every result to a linear binder (`let 1 ... := ... in`).
+
+# Opens a connection to `path`. `isolation_level=None` puts sqlite3 in
+# autocommit mode so the explicit BEGIN / COMMIT / ROLLBACK below are honored
+# exactly as written. Each call yields a fresh connection.
+def connect (path: {p:String | p != ""}) : Conn :=
+    native "sqlite3.connect(path, isolation_level=None)"
+
+# Begins a transaction, advancing the connection from `Conn` to `Txn`.
+def begin (1 c: Conn) : Txn :=
+    native "(c.execute('BEGIN'), c)[1]"
+
+# Executes one statement inside the transaction and threads the `Txn` onward.
+# `sql` must be non-empty.
+def execSql (sql: {s:String | s != ""}) (1 t: Txn) : Txn :=
+    native "(t.execute(sql), t)[1]"
+
+# Commits the transaction and returns the connection (now outside any txn) so
+# it can be reused or closed. Consumes the `Txn`.
+def commit (1 t: Txn) : Conn :=
+    native "(t.execute('COMMIT'), t)[1]"
+
+# Rolls the transaction back, discarding its writes, and returns the
+# connection. Consumes the `Txn`.
+def rollback (1 t: Txn) : Conn :=
+    native "(t.execute('ROLLBACK'), t)[1]"
+
+# Closes the connection. Consumes the `Conn`, so it cannot be used afterward.
+def close (1 c: Conn) : Unit :=
+    native "c.close() or None"

--- a/libraries/Database.ae
+++ b/libraries/Database.ae
@@ -12,7 +12,7 @@
 #      use-after-commit / double-close (``LinearUsedTooManyTimesError``).
 #
 #   2. **State (typestate).** The *kind* of handle encodes the connection state.
-#      You cannot ``execSql`` on a plain ``Conn`` (you must ``begin`` a ``Txn``
+#      You cannot ``execute`` on a plain ``Conn`` (you must ``begin`` a ``Txn``
 #      first), nor ``close`` a ``Txn`` (you must ``commit``/``rollback`` back to
 #      a ``Conn``). Illegal orderings simply do not type-check.
 #
@@ -22,7 +22,7 @@
 #
 #     let 1 c0 := connect "app.db" in
 #     let 1 t0 := begin c0 in
-#     let 1 t1 := execSql "INSERT INTO log VALUES ('x')" t0 in
+#     let 1 t1 := execute "INSERT INTO log VALUES ('x')" t0 in
 #     let 1 c1 := commit t1 in        # MUST commit or rollback — exactly once
 #     close c1                        # MUST close — and t0/t1 are now unusable
 
@@ -43,15 +43,15 @@ def row_count : (r: Rows) -> Int := uninterpreted
 
 # Runs a SELECT against `path` and returns every row. Both arguments must be
 # non-empty.
-def readAll (path: {p:String | p != ""}) (sql: {s:String | s != ""}) :
+def read_all (path: {p:String | p != ""}) (sql: {s:String | s != ""}) :
     {r: Rows | row_count r >= 0} :=
     native "__import__('aeon.bindings.database').bindings.database.read_all(path, sql)"
 
 # Number of rows returned. Pinned to the `row_count` measure; non-negative.
-def rowCount (r: Rows) : {n:Int | n = row_count r && n >= 0} := native "len(r)"
+def num_rows (r: Rows) : {n:Int | n = row_count r && n >= 0} := native "len(r)"
 
 # True exactly when the result set is empty. Tied to `row_count`.
-def isEmpty (r: Rows) : {b:Bool | b = (row_count r = 0)} := native "len(r) == 0"
+def is_empty (r: Rows) : {b:Bool | b = (row_count r = 0)} := native "len(r) == 0"
 
 # ── Linear write transactions (QTT) ─────────────────────────────────────
 #
@@ -71,7 +71,7 @@ def begin (1 c: Conn) : Txn :=
 
 # Executes one statement inside the transaction and threads the `Txn` onward.
 # `sql` must be non-empty.
-def execSql (sql: {s:String | s != ""}) (1 t: Txn) : Txn :=
+def execute (sql: {s:String | s != ""}) (1 t: Txn) : Txn :=
     native "(t.execute(sql), t)[1]"
 
 # Commits the transaction and returns the connection (now outside any txn) so

--- a/libraries/Http.ae
+++ b/libraries/Http.ae
@@ -1,0 +1,109 @@
+# Safe-by-construction bindings around the ``requests`` HTTP library.
+#
+# ``requests`` is ergonomic but quietly dangerous, and almost always in the
+# same three ways:
+#
+#   1. **No timeout.** ``requests.get(url)`` with no ``timeout`` blocks
+#      *forever* if the peer never responds — the single most common
+#      ``requests`` production incident. Every entry point here therefore
+#      *requires* a positive ``timeout`` argument; there is no timeout-less
+#      overload to reach for.
+#
+#   2. **Ignored status codes.** ``requests`` does not raise on a 4xx/5xx;
+#      callers routinely parse the body of a failed request. The HTTP status
+#      is reflected into an uninterpreted ``status`` measure so ``isSuccess``
+#      can be reasoned about, and ``raiseForStatus`` carries the postcondition
+#      ``status r < 400`` for code that wants failure to be impossible to miss.
+#
+#   3. **``.json()`` on a non-JSON body** raises ``JSONDecodeError``. ``bodyJson``
+#      hands back a ``Json`` value (see ``Json.ae``) whose shape you then query
+#      with the runtime-typed ``Json`` coercions, rather than assuming a dict.
+#
+# Preconditions (non-empty URL, positive timeout) cost nothing at runtime and
+# turn what would have been a hang or a ``MissingSchema`` into a compile error.
+
+open Map
+open Json
+
+type Response
+
+def requests : Unit := native_import "requests"
+
+# ── Measures ───────────────────────────────────────────────────────────
+
+# The HTTP status code of a response (e.g. 200, 404, 503). Uninterpreted: the
+# solver only relates it across calls — ``raiseForStatus`` pins it below 400,
+# ``isSuccess`` tests the 2xx band — it never computes it.
+def status : (r: Response) -> Int := uninterpreted
+
+# ── Requests ───────────────────────────────────────────────────────────
+#
+# ``url`` must be non-empty and ``timeout`` strictly positive (seconds). A
+# non-positive timeout is itself a bug — ``requests`` treats ``0`` as "fail
+# immediately" and ``None`` as "wait forever" — so the refinement rules both
+# out.
+
+# Issues a GET request.
+def get (url: {u:String | u != ""}) (timeout: {t:Float | t > 0.0}) : Response :=
+    native "requests.get(url, timeout=timeout)"
+
+# Issues a GET request with request headers supplied as a string→string Map.
+def getWithHeaders (url: {u:String | u != ""}) (headers: (Map String String))
+                   (timeout: {t:Float | t > 0.0}) : Response :=
+    native "requests.get(url, headers=headers, timeout=timeout)"
+
+# Issues a POST request with a raw string body.
+def post (url: {u:String | u != ""}) (body: String) (timeout: {t:Float | t > 0.0})
+    : Response :=
+    native "requests.post(url, data=body, timeout=timeout)"
+
+# Issues a POST request whose body is a JSON value (serialized for you, with
+# the ``Content-Type: application/json`` header set).
+def postJson (url: {u:String | u != ""}) (payload: Json) (timeout: {t:Float | t > 0.0})
+    : Response :=
+    native "requests.post(url, json=payload, timeout=timeout)"
+
+# Issues a PUT request with a raw string body.
+def put (url: {u:String | u != ""}) (body: String) (timeout: {t:Float | t > 0.0})
+    : Response :=
+    native "requests.put(url, data=body, timeout=timeout)"
+
+# Issues a DELETE request.
+def delete (url: {u:String | u != ""}) (timeout: {t:Float | t > 0.0}) : Response :=
+    native "requests.delete(url, timeout=timeout)"
+
+# ── Inspecting a response ──────────────────────────────────────────────
+
+# The status code as a value, pinned to the ``status`` measure so it can be
+# threaded into later refinements.
+def statusCode (r: Response) : {n:Int | n = status r} := native "r.status_code"
+
+# True exactly when the status is in the 2xx success band. Tied to the
+# ``status`` measure, so the ``then`` branch of a test can discharge
+# preconditions phrased over ``status r``.
+def isSuccess (r: Response) : {b:Bool | b = (status r >= 200 && status r < 300)} :=
+    native "(200 <= r.status_code) and (r.status_code < 300)"
+
+# Raises ``HTTPError`` on a 4xx/5xx response. Because control only returns on a
+# non-error status, the result is statically known to satisfy ``status r < 400``
+# — downstream code can read the body trusting the request succeeded.
+def raiseForStatus (r: Response) : {x:Response | status x < 400} :=
+    native "(r.raise_for_status(), r)[1]"
+
+# The response body decoded as text.
+def body (r: Response) : String := native "r.text"
+
+# The response body parsed as JSON. Raises if the body is not valid JSON; the
+# result is a ``Json`` value to be queried with the ``Json`` coercions.
+def bodyJson (r: Response) : Json := native "r.json()"
+
+# Size of the raw response body in bytes. Non-negative.
+def contentLength (r: Response) : {n:Int | n >= 0} := native "len(r.content)"
+
+# Looks up a response header (case-insensitive), returning ``default`` when the
+# header is absent — so this is total, never a KeyError.
+def getHeader (r: Response) (name: {s:String | s != ""}) (default: String) : String :=
+    native "r.headers.get(name, default)"
+
+# The final URL of the response, after any redirects.
+def finalUrl (r: Response) : String := native "r.url"

--- a/libraries/Subprocess.ae
+++ b/libraries/Subprocess.ae
@@ -22,6 +22,7 @@
 open Array
 
 type CompletedProcess
+type Process
 
 def subprocess : Unit := native_import "subprocess"
 
@@ -79,3 +80,38 @@ def stdout (p: CompletedProcess) : String := native "p.stdout"
 
 # Captured standard error (decoded text).
 def stderr (p: CompletedProcess) : String := native "p.stderr"
+
+# ── Linear (QTT) process handles ───────────────────────────────────────
+#
+# `run`/`checkRun` above are the safe all-in-one path: spawn, wait, and capture
+# in a single call. When you need a *long-running* child you start now and reap
+# later, use the linear `Process` API below.
+#
+# A `Process` is a multiplicity-1 resource: bound to a linear binder
+# (`let 1 p := Subprocess.spawn argv in ...`), the type checker forces every
+# spawned child to be reaped exactly once — via `wait`, `terminate`, or `kill`.
+# A forgotten reap (a zombie / leaked pipe) leaves the binder unconsumed
+# (`LinearUnusedError`); a double-wait reuses a consumed handle
+# (`LinearUsedTooManyTimesError`). Both are compile errors.
+
+# Spawns a child running `argv` and returns immediately, without waiting. Bind
+# the result to a linear binder. `argv` must be non-empty; no shell is involved.
+def spawn (argv: {a: (Array String) | Array.size a >= 1}) : Process :=
+    native "subprocess.Popen(argv)"
+
+# Blocks until the child exits, reaps it, and returns its exit code. Consumes
+# the handle, so the same process cannot be waited on twice or leaked.
+def wait (1 p: Process) : Int := native "p.wait()"
+
+# Like `wait` but gives up after `seconds` (> 0), raising `TimeoutExpired`.
+def waitFor (seconds: {s:Float | s > 0.0}) (1 p: Process) : Int :=
+    native "p.wait(timeout=seconds)"
+
+# Sends SIGTERM, waits for the child to exit, and returns its exit code.
+# Consumes the handle.
+def terminate (1 p: Process) : Int :=
+    native "(p.terminate(), p.wait())[1]"
+
+# Sends SIGKILL, waits, and returns the exit code. Consumes the handle.
+def kill (1 p: Process) : Int :=
+    native "(p.kill(), p.wait())[1]"


### PR DESCRIPTION
Three error-focused standard-library bindings on the `aeon-python-libraries` branch (follow-up to the merged `os`/`subprocess` work, #374). The first uses refinements alone; the latter two combine refinements with **Quantitative Type Theory** (linear/multiplicity types, as in `Socket.ae`) to make resource lifecycles state-safe.

---

## 1. `libraries/Http.ae` — `requests`, refinement-typed
Turns the three most common `requests` footguns into compile-time errors:
- **No timeout → hang forever.** Every entry point requires a strictly positive `timeout`; no timeout-less overload.
- **Ignored status codes.** Status reflected into an uninterpreted `status` measure; `isSuccess` tied to the 2xx band; `raiseForStatus` carries the postcondition `status r < 400`.
- **`.json()` on a non-JSON body.** `bodyJson` returns a `Json` value. URLs required non-empty; `getHeader` is total.

## 2. `libraries/Subprocess.ae` — linear `Process` handles (QTT)
`run`/`checkRun` (the safe all-in-one path) are unchanged. Added a multiplicity-1 `Process` layer over `subprocess.Popen` for children you start now and reap later: `spawn` returns a linear handle that must be consumed **exactly once** by `wait` / `waitFor` / `terminate` / `kill`. A forgotten reap (zombie / leaked pipe) is a `LinearUnusedError`; a double-wait is a `LinearUsedTooManyTimesError`.

## 3. `libraries/Database.ae` — state-safe sqlite3 (QTT + refinements)
The flagship combination of both ideas. `Conn` and `Txn` are distinct **linear** handle types, so the transaction lifecycle `connect → begin → execute* → commit|rollback → close` is enforced two ways:
- **Typestate** — can't `execute` on a `Conn` (must `begin` first), can't `close` a `Txn` (must `commit`/`rollback` first); illegal orderings don't type-check.
- **Linearity** — commit **xor** rollback exactly once; close exactly once. Forgotten commit (lost writes) and use-after-close become compile errors.

A non-linear one-shot `read_all` covers SELECTs that need no transaction, with non-negative `row_count` refinements; its read helper lives in `aeon/bindings/database.py`. The API is named in snake_case / DB-API style (`connect`, `execute`, `commit`, `rollback`, `close`, `read_all`, `num_rows`, `is_empty`).

---

## Verification — the guarantees actually bite

Refinements:
- ✅ `Http.get "…" 0.0` (non-positive timeout) and `Http.get "" 5.0` (empty URL) are both **rejected**.

Linearity (sqlite + process), each producing the expected error:
- ✅ Forget `close` / forget `commit`+`rollback` / forget `wait` → `Linear binding … is never used`.
- ✅ `commit` twice / `wait` twice → `Linear binding … is used 2 times`.

Typestate:
- ✅ `close` a `Txn` → `Expression has type Txn, but is expected to have type Conn`.

End-to-end runtime:
- ✅ sqlite round-trip: 2 committed inserts persist, a rolled-back insert is discarded (`read_all` returns 2 rows; verified directly against the db file).
- ✅ `spawn ["true"]` then `wait` returns exit code `0`.
- ✅ `ruff` + `mypy` clean on `aeon/bindings/database.py`; all `examples/imports/*.ae` pass; `--doc` generates clean HTML (auto-discovered via `libraries/*.ae` glob).

## Examples & docs
- Hermetic examples (`database_example.ae`, `subprocess_process_example.ae`, `http_example.ae`) follow the `socket_linear.ae` pattern — lifecycle in a helper, `main` prints a constant — so CI opens no db, spawns no child, makes no HTTP call.
- New docs: `docs/http.md`, `docs/database.md` (a QTT case study); `docs/os-subprocess.md` gains a linear-`Process` section; all linked from `docs/index.md`.

## Note on scope
This branch is pinned to `claude/aeon-python-libraries-pj280w`, so the Http commit (#375's original content) and the new QTT/Database commits share one PR. Happy to split them into separate PRs if you'd prefer — just let me know and I'll set up a second branch.

https://claude.ai/code/session_014LDN2TZ3z5WcwRYmj2WnZL