### PR TITLE
refactor(synthesis): close scope over fitness helpers; drop __internal__ trick

### DIFF
--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -74,7 +74,7 @@ def make_optimizer(
     """
     current_goals = metadata.get(fun.name, {}).get("goals", [])
     minimize_name = "minimize" if minimize else "maximize"
-    function_name = Name(f"__internal__{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
+    function_name = Name(f"_fitness_{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -145,7 +145,7 @@ def cluster(
     ``cluster`` metadata key. Other backends ignore it.
     """
     assert len(decorator.macro_args) == 1, "cluster decorator expects a single argument"
-    function_name = Name(f"__internal__cluster_{fun.name}", fresh_counter.fresh())
+    function_name = Name(f"_cluster_{fun.name}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -317,7 +317,7 @@ def example(
     # (1) An internal nullary Bool binding holding the raw assertion. The
     # ``--test`` runner locates it by name and requires it to evaluate to True.
     current = metadata.get(fun.name, {}).get("examples", [])
-    test_name = Name(f"__internal__example_{fun.name}_{len(current)}", fresh_counter.fresh())
+    test_name = Name(f"_example_{fun.name}_{len(current)}", fresh_counter.fresh())
     test_fn = Definition(name=test_name, foralls=[], args=[], type=st_bool, body=assertion)
 
     try:

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -17,6 +17,7 @@ from aeon.core.terms import Term, Var
 from aeon.core.types import Top
 from aeon.core.types import top, Type
 from aeon.decorators import Metadata
+from aeon.synthesis.scope import close_synthesis_context
 from aeon.backend.evaluator import eval
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.synthesis.identification import get_holes_info
@@ -227,6 +228,10 @@ def synthesize_holes(
 
         hole_name = holes_names[0]
         ty, tyctx = program_holes[hole_name]
+        # Search in a scope closed over the fitness/example/cluster helpers, so
+        # they never appear as building blocks (replaces the __internal__ filter).
+        assert isinstance(tyctx, TypingContext)
+        tyctx = close_synthesis_context(tyctx, metadata)
         ui.start(tyctx, ectx, hole_name.name, ty, budget)
 
         replace = make_program(term, hole_name)

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -24,6 +24,7 @@ from aeon.core.liquid import (
 from itertools import product
 
 from aeon.core.equality import canonicalize_type
+from aeon.synthesis.scope import close_synthesis_context
 from aeon.core.substitutions import substitute_vartype, substitution_in_type, substitution_liquid_in_type
 from aeon.core.terms import Abstraction, Annotation, Application, If, Literal, TypeApplication
 from aeon.core.terms import Var
@@ -954,6 +955,10 @@ def gen_grammar_nodes(
     if grammar_nodes is None:
         grammar_nodes = []
 
+    # Close the scope over the fitness/example/cluster helpers so they are not
+    # offered as building blocks (they remain in the program for evaluation).
+    ctx = close_synthesis_context(ctx, metadata)
+
     # Clean context to remove non-interpreted functions from the context.
     # Simple refinements like 0 < n && n < 10 are kept.
     ctx, _ = propagate_constants(ctx)
@@ -966,8 +971,6 @@ def gen_grammar_nodes(
     def skip(name: Name) -> bool:
         if name == synth_func_name:
             return not is_recursion_allowed
-        elif name.name.startswith("__internal__"):
-            return True
         elif name.name in ["native", "native_import", "print"]:
             return True
         else:

--- a/aeon/synthesis/modules/smt_synthesizer.py
+++ b/aeon/synthesis/modules/smt_synthesizer.py
@@ -391,8 +391,8 @@ class SMTSynthesizer(Synthesizer):
             # Skip the function being synthesized (no self-recursion)
             if var_name == fun_name:
                 continue
-            # Skip internal/system names
-            if var_name.name.startswith("__internal__") or var_name.name in _SYSTEM_NAMES:
+            # Skip system names (fitness helpers are already out of scope)
+            if var_name.name in _SYSTEM_NAMES:
                 continue
             # Try to instantiate polymorphic functions
             effective_ty: Type = var_ty

--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -50,8 +50,6 @@ class SynquidSynthesizer(Synthesizer):
         def skip(name: Name) -> bool:
             if name == fun_name:
                 return not is_recursion_allowed
-            elif name.name.startswith("__internal__"):
-                return True
             elif name.name in ["native", "native_import", "print"]:
                 return True
             else:

--- a/aeon/synthesis/modules/tdsyn/helpers.py
+++ b/aeon/synthesis/modules/tdsyn/helpers.py
@@ -70,8 +70,6 @@ def should_skip(name: Name, fun_name: Name, metadata: Metadata, is_recursion_all
     """Check if a variable should be skipped during synthesis."""
     if name == fun_name:
         return not is_recursion_allowed
-    if name.name.startswith("__internal__"):
-        return True
     if name.name in ("native", "native_import", "print"):
         return True
     return False

--- a/aeon/synthesis/scope.py
+++ b/aeon/synthesis/scope.py
@@ -1,0 +1,62 @@
+"""Closing the synthesis scope over fitness-relevant definitions.
+
+The optimization decorators (``@minimize``, ``@example``, ``@cluster``, …) emit
+auxiliary top-level definitions holding the fitness/example/cluster expressions.
+These must be evaluable (so they stay in the program, in scope for fitness
+evaluation), but must *not* be visible to the synthesizers as building blocks —
+otherwise the search would try to use a fitness function to build a candidate.
+
+Rather than tagging those definitions with a magic ``__internal__`` name prefix
+and filtering on it in every synthesizer, we gather their names from the
+``Metadata`` that already records them and hand each synthesizer a *closed*
+typing context with those bindings removed. The synthesis files own this
+exclusion; the compiler is untouched.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from aeon.typechecking.context import (
+    ReflectedBinder,
+    TypingContext,
+    UninterpretedBinder,
+    VariableBinder,
+)
+
+_VALUE_BINDERS = (VariableBinder, UninterpretedBinder, ReflectedBinder)
+
+
+def fitness_relevant_names(metadata) -> set[str]:
+    """The (surface) names of every fitness/example/cluster helper recorded in
+    ``metadata`` — the bindings that back ``@minimize``/``@maximize``,
+    ``@example`` and ``@cluster`` and so must not appear in the synthesis scope."""
+    names: set[str] = set()
+    for entry in metadata.values():
+        if not isinstance(entry, dict):
+            continue
+        for goal in entry.get("goals", []) or []:
+            fn = getattr(goal, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        for example in entry.get("examples", []) or []:
+            fn = getattr(example, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        cluster = entry.get("cluster")
+        if cluster is not None:
+            names.add(cluster.name)
+    return names
+
+
+def close_synthesis_context(ctx: TypingContext, metadata) -> TypingContext:
+    """``ctx`` with the fitness-relevant value bindings removed — the closed
+    scope a synthesizer should search in. Type-level binders are untouched, and
+    the context is returned unchanged when there is nothing to hide."""
+    hidden = fitness_relevant_names(metadata)
+    if not hidden:
+        return ctx
+    kept = [e for e in ctx.entries if not (isinstance(e, _VALUE_BINDERS) and e.name.name in hidden)]
+    if len(kept) == len(ctx.entries):
+        return ctx
+    return dataclasses.replace(ctx, entries=kept)

--- a/tests/synthesis_scope_test.py
+++ b/tests/synthesis_scope_test.py
@@ -1,0 +1,98 @@
+"""The fitness/example/cluster helpers emitted by the optimization decorators
+must stay evaluable (in the program) but must not leak into the synthesis scope,
+without relying on a ``__internal__`` name prefix."""
+
+from __future__ import annotations
+
+from aeon.synthesis.identification import get_holes_info
+from aeon.synthesis.scope import close_synthesis_context, fitness_relevant_names
+from aeon.core.types import top
+from aeon.typechecking.context import TypingContext, TypeBinder, VariableBinder, UninterpretedBinder
+from aeon.core.types import t_int
+from aeon.utils.name import Name
+
+from tests.driver import check_and_return_core
+
+
+# --------------------------------------------------------------------------- #
+# Unit: closing a context over recorded fitness names
+# --------------------------------------------------------------------------- #
+
+
+def _goal(name: Name):
+    from aeon.synthesis.decorators import Goal
+
+    return Goal(minimize=True, length=1, function=name, kind="expression")
+
+
+def test_fitness_relevant_names_gathers_all_kinds():
+    from aeon.synthesis.decorators import Example
+
+    md = {
+        Name("f", 0): {
+            "goals": [_goal(Name("_fitness_minimize_f_0", 5))],
+            "examples": [Example(Name("_example_f_0", 6), "f 1 == 1")],
+            "cluster": Name("_cluster_f", 7),
+        }
+    }
+    assert fitness_relevant_names(md) == {"_fitness_minimize_f_0", "_example_f_0", "_cluster_f"}
+
+
+def test_close_context_drops_only_fitness_value_binders():
+    md = {Name("f", 0): {"goals": [_goal(Name("_fitness_minimize_f_0", 5))]}}
+    ctx = TypingContext(
+        entries=[
+            TypeBinder(Name("Int", 0)),
+            VariableBinder(Name("f", 0), t_int),
+            VariableBinder(Name("_fitness_minimize_f_0", 5), t_int),
+            UninterpretedBinder(Name("g", 0), t_int),
+        ]
+    )
+    closed = close_synthesis_context(ctx, md)
+    names = {e.name.name for e in closed.entries if isinstance(e, (VariableBinder, UninterpretedBinder))}
+    assert "_fitness_minimize_f_0" not in names
+    assert {"f", "g"} <= names
+    # type binders are untouched
+    assert any(isinstance(e, TypeBinder) for e in closed.entries)
+    # nothing to hide -> same object back
+    assert close_synthesis_context(ctx, {}) is ctx
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: through the real decorator + lowering pipeline
+# --------------------------------------------------------------------------- #
+
+SOURCE = """
+    @minimize(g(1.0) - 5.0)
+    def g(x:Float) : Float := x
+
+    def h(y:Float) : Float := ?hole
+"""
+
+
+def test_no_internal_prefix_in_generated_names():
+    _core, _ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    names = fitness_relevant_names(metadata)
+    assert names, "expected at least one fitness helper"
+    assert all(not n.startswith("__internal__") for n in names)
+
+
+def test_fitness_helpers_excluded_from_hole_scope_but_kept_in_program():
+    core, ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    fitness = fitness_relevant_names(metadata)
+
+    holes = get_holes_info(ctx, core, top, [], refined_types=True)
+    # ``g``'s fitness helper is bound after ``g`` and so is in scope at the
+    # later hole in ``h`` — exactly the leak the synthesizers used to filter.
+    leaked = False
+    for _ty, hole_ctx in holes.values():
+        in_scope = {n.name for n, _t in hole_ctx.concrete_vars()}
+        if fitness & in_scope:
+            leaked = True
+            closed = close_synthesis_context(hole_ctx, metadata)
+            closed_scope = {n.name for n, _t in closed.concrete_vars()}
+            # The closed synthesis scope must not contain the fitness helper...
+            assert not (fitness & closed_scope), "fitness helper leaked into the closed synthesis scope"
+            # ...while the real definitions stay available to the synthesizer.
+            assert "g" in closed_scope
+    assert leaked, "expected the fitness helper to be in scope at some hole"


### PR DESCRIPTION
Removes the `__internal__` name-prefix trick used to hide the optimization decorators' fitness/example/cluster helpers from synthesis.

## Before
`@minimize`/`@example`/`@cluster` emitted helper definitions named `__internal__…`, and **four** synthesizers filtered them out of the search by `name.name.startswith("__internal__")` ([grammar_generation](aeon/synthesis/grammar/grammar_generation.py), [smt_synthesizer](aeon/synthesis/modules/smt_synthesizer.py), [tdsyn/helpers](aeon/synthesis/modules/tdsyn/helpers.py), [synquid/synthesizer](aeon/synthesis/modules/synquid/synthesizer.py)).

## After — closed scope
- New [`aeon/synthesis/scope.py`](aeon/synthesis/scope.py): `fitness_relevant_names(metadata)` gathers the helper names from the metadata that already records them (`goals`/`examples`/`cluster`); `close_synthesis_context(ctx, metadata)` returns the context with those value bindings removed.
- Called once in `create_grammar` (covers the grammar synthesizer **and** PBT input generation) and once in `synthesize_holes` (covers SMT/tdsyn/synquid).
- **All four prefix filters deleted.**
- Helpers are named `_fitness_/_cluster_/_example_` now (single leading underscore keeps them hidden in the info view); nothing matches on the name anymore.

The helpers remain in the program, so fitness/example **evaluation is unchanged** — no compiler changes, scoped entirely to the synthesis files.

## Tests
New `tests/synthesis_scope_test.py`: the generated names carry no `__internal__` prefix; `close_synthesis_context` drops only the recorded fitness value-binders (keeping type binders and real defs); and end-to-end, a helper that is in scope at a *later* function's hole is excluded from the closed scope while the real definition (`g`) remains.

Ran locally on macOS via uv (built scipy from source + auto-stubbed the handful of Fortran solvers that don't dlopen on this macOS beta): decorator, optimization, multi-objective, csv, pbt, sygus/SMT, tactic, lta, seed, and the new scope tests all pass. The `symetric` (metric-backend) tests fail **only** under that local scipy stub (identical failure on a clean baseline); they exercise no code I touched and run on CI.