### PR TITLE
feat(lsp): refine info-view context — base|predicate, turnstile goal

### DIFF
--- a/aeon/lsp/infoview.py
+++ b/aeon/lsp/infoview.py
@@ -1,10 +1,17 @@
 """Lean-style info view for the Aeon LSP.
 
 Computes the information shown in the editor's "Aeon Info View" panel for a
-cursor position: the inferred (refined) type of the expression under the
-cursor, the goal type of a hole the cursor sits on, and the typing context
-(locals and globals) in scope at that point — the same kind of contextual
-panel Lean's infoview and LiquidJava's refinement view provide.
+cursor position: the typing context in scope (locals prominently, globals
+collapsed) and the *target* — the goal type of a hole under the cursor, or
+otherwise the inferred type of the expression under the cursor — rendered
+turnstile-style (``⊢ T``) the way Lean's infoview and LiquidJava's refinement
+view present a goal.
+
+Each context entry is split into a base type and an optional refinement
+predicate, so ``v:{k:Int | k > 0}`` is reported as ``v : Int`` with predicate
+``v > 0`` — the refinement's bound variable is renamed to the *outer* binding
+name and the predicate is pretty-printed (minimal parentheses). Anonymous and
+compiler-internal binders (``_``, ``_cond``, ``_inner_…``) are hidden.
 
 This module is deliberately free of any ``lsprotocol`` import so the logic is
 unit-testable in isolation; the server serialises :class:`InfoViewData` to the
@@ -20,7 +27,18 @@ import re
 from dataclasses import asdict, dataclass, field
 from typing import Optional
 
-from aeon.core.types import Type
+from aeon.core.liquid import (
+    LiquidApp,
+    LiquidLiteralBool,
+    LiquidLiteralFloat,
+    LiquidLiteralInt,
+    LiquidLiteralString,
+    LiquidLiteralUnit,
+    LiquidTerm,
+    LiquidVar,
+)
+from aeon.core.substitutions import substitution_in_liquid
+from aeon.core.types import ExistentialType, RefinedType, Type
 from aeon.lsp.completion import format_type
 from aeon.typechecking.context import ReflectedBinder, TypingContext, UninterpretedBinder, VariableBinder
 from aeon.utils.name import Name
@@ -32,35 +50,52 @@ _HOLE_PATTERN = re.compile(r"\?([a-zA-Z_][a-zA-Z0-9_]*)")
 # excluded — they bind types, not variables.
 _VALUE_BINDERS = (VariableBinder, UninterpretedBinder, ReflectedBinder)
 
+# Fallback refinement binder when there is no outer name to rename to (a goal or
+# bare expression target), matching the convention used by ``format_type``.
+_NU = Name("ν", 0)
+
+# Precedence of the operators that appear in refinement predicates (higher binds
+# tighter). Used by ``_pp_liquid`` to drop redundant parentheses.
+_LIQUID_PREC = {
+    "||": 1,
+    "-->": 1,
+    "&&": 2,
+    "==": 3,
+    "!=": 3,
+    "<": 3,
+    "<=": 3,
+    ">": 3,
+    ">=": 3,
+    "+": 4,
+    "-": 4,
+    "*": 5,
+    "/": 5,
+    "%": 5,
+}
+
 
 @dataclass(frozen=True)
 class InfoEntry:
-    """One ``name : type`` line of the context section."""
+    """One context line: ``name : type`` with an optional refinement predicate
+    (already rendered with the outer name, e.g. ``("x", "Int", "x > 0")``)."""
 
     name: str
     type: str
+    predicate: Optional[str] = None
 
 
 @dataclass(frozen=True)
-class ExpressionInfo:
-    """The tightest expression containing the cursor and its inferred type."""
+class TargetInfo:
+    """The turnstile target: a hole's goal type, or the type of the expression
+    under the cursor, split into base type and optional refinement predicate."""
 
     type: str
-    range: tuple[int, int, int, int]  # 0-indexed (start line, start col, end line, end col)
-
-
-@dataclass(frozen=True)
-class GoalInfo:
-    """A synthesis hole the cursor sits on: its name and goal (expected) type."""
-
-    name: str
-    type: str
+    predicate: Optional[str] = None
 
 
 @dataclass(frozen=True)
 class InfoViewData:
-    expression: Optional[ExpressionInfo] = None
-    goal: Optional[GoalInfo] = None
+    target: Optional[TargetInfo] = None
     locals: list[InfoEntry] = field(default_factory=list)
     globals: list[InfoEntry] = field(default_factory=list)
 
@@ -82,6 +117,71 @@ def _hole_at(source: str, line: int, character: int) -> Optional[str]:
     return None
 
 
+def _is_hidden(name: str) -> bool:
+    """Anonymous (``_``) and compiler-internal (``_cond``, ``_self``,
+    ``_inner_…``) binders are noise — hide them from the context."""
+    return name.startswith("_")
+
+
+def _is_operator(fun: str) -> bool:
+    """Whether ``fun`` is a symbolic infix/prefix operator (``+``, ``&&``,
+    ``-->``) rather than an alphanumeric function name (``Set_mem``)."""
+    return bool(fun) and all(not c.isalnum() and c != "_" for c in fun)
+
+
+def _pp_liquid(term: LiquidTerm, parent_prec: int = 0) -> str:
+    """Pretty-print a refinement predicate with minimal parentheses, using
+    surface (``pretty``) names so the user sees ``x > 0 && x < 10`` rather than
+    the checker's ``((x⁷ > 0) && (x⁷ < 10))``."""
+    if isinstance(term, LiquidVar):
+        return term.name.pretty()
+    if isinstance(term, LiquidLiteralBool):
+        return "true" if term.value else "false"
+    if isinstance(term, (LiquidLiteralInt, LiquidLiteralFloat)):
+        return str(term.value)
+    if isinstance(term, LiquidLiteralString):
+        return '"' + str(term.value) + '"'
+    if isinstance(term, LiquidLiteralUnit):
+        return "()"
+    if isinstance(term, LiquidApp):
+        fun = term.fun.pretty()
+        if _is_operator(fun) and len(term.args) == 2:
+            prec = _LIQUID_PREC.get(fun, 0)
+            left = _pp_liquid(term.args[0], prec)
+            right = _pp_liquid(term.args[1], prec + 1)
+            s = f"{left} {fun} {right}"
+            return f"({s})" if prec < parent_prec else s
+        if _is_operator(fun) and len(term.args) == 1:
+            return f"{fun}{_pp_liquid(term.args[0], 100)}"
+        args = ", ".join(_pp_liquid(a, 0) for a in term.args)
+        return f"{fun}({args})"
+    return repr(term)
+
+
+def _split_type(ty: Type, display_name: Optional[Name]) -> tuple[str, Optional[str]]:
+    """Render ``ty`` as ``(base, predicate)``.
+
+    For a refined type the refinement's bound variable is renamed to
+    ``display_name`` (the outer binding name) so ``v:{k:Int | k > 0}`` reads as
+    ``v : Int`` with predicate ``v > 0``; an unrefined or trivially-true type
+    has predicate ``None``. ``display_name`` of ``None`` (a goal or bare
+    expression target with no outer name) falls back to ``ν``."""
+    try:
+        t = ty
+        while isinstance(t, ExistentialType):
+            t = t.body
+        if isinstance(t, RefinedType):
+            ref = t.refinement
+            if isinstance(ref, LiquidLiteralBool) and ref.value is True:
+                return format_type(t.type), None
+            repl = LiquidVar(display_name if display_name is not None else _NU)
+            pred = substitution_in_liquid(ref, repl, t.name)
+            return format_type(t.type), _pp_liquid(pred)
+        return format_type(t), None
+    except Exception:
+        return format_type(ty), None
+
+
 def _dedup_innermost(vars_: list[tuple[Name, Type]]) -> list[tuple[Name, Type]]:
     """Keep the innermost binding per surface name, preserving binding order
     (``with_var`` appends, so the last occurrence shadows earlier ones)."""
@@ -93,11 +193,16 @@ def _dedup_innermost(vars_: list[tuple[Name, Type]]) -> list[tuple[Name, Type]]:
 
 
 def _entries_to_vars(entries) -> list[tuple[Name, Type]]:
-    return [(e.name, e.type) for e in entries if isinstance(e, _VALUE_BINDERS)]
+    """The value bindings of ``entries``, excluding anonymous/internal binders."""
+    return [(e.name, e.type) for e in entries if isinstance(e, _VALUE_BINDERS) and not _is_hidden(e.name.pretty())]
 
 
 def _to_info_entries(vars_: list[tuple[Name, Type]]) -> list[InfoEntry]:
-    return [InfoEntry(name=n.pretty(), type=format_type(t)) for n, t in vars_]
+    out: list[InfoEntry] = []
+    for n, t in vars_:
+        base, predicate = _split_type(t, n)
+        out.append(InfoEntry(name=n.pretty(), type=base, predicate=predicate))
+    return out
 
 
 def _top_level_names(core) -> set[str]:
@@ -125,7 +230,8 @@ def _split_scope(
     spine, reported as globals) and the true locals (parameters, ``let``s,
     lambdas). Every in-scope value binding is reported, including operators and
     the rest of the prelude; the client keeps the globals section collapsed so
-    the large builtin set stays out of the way."""
+    the large builtin set stays out of the way. Anonymous and internal binders
+    (``_``…) are dropped by :func:`_entries_to_vars`."""
     n_prelude = len(typing_ctx.entries) if typing_ctx is not None else 0
     if scope_ctx is None:
         scope_ctx = typing_ctx
@@ -147,7 +253,7 @@ def _split_scope(
     return locals_, globals_
 
 
-def _goal_for_hole(hole_name: str, typing_ctx, core) -> Optional[tuple[GoalInfo, Optional[TypingContext]]]:
+def _goal_for_hole(hole_name: str, typing_ctx, core) -> Optional[tuple[Type, Optional[TypingContext]]]:
     """The goal type (and typing context) of the hole named ``hole_name``,
     recovered the same way the synthesiser sees it. Returns ``None`` when the
     hole cannot be typed (e.g. the last good core no longer contains it)."""
@@ -160,7 +266,7 @@ def _goal_for_hole(hole_name: str, typing_ctx, core) -> Optional[tuple[GoalInfo,
         return None
     for name, (ty, ctx) in holes.items():
         if name.pretty() == hole_name or name.name == hole_name:
-            return GoalInfo(name=hole_name, type=format_type(ty)), ctx
+            return ty, ctx
     return None
 
 
@@ -178,32 +284,31 @@ def compute_info_view(
     :class:`~aeon.lsp.typeindex.TypeIndex` for the document; ``typing_ctx`` is
     the top-level context and ``core`` the last good core program (both used to
     recover hole goals)."""
-    expression: Optional[ExpressionInfo] = None
-    goal: Optional[GoalInfo] = None
+    target_ty: Optional[Type] = None
     scope_ctx: Optional[TypingContext] = None
 
     if type_index is not None:
         scope_ctx = type_index.scope_at(line, character)
         result = type_index.type_at(line, character)
         if result is not None:
-            ty, loc = result
-            (sl, sc), (el, ec) = loc.get_start(), loc.get_end()
-            expression = ExpressionInfo(
-                type=format_type(ty),
-                range=(max(sl - 1, 0), max(sc - 1, 0), max(el - 1, 0), max(ec - 1, 0)),
-            )
+            target_ty = result[0]
 
     hole_name = _hole_at(source, line, character)
     if hole_name is not None and typing_ctx is not None and core is not None:
         found = _goal_for_hole(hole_name, typing_ctx, core)
         if found is not None:
-            goal, hole_ctx = found
+            goal_ty, hole_ctx = found
+            # The goal supersedes the polymorphic placeholder the checker
+            # synthesises for a bare hole, which is meaningless to the user.
+            target_ty = goal_ty
             # The hole's own context is the most faithful scope to display.
             if hole_ctx is not None:
                 scope_ctx = hole_ctx
-            # The polymorphic placeholder type the checker synthesises for a
-            # bare hole is meaningless to the user; the goal supersedes it.
-            expression = None
+
+    target: Optional[TargetInfo] = None
+    if target_ty is not None:
+        base, predicate = _split_type(target_ty, None)
+        target = TargetInfo(type=base, predicate=predicate)
 
     locals_, globals_ = _split_scope(typing_ctx, scope_ctx, _top_level_names(core))
-    return InfoViewData(expression=expression, goal=goal, locals=locals_, globals=globals_)
+    return InfoViewData(target=target, locals=locals_, globals=globals_)

--- a/tests/lsp_infoview_test.py
+++ b/tests/lsp_infoview_test.py
@@ -1,12 +1,13 @@
-"""Tests for the Lean-style info view: expression-at-cursor type, hole goals,
-and the local/global context split backing the ``aeon/infoView`` request."""
+"""Tests for the Lean-style info view: the turnstile target (expression type /
+hole goal), the local/global context split, the base/predicate rendering and the
+hiding of anonymous binders backing the ``aeon/infoView`` request."""
 
 from __future__ import annotations
 
 import pytest
 
 from aeon.facade.driver import AeonConfig, AeonDriver
-from aeon.lsp.infoview import compute_info_view, _hole_at
+from aeon.lsp.infoview import _hole_at, _is_hidden, _pp_liquid, compute_info_view
 from aeon.lsp.typeindex import build_type_index
 from aeon.synthesis.uis.api import SilentSynthesisUI
 
@@ -34,21 +35,22 @@ SRC = "def inc (n:Int) : Int := n + 1;\ndef main (u:Int) : Int :=\n    let x := 
 
 
 # --------------------------------------------------------------------------- #
-# Expression under the cursor
+# Turnstile target (expression type / hole goal)
 # --------------------------------------------------------------------------- #
 
 
-def test_expression_type_at_literal():
+def test_target_type_at_literal():
     info = info_at(SRC, 2, col_of(SRC, 2, "41"))
-    assert info.expression is not None
-    assert "41" in info.expression.type
-    assert info.expression.range[0] == 2  # 0-indexed line of the literal
+    assert info.target is not None
+    # The literal's singleton type ``{ν:Int | ν == 41}`` splits into base + pred.
+    assert info.target.type == "Int"
+    assert info.target.predicate is not None and "41" in info.target.predicate
 
 
-def test_expression_none_outside_any_node():
+def test_target_none_outside_any_node():
     # Line 0 column 0 is the `def` keyword: no synthesized expression there.
     info = info_at(SRC, 0, 0)
-    assert info.expression is None
+    assert info.target is None
 
 
 # --------------------------------------------------------------------------- #
@@ -73,18 +75,20 @@ def test_globals_include_top_level_defs_but_not_locals():
 
 def test_globals_include_operators_and_builtins():
     # "All variables in context": operators (non-identifier binders like `+`)
-    # and the rest of the prelude are reported in the globals section, not
-    # filtered out.
+    # and the rest of the prelude are reported in the globals section.
     info = info_at(SRC, 3, col_of(SRC, 3, "x"))
     global_names = {e.name for e in info.globals}
     assert "+" in global_names
     assert "==" in global_names
 
 
-def test_local_types_are_refined():
+def test_local_types_are_refined_with_outer_name():
     info = info_at(SRC, 3, col_of(SRC, 3, "x"))
     x = next(e for e in info.locals if e.name == "x")
-    assert "41" in x.type  # singleton refinement from `let x := 41`
+    assert x.type == "Int"
+    # singleton refinement from `let x := 41`, renamed to the outer name `x`.
+    assert x.predicate is not None
+    assert "x" in x.predicate and "41" in x.predicate
 
 
 def test_inner_scope_not_leaked_to_outer_position():
@@ -93,6 +97,53 @@ def test_inner_scope_not_leaked_to_outer_position():
     local_names = [e.name for e in info.locals]
     assert "n" in local_names
     assert "x" not in local_names
+
+
+# --------------------------------------------------------------------------- #
+# Refinement rendering: outer name, pretty predicate, anonymous hiding
+# --------------------------------------------------------------------------- #
+
+REFINED_SRC = "def f (x:{k:Int | k > 0 && k < 10}) : Int := x + 0;\n"
+
+
+def test_refinement_uses_outer_name_and_pretty_print():
+    # `x:{k:Int | k > 0 && k < 10}` is shown as `x : Int` | `x > 0 && x < 10`:
+    # bound variable renamed to the outer name, no redundant parentheses.
+    info = info_at(REFINED_SRC, 0, col_of(REFINED_SRC, 0, "x + 0"))
+    x = next(e for e in info.locals if e.name == "x")
+    assert x.type == "Int"
+    assert x.predicate == "x > 0 && x < 10"
+
+
+def test_anonymous_binders_are_hidden():
+    assert _is_hidden("_")
+    assert _is_hidden("_cond")
+    assert _is_hidden("_inner_x")
+    assert not _is_hidden("x")
+    assert not _is_hidden("+")
+    # No context entry is ever anonymous.
+    info = info_at(REFINED_SRC, 0, col_of(REFINED_SRC, 0, "x + 0"))
+    assert all(not e.name.startswith("_") for e in info.locals + info.globals)
+
+
+# --------------------------------------------------------------------------- #
+# Predicate pretty-printer
+# --------------------------------------------------------------------------- #
+
+
+def test_pp_liquid_minimal_parens():
+    from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidVar
+    from aeon.utils.name import Name
+
+    def app(op, a, b):
+        return LiquidApp(Name(op, 0), [a, b])
+
+    x = LiquidVar(Name("x", 0))
+    zero = LiquidLiteralInt(0)
+    ten = LiquidLiteralInt(10)
+    # (x > 0) && (x < 10) -> comparisons bind tighter than &&, so no parens.
+    expr = app("&&", app(">", x, zero), app("<", x, ten))
+    assert _pp_liquid(expr) == "x > 0 && x < 10"
 
 
 # --------------------------------------------------------------------------- #
@@ -110,13 +161,10 @@ def test_hole_at_detects_cursor_on_hole():
     assert _hole_at(HOLE_SRC, 2, 0) is None
 
 
-def test_goal_shown_for_hole():
+def test_goal_target_shown_for_hole():
     info = info_at(HOLE_SRC, 2, col_of(HOLE_SRC, 2, "?h") + 1)
-    assert info.goal is not None
-    assert info.goal.name == "h"
-    assert "Int" in info.goal.type
-    # The checker's polymorphic placeholder for the hole is suppressed.
-    assert info.expression is None
+    assert info.target is not None
+    assert "Int" in info.target.type
 
 
 def test_goal_context_includes_locals():
@@ -126,11 +174,6 @@ def test_goal_context_includes_locals():
     assert "u" in local_names
 
 
-def test_no_goal_away_from_hole():
-    info = info_at(HOLE_SRC, 1, col_of(HOLE_SRC, 1, "41"))
-    assert info.goal is None
-
-
 # --------------------------------------------------------------------------- #
 # Robustness and serialisation
 # --------------------------------------------------------------------------- #
@@ -138,19 +181,21 @@ def test_no_goal_away_from_hole():
 
 def test_graceful_without_analysis_state():
     info = compute_info_view(SRC, 2, 5, None, None, None)
-    assert info.expression is None and info.goal is None
+    assert info.target is None
     assert info.locals == [] and info.globals == []
 
 
 def test_to_dict_is_json_serialisable():
     import json
 
-    info = info_at(HOLE_SRC, 2, col_of(HOLE_SRC, 2, "?h") + 1)
+    info = info_at(REFINED_SRC, 0, col_of(REFINED_SRC, 0, "x + 0"))
     payload = info.to_dict()
     text = json.dumps(payload)
-    assert '"goal"' in text
-    assert payload["goal"]["name"] == "h"
+    assert '"target"' in text
     assert isinstance(payload["locals"], list)
+    x = next(e for e in payload["locals"] if e["name"] == "x")
+    assert x["type"] == "Int"
+    assert x["predicate"] == "x > 0 && x < 10"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #382, reworking the `aeon/infoView` payload for a cleaner Lean-style presentation.

## Changes
- **Context entries split into base type + predicate.** A refined binding `v:{k:Int | k > 0}` is reported as `type: "Int"`, `predicate: "v > 0"` — the refinement's bound variable renamed to the **outer** name and the predicate pretty-printed with minimal parentheses (`x > 0 && x < 10`, not `((x⁷ > 0) && (x⁷ < 10))`).
- **Anonymous/internal binders hidden.** `_`, `_cond`, `_inner_…` are dropped from the context.
- **Single turnstile `target`.** Replaces the separate `expression`/`goal` fields with one `target` (hole goal, else the type under the cursor) for `⊢ T` rendering.

New wire format: `{ target, locals, globals }` with entries `{ name, type, predicate }`.

## Tests
Updated for the new shape; added coverage for outer-name + pretty predicate (`x > 0 && x < 10`), anonymous-binder hiding, the predicate pretty-printer, and the turnstile target. Verified end-to-end through the real parser/typechecker.

> Local pytest still can't run here (this Mac's scipy/sklearn wheels); CI runs it on Linux.

## Coordination
The matching vscode-aeon client change (reorder, turnstile, aligned columns) ships alongside; both need releasing together since the wire format changed.