### PR TITLE
Use obj.method call syntax across stdlib and examples (#363)

### DIFF
--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -449,16 +449,20 @@ def resolve_qualified_names_in_sterm(
             # ``val`` is in the outer scope; ``name`` is bound only in ``body``.
             return SLet(name, rec(val), rec(body, frozenset({name.name})), loc=loc, multiplicity=t.multiplicity)
         case SRec(name, ty, val, body, decreasing_by, loc):
-            # ``name`` is recursively bound in its own value and the body.
+            # ``name`` is recursively bound in its own value and the body. Its
+            # type ascription can carry refinements that mention imports
+            # (``a : {x:_ | Array.size x = 5} := ...``), so resolve it too.
             inner = frozenset({name.name})
             nd = tuple(rec(m, inner) for m in decreasing_by)
+            nty = resolve_qualified_names_in_stype(ty, qualified_scope, unqualified_scope, constructor_defs, bound)
             return SRec(
-                name, ty, rec(val, inner), rec(body, inner), decreasing_by=nd, loc=loc, multiplicity=t.multiplicity
+                name, nty, rec(val, inner), rec(body, inner), decreasing_by=nd, loc=loc, multiplicity=t.multiplicity
             )
         case SIf(cond, then, otherwise, loc):
             return SIf(rec(cond), rec(then), rec(otherwise), loc=loc)
         case SAnnotation(expr, ty, loc):
-            return SAnnotation(rec(expr), ty, loc=loc)
+            nty = resolve_qualified_names_in_stype(ty, qualified_scope, unqualified_scope, constructor_defs, bound)
+            return SAnnotation(rec(expr), nty, loc=loc)
         case STypeApplication(body, ty, loc):
             return STypeApplication(rec(body), ty, loc=loc)
         case SRefinementApplication(body, refinement, loc):

--- a/examples/99problems/p03_kth.ae
+++ b/examples/99problems/p03_kth.ae
@@ -6,5 +6,5 @@ open Array
 def kth (l: (Array a)) (k: {n:Int | n >= 0 && n < Array.size l}) : a := native "l[k]"
 
 def main (args:Int) : Unit :=
-    xs := Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 10) 20) 30) 40;
+    xs := ((((Array.new[Int]).append 10).append 20).append 30).append 40;
     print (kth xs 2);

--- a/examples/99problems/p07_flatten.ae
+++ b/examples/99problems/p07_flatten.ae
@@ -6,10 +6,10 @@ open Array
 def flatten (l: (Array (Array Int))) : (Array Int) := native "[x for sub in l for x in sub]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.new[Int]) 1) 2;
-    b : (Array Int) := Array.append (Array.new[Int]) 3;
-    c : (Array Int) := Array.append (Array.append (Array.new[Int]) 4) 5;
-    n1 : (Array (Array Int)) := Array.append (Array.new[(Array Int)]) a;
-    n2 : (Array (Array Int)) := Array.append n1 b;
-    nested : (Array (Array Int)) := Array.append n2 c;
+    a : (Array Int) := ((Array.new[Int]).append 1).append 2;
+    b : (Array Int) := (Array.new[Int]).append 3;
+    c : (Array Int) := ((Array.new[Int]).append 4).append 5;
+    n1 : (Array (Array Int)) := (Array.new[(Array Int)]).append a;
+    n2 : (Array (Array Int)) := n1.append b;
+    nested : (Array (Array Int)) := n2.append c;
     print (flatten nested)

--- a/examples/99problems/p09_pack.ae
+++ b/examples/99problems/p09_pack.ae
@@ -8,5 +8,5 @@ def pack (l: (Array Int)) : (Array (Array Int)) :=
     native "[list(g) for k, g in itertools.groupby(l)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 1) 1) 2) 3) 3;
+    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
     print (pack a)

--- a/examples/99problems/p10_encode.ae
+++ b/examples/99problems/p10_encode.ae
@@ -9,5 +9,5 @@ def encode (l: (Array Int)) : (Array (Array Int)) :=
     native "[[len(list(g)), k] for k, g in itertools.groupby(l)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 1) 1) 2) 3) 3;
+    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
     print (encode a)

--- a/examples/99problems/p11_encode_modified.ae
+++ b/examples/99problems/p11_encode_modified.ae
@@ -10,5 +10,5 @@ def encode_modified (l: (Array Int)) : (Array (Array Int)) :=
     native "[(lambda gl: [k] if len(gl) == 1 else [len(gl), k])(list(g)) for k, g in itertools.groupby(l)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 1) 1) 2) 3) 3;
+    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
     print (encode_modified a)

--- a/examples/99problems/p12_decode.ae
+++ b/examples/99problems/p12_decode.ae
@@ -7,10 +7,10 @@ def decode (l: (Array (Array Int))) : (Array Int) :=
     native "[pair[1] for pair in l for _ in range(pair[0])]"
 
 def main (args:Int) : Unit :=
-    p1 : (Array Int) := Array.append (Array.append (Array.new[Int]) 3) 1;
-    p2 : (Array Int) := Array.append (Array.append (Array.new[Int]) 1) 2;
-    p3 : (Array Int) := Array.append (Array.append (Array.new[Int]) 2) 3;
-    enc1 : (Array (Array Int)) := Array.append (Array.new[(Array Int)]) p1;
-    enc2 : (Array (Array Int)) := Array.append enc1 p2;
-    enc : (Array (Array Int)) := Array.append enc2 p3;
+    p1 : (Array Int) := ((Array.new[Int]).append 3).append 1;
+    p2 : (Array Int) := ((Array.new[Int]).append 1).append 2;
+    p3 : (Array Int) := ((Array.new[Int]).append 2).append 3;
+    enc1 : (Array (Array Int)) := (Array.new[(Array Int)]).append p1;
+    enc2 : (Array (Array Int)) := enc1.append p2;
+    enc : (Array (Array Int)) := enc2.append p3;
     print (decode enc)

--- a/examples/99problems/p13_encode_direct.ae
+++ b/examples/99problems/p13_encode_direct.ae
@@ -9,5 +9,5 @@ def encode_direct (l: (Array Int)) : (Array (Array Int)) :=
     native "functools.reduce(lambda acc, x: acc + [[1, x]] if not acc or acc[-1][1] != x else acc[:-1] + [[acc[-1][0]+1, x]], l, [])"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 1) 1) 2) 3) 3;
+    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
     print (encode_direct a)

--- a/examples/99problems/p14_duplicate.ae
+++ b/examples/99problems/p14_duplicate.ae
@@ -7,5 +7,5 @@ def duplicate (l: (Array Int)) : {r:(Array Int) | Array.size r = 2 * Array.size 
     native "[x for x in l for _ in range(2)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3;
+    a : (Array Int) := (((Array.new[Int]).append 1).append 2).append 3;
     print (duplicate a)

--- a/examples/99problems/p15_replicate.ae
+++ b/examples/99problems/p15_replicate.ae
@@ -7,5 +7,5 @@ def replicate (l: (Array Int)) (n: {k:Int | k >= 0}) : {r:(Array Int) | Array.si
     native "[x for x in l for _ in range(n)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.new[Int]) 1) 2;
+    a : (Array Int) := ((Array.new[Int]).append 1).append 2;
     print (replicate a 3)

--- a/examples/99problems/p16_drop_every.ae
+++ b/examples/99problems/p16_drop_every.ae
@@ -7,5 +7,5 @@ def drop_every (l: (Array Int)) (n: {k:Int | k >= 1}) : (Array Int) :=
     native "[x for i, x in enumerate(l) if (i + 1) % n != 0]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3) 4) 5) 6) 7) 8;
+    a : (Array Int) := ((((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6).append 7).append 8;
     print (drop_every a 3)

--- a/examples/99problems/p17_split.ae
+++ b/examples/99problems/p17_split.ae
@@ -7,6 +7,6 @@ def split (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array.size l}) : (Array (
     native "[l[:n], l[n:]]"
 
 def main (args:Int) : Unit :=
-    a : {x:(Array Int) | Array_size x = 5} :=
+    a : {x:(Array Int) | Array.size x = 5} :=
         (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
     print (split a 2)

--- a/examples/99problems/p17_split.ae
+++ b/examples/99problems/p17_split.ae
@@ -3,10 +3,10 @@
 
 open Array
 
-def split (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array_size l}) : (Array (Array Int)) :=
+def split (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array.size l}) : (Array (Array Int)) :=
     native "[l[:n], l[n:]]"
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array_size x = 5} :=
-        Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3) 4) 5;
+        (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
     print (split a 2)

--- a/examples/99problems/p18_slice.ae
+++ b/examples/99problems/p18_slice.ae
@@ -9,6 +9,6 @@ def slice (l: (Array Int))
     native "l[i-1:k]"
 
 def main (args:Int) : Unit :=
-    a : {x:(Array Int) | Array_size x = 7} :=
+    a : {x:(Array Int) | Array.size x = 7} :=
         (((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6).append 7;
     print (slice a 3 5)

--- a/examples/99problems/p18_slice.ae
+++ b/examples/99problems/p18_slice.ae
@@ -4,11 +4,11 @@
 open Array
 
 def slice (l: (Array Int))
-          (i: {x:Int | x >= 1 && x <= Array_size l})
-          (k: {y:Int | y >= i && y <= Array_size l}) : (Array Int) :=
+          (i: {x:Int | x >= 1 && x <= Array.size l})
+          (k: {y:Int | y >= i && y <= Array.size l}) : (Array Int) :=
     native "l[i-1:k]"
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array_size x = 7} :=
-        Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3) 4) 5) 6) 7;
+        (((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6).append 7;
     print (slice a 3 5)

--- a/examples/99problems/p19_rotate.ae
+++ b/examples/99problems/p19_rotate.ae
@@ -3,9 +3,9 @@
 
 open Array
 
-def rotate (l: (Array Int)) (n: Int) : {r:(Array Int) | Array_size r = Array_size l} :=
+def rotate (l: (Array Int)) (n: Int) : {r:(Array Int) | Array.size r = Array.size l} :=
     native "l[n % len(l):] + l[:n % len(l)] if l else l"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3) 4) 5) 6) 7) 8;
+    a : (Array Int) := ((((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6).append 7).append 8;
     print (rotate a 3)

--- a/examples/99problems/p20_remove_at.ae
+++ b/examples/99problems/p20_remove_at.ae
@@ -3,11 +3,11 @@
 
 open Array
 
-def remove_at (l: (Array Int)) (k: {x:Int | x >= 0 && x < Array_size l}) :
-        {r:(Array Int) | Array_size r = Array_size l - 1} :=
+def remove_at (l: (Array Int)) (k: {x:Int | x >= 0 && x < Array.size l}) :
+        {r:(Array Int) | Array.size r = Array.size l - 1} :=
     native "l[:k] + l[k+1:]"
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array_size x = 5} :=
-        Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 10) 20) 30) 40) 50;
+        (((((Array.new[Int]).append 10).append 20).append 30).append 40).append 50;
     print (remove_at a 2)

--- a/examples/99problems/p20_remove_at.ae
+++ b/examples/99problems/p20_remove_at.ae
@@ -8,6 +8,6 @@ def remove_at (l: (Array Int)) (k: {x:Int | x >= 0 && x < Array.size l}) :
     native "l[:k] + l[k+1:]"
 
 def main (args:Int) : Unit :=
-    a : {x:(Array Int) | Array_size x = 5} :=
+    a : {x:(Array Int) | Array.size x = 5} :=
         (((((Array.new[Int]).append 10).append 20).append 30).append 40).append 50;
     print (remove_at a 2)

--- a/examples/99problems/p21_insert_at.ae
+++ b/examples/99problems/p21_insert_at.ae
@@ -3,11 +3,11 @@
 
 open Array
 
-def insert_at (x: Int) (l: (Array Int)) (k: {n:Int | n >= 0 && n <= Array_size l}) :
-        {r:(Array Int) | Array_size r = Array_size l + 1} :=
+def insert_at (x: Int) (l: (Array Int)) (k: {n:Int | n >= 0 && n <= Array.size l}) :
+        {r:(Array Int) | Array.size r = Array.size l + 1} :=
     native "l[:k] + [x] + l[k:]"
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array_size x = 4} :=
-        Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 4) 5;
+        ((((Array.new[Int]).append 1).append 2).append 4).append 5;
     print (insert_at 3 a 2)

--- a/examples/99problems/p21_insert_at.ae
+++ b/examples/99problems/p21_insert_at.ae
@@ -8,6 +8,6 @@ def insert_at (x: Int) (l: (Array Int)) (k: {n:Int | n >= 0 && n <= Array.size l
     native "l[:k] + [x] + l[k:]"
 
 def main (args:Int) : Unit :=
-    a : {x:(Array Int) | Array_size x = 4} :=
+    a : {x:(Array Int) | Array.size x = 4} :=
         ((((Array.new[Int]).append 1).append 2).append 4).append 5;
     print (insert_at 3 a 2)

--- a/examples/99problems/p22_range.ae
+++ b/examples/99problems/p22_range.ae
@@ -3,7 +3,7 @@
 
 open Array
 
-def intRange (low: Int) (high: {n:Int | n >= low}) : {r:(Array Int) | Array_size r = high - low + 1} :=
+def intRange (low: Int) (high: {n:Int | n >= low}) : {r:(Array Int) | Array.size r = high - low + 1} :=
     native "list(range(low, high + 1))"
 
 def main (args:Int) : Unit :=

--- a/examples/99problems/p23_random_select.ae
+++ b/examples/99problems/p23_random_select.ae
@@ -11,6 +11,6 @@ def rndSelect (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array.size l}) :
 
 def main (args:Int) : Unit :=
     _ := native "random.seed(42)";
-    a : {x:(Array Int) | Array_size x = 6} :=
+    a : {x:(Array Int) | Array.size x = 6} :=
         ((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6;
     print (rndSelect a 3)

--- a/examples/99problems/p23_random_select.ae
+++ b/examples/99problems/p23_random_select.ae
@@ -5,12 +5,12 @@ open Array
 
 def random : Unit := native_import "random"
 
-def rndSelect (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array_size l}) :
-        {r:(Array Int) | Array_size r = n} :=
+def rndSelect (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array.size l}) :
+        {r:(Array Int) | Array.size r = n} :=
     native "random.sample(l, n)"
 
 def main (args:Int) : Unit :=
     _ := native "random.seed(42)";
     a : {x:(Array Int) | Array_size x = 6} :=
-        Array.append (Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3) 4) 5) 6;
+        ((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6;
     print (rndSelect a 3)

--- a/examples/99problems/p24_lotto.ae
+++ b/examples/99problems/p24_lotto.ae
@@ -6,7 +6,7 @@ open Array
 def random : Unit := native_import "random"
 
 def lotto (n: {k:Int | k >= 0}) (m: {x:Int | x >= n}) :
-        {r:(Array Int) | Array_size r = n} :=
+        {r:(Array Int) | Array.size r = n} :=
     native "random.sample(range(1, m + 1), n)"
 
 def main (args:Int) : Unit :=

--- a/examples/99problems/p25_random_permutation.ae
+++ b/examples/99problems/p25_random_permutation.ae
@@ -5,10 +5,10 @@ open Array
 
 def random : Unit := native_import "random"
 
-def rndPermutation (l: (Array Int)) : {r:(Array Int) | Array_size r = Array_size l} :=
+def rndPermutation (l: (Array Int)) : {r:(Array Int) | Array.size r = Array.size l} :=
     native "random.sample(l, len(l))"
 
 def main (args:Int) : Unit :=
     _ := native "random.seed(7)";
-    a : (Array Int) := Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3) 4) 5;
+    a : (Array Int) := (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
     print (rndPermutation a)

--- a/examples/99problems/p26_combinations.ae
+++ b/examples/99problems/p26_combinations.ae
@@ -5,10 +5,10 @@ open Array
 
 def itertools : Unit := native_import "itertools"
 
-def combinations (k: {n:Int | n >= 0}) (l: {x:(Array Int) | Array_size x >= k}) : (Array (Array Int)) :=
+def combinations (k: {n:Int | n >= 0}) (l: {x:(Array Int) | Array.size x >= k}) : (Array (Array Int)) :=
     native "[list(c) for c in itertools.combinations(l, k)]"
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array_size x = 5} :=
-        Array.append (Array.append (Array.append (Array.append (Array.append (Array.new[Int]) 1) 2) 3) 4) 5;
+        (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
     print (combinations 3 a)

--- a/examples/99problems/p26_combinations.ae
+++ b/examples/99problems/p26_combinations.ae
@@ -9,6 +9,6 @@ def combinations (k: {n:Int | n >= 0}) (l: {x:(Array Int) | Array.size x >= k}) 
     native "[list(c) for c in itertools.combinations(l, k)]"
 
 def main (args:Int) : Unit :=
-    a : {x:(Array Int) | Array_size x = 5} :=
+    a : {x:(Array Int) | Array.size x = 5} :=
         (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
     print (combinations 3 a)

--- a/examples/PSB2/solved/bowling.ae
+++ b/examples/PSB2/solved/bowling.ae
@@ -14,38 +14,38 @@ def String_eq (s:String) (s2:String) : Bool := native "s == s2";
 
 def List_range_step (start:Int) (end:Int) (step:Int) : (Array Int) := native "list(range(start, end, step))"
 
- def convert_bowling(score: String) : Int := if String_eq score "X" then
+ def convert_bowling(score: String) : Int := if score.eq "X" then
     10
  else
-    if String_eq score "/" then
+    if score.eq "/" then
         10
     else
-        String_to_int score;
+        score.to_int;
 
 
-def create_mapper (scores:String) (i:Int) : Int := current : String := String_get scores i;
-    next : String := String_get scores (i+1);
-    if String_eq current "X" then
-        next_frame1 : String := String_get scores (i+2);
-        next_frame2 : String := String_get scores (i+3);
-        if String_eq next_frame2 "/" then
+def create_mapper (scores:String) (i:Int) : Int := current : String := scores.get i;
+    next : String := scores.get (i+1);
+    if current.eq "X" then
+        next_frame1 : String := scores.get (i+2);
+        next_frame2 : String := scores.get (i+3);
+        if next_frame2.eq "/" then
             20
-        else if String_eq next_frame1 "X" then
-            next_next_frame1 : String := String_get scores (i+4);
-            inc : Int := if String_eq next_next_frame1 "X" then 10 else String_to_int next_next_frame1;
+        else if next_frame1.eq "X" then
+            next_next_frame1 : String := scores.get (i+4);
+            inc : Int := if next_next_frame1.eq "X" then 10 else next_next_frame1.to_int;
             20 + inc
         else
             10 + convert_bowling next_frame1 + convert_bowling next_frame2
 
-    else if String_eq next "/" then
-        next_next : String := String_get scores (i+2);
+    else if next.eq "/" then
+        next_next : String := scores.get (i+2);
         10 + (convert_bowling next_next)
     else
-        String_to_int current + convert_bowling next;
+        current.to_int + convert_bowling next;
 
 
-def bowling_score (scores: String) : Int := scores_right_size := String_replace scores "X" "X_";
-    scores_zero := String_replace scores_right_size "-" "0";
+def bowling_score (scores: String) : Int := scores_right_size := scores.replace "X" "X_";
+    scores_zero := scores_right_size.replace "-" "0";
     r : (Array Int) := List_range_step 0 20 2;
     mapper : (i:Int) -> Int := create_mapper scores_zero;
     components : (Array Int) := List_map mapper r;

--- a/examples/PSB2/solved/camel_case.ae
+++ b/examples/PSB2/solved/camel_case.ae
@@ -13,20 +13,18 @@ def String_get : (s:String) -> (i:Int) -> String := fun s => fun i => native "s[
 def String_tail:(l:String) -> String := fun xs => native "xs[1:]"
 
 
-def camel_case (s:String) : String := groups: (Array Int) := String_split s " ";
+def camel_case (s:String) : String := groups: (Array Int) := s.split " ";
 
     camel_case_groups : (Array Int) := (Map_string_list
-        ((fun group =>  (String_concat
-                           (String_get group 0)
-                           (String_join
-                                  (Map_string_string ((fun x => String_capitalize x):(s:String) -> String) (String_tail group))
-                                  ""
+        ((fun group =>  ((group.get 0).concat
+                           ("".join
+                                  (Map_string_string ((fun x => x.capitalize):(s:String) -> String) (group.tail))
                            )
                      )
          ) : (s:String) -> String)
-        (Map_list_list ((fun g => (String_split g "-")):(s:String) -> (Array Int)) groups)
+        (Map_list_list ((fun g => (g.split "-")):(s:String) -> (Array Int)) groups)
     );
-    result : String := String_join camel_case_groups " ";
+    result : String := " ".join camel_case_groups;
     result;
 
 

--- a/examples/PSB2/solved/indices_of_substring.ae
+++ b/examples/PSB2/solved/indices_of_substring.ae
@@ -10,10 +10,10 @@ def String_equal : (i:String) -> (j:String) -> Bool := fun i => fun j => native 
 def String_slice : (i:String) -> (j:Int) -> (l:Int)-> String := fun i => fun j => fun l => native "i[j:l]"
 
 def indices_of_substring ( text :String) (target: String) : (Array Int) := start: Int := 0;
-    end: Int := ((String_len text) - (String_len target)) + 1 ;
+    end: Int := ((text.len) - (target.len)) + 1 ;
     step: Int := 1;
     indices : (Array Int) := Range start end step;
-    matching_indices : (Array Int) := Filter ((fun i => String_equal (String_slice text i (i + (String_len target))) target):(s:Int) -> Bool)  indices;
+    matching_indices : (Array Int) := Filter ((fun i => (text.slice i (i + (target.len))).equal target):(s:Int) -> Bool)  indices;
     matching_indices;
 
 def main (args:Int) : Unit := print(indices_of_substring "hello world" "lo" )

--- a/examples/PSB2/solved/mastermind.ae
+++ b/examples/PSB2/solved/mastermind.ae
@@ -21,12 +21,12 @@ def Counter_intersection : (c1:Counter) -> (c2:Counter) -> Counter := fun c1 => 
 def Counter_values : (c:Counter) -> (Array Int) := fun c => native "list(c.values())"
 def Tuple : (a:Int) -> (b:Int) -> (Array Int) := fun a => fun b => native "[a,b]"
 
-def mastermind ( code : String) (guess: String ) : (Array Int) := items_eq : (x:(Array Int)) -> Int := fun x => if String_eq (List_get_fst x) (List_get_snd x) then 1 else 0;
-    black_map : (Array Int) := Map_bool items_eq (String_Zip code guess);
+def mastermind ( code : String) (guess: String ) : (Array Int) := items_eq : (x:(Array Int)) -> Int := fun x => if (List_get_fst x).eq (List_get_snd x) then 1 else 0;
+    black_map : (Array Int) := Map_bool items_eq (code.Zip guess);
     black_pegs : Int := List_sum black_map;
 
-    paired: (Array Int) := Zip (String_toList code) (String_toList guess);
-    unmatched: (Array Int) := Filter ((fun z => String_neq (List_get_fst z) (List_get_snd z)):(s:(Array Int)) -> Bool) paired;
+    paired: (Array Int) := Zip (code.toList) (guess.toList);
+    unmatched: (Array Int) := Filter ((fun z => (List_get_fst z).neq (List_get_snd z)):(s:(Array Int)) -> Bool) paired;
 
     code_unmatched: (Array Int) := Map List_get_fst unmatched;
     guess_unmatched: (Array Int) := Map List_get_snd unmatched;

--- a/examples/PSB2/solved/middle_char.ae
+++ b/examples/PSB2/solved/middle_char.ae
@@ -10,7 +10,7 @@ def String_slice : (i:String) -> (j:Int) -> (l:Int)-> String := fun i => fun j =
 
 def equal_int : (a: Int) -> (b: Int) -> Bool := fun x => fun y => native "x == y";
 
-def middle_char  (s: String) : String := str_len : Int := String_len s;
+def middle_char  (s: String) : String := str_len : Int := s.len;
     a : Int := (str_len % 2);
     b : Bool := equal_int a 0;
     if (b) then
@@ -18,13 +18,13 @@ def middle_char  (s: String) : String := str_len : Int := String_len s;
         y: Float := (x / 2.0);
         snd_mid_char_index : Int := (Math_floor y) + 1;
         fst_mid_char_index : Int := snd_mid_char_index - 2 ;
-        mid_chars := String_slice s fst_mid_char_index snd_mid_char_index;
+        mid_chars := s.slice fst_mid_char_index snd_mid_char_index;
         mid_chars
     else
         x: Float := Math_toFloat str_len;
         y: Float := (x / 2.0);
         mid_char_index: Int := (Math_floor y);
-        m_char := String_slice s mid_char_index (mid_char_index+1);
+        m_char := s.slice mid_char_index (mid_char_index+1);
         m_char;
 
 

--- a/examples/PSB2/solved/paired_digits.ae
+++ b/examples/PSB2/solved/paired_digits.ae
@@ -14,10 +14,10 @@ def filter :  (f: (s:String) -> Bool) -> (l:(Array Int)) -> (Array Int) := fun f
 def List_sum: (l:(Array Int)) -> Int := fun xs => native "sum(xs)"
 def List_map_String_Int: (function:(a: String) -> Int) -> (l: (Array Int)) -> (Array Int) := fun f => fun xs => native "map(f, xs)"
 
-def paired_digits (nums: String) : Int := pairs: (Array Int) := String_to_List (String_zip (nums) (String_slice nums 1 (String_len nums)));
+def paired_digits (nums: String) : Int := pairs: (Array Int) := (nums.zip (nums.slice 1 (nums.len))).to_List;
     pred : (x:String) -> Bool := fun x => (get_fst x) = (get_snd x);
     matching_pairs : (Array Int) := filter pred pairs;
-    mapper : (x: String) -> Int := fun x => String_to_Int (get_fst x);
+    mapper : (x: String) -> Int := fun x => (get_fst x).to_Int;
     total_sum : Int := List_sum (List_map_String_Int mapper matching_pairs);
     total_sum;
 

--- a/examples/PSB2/solved/solve_boolean.ae
+++ b/examples/PSB2/solved/solve_boolean.ae
@@ -12,19 +12,19 @@ def String_slice: (s:String) -> (start:Int) -> (end:Int) -> String := fun s => f
 def String_length: (s:String) -> Int := fun s => native "len(s)"
 def List_get: (l:(Array Int)) -> (i:Int) -> String := fun xs => fun i => native "xs[i]"
 
-def solve_boolean ( s : String ) : Bool := if (String_equal s "t") then
+def solve_boolean ( s : String ) : Bool := if (s.equal "t") then
         true
     else
-        if (String_equal s "f") then
+        if (s.equal "f") then
             false
         else
-             if (String_equal (String_get s (-2))  "&") then
-                operand1: String := String_slice s 0 (-2);
-                operand2: String := String_slice s (-1) (String_length s);
+             if ((s.get (-2)).equal "&") then
+                operand1: String := s.slice 0 (-2);
+                operand2: String := s.slice (-1) (s.length);
                 solve_boolean operand1 && solve_boolean operand2
              else
-                operand1: String := String_slice s 0 (-2);
-                operand2: String := String_slice s (-1) (String_length s);
+                operand1: String := s.slice 0 (-2);
+                operand2: String := s.slice (-1) (s.length);
                 solve_boolean operand1 || solve_boolean operand2;
 
 

--- a/examples/PSB2/solved/spin_words.ae
+++ b/examples/PSB2/solved/spin_words.ae
@@ -5,8 +5,8 @@ def map_String_String_List : (function:(a: String) -> String) -> (l: (Array Int)
 def String_split : (i:String) -> (j:String) -> (Array Int) := fun i => fun j => native "i.split(j)"
 def String_reverse : (i:String) -> String := fun i => native "i[::-1]"
 
-def spin_words (phrase: String) : String := words: (Array Int) := String_split phrase " ";
-    rev : (x:String) -> String := fun x => if String_len(x) >= 5 then String_reverse x else x;
+def spin_words (phrase: String) : String := words: (Array Int) := phrase.split " ";
+    rev : (x:String) -> String := fun x => if x.len >= 5 then x.reverse else x;
     reversed_words : (Array Int) := map_String_String_List rev words;
     String_list_to_String reversed_words;
 

--- a/examples/PSB2/solved/square_digits.ae
+++ b/examples/PSB2/solved/square_digits.ae
@@ -14,6 +14,6 @@ def square_digits ( n : Int) : String := if n = 0 then
         if floor = 0 then
             String_intToString(square)
         else
-            String_concat (square_digits(Math_floor_division n 10)) (String_intToString(square));
+            (square_digits(Math_floor_division n 10)).concat (String_intToString(square));
 
 def main (n : Int) : Unit := print (square_digits 44 )

--- a/examples/PSB2/solved/substitution_cipher.ae
+++ b/examples/PSB2/solved/substitution_cipher.ae
@@ -11,7 +11,7 @@ def Dict_get : (d: Dict) -> (k: String) -> (default: String) -> String := fun d 
 def Map_String_String: (function: (a:String) -> String) -> (l: String) -> (Array Int) := fun f => fun xs => native "map(f, xs)"
 
 def cipher (cipher_from: String) ( cypher_to: String) (msg: String) : String := cipher_dict: Dict := Dict_zip (Zip_String_String cipher_from cypher_to);
- mapper : (x:String) -> String := fun x => Dict_get cipher_dict x x;
+ mapper : (x:String) -> String := fun x => cipher_dict.get x x;
  deciphered_chars: (Array Int) := Map_String_String mapper msg;
  String_list_to_String deciphered_chars;
 

--- a/examples/PSB2/solved/twitter.ae
+++ b/examples/PSB2/solved/twitter.ae
@@ -4,7 +4,7 @@ def String_intToString : (i:Int) -> String := fun i => native "str(i)"
 def String_concat : (i:String) -> (j:String) -> String := fun i => fun j => native "i + j"
 
 
-def validate_tweet (tweet: String) : String := tweet_length := String_len(tweet);
+def validate_tweet (tweet: String) : String := tweet_length := tweet.len;
     if tweet_length = 0 then
         "You didn’t type anything"
     else
@@ -12,7 +12,7 @@ def validate_tweet (tweet: String) : String := tweet_length := String_len(tweet)
             "Too many characters"
         else
             tweet_length_str := String_intToString(tweet_length);
-            String_concat (String_concat "Your tweet has " tweet_length_str)   " characters";
+            ("Your tweet has ".concat tweet_length_str).concat " characters";
 
 def  main (x: Int) : Unit := tweet := validate_tweet "Hello, World!";
     print tweet;

--- a/examples/bug.ae
+++ b/examples/bug.ae
@@ -1,6 +1,6 @@
 import List
 
 def main (args:Int) : Unit :=
-    e : {x:(List Int) | List_size x = 0} := List.nil;
+    e : {x:(List Int) | List.size x = 0} := List.nil;
     b : Bool := e.empty;
     print b

--- a/examples/bug.ae
+++ b/examples/bug.ae
@@ -2,5 +2,5 @@ import List
 
 def main (args:Int) : Unit :=
     e : {x:(List Int) | List_size x = 0} := List.nil;
-    b : Bool := List.empty e;
+    b : Bool := e.empty;
     print b

--- a/examples/demos/2_image.ae
+++ b/examples/demos/2_image.ae
@@ -5,8 +5,8 @@ open Color
 def main (steps:Int) : Image := white : Color := Color.mk 255 255 255;
     green : Color := Color.mk 0 255 0;
     image0 := Image.mk 64 64 white;
-    image1 := Image.draw_rectangle image0 0 0 32 32 white;
-    image2 := Image.draw_rectangle image1 0 32 32 32 green;
-    image3 := Image.draw_rectangle image2 32 0 32 32 green;
-    image4 := Image.draw_rectangle image3 32 32 32 32 white;
+    image1 := image0.draw_rectangle 0 0 32 32 white;
+    image2 := image1.draw_rectangle 0 32 32 32 green;
+    image3 := image2.draw_rectangle 32 0 32 32 green;
+    image4 := image3.draw_rectangle 32 32 32 32 white;
     image4;

--- a/examples/image/key.ae
+++ b/examples/image/key.ae
@@ -37,11 +37,11 @@ def synth_key : { img : Image | (width img = target_w) && (height img = target_h
 # Human-readable reference for the shape (matches the historical hand-written key program).
 def reference_key : Image :=
     image0 := Image.mk target_w target_h white;
-    image1 := Image.draw_rectangle image0 170 256 256 256 key_grey;
-    image2 := Image.draw_rectangle image1 255 341 85 83 white;
-    image3 := Image.draw_rectangle image2 426 341 509 83 key_grey;
-    image4 := Image.draw_rectangle image3 836 424 100 68 key_grey;
-    image5 := Image.draw_rectangle image4 686 424 100 48 key_grey;
+    image1 := image0.draw_rectangle 170 256 256 256 key_grey;
+    image2 := image1.draw_rectangle 255 341 85 83 white;
+    image3 := image2.draw_rectangle 426 341 509 83 key_grey;
+    image4 := image3.draw_rectangle 836 424 100 68 key_grey;
+    image5 := image4.draw_rectangle 686 424 100 48 key_grey;
     image5;
 
-# def dump_reference : Unit = Image.save reference_key "examples/image/key.jpg"
+# def dump_reference : Unit = reference_key.save "examples/image/key.jpg"

--- a/examples/image/pil_style.ae
+++ b/examples/image/pil_style.ae
@@ -8,10 +8,10 @@ def accent : Color := Color.mk 220 90 50
 def demo : Image :=
     base := Image.mk 400 300 white;
     stamp := Image.mk 80 60 accent;
-    layered := Image.paste base stamp 40 30;
-    region := Image.crop layered 20 20 200 120;
-    thumb := Image.resize region 100 60;
+    layered := base.paste stamp 40 30;
+    region := layered.crop 20 20 200 120;
+    thumb := region.resize 100 60;
     thumb;
 
 # Writing to disk is side-effecting; keep as a named unit if you add a main later.
-# def _save : Unit = Image.save demo "examples/image/pil_style_out.png"
+# def _save : Unit = demo.save "examples/image/pil_style_out.png"

--- a/examples/image/pixels.ae
+++ b/examples/image/pixels.ae
@@ -7,16 +7,16 @@ def black : Color := Color.mk 0 0 0
 
 def line_scan : Color :=
     canvas := Image.mk 32 1 white;
-    c0 := Image.get_pixel canvas 0 0;
-    dotted := Image.put_pixel canvas 16 0 black;
-    c1 := Image.get_pixel dotted 16 0;
+    c0 := canvas.get_pixel 0 0;
+    dotted := canvas.put_pixel 16 0 black;
+    c1 := dotted.get_pixel 16 0;
     # A tiny pipeline: read default white, then read after painting black
     c1;
 
 def negated : Image :=
     small := Image.mk 64 64 white;
-    Image.invert small;
+    small.invert;
 
 def softened : Image :=
     small := Image.mk 64 64 white;
-    Image.blur small 2.0;
+    small.blur 2.0;

--- a/examples/imports/json_example.ae
+++ b/examples/imports/json_example.ae
@@ -4,12 +4,12 @@ open Json
 
 def built : Json :=
     o0 : Json := Json.mkObject;
-    o1 : Json := Json.setKey o0 "name" (Json.mkString "Aeon");
-    Json.setKey o1 "version" (Json.mkInt 4)
+    o1 : Json := o0.setKey "name" (Json.mkString "Aeon");
+    o1.setKey "version" (Json.mkInt 4)
 
 # stringify is refined non-empty, so it can be passed directly to parse.
-def decoded : Json := Json.parse (Json.stringify built)
+def decoded : Json := Json.parse (built.stringify)
 
-def name : String := Json.asString (Json.get decoded "name")
+def name : String := (decoded.get "name").asString
 
 def main (_:Int) : Unit := print name

--- a/examples/imports/path_example.ae
+++ b/examples/imports/path_example.ae
@@ -4,11 +4,11 @@ open Path
 # query it. Pure operations only — no filesystem mutations so the
 # example is reproducible.
 
-def projectFile : Path := Path.join (Path.cwd unit) "pyproject.toml"
+def projectFile : Path := (Path.cwd unit).join "pyproject.toml"
 
-def fileName : String := Path.name projectFile
+def fileName : String := projectFile.name
 
-def fileSuffix : String := Path.suffix projectFile
+def fileSuffix : String := projectFile.suffix
 
 def main (_:Int) : Unit :=
     _ : Unit := print fileName;

--- a/examples/imports/subprocess_example.ae
+++ b/examples/imports/subprocess_example.ae
@@ -6,7 +6,7 @@ open Array
 # `Array.size` postconditions of `append` discharge that automatically.
 
 def echoArgs : {a: (Array String) | Array.size a >= 1} :=
-    Array.append (Array.append (Array.new[String]) "echo") "hello"
+    ((Array.new[String]).append "echo").append "hello"
 
 # Inspect the exit code before trusting the output. `succeeded` ties the
 # boolean to the `exitCode` measure, so the branch reads cleanly.

--- a/examples/imports/sys_example.ae
+++ b/examples/imports/sys_example.ae
@@ -2,7 +2,7 @@ open Sys
 open Array
 
 # argv is statically known to be non-empty, so Array.head is well-typed.
-def progName : String := Array.head Sys.argv
+def progName : String := (Sys.argv).head
 
 def show : Unit :=
     _ : Unit := print Sys.platform;

--- a/examples/list/test_list_main.ae
+++ b/examples/list/test_list_main.ae
@@ -6,9 +6,9 @@ def pos : Int := consume (List.snoc (List.nil[Int]) 1)
 
 def main (x:Int) : Unit :=
     nil0 : (List Int) := List.nil[Int];
-    one : (List Int) := List.snoc nil0 3;
-    two : (List Int) := List.snoc one 2;
-    three : (List Int) := List.snoc two 1;
+    one : (List Int) := nil0.snoc 3;
+    two : (List Int) := one.snoc 2;
+    three : (List Int) := two.snoc 1;
     plus : (x:Int) -> (y: Int) -> Int := (fun x => fun y => x + y);
-    v : Int := (List.foldr plus 0 three);
+    v : Int := (three.foldr plus 0);
     print v;

--- a/examples/pair.ae
+++ b/examples/pair.ae
@@ -1,21 +1,21 @@
 type Pair
 
-def Pair_fst_logical : (p:Pair) -> Int := uninterpreted
+def Pair.fst_logical : (p:Pair) -> Int := uninterpreted
 
-def Pair_snd_logical : (p:Pair) -> Int := uninterpreted
+def Pair.snd_logical : (p:Pair) -> Int := uninterpreted
 
-def Pair_mk (x:Int) (y:{ y:Int | y > x}) : Pair := native "(x,y)"
+def Pair.mk (x:Int) (y:{ y:Int | y > x}) : Pair := native "(x,y)"
 
 
 def assert : (b:{b:Bool | b}) -> Unit := native "()"
 
-# def Pair_fst (p:Pair) : Int { native "p[0]" }
+# def Pair.fst (p:Pair) : Int { native "p[0]" }
 
-# def Pair_snd (p:Pair) : { y:Int | y == Pair_snd_logical p } { native "p[1]" }
+# def Pair.snd (p:Pair) : { y:Int | y == Pair.snd_logical p } { native "p[1]" }
 
 
 def main (args:Int) : Unit := a := 1;
     b := 3;
-    #x = Pair_mk a b;
+    #x = Pair.mk a b;
     #y = assert true;
     print "hello";

--- a/examples/pbt/pbt_reverse.ae
+++ b/examples/pbt/pbt_reverse.ae
@@ -1,10 +1,10 @@
 open Array
 open PropTesting
 
-def reverse (xs: (Array Int)) : (Array Int) := Array.reversed(xs)
+def reverse (xs: (Array Int)) : (Array Int) := xs.reversed
 
 
-def prop_reversed_lists_same_size (xs:(Array Int)) : Bool := (Array.length xs) = (Array.length (reverse xs));
+def prop_reversed_lists_same_size (xs:(Array Int)) : Bool := (xs.length) = ((reverse xs).length);
 
 def list_property_testing (y: Int) : Float := forAllLists prop_reversed_lists_same_size
 

--- a/examples/pbt/props_args.ae
+++ b/examples/pbt/props_args.ae
@@ -33,10 +33,10 @@ def argvOutFile : (Array String) := native "['--out', 'file.txt']"
 def argvNum99 : (Array String) := native "['--num', '99']"
 def argvModeSlow : (Array String) := native "['--mode', 'slow']"
 
-# Built via Array.append so its size (2 > 0) is provable — addChoice requires
+# Built by chaining .append so its size (2 > 0) is provable — addChoice requires
 # a statically non-empty list of options.
 def choicesModes : {l : (Array String) | Array.size l > 0} :=
-    Array.append (Array.append Array.new "fast") "slow"
+    ((Array.new[String]).append "fast").append "slow"
 
 def singleton (x : String) : (Array String) := native "[x]"
 
@@ -75,7 +75,7 @@ def prop_int_positional_roundtrips (d : {v : Int | v >= 0}) : Bool :=
 def getName (argv : (Array String)) : Bool :=
     p : Parser := Args.addArg (Args.newParser "t") "name" "";
     a : ParsedArgs := Args.parseList p argv;
-    String.equal (Args.getString a "name") "alice";
+    (Args.getString a "name").equal "alice";
 
 # Required int positional.
 @example(getCount argv42 = 42)

--- a/examples/sets/verified_list.ae
+++ b/examples/sets/verified_list.ae
@@ -18,27 +18,27 @@ def elts : (l:IntList) -> Set := uninterpreted
 def empty : {l:IntList | elts l = Set_empty} := native "[]"
 
 # Cons adds exactly one element
-def cons (x:Int) (xs:IntList) : {l:IntList | elts l = Set_cup (Set_sng x) (elts xs)} :=
+def IntList.cons (x:Int) (xs:IntList) : {l:IntList | elts l = Set_cup (Set_sng x) (elts xs)} :=
     native "[x] + xs"
 
 # Append is union of elements
-def append (xs:IntList) (ys:IntList) : {l:IntList | elts l = Set_cup (elts xs) (elts ys)} :=
+def IntList.append (xs:IntList) (ys:IntList) : {l:IntList | elts l = Set_cup (elts xs) (elts ys)} :=
     native "xs + ys"
 
 # Sort preserves elements (permutation property)
-def sort (xs:IntList) : {l:IntList | elts l = elts xs} := native "sorted(xs)"
+def IntList.sort (xs:IntList) : {l:IntList | elts l = elts xs} := native "sorted(xs)"
 
 # Filter returns a subset
-def myfilter (xs:IntList) : {l:IntList | Set_sub (elts l) (elts xs)} :=
+def IntList.myfilter (xs:IntList) : {l:IntList | Set_sub (elts l) (elts xs)} :=
     native "[x for x in xs if x > 0]"
 
 # Membership check is faithful
-def contains (x:Int) (xs:IntList) : {b:Bool | b = Set_mem x (elts xs)} :=
+def IntList.contains (x:Int) (xs:IntList) : {b:Bool | b = Set_mem x (elts xs)} :=
     native "x in xs"
 
 def main (_:Int) : Unit :=
-    a := cons 3 (cons 1 (cons 2 empty));
-    b := sort a;
-    c := append a b;
-    d := myfilter c;
-    print(contains 3 d)
+    a := ((empty.cons 2).cons 1).cons 3;
+    b := a.sort;
+    c := a.append b;
+    d := c.myfilter;
+    print (d.contains 3)

--- a/examples/syntax/length.ae
+++ b/examples/syntax/length.ae
@@ -1,5 +1,5 @@
 import List
 
-def create (i:Int) : {l:(List Int) | List_size l = 0} := List.nil
+def create (i:Int) : {l:(List Int) | List.size l = 0} := List.nil
 
 def main (args:Int) : Unit := print "Hello World"

--- a/examples/synthesis/dace/aggregate_sum.ae
+++ b/examples/synthesis/dace/aggregate_sum.ae
@@ -3,6 +3,6 @@ open Table
 
 def t : Table := native "[{'amount':10},{'amount':20},{'amount':5}]";
 
-def total : Int := Table.sum_col t "amount";  # 35
+def total : Int := t.sum_col "amount";  # 35
 
 def main (x:Int) : Unit := print total;

--- a/examples/synthesis/dace/column_formula.ae
+++ b/examples/synthesis/dace/column_formula.ae
@@ -6,9 +6,9 @@ open Table
 def orders : Table :=
     native "[{'item':'a','qty':2,'price':3},{'item':'b','qty':5,'price':4},{'item':'c','qty':1,'price':7}]";
 
-def completed : Table := Table.mutate orders "total" (fun row => native "row['qty'] * row['price']");
+def completed : Table := orders.mutate "total" (fun row => native "row['qty'] * row['price']");
 
 # 2*3 + 5*4 + 1*7 = 33
-def grand_total : Int := Table.sum_col completed "total";
+def grand_total : Int := completed.sum_col "total";
 
 def main (x:Int) : Unit := print grand_total;

--- a/examples/synthesis/dace/filter_aggregate.ae
+++ b/examples/synthesis/dace/filter_aggregate.ae
@@ -3,8 +3,8 @@ open Table
 
 def t : Table := native "[{'ok':1,'v':10},{'ok':0,'v':20},{'ok':1,'v':5}]";
 
-def kept : Table := Table.filter t (fun row => native "row['ok'] == 1");
+def kept : Table := t.filter (fun row => native "row['ok'] == 1");
 
-def total : Int := Table.sum_col kept "v";  # 10 + 5 = 15
+def total : Int := kept.sum_col "v";  # 10 + 5 = 15
 
 def main (x:Int) : Unit := print total;

--- a/examples/synthesis/dace/group_average.ae
+++ b/examples/synthesis/dace/group_average.ae
@@ -6,8 +6,8 @@ open Table
 def sales : Table :=
     native "[{'region':'N','v':10},{'region':'N','v':20},{'region':'S','v':6}]";
 
-def north : Table := Table.filter sales (fun row => native "row['region'] == 'N'");
+def north : Table := sales.filter (fun row => native "row['region'] == 'N'");
 
-def north_avg : Int := Table.mean_col north "v";  # (10 + 20) / 2 = 15
+def north_avg : Int := north.mean_col "v";  # (10 + 20) / 2 = 15
 
 def main (x:Int) : Unit := print north_avg;

--- a/examples/synthesis/dace/join_lookup.ae
+++ b/examples/synthesis/dace/join_lookup.ae
@@ -5,9 +5,9 @@ open Table
 def orders : Table := native "[{'item':1,'qty':2},{'item':2,'qty':3}]";
 def prices : Table := native "[{'item':1,'price':10},{'item':2,'price':7}]";
 
-def joined    : Table := Table.join orders prices "item";
-def with_cost : Table := Table.mutate joined "cost" (fun row => native "row['qty'] * row['price']");
+def joined    : Table := orders.join prices "item";
+def with_cost : Table := joined.mutate "cost" (fun row => native "row['qty'] * row['price']");
 
-def total_cost : Int := Table.sum_col with_cost "cost";  # 2*10 + 3*7 = 41
+def total_cost : Int := with_cost.sum_col "cost";  # 2*10 + 3*7 = 41
 
 def main (x:Int) : Unit := print total_cost;

--- a/examples/synthesis/dace/melt_long.ae
+++ b/examples/synthesis/dace/melt_long.ae
@@ -6,8 +6,8 @@ def wide : Table := native "[{'id':1,'x':7,'y':8}]";
 def ids  : (Array String) := native "['id']";
 def vals : (Array String) := native "['x','y']";
 
-def long : Table := Table.melt wide ids vals "k" "v";
+def long : Table := wide.melt ids vals "k" "v";
 
-def v1 : Int := Table.cell long 1 "v";  # second melted row (y) -> 8
+def v1 : Int := long.cell 1 "v";  # second melted row (y) -> 8
 
 def main (x:Int) : Unit := print v1;

--- a/examples/synthesis/dace/pivot_wide.ae
+++ b/examples/synthesis/dace/pivot_wide.ae
@@ -4,8 +4,8 @@ open Table
 def long : Table :=
     native "[{'id':1,'k':'x','v':7},{'id':1,'k':'y','v':8},{'id':2,'k':'x','v':9}]";
 
-def wide : Table := Table.pivot long "id" "k" "v";
+def wide : Table := long.pivot "id" "k" "v";
 
-def cell_x0 : Int := Table.cell wide 0 "x";  # row id=1, column x -> 7
+def cell_x0 : Int := wide.cell 0 "x";  # row id=1, column x -> 7
 
 def main (x:Int) : Unit := print cell_x0;

--- a/examples/synthesis/dace/running_balance.ae
+++ b/examples/synthesis/dace/running_balance.ae
@@ -4,8 +4,8 @@ open Table
 
 def tx : Table := native "[{'d':1,'amt':10},{'d':2,'amt':-3},{'d':3,'amt':5}]";
 
-def withbal : Table := Table.cumsum tx "amt" "balance";
+def withbal : Table := tx.cumsum "amt" "balance";
 
-def final_balance : Int := Table.cell withbal 2 "balance";  # 10 - 3 + 5 = 12
+def final_balance : Int := withbal.cell 2 "balance";  # 10 - 3 + 5 = 12
 
 def main (x:Int) : Unit := print final_balance;

--- a/examples/testing/image_tests.ae
+++ b/examples/testing/image_tests.ae
@@ -33,33 +33,33 @@ open Image
 @property(1)
 def test_mk_dimensions : Bool :=
     img := Image.mk 4 3 (Color.mk 255 0 0);
-    both (assertEqual (Image.get_width img) 4)
-         (assertEqual (Image.get_height img) 3);
+    both (assertEqual (img.get_width) 4)
+         (assertEqual (img.get_height) 3);
 
 # `crop` returns an image of the requested size.
 @property(1)
 def test_crop_dimensions : Bool :=
-    cropped := Image.crop (Image.mk 10 10 (Color.mk 0 0 0)) 2 2 5 4;
-    both (assertEqual (Image.get_width cropped) 5)
-         (assertEqual (Image.get_height cropped) 4);
+    cropped := (Image.mk 10 10 (Color.mk 0 0 0)).crop 2 2 5 4;
+    both (assertEqual (cropped.get_width) 5)
+         (assertEqual (cropped.get_height) 4);
 
 # `resize` resamples to an exact width and height.
 @property(1)
 def test_resize_dimensions : Bool :=
-    resized := Image.resize (Image.mk 8 8 (Color.mk 0 0 0)) 32 16;
-    both (assertEqual (Image.get_width resized) 32)
-         (assertEqual (Image.get_height resized) 16);
+    resized := (Image.mk 8 8 (Color.mk 0 0 0)).resize 32 16;
+    both (assertEqual (resized.get_width) 32)
+         (assertEqual (resized.get_height) 16);
 
 # `flip` and `invert` preserve dimensions.
 @property(1)
 def test_transforms_preserve_size : Bool :=
     img := Image.mk 6 4 (Color.mk 7 7 7);
-    flipped := Image.flip_horizontal img;
-    inverted := Image.invert img;
-    allOf4 (assertEqual (Image.get_width flipped) 6)
-           (assertEqual (Image.get_height flipped) 4)
-           (assertEqual (Image.get_width inverted) 6)
-           (assertEqual (Image.get_height inverted) 4);
+    flipped := img.flip_horizontal;
+    inverted := img.invert;
+    allOf4 (assertEqual (flipped.get_width) 6)
+           (assertEqual (flipped.get_height) 4)
+           (assertEqual (inverted.get_width) 6)
+           (assertEqual (inverted.get_height) 4);
 
 # ── Unit tests: pixel content ────────────────────────────────────────────────
 
@@ -67,94 +67,94 @@ def test_transforms_preserve_size : Bool :=
 @property(1)
 def test_mk_is_solid : Bool :=
     img := Image.mk 4 4 (Color.mk 10 20 30);
-    both (assertEqual (Image.get_pixel img 0 0) (Color.mk 10 20 30))
-         (assertEqual (Image.get_pixel img 3 3) (Color.mk 10 20 30));
+    both (assertEqual (img.get_pixel 0 0) (Color.mk 10 20 30))
+         (assertEqual (img.get_pixel 3 3) (Color.mk 10 20 30));
 
 # `copy` is content-preserving: an exact copy differs from the original by 0.
 @property(1)
 def test_copy_is_identical : Bool :=
     img := Image.mk 8 8 (Color.mk 1 2 3);
-    assertClose (Image.diff (Image.copy img) img) 0.0 0.0001;
+    assertClose ((img.copy).diff img) 0.0 0.0001;
 
 # `put_pixel` writes the pixel you asked for and leaves the rest alone.
 @property(1)
 def test_put_pixel_writes_and_isolates : Bool :=
     img := Image.mk 4 4 (Color.mk 0 0 0);
-    painted := Image.put_pixel img 1 2 (Color.mk 9 8 7);
-    allOf3 (assertEqual (Image.get_pixel painted 1 2) (Color.mk 9 8 7))
-           (assertEqual (Image.get_pixel painted 0 0) (Color.mk 0 0 0))
-           (assertEqual (Image.get_pixel painted 3 3) (Color.mk 0 0 0));
+    painted := img.put_pixel 1 2 (Color.mk 9 8 7);
+    allOf3 (assertEqual (painted.get_pixel 1 2) (Color.mk 9 8 7))
+           (assertEqual (painted.get_pixel 0 0) (Color.mk 0 0 0))
+           (assertEqual (painted.get_pixel 3 3) (Color.mk 0 0 0));
 
 # `crop` returns the requested sub-region's content at the new origin.
 @property(1)
 def test_crop_content : Bool :=
     base := Image.mk 4 4 (Color.mk 0 0 0);
-    img := Image.put_pixel base 2 2 (Color.mk 1 2 3);
-    cropped := Image.crop img 2 2 2 2;
-    assertEqual (Image.get_pixel cropped 0 0) (Color.mk 1 2 3);
+    img := base.put_pixel 2 2 (Color.mk 1 2 3);
+    cropped := img.crop 2 2 2 2;
+    assertEqual (cropped.get_pixel 0 0) (Color.mk 1 2 3);
 
 # Resampling a solid image leaves it the same solid colour.
 @property(1)
 def test_resize_solid_keeps_colour : Bool :=
     red := Image.mk 8 8 (Color.mk 200 10 10);
-    small := Image.resize red 4 4;
-    assertEqual (Image.get_pixel small 0 0) (Color.mk 200 10 10);
+    small := red.resize 4 4;
+    assertEqual (small.get_pixel 0 0) (Color.mk 200 10 10);
 
 # Rotating a full turn is the identity.
 @property(1)
 def test_rotate_full_turn_identity : Bool :=
     base := Image.mk 4 4 (Color.mk 0 0 0);
-    img := Image.put_pixel base 0 0 (Color.mk 255 255 255);
-    assertClose (Image.diff (Image.rotate img 360.0) img) 0.0 0.0001;
+    img := base.put_pixel 0 0 (Color.mk 255 255 255);
+    assertClose ((img.rotate 360.0).diff img) 0.0 0.0001;
 
 # Flipping horizontally moves a pixel from column 0 to the last column, and is
 # its own inverse.
 @property(1)
 def test_flip_horizontal_swaps_and_involution : Bool :=
     base := Image.mk 4 4 (Color.mk 0 0 0);
-    img := Image.put_pixel base 0 1 (Color.mk 255 255 255);
-    flipped := Image.flip_horizontal img;
-    twice := Image.flip_horizontal flipped;
-    allOf3 (assertEqual (Image.get_pixel flipped 3 1) (Color.mk 255 255 255))
-           (assertEqual (Image.get_pixel flipped 0 1) (Color.mk 0 0 0))
-           (assertClose (Image.diff twice img) 0.0 0.0001);
+    img := base.put_pixel 0 1 (Color.mk 255 255 255);
+    flipped := img.flip_horizontal;
+    twice := flipped.flip_horizontal;
+    allOf3 (assertEqual (flipped.get_pixel 3 1) (Color.mk 255 255 255))
+           (assertEqual (flipped.get_pixel 0 1) (Color.mk 0 0 0))
+           (assertClose (twice.diff img) 0.0 0.0001);
 
 # Flipping vertically twice is the identity.
 @property(1)
 def test_flip_vertical_involution : Bool :=
     base := Image.mk 4 4 (Color.mk 0 0 0);
-    img := Image.put_pixel base 1 0 (Color.mk 255 255 255);
-    twice := Image.flip_vertical (Image.flip_vertical img);
-    assertClose (Image.diff twice img) 0.0 0.0001;
+    img := base.put_pixel 1 0 (Color.mk 255 255 255);
+    twice := (img.flip_vertical).flip_vertical;
+    assertClose (twice.diff img) 0.0 0.0001;
 
 # Inverting black yields white, and inverting white yields black.
 @property(1)
 def test_invert_endpoints : Bool :=
     black := Image.mk 4 4 (Color.mk 0 0 0);
     white := Image.mk 4 4 (Color.mk 255 255 255);
-    both (assertEqual (Image.get_pixel (Image.invert black) 0 0) (Color.mk 255 255 255))
-         (assertEqual (Image.get_pixel (Image.invert white) 0 0) (Color.mk 0 0 0));
+    both (assertEqual ((black.invert).get_pixel 0 0) (Color.mk 255 255 255))
+         (assertEqual ((white.invert).get_pixel 0 0) (Color.mk 0 0 0));
 
 # Inverting twice is the identity.
 @property(1)
 def test_invert_involution : Bool :=
     img := Image.mk 4 4 (Color.mk 30 90 200);
-    twice := Image.invert (Image.invert img);
-    assertClose (Image.diff twice img) 0.0 0.0001;
+    twice := (img.invert).invert;
+    assertClose (twice.diff img) 0.0 0.0001;
 
 # Grayscaling an already-grey image (R = G = B) leaves it (essentially) unchanged.
 @property(1)
 def test_grayscale_of_grey_is_stable : Bool :=
     grey := Image.mk 8 8 (Color.mk 100 100 100);
-    assertClose (Image.diff (Image.grayscale grey) grey) 0.0 4.0;
+    assertClose ((grey.grayscale).diff grey) 0.0 4.0;
 
 # `diff` is zero for equal images and strictly positive for different ones.
 @property(1)
 def test_diff_detects_difference : Bool :=
     black := Image.mk 8 8 (Color.mk 0 0 0);
     white := Image.mk 8 8 (Color.mk 255 255 255);
-    both (assertClose (Image.diff black black) 0.0 0.0001)
-         (assertGreater (Image.diff black white) 0.0);
+    both (assertClose (black.diff black) 0.0 0.0001)
+         (assertGreater (black.diff white) 0.0);
 
 # `paste` drops the source at the given origin and keeps the rest of the
 # destination intact.
@@ -162,9 +162,9 @@ def test_diff_detects_difference : Bool :=
 def test_paste_places_source : Bool :=
     dest := Image.mk 8 8 (Color.mk 0 0 0);
     src := Image.mk 4 4 (Color.mk 255 255 255);
-    pasted := Image.paste dest src 0 0;
-    both (assertEqual (Image.get_pixel pasted 0 0) (Color.mk 255 255 255))
-         (assertEqual (Image.get_pixel pasted 7 7) (Color.mk 0 0 0));
+    pasted := dest.paste src 0 0;
+    both (assertEqual (pasted.get_pixel 0 0) (Color.mk 255 255 255))
+         (assertEqual (pasted.get_pixel 7 7) (Color.mk 0 0 0));
 
 # ── Property-based tests ─────────────────────────────────────────────────────
 # The coordinates and colour channels are generated from their refinement types,
@@ -177,8 +177,8 @@ def prop_mk_dimensions
     (h : {v : Int | v > 0 && v < 64}) :
     Bool :=
     img := Image.mk w h (Color.mk 0 0 0);
-    both (assertEqual (Image.get_width img) w)
-         (assertEqual (Image.get_height img) h);
+    both (assertEqual (img.get_width) w)
+         (assertEqual (img.get_height) h);
 
 # `resize` always produces exactly the requested size.
 @property
@@ -186,9 +186,9 @@ def prop_resize_dimensions
     (w : {v : Int | v > 0 && v < 64})
     (h : {v : Int | v > 0 && v < 64}) :
     Bool :=
-    resized := Image.resize (Image.mk 8 8 (Color.mk 1 2 3)) w h;
-    both (assertEqual (Image.get_width resized) w)
-         (assertEqual (Image.get_height resized) h);
+    resized := (Image.mk 8 8 (Color.mk 1 2 3)).resize w h;
+    both (assertEqual (resized.get_width) w)
+         (assertEqual (resized.get_height) h);
 
 # A solid image reads back its fill colour at the origin, whatever the colour.
 @property
@@ -198,7 +198,7 @@ def prop_solid_pixel_is_fill
     (b : {v : Int | v >= 0 && v < 256}) :
     Bool :=
     col := Color.mk r g b;
-    assertEqual (Image.get_pixel (Image.mk 8 8 col) 0 0) col;
+    assertEqual ((Image.mk 8 8 col).get_pixel 0 0) col;
 
 # put_pixel / get_pixel round-trip: whatever colour you write at an in-bounds
 # coordinate, you read the same colour back.
@@ -211,8 +211,8 @@ def prop_put_get_roundtrip
     (b : {v : Int | v >= 0 && v < 256}) :
     Bool :=
     col := Color.mk r g b;
-    painted := Image.put_pixel (Image.mk 16 16 (Color.mk 0 0 0)) x y col;
-    assertEqual (Image.get_pixel painted x y) col;
+    painted := (Image.mk 16 16 (Color.mk 0 0 0)).put_pixel x y col;
+    assertEqual (painted.get_pixel x y) col;
 
 # Invert is its own inverse for any fill colour.
 @property
@@ -222,7 +222,7 @@ def prop_invert_involution
     (b : {v : Int | v >= 0 && v < 256}) :
     Bool :=
     img := Image.mk 6 6 (Color.mk r g b);
-    assertClose (Image.diff (Image.invert (Image.invert img)) img) 0.0 0.0001;
+    assertClose (((img.invert).invert).diff img) 0.0 0.0001;
 
 # Every image is identical to itself: diff with self is always zero.
 @property
@@ -232,4 +232,4 @@ def prop_diff_self_is_zero
     (b : {v : Int | v >= 0 && v < 256}) :
     Bool :=
     img := Image.mk 8 8 (Color.mk r g b);
-    assertClose (Image.diff img img) 0.0 0.0001;
+    assertClose (img.diff img) 0.0 0.0001;

--- a/examples/testing/string_tests.ae
+++ b/examples/testing/string_tests.ae
@@ -101,5 +101,5 @@ def test_replace_word : Bool := assertEqual (replace "foofoo" "foo" "bar") "barb
 @property(1)
 def test_split : Bool :=
     parts := split "a,b,c" ",";
-    both (assertEqual (Array.length parts) 3)
-         (assertEqual (Array.get parts 0) "a");
+    both (assertEqual (parts.length) 3)
+         (assertEqual (parts.get 0) "a");

--- a/libraries/Array.ae
+++ b/libraries/Array.ae
@@ -28,7 +28,7 @@ def new : {arr:(Array a) | size arr = 0} :=
 
 # True when the array is empty.
 def empty (arr: (Array a)) : {b:Bool | b = (size arr = 0)} :=
-    (length arr) = 0
+    arr.length = 0
 
 
 # Append an element to the back; the value must satisfy the refinement ``p``.

--- a/libraries/List.ae
+++ b/libraries/List.ae
@@ -56,12 +56,12 @@ def reverse_acc (xs: (List a)) (acc: (List a)) : (List a) :=
 
 # Reverse a list.
 def reversed (l: (List a)) : (List a) :=
-    reverse_acc l nil;
+    l.reverse_acc nil;
 
 
 # Append a value at the back of the list (snoc).
 def snoc (l: (List a)) (x: a) : (List a) :=
-    append l (cons x nil);
+    l.append (cons x nil);
 
 
 # Sum of a list of integers.

--- a/libraries/Maybe.ae
+++ b/libraries/Maybe.ae
@@ -9,10 +9,10 @@ inductive Maybe a
 | just (v:a) : (Maybe a)
 
 # Returns ``true`` when the value is absent.
-def isNone (m:(Maybe a)) : Bool := Maybe_rec m true (fun v => false)
+def isNone (m:(Maybe a)) : Bool := m.rec true (fun v => false)
 
 # Returns ``true`` when the value is present.
-def isJust (m:(Maybe a)) : Bool := Maybe_rec m false (fun v => true)
+def isJust (m:(Maybe a)) : Bool := m.rec false (fun v => true)
 
 # Returns the contained value, or ``d`` if the value is absent.
-def withDefault (d:a) (m:(Maybe a)) : a := Maybe_rec m d (fun v => v)
+def withDefault (d:a) (m:(Maybe a)) : a := m.rec d (fun v => v)

--- a/libraries/PropTesting.ae
+++ b/libraries/PropTesting.ae
@@ -11,7 +11,7 @@ def generateInt (r:Random) : Int := native "r.randint(-1000, 1000)"
 
 def generateFloat (r:Random) : Float := native "r.uniform(0, 100)"
 
-def generateList (r:Random) : (Array Int) := native "[[r.randint(0, 100) for _ in range(r.randint(0, 10))] for _ in range(100)]"
+def generateList (r:Random) : (Array Int) := native "[r.randint(0, 100) for _ in range(r.randint(0, 10))]"
 
 
 # Property Wrappers
@@ -39,14 +39,14 @@ def forAllFloats (func:(a: Float) -> Bool) : Float :=
     vs := repeat random n;
     rds := vs.map generateFloat;
     rs := rds.map func;
-    positive := (countTrues rds);
+    positive := (countTrues rs);
     ratio positive n
 
 
-def forAllLists (func:(a: List) -> Bool) : Float :=
+def forAllLists (func:(a: (Array Int)) -> Bool) : Float :=
     n := 1000;
     vs := repeat random n;
     rds := vs.map generateList;
     rs := rds.map func;
-    positive := (countTrues rds);
+    positive := (countTrues rs);
     ratio positive n

--- a/libraries/PropTesting.ae
+++ b/libraries/PropTesting.ae
@@ -28,8 +28,8 @@ def ratio (a:Int) (b:Int) : Float := native "a/b"
 def forAllInts (func:(a: Int) -> Bool) : Float :=
     n := 1000;
     vs := repeat random n;
-    rds := Array.map generateInt vs;
-    rs := Array.map func rds;
+    rds := vs.map generateInt;
+    rs := rds.map func;
     positive := (countTrues rs);
     ratio positive n
 
@@ -37,8 +37,8 @@ def forAllInts (func:(a: Int) -> Bool) : Float :=
 def forAllFloats (func:(a: Float) -> Bool) : Float :=
     n := 1000;
     vs := repeat random n;
-    rds := Array.map generateFloat vs;
-    rs := Array.map func rds;
+    rds := vs.map generateFloat;
+    rs := rds.map func;
     positive := (countTrues rds);
     ratio positive n
 
@@ -46,7 +46,7 @@ def forAllFloats (func:(a: Float) -> Bool) : Float :=
 def forAllLists (func:(a: List) -> Bool) : Float :=
     n := 1000;
     vs := repeat random n;
-    rds := Array.map generateList vs;
-    rs := Array.map func rds;
+    rds := vs.map generateList;
+    rs := rds.map func;
     positive := (countTrues rds);
     ratio positive n

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -224,3 +224,25 @@ def main (args: Int): Unit :=
         assert len(program.imports) == 1
         assert program.imports[0].module_path == "Math"
         assert program.imports[0].selected_names == ["abs", "pow"]
+
+
+class TestQualifiedNamesInBodyAnnotations:
+    """Qualified imports resolve inside type ascriptions written in bodies.
+
+    ``Array.size`` already resolved in parameter and return-type refinements;
+    the same predicate in a body-level ascription (``a : {x:_ | Array.size x
+    = 2} := ...``) used to be skipped by ``resolve_qualified_names_in_sterm``
+    and died in liquefaction (issue #363 follow-up).
+    """
+
+    def test_qualified_name_in_body_annotation_refinement(self):
+        from aeon.sugar.ast_helpers import st_top
+        from tests.driver import check_compile
+
+        source = (
+            "import Array;\n"
+            "def main (i:Int) : Int :=\n"
+            "    a : {x:(Array Int) | Array.size x = 2} := ((Array.new[Int]).append 1).append 2;\n"
+            "    a.length;\n"
+        )
+        assert check_compile(source, st_top, 2)


### PR DESCRIPTION
Addresses #363 — make the libraries and examples use the method-call (dot) syntax instead of prefix `Type.method obj` calls and leaked internal underscore names (`Type_method obj`).

## What changed (mechanical syntax, plus two bug fixes found along the way)

**Standard library**
- `Maybe`: `Maybe_rec m d f` → `m.rec d f` in `isNone` / `isJust` / `withDefault`
- `Array.empty`: `(length arr) = 0` → `arr.length = 0`
- `List.reversed` / `List.snoc`: chain on the parameter (`l.reverse_acc nil`, `l.append (cons x nil)`)
- `PropTesting`: `Array.map f vs` → `vs.map f`

**Examples** — executable positions converted to chaining, e.g. `(((Array.new[Int]).append 1).append 2).append 3`, `img.crop 2 2 5 4`, `canvas.put_pixel 16 0 black`, `tweet.len`, `xs.foldr plus 0`, across: 99problems, image, imports, list, syntax, synthesis/dace, PSB2/solved, pbt, testing, demos, sets, bug.ae. `examples/pair.ae` and `examples/sets/verified_list.ae` now define helpers with dotted names (`def Pair.mk`, `def IntList.cons`) so call sites dispatch as methods.

## Bug fixes (second commit)

1. **Desugarer: qualified names now resolve in body-level type ascriptions.** `resolve_qualified_names_in_sterm` returned the type of `SAnnotation`/`SRec` nodes untouched, so `a : {x:_ | Array.size x = 5} := ...` inside a body crashed liquefaction while the identical predicate worked in signatures. Fixed by resolving those types with `resolve_qualified_names_in_stype`; regression test in `tests/test_imports.py`. The examples that were stuck on the leaked `Array_size` spelling because of this (p17/p18/p20/p21/p23/p26, bug.ae) now use `Array.size`/`List.size`.
2. **PropTesting reported wrong pass ratios.** `forAllFloats`/`forAllLists` counted `rds` (the generated inputs) instead of `rs` (the property results), so float properties always reported ~1.0 (truthy-float count) while printing a type error the CLI swallowed (exit 0). `forAllLists` was additionally untypeable — its property argument was typed over a bare `List` while `generateList` produced `(Array Int)`, and the generator built 100 lists per sample instead of one. `forAllFloats` on `x < 50.0` over uniform(0,100) now reports ~0.5; `pbt_reverse.ae` prints `1.0` with no type errors.

## What deliberately keeps the qualified form

These are the positions where the language cannot dispatch today (each verified empirically):
- **Refinement predicates** — liquefaction rejects method selectors (`(.len? x) is not a valid predicate`); they use `Module.name x` (and underscore-only compiler-generated names like `Pair_mk_fst`, `X_rec` stay as-is there)
- **Match-branch binders** — `tl.append ys` inside `match` fails with *receiver's type could not be determined*, so the recursive `List` bodies keep prefix calls
- **No receiver-typed parameter** — `Array.new`, `Color.mk`, `Image.mk` etc.
- **Module ≠ type name** — `resolve_method` looks up `Type.method` / `Type_method` by the *receiver's type*, so Args (Parser), NN (Network), Database (Conn/Rows), Http (Response), Subprocess, OS, Socket cannot use dot syntax

Out of scope: `examples/MBPP` (not exercised by CI, machine-ported, heavy use of local constructor names) and synthesis refinement specs (synquid/srbench — everything there lives in refinements). PSB2 files defining their own local `String_len`/`List_size` helpers keep them (they are local defs, not leaked module names).

## Verification
- `uv run pytest`: **1570 passed, 11 skipped** (includes the new regression test)
- `bash run_examples.sh`: all pass (same set as CI), re-run after the bug fixes
- Each touched example also run individually during the migration; conversions that didn't resolve were reverted rather than forced

🤖 Generated with [Claude Code](https://claude.com/claude-code)