### PR TITLE
feat(lsp): present info-view refinements in CNF; space function applications

### DIFF
--- a/aeon/lsp/infoview.py
+++ b/aeon/lsp/infoview.py
@@ -177,10 +177,10 @@ def _pp_liquid(term: LiquidTerm, parent_prec: int = 0) -> str:
         if _is_operator(fun) and len(term.args) == 1:
             return f"{fun}{_pp_liquid(term.args[0], 100)}"
         args = ", ".join(_pp_liquid(a, 0) for a in term.args)
-        return f"{fun}({args})"
+        return f"{fun} ({args})"
     if isinstance(term, LiquidHornApplication):
         args = ", ".join(_pp_liquid(a, 0) for a, _ in term.argtypes)
-        return f"{term.name.pretty()}({args})"
+        return f"{term.name.pretty()} ({args})"
     if isinstance(term, LiquidHole):
         return "?"
     return _strip_ids(repr(term))
@@ -188,6 +188,118 @@ def _pp_liquid(term: LiquidTerm, parent_prec: int = 0) -> str:
 
 def _is_trivial(ref: LiquidTerm) -> bool:
     return isinstance(ref, LiquidLiteralBool) and ref.value is True
+
+
+# --- refinement → CNF (a conjunction of disjunctions) ----------------------- #
+# So the info view can present a refinement as a flat list of conditions.
+
+_BOOL_BINARY = ("&&", "||", "-->")
+_CNF_SIZE_LIMIT = 40  # above this, skip distribution (worst-case exponential)
+
+
+def _mk(op: str, args: list[LiquidTerm]) -> LiquidTerm:
+    return LiquidApp(Name(op, 0), args)
+
+
+def _bool_op(t: LiquidTerm) -> Optional[str]:
+    """The boolean connective of ``t`` (``&&``/``||``/``-->``/``!``), or ``None``
+    if ``t`` is an atom (comparison, application, literal, variable)."""
+    if isinstance(t, LiquidApp):
+        op = t.fun.pretty()
+        if op in _BOOL_BINARY and len(t.args) == 2:
+            return op
+        if op == "!" and len(t.args) == 1:
+            return op
+    return None
+
+
+def _elim_impl(t: LiquidTerm) -> LiquidTerm:
+    """Rewrite ``a --> b`` to ``!a || b`` throughout."""
+    if isinstance(t, LiquidApp):
+        op = _bool_op(t)
+        if op == "-->":
+            return _mk("||", [_mk("!", [_elim_impl(t.args[0])]), _elim_impl(t.args[1])])
+        if op in ("&&", "||"):
+            return _mk(op, [_elim_impl(t.args[0]), _elim_impl(t.args[1])])
+        if op == "!":
+            return _mk("!", [_elim_impl(t.args[0])])
+    return t
+
+
+def _nnf(t: LiquidTerm, neg: bool = False) -> LiquidTerm:
+    """Negation normal form: push ``!`` down to the atoms (implications must be
+    eliminated first). A negated atom is kept as ``!atom``."""
+    if isinstance(t, LiquidApp):
+        op = _bool_op(t)
+        if op == "!":
+            return _nnf(t.args[0], not neg)
+        if op == "&&":
+            return _mk("||" if neg else "&&", [_nnf(t.args[0], neg), _nnf(t.args[1], neg)])
+        if op == "||":
+            return _mk("&&" if neg else "||", [_nnf(t.args[0], neg), _nnf(t.args[1], neg)])
+    return _mk("!", [t]) if neg else t
+
+
+def _distribute(t: LiquidTerm) -> LiquidTerm:
+    """Distribute ``||`` over ``&&`` (input in NNF) so the result is a
+    conjunction of disjunctions."""
+    if not isinstance(t, LiquidApp):
+        return t
+    op = _bool_op(t)
+    if op == "&&":
+        return _mk("&&", [_distribute(t.args[0]), _distribute(t.args[1])])
+    if op == "||":
+        a, b = _distribute(t.args[0]), _distribute(t.args[1])
+        if isinstance(a, LiquidApp) and _bool_op(a) == "&&":
+            return _distribute(_mk("&&", [_mk("||", [a.args[0], b]), _mk("||", [a.args[1], b])]))
+        if isinstance(b, LiquidApp) and _bool_op(b) == "&&":
+            return _distribute(_mk("&&", [_mk("||", [a, b.args[0]]), _mk("||", [a, b.args[1]])]))
+        return _mk("||", [a, b])
+    return t
+
+
+def _flatten_and(t: LiquidTerm) -> list[LiquidTerm]:
+    if isinstance(t, LiquidApp) and _bool_op(t) == "&&":
+        return _flatten_and(t.args[0]) + _flatten_and(t.args[1])
+    return [t]
+
+
+def _bool_size(t: LiquidTerm) -> int:
+    if isinstance(t, LiquidApp) and _bool_op(t) is not None:
+        return 1 + sum(_bool_size(a) for a in t.args)
+    return 1
+
+
+def _cnf_conjuncts(refinement: LiquidTerm) -> list[LiquidTerm]:
+    """The top-level conjuncts of ``refinement`` in CNF — a list of conditions,
+    each a disjunction of literals or a single literal. Falls back to the
+    formula's existing top-level conjuncts if it is large enough that CNF
+    distribution risks blowing up, or if anything goes wrong."""
+    try:
+        if _bool_size(refinement) > _CNF_SIZE_LIMIT:
+            return _flatten_and(refinement)
+        return _flatten_and(_distribute(_nnf(_elim_impl(refinement))))
+    except Exception:
+        return _flatten_and(refinement)
+
+
+def _pp_refinement(refinement: LiquidTerm) -> str:
+    """Render a refinement as its CNF conditions joined by ``&&``: each
+    condition pretty-printed (disjunctions parenthesised when there is more than
+    one, so the ``&&`` split is unambiguous), trivially-true conditions dropped,
+    duplicates removed."""
+    terms = [c for c in _cnf_conjuncts(refinement) if not _is_trivial(c)]
+    if not terms:
+        return _pp_liquid(refinement)
+    prec = _LIQUID_PREC["&&"] if len(terms) > 1 else 0
+    seen: set[str] = set()
+    out: list[str] = []
+    for c in terms:
+        s = _pp_liquid(c, prec)
+        if s not in seen:
+            seen.add(s)
+            out.append(s)
+    return " && ".join(out)
 
 
 def _pp_type_atom(ty: Type) -> str:
@@ -215,7 +327,7 @@ def _pp_type(ty: Type) -> str:
         if isinstance(ty, RefinedType):
             if _is_trivial(ty.refinement):
                 return _pp_type(ty.type)
-            pred = _pp_liquid(substitution_in_liquid(ty.refinement, LiquidVar(_NU), ty.name))
+            pred = _pp_refinement(substitution_in_liquid(ty.refinement, LiquidVar(_NU), ty.name))
             return f"{{{_NU.pretty()}:{_pp_type(ty.type)} | {pred}}}"
         if isinstance(ty, AbstractionType):
             dom, cod = _pp_type(ty.var_type), _pp_type(ty.type)
@@ -248,7 +360,7 @@ def _split_type(ty: Type, display_name: Optional[Name]) -> tuple[str, Optional[s
         if isinstance(t, RefinedType) and not _is_trivial(t.refinement):
             repl = LiquidVar(display_name if display_name is not None else _NU)
             pred = substitution_in_liquid(t.refinement, repl, t.name)
-            return _strip_ids(_pp_type(t.type)), _strip_ids(_pp_liquid(pred))
+            return _strip_ids(_pp_type(t.type)), _strip_ids(_pp_refinement(pred))
         if isinstance(t, RefinedType):
             return _strip_ids(_pp_type(t.type)), None
         return _strip_ids(_pp_type(t)), None

--- a/tests/lsp_infoview_test.py
+++ b/tests/lsp_infoview_test.py
@@ -7,7 +7,15 @@ from __future__ import annotations
 import pytest
 
 from aeon.facade.driver import AeonConfig, AeonDriver
-from aeon.lsp.infoview import _hole_at, _is_hidden, _pp_liquid, _pp_type, _strip_ids, compute_info_view
+from aeon.lsp.infoview import (
+    _hole_at,
+    _is_hidden,
+    _pp_liquid,
+    _pp_refinement,
+    _pp_type,
+    _strip_ids,
+    compute_info_view,
+)
 from aeon.lsp.typeindex import build_type_index
 from aeon.synthesis.uis.api import SilentSynthesisUI
 
@@ -199,6 +207,60 @@ def test_pp_liquid_minimal_parens():
     # (x > 0) && (x < 10) -> comparisons bind tighter than &&, so no parens.
     expr = app("&&", app(">", x, zero), app("<", x, ten))
     assert _pp_liquid(expr) == "x > 0 && x < 10"
+
+
+def test_function_application_has_space_before_args():
+    from aeon.core.liquid import LiquidApp, LiquidVar
+    from aeon.utils.name import Name
+
+    def v(n):
+        return LiquidVar(Name(n, 0))
+
+    # `f(a && b)` reads as `f (a && b)`.
+    expr = LiquidApp(Name("f", 0), [LiquidApp(Name("&&", 0), [v("a"), v("b")])])
+    assert _pp_liquid(expr) == "f (a && b)"
+
+
+# --------------------------------------------------------------------------- #
+# Refinements are presented in CNF (a list of conditions)
+# --------------------------------------------------------------------------- #
+
+
+def _v(n):
+    from aeon.core.liquid import LiquidVar
+    from aeon.utils.name import Name
+
+    return LiquidVar(Name(n, 0))
+
+
+def _app(op, *args):
+    from aeon.core.liquid import LiquidApp
+    from aeon.utils.name import Name
+
+    return LiquidApp(Name(op, 0), list(args))
+
+
+def test_cnf_distributes_or_over_and():
+    # a || (b && c)  ->  (a || b) && (a || c)
+    expr = _app("||", _v("a"), _app("&&", _v("b"), _v("c")))
+    assert _pp_refinement(expr) == "(a || b) && (a || c)"
+
+
+def test_cnf_eliminates_implication():
+    # a --> b  ->  !a || b  (single condition, so no surrounding parens)
+    assert _pp_refinement(_app("-->", _v("a"), _v("b"))) == "!a || b"
+
+
+def test_cnf_pushes_negation_inwards():
+    # !(a && b)  ->  !a || !b
+    assert _pp_refinement(_app("!", _app("&&", _v("a"), _v("b")))) == "!a || !b"
+
+
+def test_cnf_keeps_conjunction_as_condition_list():
+    from aeon.core.liquid import LiquidLiteralInt
+
+    expr = _app("&&", _app(">", _v("x"), LiquidLiteralInt(0)), _app("<", _v("x"), LiquidLiteralInt(10)))
+    assert _pp_refinement(expr) == "x > 0 && x < 10"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Two info-view rendering refinements (compiler-side; the shipped extension already lists `&&`-joined conditions on separate lines).

## CNF refinements
Each refinement is normalised to **conjunctive normal form** before rendering, so it reads as a flat list of conditions:
- implications eliminated — `a --> b` ⇒ `!a || b`
- negations pushed to atoms — `!(a && b)` ⇒ `!a || !b`
- `||` distributed over `&&` — `a || (b && c)` ⇒ `(a || b) && (a || c)`

Each top-level conjunct becomes one line in the extension's per-conjunct view. Distribution is skipped for large formulas (>40 boolean nodes) to avoid worst-case blow-up, falling back to the existing top-level conjuncts.

## Spacing
Function applications in predicates now have a space: `f(a && b)` ⇒ `f (a && b)` (and horn applications, `p (ν)`).

## Tests
Unit tests for the spacing and CNF (distribution, implication elimination, De Morgan, conjunction-as-list). Verified end-to-end through the real parser/typechecker.

> Local pytest still blocked by this Mac's scipy/sklearn wheels; CI runs it on Linux.