### PR TITLE
Selfify application results and let termination obligations see let-bound facts (#378)

### DIFF
--- a/aeon/typechecking/termination.py
+++ b/aeon/typechecking/termination.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidLiteralInt, LiquidTerm, LiquidVar
+from aeon.core.liquid import LiquidApp, LiquidLiteralBool, LiquidLiteralInt, LiquidTerm, LiquidVar, liquid_free_vars
 from aeon.core.liquid_ops import mk_liquid_and, mk_liquid_or
 from aeon.core.substitutions import inline_lets, liquefy, substitution, substitution_in_liquid
 from aeon.core.terms import (
@@ -115,8 +115,45 @@ def collect_recursive_calls_with_paths(
     term_formals: list[Name],
     type_formals: list[Name],
 ) -> list[tuple[list[Term], Location | None, tuple[Term, ...], tuple[LiquidTerm, ...]]]:
-    """Self-calls with ``arity`` args, ``If`` path guards, and nested binder refinements (e.g. match)."""
+    """Self-calls with ``arity`` args, ``If`` path guards, and nested binder refinements.
+
+    The walk traverses the *original* body — ``let`` bindings are not inlined
+    away beforehand. Each ``let`` contributes:
+
+    * a substitution (binder → inlined value) applied to recorded call
+      arguments and path guards, so obligations stay phrased over the
+      function's formals (what the former global ``inline_lets`` achieved);
+    * a path-scoped hypothesis: the binder's synthesised refinement, opened at
+      the liquefied value (issue #378). This is what lets an instantiated
+      axiom (``b := fdiv_bounds n 10``) or a refined native's return type
+      guard the termination obligation of a recursive call under it. Facts are
+      attached at the let's position in the walk, never hoisted, so a fact
+      established under one branch cannot leak into another.
+    """
     found: list[tuple[list[Term], Location | None, tuple[Term, ...], tuple[LiquidTerm, ...]]] = []
+    base_vars = set(term_formals) | {fn}
+    if typing_ctx is not None:
+        base_vars |= {n for n, _ in typing_ctx.vars()}
+
+    def apply_env(term: Term, env: tuple[tuple[Name, Term], ...]) -> Term:
+        for n, v in reversed(env):
+            term = substitution(term, v, n)
+        return inline_lets(term)
+
+    def let_fact(name: Name, val: Term, ty_v: Type | None, env: tuple[tuple[Name, Term], ...]) -> LiquidTerm | None:
+        """The let binder's refinement, opened at the binder's (inlined) value."""
+        match ty_v:
+            case RefinedType(bname, _, ref):
+                if any(v == bname for v in liquid_free_vars(ref)):
+                    lv = liquefy(apply_env(val, env))
+                    if lv is None:
+                        return None
+                    ref = substitution_in_liquid(ref, lv, bname)
+                if any(v not in base_vars for v in liquid_free_vars(ref)):
+                    return None
+                return align_liquid_to_type_formals(ref, term_formals, type_formals)
+            case _:
+                return None
 
     def walk(
         tt: Term,
@@ -124,57 +161,67 @@ def collect_recursive_calls_with_paths(
         nested_refs: tuple[LiquidTerm, ...],
         ctx: TypingContext | None,
         expect_ty: Type | None,
+        env: tuple[tuple[Name, Term], ...],
     ) -> None:
         match tt:
             case Application(_, _, _):
                 head, args = peel_application_chain(tt)
                 if isinstance(head, Var) and head.name == fn and len(args) == arity:
-                    found.append((args, tt.loc, path, nested_refs))
+                    found.append(([apply_env(a, env) for a in args], tt.loc, path, nested_refs))
             case _:
                 pass
         match tt:
+            case Application(Abstraction(bname, abody, _), arg, _):
+                # Beta redex: bind like a let so recorded terms stay closed.
+                walk(arg, path, nested_refs, ctx, None, env)
+                walk(abody, path, nested_refs, ctx, expect_ty, env + ((bname, apply_env(arg, env)),))
             case Application(fun, arg, _):
                 f_ty = _synth_type(ctx, fun) if ctx is not None else None
-                walk(fun, path, nested_refs, ctx, f_ty)
+                walk(fun, path, nested_refs, ctx, f_ty, env)
                 arg_ty: Type | None = None
                 match f_ty:
                     case AbstractionType(_, vt, _):
                         arg_ty = vt
-                walk(arg, path, nested_refs, ctx, arg_ty)
+                walk(arg, path, nested_refs, ctx, arg_ty, env)
             case Abstraction(name, body, _):
                 if isinstance(expect_ty, AbstractionType):
                     vty = expect_ty.var_type
                     new_ctx = ctx.with_var(name, vty) if ctx is not None else None
                     ref_l = _opened_refinement_liquid(vty, name, term_formals, type_formals)
                     nrefs = nested_refs + (ref_l,) if ref_l is not None else nested_refs
-                    walk(body, path, nrefs, new_ctx, expect_ty.type)
+                    walk(body, path, nrefs, new_ctx, expect_ty.type, env)
                 else:
-                    walk(body, path, nested_refs, ctx, None)
-            case Let(_, val, body, _):
-                walk(val, path, nested_refs, ctx, None)
-                walk(body, path, nested_refs, ctx, None)
-            case Rec(_, _, val, body, _, _):
-                walk(val, path, nested_refs, ctx, None)
-                walk(body, path, nested_refs, ctx, None)
+                    walk(body, path, nested_refs, ctx, None, env)
+            case Let(name, val, body, _):
+                walk(val, path, nested_refs, ctx, None, env)
+                ty_v = _synth_type(ctx, val) if ctx is not None else None
+                fact = let_fact(name, val, ty_v, env)
+                nrefs = nested_refs + (fact,) if fact is not None else nested_refs
+                new_ctx = ctx.with_var(name, ty_v) if ctx is not None and ty_v is not None else ctx
+                walk(body, path, nrefs, new_ctx, expect_ty, env + ((name, apply_env(val, env)),))
+            case Rec(name, _, val, body, _, _):
+                walk(val, path, nested_refs, ctx, None, env)
+                walk(body, path, nested_refs, ctx, expect_ty, env + ((name, apply_env(val, env)),))
             case Annotation(expr, _, _):
-                walk(expr, path, nested_refs, ctx, expect_ty)
+                walk(expr, path, nested_refs, ctx, expect_ty, env)
             case If(cond, then, otherwise, _):
-                walk(cond, path, nested_refs, ctx, None)
-                walk(then, path + (cond,), nested_refs, ctx, expect_ty)
-                walk(otherwise, path + (_term_bool_not(cond),), nested_refs, ctx, expect_ty)
+                cond_s = apply_env(cond, env)
+                walk(cond, path, nested_refs, ctx, None, env)
+                walk(then, path + (cond_s,), nested_refs, ctx, expect_ty, env)
+                walk(otherwise, path + (_term_bool_not(cond_s),), nested_refs, ctx, expect_ty, env)
             case TypeApplication(body, _, _):
-                walk(body, path, nested_refs, ctx, expect_ty)
+                walk(body, path, nested_refs, ctx, expect_ty, env)
             case TypeAbstraction(_, _, body, _):
-                walk(body, path, nested_refs, ctx, expect_ty)
+                walk(body, path, nested_refs, ctx, expect_ty, env)
             case RefinementApplication(body, refinement, _):
-                walk(body, path, nested_refs, ctx, expect_ty)
-                walk(refinement, path, nested_refs, ctx, None)
+                walk(body, path, nested_refs, ctx, expect_ty, env)
+                walk(refinement, path, nested_refs, ctx, None, env)
             case RefinementAbstraction(_, _, body, _):
-                walk(body, path, nested_refs, ctx, expect_ty)
+                walk(body, path, nested_refs, ctx, expect_ty, env)
             case _:
                 pass
 
-    walk(t, (), (), typing_ctx, inner_expect_ty)
+    walk(t, (), (), typing_ctx, inner_expect_ty, ())
     return found
 
 
@@ -320,10 +367,9 @@ def termination_metric_constraints(rec: Rec, typing_ctx: TypingContext | None = 
     if len(type_formals) != len(formals):
         return LiquidConstraint(LiquidLiteralBool(False))
     entry_refs = entry_refinement_liquids(rec.var_type, formals, type_formals)
-    # Inline let-bindings so call arguments are expressed in terms of the
-    # function's parameters; otherwise liquefy would mention intermediate
-    # let-bound temporaries instead.
-    inner = inline_lets(inner)
+    # Let-bindings are NOT inlined away here: the walk substitutes them into
+    # recorded call arguments and path guards itself, and additionally turns
+    # each binder's refinement into a path-scoped hypothesis (issue #378).
     arity = len(formals)
     inner_ctx: TypingContext | None = None
     inner_expect: Type | None = None

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -73,6 +73,7 @@ from aeon.typechecking.well_formed import wellformed
 from aeon.verification.horn import fresh
 from aeon.verification.sub import ensure_refined
 from aeon.verification.sub import implication_constraint
+from aeon.verification.sub import is_first_order_function
 from aeon.verification.sub import sub
 from aeon.verification.vcs import Conjunction, UninterpretedFunctionDeclaration
 from aeon.verification.vcs import Constraint
@@ -200,6 +201,85 @@ def _reflected_impl_for(
         # whose runtime body is independent of the refinement predicate symbol.
         return None
     return (tuple(ty_params), liq)
+
+
+def _selfification_liquid(ctx: TypingContext, t: Term) -> LiquidTerm | None:
+    """Liquid encoding of an application term for selfification (issue #378).
+
+    Returns the ``LiquidTerm`` for ``t`` when the whole term is expressible in
+    the liquid fragment and every applied symbol will exist on the SMT side:
+    a primitive operator, or a context-bound function that
+    ``implication_constraint`` / ``entailment_context`` declares (first-order,
+    and for polymorphic functions, with a concrete base result). Otherwise
+    ``None`` — the caller simply skips selfification.
+
+    Note: encoding an application as an SMT function term identifies
+    syntactically equal calls (congruence). This is the purity assumption the
+    liquid fragment already makes everywhere applications appear in
+    refinements and termination metrics; selfification adds no new trust.
+    """
+    liq = liquefy(t)
+    if liq is None:
+        return None
+    if any(v.name in {"native", "native_import", "uninterpreted"} for v in liquid_free_vars(liq)):
+        return None
+
+    op_names = {op.name for op in ops} | {"ite"}
+
+    def heads_declarable(lt: LiquidTerm) -> bool:
+        match lt:
+            case LiquidHornApplication():
+                return False
+            case LiquidApp(fun, args):
+                if fun.name not in op_names:
+                    # Only monomorphic first-order functions are reliably
+                    # declared on the SMT side (``implication_constraint`` for
+                    # let-chain binders, ``entailment_context`` for prelude
+                    # entries — the latter skips polymorphic binders entirely).
+                    fun_ty = ctx.type_of(fun)
+                    if not (isinstance(fun_ty, AbstractionType) and is_first_order_function(fun_ty)):
+                        return False
+                return all(heads_declarable(a) for a in args)
+            case _:
+                return True
+
+    if not heads_declarable(liq):
+        return None
+    return liq
+
+
+def _selfify_application_type(ctx: TypingContext, t: Term, ty: Type) -> Type:
+    """Strengthen an application's synthesised type with ``v == ⟦t⟧``.
+
+    Only fires when the result type carries no information of its own — a bare
+    base type or a trivially-refined one. Refined codomains (primitive
+    operators, refined natives) already state their contract; adding the
+    equality there would only grow VCs. This is what lets facts proved about
+    the *application term* (e.g. an instantiated axiom about ``fdiv n 10``)
+    reach obligations phrased about its *result* (issue #378).
+    """
+
+    def selfifiable_base(base: Type) -> bool:
+        # Non-parametric constructors only: scalars (Int, Float, Bool, String)
+        # and opaque user types map to one SMT sort each. Unit carries no
+        # information, and parametric constructors go through per-instantiation
+        # sort mangling that selfification should not interfere with.
+        return isinstance(base, TypeConstructor) and not base.args and base.name.name != "Unit"
+
+    match ty:
+        case TypeConstructor(_, _) if selfifiable_base(ty):
+            liq = _selfification_liquid(ctx, t)
+            if liq is None:
+                return ty
+            v = Name("_self", fresh_counter.fresh())
+            return RefinedType(v, ty, LiquidApp(Name("==", 0), [LiquidVar(v), liq]))
+        case RefinedType(name, base, LiquidLiteralBool(True)) if selfifiable_base(base):
+            liq = _selfification_liquid(ctx, t)
+            if liq is None:
+                return ty
+            return RefinedType(name, base, LiquidApp(Name("==", 0), [LiquidVar(name), liq]))
+        case _:
+            return ty
 
 
 def is_compatible(a: Kind, b: Kind):
@@ -521,6 +601,9 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                     c0: Constraint = Conjunction(c, cp)
                     for bn, bt in reversed(fun_binders):
                         c0 = implication_constraint(bn, bt, c0, t.loc)
+                    # Selfify uninformative result types so the value stays
+                    # connected to the call that produced it (issue #378).
+                    t_subs = _selfify_application_type(ctx_inner, t, t_subs)
                     return (c0, with_binders(outer_binders, t_subs))
                 case _:
                     raise CoreInvalidApplicationError(t, ty)

--- a/tests/selfification_test.py
+++ b/tests/selfification_test.py
@@ -1,0 +1,152 @@
+"""Selfification of application results and let-fact hypotheses in
+termination obligations (issue #378, options 2 and 3).
+
+An application whose codomain is a bare base type used to synthesise an
+anonymous ``{v | true}`` — no connection between the value and the call that
+produced it — so facts proved *about the call* (an instantiated axiom, a
+refined native's contract) could never reach obligations phrased about the
+*result*. Application results are now selfified (``{v | v == f(args)}``), and
+termination obligations carry the refinements of let binders on the path to
+the recursive call.
+"""
+
+from __future__ import annotations
+
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import DesugaredProgram, desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_main_program
+from aeon.typechecking.typeinfer import check_type_errors
+
+
+def _typechecks(src: str) -> bool:
+    """Full front-to-typecheck pipeline; True iff no type errors (mirrors
+    ``recursion_soundness_test.py``)."""
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(
+        progt, ctx, desugared.metadata, desugared.constructor_to_type, desugared.constructor_defs
+    )
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    errors = list(check_type_errors(typing_ctx, core_ast, top))
+    return errors == []
+
+
+FDIV_AXIOM = """
+def fdiv : (i:Int) -> (j:Int) -> Int := fun i => fun j => native "i // j"
+
+axiom fdiv_bounds : (i: Int) -> (j: Int) ->
+    {u: Unit | (i >= 0 && j >= 2) --> (fdiv i j >= 0 && (i = 0 || fdiv i j < i))} ;
+"""
+
+FDIV_REFINED = """
+def fdiv (i:{v:Int | v >= 0}) (j:{v:Int | v >= 2}) : {r:Int | r >= 0 && (i = 0 || r < i)} :=
+    native "i // j"
+"""
+
+
+def test_axiom_fact_reaches_argument_check():
+    """``fdiv n 10`` as an argument satisfies ``{v | v >= 0}`` via the axiom."""
+    src = (
+        FDIV_AXIOM
+        + """
+def needs_nat (m : {v:Int | v >= 0}) : Int := m;
+
+def test (n : {v:Int | v >= 0}) : Int :=
+    b := fdiv_bounds n 10;
+    needs_nat (fdiv n 10);
+
+def main (_:Int) : Int := test 44
+"""
+    )
+    assert _typechecks(src)
+
+
+def test_axiom_fact_reaches_let_bound_use():
+    """The let-bound result stays connected to the call through selfification."""
+    src = (
+        FDIV_AXIOM
+        + """
+def needs_nat (m : {v:Int | v >= 0}) : Int := m;
+
+def test (n : {v:Int | v >= 0}) : Int :=
+    b := fdiv_bounds n 10;
+    floor := fdiv n 10;
+    needs_nat floor;
+
+def main (_:Int) : Int := test 44
+"""
+    )
+    assert _typechecks(src)
+
+
+def test_axiom_fact_guards_termination_of_natural_recursion():
+    """Digit-style recursion through an uninterpreted native terminates via the axiom."""
+    src = (
+        FDIV_AXIOM
+        + """
+def square_digits (n : {v:Int | v >= 0}) : Int :=
+    if n = 0 then 0
+    else
+        b := fdiv_bounds n 10;
+        d := n % 10;
+        (d * d) + square_digits (fdiv n 10);
+
+def main (_:Int) : Int := square_digits 44
+"""
+    )
+    assert _typechecks(src)
+
+
+def test_refined_native_guards_termination_via_let():
+    """A refined native's contract flows through a let binder — no axiom needed."""
+    src = (
+        FDIV_REFINED
+        + """
+def count (n : {v:Int | v >= 0}) : Int :=
+    if n = 0 then 0
+    else
+        floor := fdiv n 10;
+        1 + count floor;
+
+def main (_:Int) : Int := count 44
+"""
+    )
+    assert _typechecks(src)
+
+
+def test_fact_does_not_leak_across_branches():
+    """An axiom instantiated in one branch must not justify the other branch's recursion."""
+    src = (
+        FDIV_AXIOM
+        + """
+def count (n : {v:Int | v >= 0}) : Int :=
+    if n = 0 then
+        b := fdiv_bounds n 10;
+        0
+    else
+        1 + count (fdiv n 10);
+
+def main (_:Int) : Int := count 44
+"""
+    )
+    assert not _typechecks(src)
+
+
+def test_nontermination_still_rejected():
+    src = """
+def loopy (n : {v:Int | v >= 0}) : Int :=
+    if n = 0 then 0 else 1 + loopy n;
+
+def main (_:Int) : Int := loopy 1
+"""
+    assert not _typechecks(src)


### PR DESCRIPTION
Implements options 2 and 3 of #378: recursion through native helpers (floor division, etc.) is now verifiable.

## The two changes

### 1. Selfification of application results (`aeon/typechecking/typeinfer.py`)

An application whose synthesised result type carried no information — a bare base type or `{v | true}` — produced a value with no logical connection to the call: the failing VC was literally `∀v:Int | true ⟹ v ≥ 0`, unprovable by construction no matter what facts were in scope. Such results are now typed `{v | v == f(args)}`.

Scope guards, derived from what the SMT layer actually declares:
- only liquefiable terms whose applied heads are primitive operators or **monomorphic first-order** context functions (`entailment_context` skips polymorphic prelude binders like `print`, so those are excluded);
- only **uninformative** result types — refined codomains (primitive ops, refined natives) already state their contract and are untouched, keeping VC growth minimal;
- only non-parametric, non-Unit result sorts.

Encoding a call as an SMT function term identifies syntactically equal calls (congruence). That purity assumption is one the liquid fragment already makes wherever applications appear in refinements and termination metrics — no new trust.

### 2. Termination obligations see let-bound facts (`aeon/typechecking/termination.py`)

The recursive-call walk ran on `inline_lets(body)`, which erased every let binder **together with the fact carried by its type** — so the documented ghost-instantiation idiom (`b := fdiv_bounds n 10`) could never guard a termination obligation, and neither could a refined native's return contract flowing through a binder.

The walk now traverses the original body. Each `let` contributes:
- a substitution (binder → inlined value) applied to recorded call arguments and path guards, preserving the old behavior that obligations are phrased over the function's formals;
- a **path-scoped hypothesis**: the binder's synthesised refinement, opened at its liquefied value.

Facts attach at the let's position and never hoist — a fact established under one branch cannot justify recursion in another (pinned by a dedicated negative test; this matters because a refined native's postcondition is only meaningful where its precondition was checked).

## What this enables (from the issue's repros)

```aeon
def fdiv : (i:Int) -> (j:Int) -> Int := fun i => fun j => native "i // j"
axiom fdiv_bounds : (i:Int) -> (j:Int) ->
    {u:Unit | (i >= 0 && j >= 2) --> (fdiv i j >= 0 && (i = 0 || fdiv i j < i))} ;

def square_digits (n : {v:Int | v >= 0}) : Int :=
    if n = 0 then 0
    else
        b := fdiv_bounds n 10;
        d := n % 10;
        (d * d) + square_digits (fdiv n 10);   -- ✓ typechecks and runs
```

- repro 2 (axiom fact → argument check) ✓
- repro 3 (let-bound result keeps its connection) ✓
- natural digit recursion with an axiom ✓ — the `fuel` workaround from #377 is no longer the only option
- refined `fdiv` + let-bound recursion ✓ — **no axiom needed at all**
- refined `fdiv` applied *directly* in the recursive argument: still requires option 1 of #378 (per-call-site instantiation of native return refinements) — intentionally out of scope here

## Corrected diagnosis from the issue

The "empty hypothesis context" in manifestation 2 was a display artifact: `remove_unrelated_context` prunes the *error message*, not the solved VC (verified by dumping the pre-pruning constraint — all facts were present). The real defects were the missing selfification equality and the termination walk's let erasure. I'll note this on the issue.

## Verification
- Full suite: **1575 passed, 11 skipped** (1569 baseline + 6 new in `tests/selfification_test.py`)
- All existing recursion/termination/soundness tests pass unchanged; new negative tests pin branch-leak rejection and non-termination rejection
- `bash run_examples.sh`: exit 0, zero failures
- mypy and ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)