### PR TITLE
feat(cli): add --export=fun_name to emit a pure-Python version of a function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@ Beyond refinement types, Aeon also offers:
 
 - **Python FFI** — call any Python function natively, giving you access to the full Python ecosystem.
 - **Program synthesis** — leave `?hole`s in your program and let Aeon fill them in using genetic programming, enumerative search, or LLM-backed synthesis.
+- **Export to Python** — `--export=fun` prints a stand-alone, pure-Python version of any function (with its dependencies and FFI bundled, and holes synthesized first).
 - **A growing standard library** — modules for `List`, `Math`, `Array`, `Image`, and more.
 
 Aeon is implemented as a Python interpreter and is under active development.

--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -138,6 +138,14 @@ def _parse_common_arguments(parser: ArgumentParser):
     )
 
     parser.add_argument(
+        "--export",
+        type=str,
+        default=None,
+        metavar="FUN_NAME",
+        help="Print a stand-alone, pure-Python version of the named function to stdout",
+    )
+
+    parser.add_argument(
         "--doc",
         action="store_true",
         help="Generate HTML documentation from the source file",
@@ -234,9 +242,10 @@ def main() -> None:
         synthesis_ui=select_synthesis_ui(),
         synthesis_budget=args.budget,
         timings=args.timings,
-        # Property evaluation splices the call into the program's main slot, so
-        # the slot must exist — force the main hole even if --no-main was passed.
-        no_main=args.no_main and not run_tests,
+        # ``--export`` forces ``no_main`` (no synthesis hole in main), but
+        # property evaluation splices the call into the program's main slot, so
+        # under ``--test`` the slot must exist even if ``--no-main`` was passed.
+        no_main=(args.no_main or bool(getattr(args, "export", None))) and not run_tests,
         synthesis_format=SynthesisFormat.from_string(args.synthesis_format),
     )
     driver = AeonDriver(cfg)
@@ -264,6 +273,17 @@ def main() -> None:
     errors = driver.parse(args.filename)
 
     match errors:
+        case [] if args.export:
+            from aeon.backend.python_export import PythonExportError
+
+            try:
+                print(driver.export(args.export))
+            except SynthesisNotSuccessful:
+                print(f"Cannot find a suitable expression within {args.budget} seconds.", file=sys.stderr)
+                sys.exit(2)
+            except PythonExportError as e:
+                print(f">>> Export error: {e}", file=sys.stderr)
+                sys.exit(2)
         case []:
             if run_tests:
                 if not driver.has_tests():

--- a/aeon/backend/python_export.py
+++ b/aeon/backend/python_export.py
@@ -1,0 +1,328 @@
+"""Export an Aeon function as a stand-alone, pure-Python definition.
+
+This backs the ``--export=fun_name`` CLI flag. The output bundles
+``fun_name`` with every top-level binding it transitively depends on
+(unreferenced bindings are dropped, but ``native_import`` bindings are always
+kept since ``native`` strings reference the imported modules by name). For
+each binding the pipeline is:
+
+1. Locate the top-level binding for ``fun_name`` in the core AST.
+2. Reduce its body to weak-head normal form (``whnf``) — this strips the
+   type-level wrappers introduced by elaboration (type/refinement
+   abstractions and applications, annotations) and beta-reduces any redex
+   at the head, exposing the underlying ``Abstraction``.
+3. Walk the resulting term and emit Python source, mirroring the choices the
+   interpreter (``aeon/backend/evaluator.py``) makes at runtime: curried
+   lambdas for abstractions, ternaries for ``if``, immediately-applied
+   lambdas for ``let``. ``native`` strings are inlined verbatim, exactly as
+   the interpreter would ``eval`` them.
+
+The emitted function preserves Aeon's currying convention, so a binary call
+``f a b`` becomes ``f(a)(b)`` and the inlined native strings (which reference
+the source-level parameter names) resolve against the surrounding lambdas.
+"""
+
+from __future__ import annotations
+
+from aeon.core.substitutions import substitution
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    Hole,
+    If,
+    Let,
+    Literal,
+    Rec,
+    RefinementAbstraction,
+    RefinementApplication,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+    Var,
+)
+from aeon.core.types import t_bool, t_string, t_unit
+from aeon.utils.name import Name
+
+# Aeon operators that map onto a Python infix operator. The interpreter
+# defines each as a curried lambda in the prelude; here we render the
+# saturated application directly as ``(a <op> b)``.
+BINARY_OPERATORS: dict[str, str] = {
+    "+": "+",
+    "-": "-",
+    "*": "*",
+    "/": "/",
+    "%": "%",
+    "<": "<",
+    ">": ">",
+    "<=": "<=",
+    ">=": ">=",
+    "==": "==",
+    "!=": "!=",
+    "&&": "and",
+    "||": "or",
+}
+
+
+class PythonExportError(Exception):
+    """Raised when a term cannot be translated to pure Python."""
+
+
+def find_binding(core: Term, fun_name: str) -> tuple[Name, Term] | None:
+    """Walk the top-level ``Rec``/``Let`` chain and return the
+    ``(name, value)`` pair whose source name matches ``fun_name``."""
+    t = core
+    while isinstance(t, (Rec, Let)):
+        if t.var_name.name == fun_name:
+            return t.var_name, t.var_value
+        t = t.body
+    return None
+
+
+def whnf(t: Term) -> Term:
+    """Reduce ``t`` to weak-head normal form.
+
+    Strips the administrative wrappers elaboration leaves around values
+    (annotations, type/refinement abstractions and applications) and
+    beta-reduces any redex sitting at the head. Reduction stops as soon as
+    the head is a value (an ``Abstraction``, ``Literal``, ...) or a stuck
+    application — it never descends into a lambda body.
+    """
+    while True:
+        match t:
+            case Annotation(expr, _):
+                t = expr
+            case TypeAbstraction(_, _, body):
+                t = body
+            case RefinementAbstraction(_, _, body):
+                t = body
+            case TypeApplication(body, _):
+                t = body
+            case RefinementApplication(body, _):
+                t = body
+            case Application(fun, arg):
+                f = whnf(fun)
+                if isinstance(f, Abstraction):
+                    t = substitution(f.body, arg, f.var_name)
+                else:
+                    return Application(f, arg, t.loc)
+            case _:
+                return t
+
+
+def _strip_type_wrappers(t: Term) -> Term:
+    """Peel only the type-level wrappers, exposing the operational head of
+    an application spine (e.g. the ``Var`` behind a ``native [a]`` instance)."""
+    while True:
+        match t:
+            case Annotation(expr, _):
+                t = expr
+            case TypeApplication(body, _):
+                t = body
+            case RefinementApplication(body, _):
+                t = body
+            case TypeAbstraction(_, _, body):
+                t = body
+            case RefinementAbstraction(_, _, body):
+                t = body
+            case _:
+                return t
+
+
+def _unfold_application(t: Application) -> tuple[Term, list[Term]]:
+    """Flatten a curried application spine into ``(head, args)`` with the
+    type wrappers stripped from the head."""
+    args: list[Term] = []
+    cur: Term = t
+    while isinstance(cur, Application):
+        args.append(cur.arg)
+        cur = cur.fun
+    args.reverse()
+    return _strip_type_wrappers(cur), args
+
+
+def _literal_to_python(value: object, type) -> str:
+    if type == t_string:
+        return repr(value)
+    if type == t_bool:
+        return "True" if value else "False"
+    if type == t_unit or value is None:
+        return "None"
+    return repr(value)
+
+
+def gen(t: Term) -> str:
+    """Translate a core ``Term`` into a pure-Python expression string."""
+    match t:
+        case Literal(value, ty):
+            return _literal_to_python(value, ty)
+        case Var(name):
+            return name.name
+        case Annotation(expr, _):
+            return gen(expr)
+        case TypeAbstraction(_, _, body) | RefinementAbstraction(_, _, body):
+            return gen(body)
+        case TypeApplication(body, _) | RefinementApplication(body, _):
+            return gen(body)
+        case Abstraction(var_name, body):
+            return f"(lambda {var_name.name}: {gen(body)})"
+        case If(cond, then, otherwise):
+            return f"({gen(then)} if {gen(cond)} else {gen(otherwise)})"
+        case Let(var_name, var_value, body):
+            return f"(lambda {var_name.name}: {gen(body)})({gen(var_value)})"
+        case Application():
+            return _gen_application(t)
+        case Hole(name):
+            raise PythonExportError(f"cannot export a function with an unfilled hole: ?{name}")
+        case Rec(var_name, _, _, _, _, _, _):
+            raise PythonExportError(
+                f"cannot export local recursive binding '{var_name.name}'; only top-level functions are supported"
+            )
+        case _:
+            raise PythonExportError(f"unsupported term in export: {type(t).__name__}")
+
+
+def _gen_application(t: Application) -> str:
+    head, args = _unfold_application(t)
+
+    if isinstance(head, Var):
+        op = head.name.name
+        first = _strip_type_wrappers(args[0]) if args else None
+        # Inline ``native "..."`` strings verbatim, as the interpreter evals them.
+        if op == "native" and isinstance(first, Literal):
+            return f"({first.value})"
+        if op == "native_import" and isinstance(first, Literal):
+            return f"__import__({first.value!r})"
+        # ``print`` mirrors the prelude's ``p``: print and yield 0.
+        if op == "print" and len(args) == 1:
+            return f"(print(str({gen(args[0])})) or 0)"
+        # ``!`` is unary boolean negation.
+        if op == "!" and len(args) == 1:
+            return f"(not {gen(args[0])})"
+        # ``-->`` is logical implication.
+        if op == "-->" and len(args) == 2:
+            return f"((not {gen(args[0])}) or {gen(args[1])})"
+        # ``$`` is application.
+        if op == "$" and len(args) == 2:
+            return f"({gen(args[0])})({gen(args[1])})"
+        if op in BINARY_OPERATORS and len(args) == 2:
+            return f"({gen(args[0])} {BINARY_OPERATORS[op]} {gen(args[1])})"
+
+    # Fall back to plain curried application.
+    out = gen(head)
+    for arg in args:
+        out = f"({out})({gen(arg)})"
+    return out
+
+
+def top_level_bindings(core: Term) -> list[tuple[Name, Term]]:
+    """Return every top-level ``(name, value)`` binding in source order."""
+    out: list[tuple[Name, Term]] = []
+    t = core
+    while isinstance(t, (Rec, Let)):
+        out.append((t.var_name, t.var_value))
+        t = t.body
+    return out
+
+
+def _collect_refs(t: Term, acc: set[Name]) -> None:
+    """Accumulate the names of every ``Var`` that occurs in ``t``."""
+    match t:
+        case Var(name):
+            acc.add(name)
+        case Literal() | Hole():
+            return
+        case Application(fun, arg):
+            _collect_refs(fun, acc)
+            _collect_refs(arg, acc)
+        case Abstraction(_, body):
+            _collect_refs(body, acc)
+        case Annotation(expr, _):
+            _collect_refs(expr, acc)
+        case If(cond, then, otherwise):
+            _collect_refs(cond, acc)
+            _collect_refs(then, acc)
+            _collect_refs(otherwise, acc)
+        case Let(_, var_value, body):
+            _collect_refs(var_value, acc)
+            _collect_refs(body, acc)
+        case Rec(_, _, var_value, body):
+            _collect_refs(var_value, acc)
+            _collect_refs(body, acc)
+        case TypeAbstraction(_, _, body) | RefinementAbstraction(_, _, body):
+            _collect_refs(body, acc)
+        case TypeApplication(body, _) | RefinementApplication(body, _):
+            _collect_refs(body, acc)
+
+
+def _native_import_module(value: Term) -> str | None:
+    """If ``value`` is a ``native_import "mod"`` binding, return ``"mod"``."""
+    head = value
+    if isinstance(head, Application):
+        head, args = _unfold_application(head)
+        if isinstance(head, Var) and head.name.name == "native_import" and args:
+            first = _strip_type_wrappers(args[0])
+            if isinstance(first, Literal):
+                return str(first.value)
+    return None
+
+
+def _render_binding(name: Name, value: Term) -> str:
+    """Render a single top-level binding as Python.
+
+    Functions (terms with leading abstractions) become curried ``def``s;
+    value bindings — including ``native_import`` and ``native`` constants —
+    become module-level assignments so references resolve to the value
+    itself, exactly as the interpreter binds them."""
+    body = whnf(value)
+    params: list[str] = []
+    while isinstance(body, Abstraction):
+        params.append(body.var_name.name)
+        body = whnf(body.body)
+    body_src = gen(body)
+
+    if not params:
+        return f"{name.name} = {body_src}"
+
+    head, *rest = params
+    inner = body_src
+    for p in reversed(rest):
+        inner = f"lambda {p}: {inner}"
+    return f"def {name.name}({head}):\n    return {inner}"
+
+
+def export_function(core: Term, fun_name: str) -> str:
+    """Produce a pure-Python rendering of ``fun_name`` and its dependencies.
+
+    The output bundles ``fun_name`` together with every top-level binding it
+    transitively references, dropping anything unmentioned — except
+    ``native_import`` bindings, which are always kept (the ``native`` strings
+    that depend on them reference the imported modules by name, invisibly to
+    AST-level dependency analysis)."""
+    bindings = top_level_bindings(core)
+    by_name = {name: value for name, value in bindings}
+
+    target = next((name for name, _ in bindings if name.name == fun_name), None)
+    if target is None:
+        raise PythonExportError(f"no top-level function named '{fun_name}' was found")
+
+    top_names = set(by_name)
+
+    # Transitive closure of the dependencies reachable from the target.
+    needed: set[Name] = {target}
+    worklist = [target]
+    while worklist:
+        refs: set[Name] = set()
+        _collect_refs(by_name[worklist.pop()], refs)
+        for ref in refs:
+            if ref in top_names and ref not in needed:
+                needed.add(ref)
+                worklist.append(ref)
+
+    # ``native_import`` bindings are always included.
+    for name, value in bindings:
+        if _native_import_module(value) is not None:
+            needed.add(name)
+
+    parts = [_render_binding(name, value) for name, value in bindings if name in needed]
+    return "\n\n".join(parts) + "\n"

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable
 
 from aeon.backend.evaluator import EvaluationContext
 from aeon.backend.evaluator import eval
+from aeon.backend.python_export import export_function
 from aeon.core.bind import bind_ids
 from aeon.core.substitutions import substitution
 from aeon.core.terms import Term
@@ -23,7 +24,7 @@ from aeon.sugar.program import Program, STerm
 from aeon.synthesis.entrypoint import synthesize_holes
 from aeon.synthesis.identification import incomplete_functions_and_holes
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
-from aeon.synthesis.uis.api import SynthesisUI, SynthesisFormat
+from aeon.synthesis.uis.api import SilentSynthesisUI, SynthesisUI, SynthesisFormat
 from aeon.typechecking.typeinfer import check_type_errors
 from aeon.utils.name import Name
 from aeon.utils.pprint import pretty_print_node
@@ -126,6 +127,17 @@ class AeonDriver:
         with RecordTime("Evaluation"):
             return eval(self.core, self.evaluation_ctx)
 
+    def export(self, fun_name: str) -> str:
+        """Return a stand-alone, pure-Python definition of ``fun_name``.
+
+        Synthesis runs first when the program still has holes, so an exported
+        function that contains a hole is rendered with the synthesized result
+        substituted in. Synthesis is silent here to keep stdout pure Python."""
+        if self.has_synth():
+            self._run_synthesis(SilentSynthesisUI())
+        with RecordTime("Export"):
+            return export_function(self.core, fun_name)
+
     def has_tests(self) -> bool:
         """Whether the program declares any ``@property`` functions or
         ``@example`` assertions."""
@@ -170,30 +182,34 @@ class AeonDriver:
             )
             return bool(self.incomplete_functions)
 
+    def _run_synthesis(self, ui: SynthesisUI) -> dict[Name, STerm]:
+        """Synthesize the open holes, substitute the results into ``self.core``
+        in place, and return the per-hole solutions lifted to sugar terms."""
+        synthesizer = make_synthesizer(self.cfg.synthesizer)
+        mapping: dict[Name, Term] = synthesize_holes(
+            self.typing_ctx,
+            self.evaluation_ctx,
+            self.core,
+            self.incomplete_functions,
+            self.metadata,
+            synthesizer,
+            self.cfg.synthesis_budget,
+            ui,
+        )
+
+        synthesized_core: Term = self.core
+        for k, v in mapping.items():
+            if v is not None:
+                synthesized_core = substitution(synthesized_core, v, k)
+        self.core = synthesized_core
+
+        return {k: lift(v) for k, v in mapping.items() if v is not None}
+
     def synth(self) -> STerm:
         with RecordTime("Synthesis"):
-            synthesizer = make_synthesizer(self.cfg.synthesizer)
-            mapping: dict[Name, Term] = synthesize_holes(
-                self.typing_ctx,
-                self.evaluation_ctx,
-                self.core,
-                self.incomplete_functions,
-                self.metadata,
-                synthesizer,
-                self.cfg.synthesis_budget,
-                self.cfg.synthesis_ui,
-            )
-
-            synthesized_core: Term = self.core
-            for k, v in mapping.items():
-                if v is not None:
-                    synthesized_core = substitution(synthesized_core, v, k)
-
-            sterm_mapping: dict[Name, STerm] = {k: lift(v) for k, v in mapping.items() if v is not None}
-
-            self.cfg.synthesis_ui.display_results(synthesized_core, sterm_mapping, self.cfg.synthesis_format)
-
-            return lift(synthesized_core)
+            sterm_mapping = self._run_synthesis(self.cfg.synthesis_ui)
+            self.cfg.synthesis_ui.display_results(self.core, sterm_mapping, self.cfg.synthesis_format)
+            return lift(self.core)
 
     def pretty_print(self, filename: str = None, should_be_fixed: bool = False) -> None:
         aeon_code = read_file(filename)

--- a/docs/index.md
+++ b/docs/index.md
@@ -465,6 +465,7 @@ The generated files are gitignored; they are produced from source by the
 | --budget | Time budget for synthesis in seconds (default: 60)                          |
 | --format | Prints a pretty-printed version of the code to stdout                       |
 | --fix | Reformats the source file in place using the pretty printer                    |
+| --export | Prints a stand-alone, pure-Python version of the named function — see [Exporting to Python](#exporting-to-python) |
 | -lsp, --language-server-mode | Runs aeon in Language Server Protocol mode               |
 | --tcp | Specifies the TCP port or hostname:port for the LSP server                     |
 
@@ -608,3 +609,62 @@ def synth (x: Int) : Int := (let oracle := unit in (?hole : Int))
 Inside the hole, `oracle` now has type `Unit`, so the type-directed grammar
 never builds it into a candidate. This relies on ordinary lexical shadowing and
 replaces the former `@hide` / `@hide_types` decorators.
+
+## Exporting to Python
+
+The `--export=FUN_NAME` flag prints a stand-alone, pure-Python version of a top-level
+function to stdout. Aeon evaluates the function body to weak-head normal form (stripping
+the type-level machinery that elaboration introduces) and then renders it as Python,
+mirroring the choices the interpreter makes at runtime:
+
+- `native "..."` strings are **inlined verbatim**, so the FFI code runs directly;
+- operators, `if`/`then`/`else`, `let`, and currying are rendered to their Python equivalents.
+
+```bash
+uv run python -m aeon examples/fibonacci.ae --export=fib
+```
+
+```python
+def fib(n):
+    return (n if (n < 2) else ((fib)((n - 1)) + (fib)((n - 2))))
+```
+
+### Dependencies are bundled
+
+The export includes every top-level binding the function transitively depends on, and
+drops the rest — **except** `native_import` bindings, which are always kept (the `native`
+strings that use them reference the imported modules by name, which is invisible to the
+dependency analysis). Value bindings — constants, `native`, and `native_import` — are
+emitted as module-level assignments so references resolve to the value itself, exactly as
+the interpreter binds them. This makes FFI-backed exports runnable as-is:
+
+```bash
+uv run python -m aeon examples/ml/linear_regression.ae --export=predict
+```
+
+```python
+numpy = __import__('numpy')
+
+sklearn = __import__('sklearn')
+
+def predict(model):
+    return lambda x: (float(model.predict(numpy.array([[x]]))[0]))
+```
+
+### Holes are synthesized first
+
+If the program still contains a `?hole`, synthesis runs **before** the export, so an
+exported function whose body contains a hole is rendered with the synthesized result
+substituted in. Given:
+
+```
+def f (x:Int) : {y:Int | y = x} := ?h;
+```
+
+```bash
+uv run python -m aeon file.ae --export=f --budget 5
+```
+
+prints a fully concrete Python function — the hole is gone, replaced by whatever the
+synthesizer found to satisfy `y == x` (e.g. `x + (x - x)`). Synthesis output is kept
+off stdout so the printed result is pure Python.

--- a/examples/fibonacci.ae
+++ b/examples/fibonacci.ae
@@ -1,0 +1,9 @@
+# Naive recursive Fibonacci. `fib` is unary, so Aeon auto-infers the
+# termination metric on `n`; in the `else` branch `n >= 2`, so both `n - 1`
+# and `n - 2` decrease and stay non-negative.
+@example(fib 0 = 0)
+@example(fib 1 = 1)
+@example(fib 10 = 55)
+def fib (n:Int) : Int := if n < 2 then n else (fib (n-1) + fib (n-2));
+
+def main (_:Int) : Unit := print (fib 10)

--- a/examples/ml/linear_regression.ae
+++ b/examples/ml/linear_regression.ae
@@ -1,0 +1,27 @@
+# Linear regression with scikit-learn, via Aeon's Python FFI.
+#
+# ``native_import`` pulls a Python module into scope so the ``native`` blocks
+# below can call into it — this example genuinely requires ``numpy`` and
+# ``scikit-learn`` to be installed. ``Model`` is an opaque native type that
+# wraps a fitted scikit-learn estimator.
+
+type Model
+
+def numpy : Unit := native_import "numpy"
+def sklearn : Unit := native_import "sklearn"
+
+
+# Fit an ordinary least-squares line to the four points
+# (1, 2), (2, 4), (3, 6), (4, 8) — a perfect ``y = 2x`` relationship.
+def train : Model :=
+    native "sklearn.linear_model.LinearRegression().fit(numpy.array([[1.0],[2.0],[3.0],[4.0]]), numpy.array([2.0,4.0,6.0,8.0]))"
+
+
+# Predict the response for a single feature value.
+def predict (model: Model) (x: Float) : Float :=
+    native "float(model.predict(numpy.array([[x]]))[0])"
+
+
+def main (_:Int) : Unit :=
+    let model := train in
+    print (predict model 10.0)

--- a/tests/python_export_test.py
+++ b/tests/python_export_test.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from aeon.backend.evaluator import eval as aeon_eval
+from aeon.backend.python_export import PythonExportError, find_binding
+from aeon.core.terms import Application, Let, Literal, Rec, Term, Var
+from aeon.core.types import t_int
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.uis.api import SynthesisFormat
+from aeon.synthesis.uis.terminal import TerminalUI
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+
+
+def _driver(budget: int = 1) -> AeonDriver:
+    cfg = AeonConfig(
+        synthesizer="tdsyn_enumerative",
+        synthesis_ui=TerminalUI(),
+        synthesis_budget=budget,
+        no_main=True,
+        synthesis_format=SynthesisFormat.DEFAULT,
+    )
+    return AeonDriver(cfg)
+
+
+def _export(source: str, fun_name: str) -> str:
+    driver = _driver()
+    errors = list(driver.parse(filename=None, aeon_code=source))
+    assert errors == [], errors
+    return driver.export(fun_name)
+
+
+def _run(source: str, fun_name: str):
+    """Export a function, exec the generated Python, and return the callable."""
+    code = _export(source, fun_name)
+    ns: dict = {}
+    exec(code, ns)
+    return ns[fun_name]
+
+
+def test_export_bundles_dependencies():
+    src = (
+        "def inc (x:Int) : Int := x + 1;\ndef twice (x:Int) : Int := inc (inc x);\ndef unused (x:Int) : Int := x - 1;\n"
+    )
+    code = _export(src, "twice")
+    # The transitive dependency is pulled in, the unrelated one is dropped.
+    assert "def inc(" in code
+    assert "unused" not in code
+    assert _run(src, "twice")(5) == 7
+
+
+def test_export_keeps_native_import_even_if_not_referenced_in_ast():
+    # ``sq`` mentions ``math`` only inside a native string, so the import must
+    # be force-included for the export to be runnable.
+    src = 'def math : Unit := native_import "math";\ndef sq (x:Float) : Float := native "math.sqrt(x)";\n'
+    code = _export(src, "sq")
+    assert "math = __import__('math')" in code
+    ns: dict = {}
+    exec(code, ns)
+    assert ns["sq"](16.0) == 4.0
+
+
+def test_export_simple_arithmetic():
+    src = "def double (x:Int) : Int := x + x;"
+    code = _export(src, "double")
+    assert "def double(x):" in code
+    assert _run(src, "double")(21) == 42
+
+
+def test_export_if_is_ternary():
+    src = "def clamp (x:Int) : Int := if x < 0 then 0 else x;"
+    code = _export(src, "clamp")
+    assert "if" in code and "else" in code
+    fn = _run(src, "clamp")
+    assert fn(-5) == 0
+    assert fn(7) == 7
+
+
+def test_export_recursion():
+    src = "def fib (n:Int) : Int := if n < 2 then n else fib (n - 1) + fib (n - 2);"
+    fn = _run(src, "fib")
+    assert fn(10) == 55
+
+
+def test_export_multi_arg_is_curried():
+    src = "def add (x:Int) (y:Int) : Int := x + y;"
+    code = _export(src, "add")
+    assert "lambda y" in code
+    assert _run(src, "add")(3)(4) == 7
+
+
+def test_export_string_literal_inlined():
+    src = "def tag (s:String) : String := s;"
+    fn = _run(src, "tag")
+    assert fn("hello") == "hello"
+
+
+def test_export_boolean_operators():
+    src = "def both (a:Bool) (b:Bool) : Bool := a && b;"
+    fn = _run(src, "both")
+    assert fn(True)(True) is True
+    assert fn(True)(False) is False
+
+
+def test_export_native_string_inlined():
+    src = 'def mylen (xs:String) : Int := native "len(xs)";'
+    code = _export(src, "mylen")
+    assert "len(xs)" in code
+    assert _run(src, "mylen")("abcd") == 4
+
+
+def test_export_runs_synthesis_to_fill_holes():
+    # ``f`` is defined with a hole. Exporting it must run synthesis first, so
+    # the emitted Python contains the synthesized result and no unfilled '?'.
+    src = "def f (x:Int) : {y:Int | y = x} := ?h;\n"
+    driver = _driver(budget=3)
+    assert list(driver.parse(filename=None, aeon_code=src)) == []
+    code = driver.export("f")
+    assert "def f(x):" in code
+    assert "?" not in code  # the hole was replaced by the synthesized term
+
+
+def test_export_unknown_function_raises():
+    src = "def double (x:Int) : Int := x + x;"
+    driver = _driver()
+    assert list(driver.parse(filename=None, aeon_code=src)) == []
+    with pytest.raises(PythonExportError):
+        driver.export("nonexistent")
+
+
+# --- Cross-check: exported Python matches the Aeon interpreter ---------------
+
+
+def _replace_tail(core, new_tail):
+    """Swap the innermost body of the top-level binding chain so the program
+    evaluates to ``new_tail`` instead of ``main``."""
+    if isinstance(core, (Rec, Let)):
+        return dataclasses.replace(core, body=_replace_tail(core.body, new_tail))
+    return new_tail
+
+
+def _eval_with_aeon(driver: AeonDriver, fun_name: str, args: list[int]) -> object:
+    """Apply ``fun_name`` to integer ``args`` and evaluate it with the Aeon
+    interpreter, reusing the program's own top-level bindings."""
+    binding = find_binding(driver.core, fun_name)
+    assert binding is not None
+    name, _ = binding
+    call: Term = Var(name)
+    for a in args:
+        call = Application(call, Literal(a, t_int))
+    program = _replace_tail(driver.core, call)
+    return aeon_eval(program, driver.evaluation_ctx)
+
+
+def _eval_with_python(driver: AeonDriver, fun_name: str, args: list[int]) -> object:
+    """Export ``fun_name`` to Python, exec it, and apply it (curried) to ``args``."""
+    ns: dict = {}
+    exec(driver.export(fun_name), ns)
+    fn = ns[fun_name]
+    for a in args:
+        fn = fn(a)
+    return fn
+
+
+# (example file, function, argument list) — small, self-contained functions
+# drawn from the examples/ folder, covering recursion, currying, nested
+# conditionals and inlined ``native`` strings.
+EXPORT_EXAMPLES = [
+    ("fibonacci.ae", "fib", [10]),
+    ("factorial.ae", "factorial", [5]),
+    ("syntax/mult.ae", "mult2", [6, 7]),
+    ("syntax/mult.ae", "mult4", [6, 7]),
+    ("syntax/maxI.ae", "maxI", [3, 9]),
+    ("syntax/ackermann.ae", "ack", [2, 3]),
+]
+
+
+@pytest.mark.parametrize("filename,fun_name,args", EXPORT_EXAMPLES)
+def test_exported_python_matches_aeon(filename: str, fun_name: str, args: list[int]):
+    driver = _driver()
+    errors = list(driver.parse(filename=str(EXAMPLES / filename)))
+    assert errors == [], errors
+
+    aeon_result = _eval_with_aeon(driver, fun_name, args)
+    python_result = _eval_with_python(driver, fun_name, args)
+    assert python_result == aeon_result


### PR DESCRIPTION
## Summary

Adds a `--export=FUN_NAME` CLI flag that prints a stand-alone, **pure-Python** version of a top-level Aeon function to stdout.

Aeon evaluates the function body to weak-head normal form — stripping the type/refinement abstractions, type/refinement applications, and annotations that elaboration wraps around values — and then renders it as Python, mirroring the interpreter (`aeon/backend/evaluator.py`):

- curried lambdas for abstractions, ternaries for `if`, immediately-applied lambdas for `let`;
- operators / `print` / `native_import` rendered to their Python equivalents;
- `native "..."` strings **inlined verbatim** (exactly what the interpreter would `eval`).

The emitted function preserves Aeon's currying convention (`f a b` → `f(a)(b)`), so inlined native strings — which reference source-level parameter names — resolve against the surrounding lambdas.

```
$ uv run python -m aeon examples/fibonacci.ae --export=fib
def fib(n):
    return (n if (n < 2) else ((fib)((n - 1)) + (fib)((n - 2))))
```

## Dependencies are bundled

The export includes every top-level binding the target transitively references and drops the rest — **except** `native_import` bindings, which are always kept (the `native` strings that use them reference imported modules by name, invisible to AST dependency analysis). Value bindings (constants, `native`, `native_import`) are emitted as module-level assignments so references resolve to the value itself, matching the interpreter. This makes FFI-backed exports runnable as-is:

```
$ uv run python -m aeon examples/ml/linear_regression.ae --export=predict
numpy = __import__('numpy')

sklearn = __import__('sklearn')

def predict(model):
    return lambda x: (float(model.predict(numpy.array([[x]]))[0]))
```

## Holes are synthesized first

If the program still contains a `?hole`, **synthesis runs before the export**, so an exported function whose body contains a hole is rendered with the synthesized result substituted in. Synthesis runs with a silent UI so stdout stays pure Python.

```
$ uv run python -m aeon file.ae --export=f --budget 5   # def f (x:Int) : {y:Int | y == x} = ?h
def f(x):
    return (x + (x - x))     # hole filled by synthesis
```

`AeonDriver.synth` was refactored into a reusable `_run_synthesis` helper that persists the filled core onto `self.core`; both the normal synthesis path and the export path share it.

## Examples

- `examples/fibonacci.ae` — recursion demo used in the docs.
- Made the well-founded `factorial` the de facto `examples/factorial.ae` (the old metric-less version no longer typechecks under well-founded-recursion checking) and dropped the `syntax/factorial_decreasing.ae` duplicate.
- `examples/ml/linear_regression.ae` — scikit-learn linear regression via Aeon's Python FFI (`native_import` of numpy and sklearn).

## Documentation

- `docs/index.md`: `--export` added to the CLI options table, plus a new **Exporting to Python** section covering native inlining, dependency bundling, and hole synthesis.
- `README.md`: feature bullet.

## Testing

`tests/python_export_test.py` (17 tests):
- unit cases — arithmetic, `if`, recursion, curried multi-arg, string literals, boolean ops, inlined `native`, unknown-function error;
- dependency bundling — transitive dep included, unrelated dropped, `native_import` always kept and runnable;
- synthesis-before-export — a holed function exports with no `?` remaining;
- cross-check — for `fib`, `factorial`, `mult2`, `mult4`, `maxI`, `ack`, the exported Python is exec'd and asserted equal to the Aeon interpreter on the same inputs.

`mypy` and `ruff` clean (pre-commit passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)