### PR TITLE
feat(lsp): pretty-print info-view types id-free

### DIFF
--- a/aeon/lsp/infoview.py
+++ b/aeon/lsp/infoview.py
@@ -29,6 +29,7 @@ from typing import Optional
 
 from aeon.core.liquid import (
     LiquidApp,
+    LiquidHole,
     LiquidLiteralBool,
     LiquidLiteralFloat,
     LiquidLiteralInt,
@@ -38,12 +39,34 @@ from aeon.core.liquid import (
     LiquidVar,
 )
 from aeon.core.substitutions import substitution_in_liquid
-from aeon.core.types import ExistentialType, RefinedType, Type
+from aeon.core.types import (
+    AbstractionType,
+    ExistentialType,
+    LiquidHornApplication,
+    RefinedType,
+    RefinementPolymorphism,
+    Top,
+    Type,
+    TypeConstructor,
+    TypePolymorphism,
+    TypeVar,
+    type_free_term_vars,
+)
 from aeon.lsp.completion import format_type
 from aeon.typechecking.context import ReflectedBinder, TypingContext, UninterpretedBinder, VariableBinder
 from aeon.utils.name import Name
 
 _HOLE_PATTERN = re.compile(r"\?([a-zA-Z_][a-zA-Z0-9_]*)")
+
+# Internal name ids render as superscript digits (``v⁴⁴⁸``); ``.pretty()`` drops
+# them. This strips any that slip through a fallback rendering path so the user
+# never sees a checker-internal id in a type, predicate or context entry.
+_SUPERSCRIPT_DIGITS = str.maketrans("", "", "⁰¹²³⁴⁵⁶⁷⁸⁹")
+
+
+def _strip_ids(s: str) -> str:
+    return s.translate(_SUPERSCRIPT_DIGITS)
+
 
 # Term-level binders that introduce a usable ``name : type`` value into scope.
 # Type-level binders (``TypeBinder``/``TypeConstructorBinder``) are deliberately
@@ -155,11 +178,63 @@ def _pp_liquid(term: LiquidTerm, parent_prec: int = 0) -> str:
             return f"{fun}{_pp_liquid(term.args[0], 100)}"
         args = ", ".join(_pp_liquid(a, 0) for a in term.args)
         return f"{fun}({args})"
-    return repr(term)
+    if isinstance(term, LiquidHornApplication):
+        args = ", ".join(_pp_liquid(a, 0) for a, _ in term.argtypes)
+        return f"{term.name.pretty()}({args})"
+    if isinstance(term, LiquidHole):
+        return "?"
+    return _strip_ids(repr(term))
+
+
+def _is_trivial(ref: LiquidTerm) -> bool:
+    return isinstance(ref, LiquidLiteralBool) and ref.value is True
+
+
+def _pp_type_atom(ty: Type) -> str:
+    """Like :func:`_pp_type` but parenthesises compound types used as arguments."""
+    inner = _pp_type(ty)
+    if isinstance(ty, (AbstractionType, TypeConstructor)) and " " in inner:
+        return f"({inner})"
+    return inner
+
+
+def _pp_type(ty: Type) -> str:
+    """Pretty-print a full type id-free, rendering nested refinements with the
+    minimal-parenthesis :func:`_pp_liquid` so every part — including globals'
+    function types — reads cleanly (``∀a. a -> a -> Bool``, ``{ν:Int | ν > 0}``)
+    rather than carrying the checker's internal name ids."""
+    try:
+        if isinstance(ty, Top):
+            return "⊤"
+        if isinstance(ty, TypeVar):
+            return ty.name.pretty()
+        if isinstance(ty, TypeConstructor):
+            if not ty.args:
+                return ty.name.pretty()
+            return ty.name.pretty() + " " + " ".join(_pp_type_atom(a) for a in ty.args)
+        if isinstance(ty, RefinedType):
+            if _is_trivial(ty.refinement):
+                return _pp_type(ty.type)
+            pred = _pp_liquid(substitution_in_liquid(ty.refinement, LiquidVar(_NU), ty.name))
+            return f"{{{_NU.pretty()}:{_pp_type(ty.type)} | {pred}}}"
+        if isinstance(ty, AbstractionType):
+            dom, cod = _pp_type(ty.var_type), _pp_type(ty.type)
+            if ty.var_name in type_free_term_vars(ty.type):
+                return f"({ty.var_name.pretty()}:{dom}) -> {cod}"
+            return f"{dom} -> {cod}"
+        if isinstance(ty, TypePolymorphism):
+            return f"∀{ty.name.pretty()}. {_pp_type(ty.body)}"
+        if isinstance(ty, RefinementPolymorphism):
+            return f"∀<{ty.name.pretty()}:{_pp_type(ty.sort)}>. {_pp_type(ty.body)}"
+        if isinstance(ty, ExistentialType):
+            return _pp_type(ty.body)
+        return _strip_ids(format_type(ty))
+    except Exception:
+        return _strip_ids(format_type(ty))
 
 
 def _split_type(ty: Type, display_name: Optional[Name]) -> tuple[str, Optional[str]]:
-    """Render ``ty`` as ``(base, predicate)``.
+    """Render ``ty`` as ``(base, predicate)``, both id-free.
 
     For a refined type the refinement's bound variable is renamed to
     ``display_name`` (the outer binding name) so ``v:{k:Int | k > 0}`` reads as
@@ -170,16 +245,15 @@ def _split_type(ty: Type, display_name: Optional[Name]) -> tuple[str, Optional[s
         t = ty
         while isinstance(t, ExistentialType):
             t = t.body
-        if isinstance(t, RefinedType):
-            ref = t.refinement
-            if isinstance(ref, LiquidLiteralBool) and ref.value is True:
-                return format_type(t.type), None
+        if isinstance(t, RefinedType) and not _is_trivial(t.refinement):
             repl = LiquidVar(display_name if display_name is not None else _NU)
-            pred = substitution_in_liquid(ref, repl, t.name)
-            return format_type(t.type), _pp_liquid(pred)
-        return format_type(t), None
+            pred = substitution_in_liquid(t.refinement, repl, t.name)
+            return _strip_ids(_pp_type(t.type)), _strip_ids(_pp_liquid(pred))
+        if isinstance(t, RefinedType):
+            return _strip_ids(_pp_type(t.type)), None
+        return _strip_ids(_pp_type(t)), None
     except Exception:
-        return format_type(ty), None
+        return _strip_ids(format_type(ty)), None
 
 
 def _dedup_innermost(vars_: list[tuple[Name, Type]]) -> list[tuple[Name, Type]]:

--- a/tests/lsp_infoview_test.py
+++ b/tests/lsp_infoview_test.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import pytest
 
 from aeon.facade.driver import AeonConfig, AeonDriver
-from aeon.lsp.infoview import _hole_at, _is_hidden, _pp_liquid, compute_info_view
+from aeon.lsp.infoview import _hole_at, _is_hidden, _pp_liquid, _pp_type, _strip_ids, compute_info_view
 from aeon.lsp.typeindex import build_type_index
 from aeon.synthesis.uis.api import SilentSynthesisUI
 
@@ -124,6 +124,61 @@ def test_anonymous_binders_are_hidden():
     # No context entry is ever anonymous.
     info = info_at(REFINED_SRC, 0, col_of(REFINED_SRC, 0, "x + 0"))
     assert all(not e.name.startswith("_") for e in info.locals + info.globals)
+
+
+# --------------------------------------------------------------------------- #
+# Pretty printing never shows internal name ids
+# --------------------------------------------------------------------------- #
+
+# Internal name ids render as superscript digits (``v⁴⁴⁸``, ``p⁷²``).
+SUPERSCRIPT_DIGITS = "⁰¹²³⁴⁵⁶⁷⁸⁹"
+
+
+def _has_id(s) -> bool:
+    return s is not None and any(ch in SUPERSCRIPT_DIGITS for ch in s)
+
+
+def test_strip_ids_removes_superscript_digits():
+    assert _strip_ids("v⁴⁴⁸") == "v"
+    assert _strip_ids("p⁷²(ν)") == "p(ν)"
+    assert _strip_ids("Int") == "Int"
+
+
+def test_pp_type_strips_ids_of_terms():
+    from aeon.core.liquid import LiquidApp, LiquidVar
+    from aeon.core.types import RefinedType, t_int
+    from aeon.utils.name import Name
+
+    # A refinement whose bound and free variables carry non-zero ids.
+    k = Name("k", 7)
+    x = Name("x", 12)
+    ref = LiquidApp(Name(">", 0), [LiquidVar(k), LiquidVar(x)])
+    ty = RefinedType(k, t_int, ref)
+    rendered = _pp_type(ty)
+    assert not _has_id(rendered), rendered
+    # the free variable keeps its surface name, without the id
+    assert "x" in rendered and "x¹²" not in rendered
+
+
+def test_pp_liquid_uses_surface_names_without_ids():
+    from aeon.core.liquid import LiquidApp, LiquidVar
+    from aeon.utils.name import Name
+
+    expr = LiquidApp(Name(">", 0), [LiquidVar(Name("v", 448)), LiquidVar(Name("y", 3))])
+    assert _pp_liquid(expr) == "v > y"
+
+
+def test_no_ids_anywhere_in_context_or_target():
+    # The prelude binds polymorphic operators (e.g. `$`) whose types carry
+    # horn-application ids like `p⁷²(ν)`; none must reach the rendered output.
+    info = info_at(SRC, 3, col_of(SRC, 3, "x"))
+    for e in info.locals + info.globals:
+        assert not _has_id(e.name), e.name
+        assert not _has_id(e.type), (e.name, e.type)
+        assert not _has_id(e.predicate), (e.name, e.predicate)
+    if info.target is not None:
+        assert not _has_id(info.target.type)
+        assert not _has_id(info.target.predicate)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Follow-up to #383. Makes the info view render globals, locals and the target goal without ever exposing the checker's internal name ids.

## Problem
Name ids render as superscript digits (`v⁴⁴⁸`, and horn-application names like `p⁷²(ν)` in polymorphic prelude types such as `$`). The previous rendering went through `format_type`, which only normalised the *bound* refinement variable and leaked ids for free variables and horn applications.

## Change
- A dedicated id-free type pretty-printer (`_pp_type`) used for base types, rendering nested refinements through the minimal-parenthesis predicate printer (`_pp_liquid`).
- `_pp_liquid` now handles horn applications and holes, using surface (`pretty`) names.
- A superscript-digit strip (`_strip_ids`) guards any fallback path.

Result: `$` shows `… {ν:a | p(ν)} -> {ν:b | q(ν)} …` instead of `p⁷²(ν)`; `>=` shows `∀a. a -> a -> Bool`.

## Tests
Adds tests asserting **no id is shown** when pretty-printing terms (`_pp_type`, `_pp_liquid`, `_strip_ids`) or whole contexts (a scan over locals/globals/target for superscript digits). Verified end-to-end through the real parser/typechecker.

> Local pytest still blocked by this Mac's scipy/sklearn wheels; CI runs it on Linux.