### PR TITLE
feat(lsp): Lean-style info view (aeon/infoView custom request)

### DIFF
--- a/aeon/lsp/infoview.py
+++ b/aeon/lsp/infoview.py
@@ -1,0 +1,204 @@
+"""Lean-style info view for the Aeon LSP.
+
+Computes the information shown in the editor's "Aeon Info View" panel for a
+cursor position: the inferred (refined) type of the expression under the
+cursor, the goal type of a hole the cursor sits on, and the typing context
+(locals and globals) in scope at that point — the same kind of contextual
+panel Lean's infoview and LiquidJava's refinement view provide.
+
+This module is deliberately free of any ``lsprotocol`` import so the logic is
+unit-testable in isolation; the server serialises :class:`InfoViewData` to the
+JSON payload of the custom ``aeon/infoView`` request.
+
+All positions taken and returned by this module are **0-indexed** (LSP
+convention); core source ranges are 1-indexed and converted internally.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+from aeon.core.types import Type
+from aeon.lsp.completion import format_type
+from aeon.typechecking.context import TypingContext, VariableBinder
+from aeon.utils.name import Name
+
+_HOLE_PATTERN = re.compile(r"\?([a-zA-Z_][a-zA-Z0-9_]*)")
+_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
+
+
+@dataclass(frozen=True)
+class InfoEntry:
+    """One ``name : type`` line of the context section."""
+
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class ExpressionInfo:
+    """The tightest expression containing the cursor and its inferred type."""
+
+    type: str
+    range: tuple[int, int, int, int]  # 0-indexed (start line, start col, end line, end col)
+
+
+@dataclass(frozen=True)
+class GoalInfo:
+    """A synthesis hole the cursor sits on: its name and goal (expected) type."""
+
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class InfoViewData:
+    expression: Optional[ExpressionInfo] = None
+    goal: Optional[GoalInfo] = None
+    locals: list[InfoEntry] = field(default_factory=list)
+    globals: list[InfoEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """A JSON-serialisable payload for the ``aeon/infoView`` response."""
+        return asdict(self)
+
+
+def _hole_at(source: str, line: int, character: int) -> Optional[str]:
+    """The name of the ``?hole`` token containing the 0-indexed cursor, or
+    ``None``. The position just past the last character still counts, so the
+    goal stays visible while the user types the hole name."""
+    lines = source.splitlines()
+    if not (0 <= line < len(lines)):
+        return None
+    for m in _HOLE_PATTERN.finditer(lines[line]):
+        if m.start() <= character <= m.end():
+            return m.group(1)
+    return None
+
+
+def _dedup_innermost(vars_: list[tuple[Name, Type]]) -> list[tuple[Name, Type]]:
+    """Keep the innermost binding per surface name, preserving binding order
+    (``with_var`` appends, so the last occurrence shadows earlier ones)."""
+    latest: dict[str, tuple[Name, Type]] = {}
+    for name, ty in vars_:
+        latest.pop(name.pretty(), None)
+        latest[name.pretty()] = (name, ty)
+    return list(latest.values())
+
+
+def _entries_to_vars(entries) -> list[tuple[Name, Type]]:
+    return [(e.name, e.type) for e in entries if isinstance(e, VariableBinder)]
+
+
+def _to_info_entries(vars_: list[tuple[Name, Type]]) -> list[InfoEntry]:
+    return [InfoEntry(name=n.pretty(), type=format_type(t)) for n, t in vars_]
+
+
+def _top_level_names(core) -> set[str]:
+    """The names of the program's top-level definitions (the ``Rec`` spine)."""
+    from aeon.core.terms import Rec
+
+    names: set[str] = set()
+    t = core
+    while isinstance(t, Rec):
+        names.add(t.var_name.pretty())
+        t = t.body
+    return names
+
+
+def _split_scope(
+    typing_ctx: Optional[TypingContext],
+    scope_ctx: Optional[TypingContext],
+    top_level: set[str],
+) -> tuple[list[InfoEntry], list[InfoEntry]]:
+    """Split the cursor's scope into (locals, globals).
+
+    ``with_var`` builds contexts by appending to the prelude context, so the
+    scope's entry list has the prelude as a prefix; everything after it was
+    bound while checking — the program's top-level definitions (the ``Rec``
+    spine, reported as globals) and the true locals (parameters, ``let``s,
+    lambdas). Globals are filtered to plain identifiers — operator binders like
+    ``+`` would only add noise."""
+    n_prelude = len(typing_ctx.entries) if typing_ctx is not None else 0
+    if scope_ctx is None:
+        scope_ctx = typing_ctx
+    if scope_ctx is None:
+        return [], []
+
+    entries = scope_ctx.entries
+    inner_entries = entries[n_prelude:] if len(entries) >= n_prelude else []
+    prelude_entries = entries[:n_prelude] if len(entries) >= n_prelude else entries
+
+    inner_vars = _dedup_innermost(_entries_to_vars(inner_entries))
+    locals_ = _to_info_entries([(n, t) for n, t in inner_vars if n.pretty() not in top_level])
+    local_names = {e.name for e in locals_}
+
+    global_vars = _dedup_innermost(_entries_to_vars(prelude_entries)) + [
+        (n, t) for n, t in inner_vars if n.pretty() in top_level
+    ]
+    globals_ = [e for e in _to_info_entries(global_vars) if _IDENTIFIER.match(e.name) and e.name not in local_names]
+    return locals_, globals_
+
+
+def _goal_for_hole(hole_name: str, typing_ctx, core) -> Optional[tuple[GoalInfo, Optional[TypingContext]]]:
+    """The goal type (and typing context) of the hole named ``hole_name``,
+    recovered the same way the synthesiser sees it. Returns ``None`` when the
+    hole cannot be typed (e.g. the last good core no longer contains it)."""
+    try:
+        from aeon.core.types import top
+        from aeon.synthesis.identification import get_holes_info
+
+        holes = get_holes_info(typing_ctx, core, top, [], refined_types=True)
+    except Exception:
+        return None
+    for name, (ty, ctx) in holes.items():
+        if name.pretty() == hole_name or name.name == hole_name:
+            return GoalInfo(name=hole_name, type=format_type(ty)), ctx
+    return None
+
+
+def compute_info_view(
+    source: str,
+    line: int,
+    character: int,
+    typing_ctx: Optional[TypingContext],
+    type_index=None,
+    core=None,
+) -> InfoViewData:
+    """Top-level entry: the info view contents for the 0-indexed cursor.
+
+    ``type_index`` is the last successfully-built
+    :class:`~aeon.lsp.typeindex.TypeIndex` for the document; ``typing_ctx`` is
+    the top-level context and ``core`` the last good core program (both used to
+    recover hole goals)."""
+    expression: Optional[ExpressionInfo] = None
+    goal: Optional[GoalInfo] = None
+    scope_ctx: Optional[TypingContext] = None
+
+    if type_index is not None:
+        scope_ctx = type_index.scope_at(line, character)
+        result = type_index.type_at(line, character)
+        if result is not None:
+            ty, loc = result
+            (sl, sc), (el, ec) = loc.get_start(), loc.get_end()
+            expression = ExpressionInfo(
+                type=format_type(ty),
+                range=(max(sl - 1, 0), max(sc - 1, 0), max(el - 1, 0), max(ec - 1, 0)),
+            )
+
+    hole_name = _hole_at(source, line, character)
+    if hole_name is not None and typing_ctx is not None and core is not None:
+        found = _goal_for_hole(hole_name, typing_ctx, core)
+        if found is not None:
+            goal, hole_ctx = found
+            # The hole's own context is the most faithful scope to display.
+            if hole_ctx is not None:
+                scope_ctx = hole_ctx
+            # The polymorphic placeholder type the checker synthesises for a
+            # bare hole is meaningless to the user; the goal supersedes it.
+            expression = None
+
+    locals_, globals_ = _split_scope(typing_ctx, scope_ctx, _top_level_names(core))
+    return InfoViewData(expression=expression, goal=goal, locals=locals_, globals=globals_)

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -66,6 +66,12 @@ SYNTHESIZERS = [
 ]
 SYNTHESIZE_COMMAND = "aeon.synthesize"
 
+# Custom (non-standard) request backing the editor's Lean-style info view
+# panel. Params: {"textDocument": {"uri": ...}, "position": {"line": ..., "character": ...}}
+# (0-indexed, LSP convention). Response: the JSON form of
+# :class:`aeon.lsp.infoview.InfoViewData`.
+INFOVIEW_REQUEST = "aeon/infoView"
+
 
 class AeonLanguageServer(LanguageServer):
     def __init__(self, aeon_driver: AeonDriver):
@@ -277,6 +283,33 @@ class AeonLanguageServer(LanguageServer):
                     )
                 )
             return out
+
+        @self.feature(INFOVIEW_REQUEST)
+        async def info_view(
+            ls: AeonLanguageServer,
+            params,
+        ) -> dict:
+            from . import aeon_adapter
+            from aeon.lsp.infoview import InfoViewData, compute_info_view
+
+            # Custom method: params arrive as a generic pygls ``Object`` with
+            # the wire-format (camelCase) attribute names.
+            uri = params.textDocument.uri
+            line = params.position.line
+            character = params.position.character
+
+            # Make sure the document has been analysed at least once (cached).
+            await aeon_adapter.parse(ls, uri)
+
+            document = ls.workspace.get_text_document(uri)
+            index = aeon_adapter.get_type_index(uri)
+            typing_ctx = aeon_adapter.get_typing_ctx(uri) or getattr(ls.aeon_driver, "typing_ctx", None)
+            core = aeon_adapter.get_core(uri)
+            try:
+                data = compute_info_view(document.source, line, character, typing_ctx, index, core)
+            except Exception:
+                return InfoViewData().to_dict()
+            return data.to_dict()
 
         @self.feature(
             TEXT_DOCUMENT_CODE_ACTION,

--- a/tests/lsp_infoview_test.py
+++ b/tests/lsp_infoview_test.py
@@ -1,0 +1,147 @@
+"""Tests for the Lean-style info view: expression-at-cursor type, hole goals,
+and the local/global context split backing the ``aeon/infoView`` request."""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.lsp.infoview import compute_info_view, _hole_at
+from aeon.lsp.typeindex import build_type_index
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def analyse(src: str):
+    """Parse ``src`` and return ``(driver, type_index, errors)``."""
+    cfg = AeonConfig(synthesizer="gp", synthesis_ui=SilentSynthesisUI(), synthesis_budget=1)
+    d = AeonDriver(cfg)
+    errors = list(d.parse(filename="file:///t.ae", aeon_code=src))
+    index = build_type_index(d.typing_ctx, d.core) if getattr(d, "core", None) is not None else None
+    return d, index, errors
+
+
+def info_at(src: str, line: int, character: int):
+    d, index, _ = analyse(src)
+    return compute_info_view(src, line, character, d.typing_ctx, index, getattr(d, "core", None))
+
+
+def col_of(src: str, line0: int, needle: str) -> int:
+    """0-indexed column of ``needle`` on (0-indexed) ``line0``."""
+    return src.splitlines()[line0].index(needle)
+
+
+SRC = "def inc (n:Int) : Int := n + 1;\ndef main (u:Int) : Int :=\n    let x := 41 in\n    inc x;\n"
+
+
+# --------------------------------------------------------------------------- #
+# Expression under the cursor
+# --------------------------------------------------------------------------- #
+
+
+def test_expression_type_at_literal():
+    info = info_at(SRC, 2, col_of(SRC, 2, "41"))
+    assert info.expression is not None
+    assert "41" in info.expression.type
+    assert info.expression.range[0] == 2  # 0-indexed line of the literal
+
+
+def test_expression_none_outside_any_node():
+    # Line 0 column 0 is the `def` keyword: no synthesized expression there.
+    info = info_at(SRC, 0, 0)
+    assert info.expression is None
+
+
+# --------------------------------------------------------------------------- #
+# Context: locals vs globals
+# --------------------------------------------------------------------------- #
+
+
+def test_locals_include_let_binding_and_parameter():
+    info = info_at(SRC, 3, col_of(SRC, 3, "x"))
+    local_names = [e.name for e in info.locals]
+    assert "x" in local_names
+    assert "u" in local_names
+
+
+def test_globals_include_top_level_defs_but_not_locals():
+    info = info_at(SRC, 3, col_of(SRC, 3, "x"))
+    global_names = [e.name for e in info.globals]
+    assert "inc" in global_names
+    assert "main" in global_names
+    assert "x" not in global_names
+
+
+def test_local_types_are_refined():
+    info = info_at(SRC, 3, col_of(SRC, 3, "x"))
+    x = next(e for e in info.locals if e.name == "x")
+    assert "41" in x.type  # singleton refinement from `let x := 41`
+
+
+def test_inner_scope_not_leaked_to_outer_position():
+    # In `inc`'s body only `n` is local; `x`/`u` belong to `main`.
+    info = info_at(SRC, 0, col_of(SRC, 0, "n +"))
+    local_names = [e.name for e in info.locals]
+    assert "n" in local_names
+    assert "x" not in local_names
+
+
+# --------------------------------------------------------------------------- #
+# Hole goals
+# --------------------------------------------------------------------------- #
+
+HOLE_SRC = "def main (u:Int) : Int :=\n    let x := 41 in\n    ?h;\n"
+
+
+def test_hole_at_detects_cursor_on_hole():
+    line = HOLE_SRC.splitlines()[2]
+    c = line.index("?h")
+    assert _hole_at(HOLE_SRC, 2, c) == "h"
+    assert _hole_at(HOLE_SRC, 2, c + 2) == "h"  # just past the name still counts
+    assert _hole_at(HOLE_SRC, 2, 0) is None
+
+
+def test_goal_shown_for_hole():
+    info = info_at(HOLE_SRC, 2, col_of(HOLE_SRC, 2, "?h") + 1)
+    assert info.goal is not None
+    assert info.goal.name == "h"
+    assert "Int" in info.goal.type
+    # The checker's polymorphic placeholder for the hole is suppressed.
+    assert info.expression is None
+
+
+def test_goal_context_includes_locals():
+    info = info_at(HOLE_SRC, 2, col_of(HOLE_SRC, 2, "?h") + 1)
+    local_names = [e.name for e in info.locals]
+    assert "x" in local_names
+    assert "u" in local_names
+
+
+def test_no_goal_away_from_hole():
+    info = info_at(HOLE_SRC, 1, col_of(HOLE_SRC, 1, "41"))
+    assert info.goal is None
+
+
+# --------------------------------------------------------------------------- #
+# Robustness and serialisation
+# --------------------------------------------------------------------------- #
+
+
+def test_graceful_without_analysis_state():
+    info = compute_info_view(SRC, 2, 5, None, None, None)
+    assert info.expression is None and info.goal is None
+    assert info.locals == [] and info.globals == []
+
+
+def test_to_dict_is_json_serialisable():
+    import json
+
+    info = info_at(HOLE_SRC, 2, col_of(HOLE_SRC, 2, "?h") + 1)
+    payload = info.to_dict()
+    text = json.dumps(payload)
+    assert '"goal"' in text
+    assert payload["goal"]["name"] == "h"
+    assert isinstance(payload["locals"], list)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds the server side of a Lean-style **info view** (à la Lean's infoview / LiquidJava's refinement view): a custom LSP request `aeon/infoView` that returns contextual information for the cursor position, rendered by the vscode-aeon extension in an "Aeon Info View" webview panel beside the editor.

For a 0-indexed `{textDocument, position}` the request returns (`aeon/lsp/infoview.py`, serialised from `InfoViewData`):

- **Goal** — when the cursor sits on a `?hole`, its goal (expected) type, recovered with `get_holes_info` exactly the way the synthesizer sees it, together with the hole's own typing context.
- **Expression** — the inferred (refined) type and source range of the tightest expression containing the cursor, from the existing `TypeIndex`.
- **Context** — the typing context in scope at the cursor, split into *locals* (parameters, `let`s, lambdas, with their refined types, innermost binding per name) and *globals* (top-level definitions of the file + prelude, operator binders filtered out; the client renders these collapsed).

Example, cursor on `?h` in

```aeon
def main (u:Int) : Int :=
    let x := 41 in
    ?h;
```

```json
{"goal": {"name": "h", "type": "Int"},
 "locals": [{"name": "u", "type": "Int"}, {"name": "x", "type": "{ν:Int | (ν == 41)}"}],
 ...}
```

## Implementation notes

- `aeon/lsp/infoview.py` is `lsprotocol`-free (same convention as `completion.py`) so the logic is unit-testable in isolation; the handler in `server.py` just extracts params (custom methods arrive as generic pygls `Object`s with camelCase attributes) and returns `InfoViewData.to_dict()`.
- The local/global split slices the scope's entry list at the prelude prefix (`with_var` appends), then classifies the `Rec`-spine names as globals.
- On a hole, the checker's meaningless polymorphic placeholder type is suppressed in favour of the goal.
- Any failure degrades to an empty payload rather than an error, so the panel never breaks editing.

## Client side (vscode-aeon)

The companion change to [alcides/vscode-aeon](https://github.com/alcides/vscode-aeon) (webview panel, cursor tracking with debounce + stale-response guard, `aeon.infoView.toggle`/`open` commands, `aeon.infoView.autoOpen` setting, diagnostics-at-cursor section) was developed alongside this PR but could not be pushed from this session (no access to that repository); the patch was handed to the author separately.

## Testing

- `tests/lsp_infoview_test.py`: 12 new tests (expression type, locals/globals split, refined local types, scope isolation between functions, hole goal + goal context, robustness without analysis state, JSON serialisability).
- Existing `tests/lsp_test.py` + `tests/lsp_features_test.py` still pass (59 tests).
- `mypy` clean for the new module; pre-commit hooks pass.
- End-to-end smoke test through the registered pygls handler with wire-format params.

https://claude.ai/code/session_01HmqacpRLu5LFS5YGntVzeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmqacpRLu5LFS5YGntVzeT)_