### PR TITLE
refactor(synthesis): hide fitness helpers by let-shadowing, not __internal__

### DIFF
--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -74,7 +74,7 @@ def make_optimizer(
     """
     current_goals = metadata.get(fun.name, {}).get("goals", [])
     minimize_name = "minimize" if minimize else "maximize"
-    function_name = Name(f"__internal__{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
+    function_name = Name(f"_fitness_{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -145,7 +145,7 @@ def cluster(
     ``cluster`` metadata key. Other backends ignore it.
     """
     assert len(decorator.macro_args) == 1, "cluster decorator expects a single argument"
-    function_name = Name(f"__internal__cluster_{fun.name}", fresh_counter.fresh())
+    function_name = Name(f"_cluster_{fun.name}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -317,7 +317,7 @@ def example(
     # (1) An internal nullary Bool binding holding the raw assertion. The
     # ``--test`` runner locates it by name and requires it to evaluate to True.
     current = metadata.get(fun.name, {}).get("examples", [])
-    test_name = Name(f"__internal__example_{fun.name}_{len(current)}", fresh_counter.fresh())
+    test_name = Name(f"_example_{fun.name}_{len(current)}", fresh_counter.fresh())
     test_fn = Definition(name=test_name, foralls=[], args=[], type=st_bool, body=assertion)
 
     try:

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -17,6 +17,7 @@ from aeon.core.terms import Term, Var
 from aeon.core.types import Top
 from aeon.core.types import top, Type
 from aeon.decorators import Metadata
+from aeon.synthesis.scope import shadow_fitness_helpers
 from aeon.backend.evaluator import eval
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.synthesis.identification import get_holes_info
@@ -227,6 +228,10 @@ def synthesize_holes(
 
         hole_name = holes_names[0]
         ty, tyctx = program_holes[hole_name]
+        assert isinstance(tyctx, TypingContext)
+        # Let-shadow the fitness/example/cluster helpers to Unit at the hole, so
+        # the synthesizer never builds them (replaces the __internal__ filter).
+        tyctx = shadow_fitness_helpers(tyctx, metadata)
         ui.start(tyctx, ectx, hole_name.name, ty, budget)
 
         replace = make_program(term, hole_name)

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -37,6 +37,7 @@ from aeon.core.types import t_float
 from aeon.core.types import t_int
 from aeon.core.types import t_string
 from aeon.decorators import Metadata
+from aeon.synthesis.scope import shadow_fitness_helpers
 from aeon.synthesis.grammar.mangling import mangle_name, mangle_var, mangle_type
 from aeon.synthesis.grammar.refinements import refined_type_to_metahandler
 from aeon.synthesis.grammar.utils import prelude_ops, aeon_to_python
@@ -954,6 +955,10 @@ def gen_grammar_nodes(
     if grammar_nodes is None:
         grammar_nodes = []
 
+    # Let-shadow the fitness/example/cluster helpers to Unit so they are not
+    # offered as building blocks (they stay in the program for evaluation).
+    ctx = shadow_fitness_helpers(ctx, metadata)
+
     # Clean context to remove non-interpreted functions from the context.
     # Simple refinements like 0 < n && n < 10 are kept.
     ctx, _ = propagate_constants(ctx)
@@ -966,8 +971,6 @@ def gen_grammar_nodes(
     def skip(name: Name) -> bool:
         if name == synth_func_name:
             return not is_recursion_allowed
-        elif name.name.startswith("__internal__"):
-            return True
         elif name.name in ["native", "native_import", "print"]:
             return True
         else:

--- a/aeon/synthesis/modules/smt_synthesizer.py
+++ b/aeon/synthesis/modules/smt_synthesizer.py
@@ -391,8 +391,8 @@ class SMTSynthesizer(Synthesizer):
             # Skip the function being synthesized (no self-recursion)
             if var_name == fun_name:
                 continue
-            # Skip internal/system names
-            if var_name.name.startswith("__internal__") or var_name.name in _SYSTEM_NAMES:
+            # Skip system names (fitness helpers are shadowed to Unit upstream)
+            if var_name.name in _SYSTEM_NAMES:
                 continue
             # Try to instantiate polymorphic functions
             effective_ty: Type = var_ty

--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -50,8 +50,6 @@ class SynquidSynthesizer(Synthesizer):
         def skip(name: Name) -> bool:
             if name == fun_name:
                 return not is_recursion_allowed
-            elif name.name.startswith("__internal__"):
-                return True
             elif name.name in ["native", "native_import", "print"]:
                 return True
             else:

--- a/aeon/synthesis/modules/tdsyn/helpers.py
+++ b/aeon/synthesis/modules/tdsyn/helpers.py
@@ -70,8 +70,6 @@ def should_skip(name: Name, fun_name: Name, metadata: Metadata, is_recursion_all
     """Check if a variable should be skipped during synthesis."""
     if name == fun_name:
         return not is_recursion_allowed
-    if name.name.startswith("__internal__"):
-        return True
     if name.name in ("native", "native_import", "print"):
         return True
     return False

--- a/aeon/synthesis/scope.py
+++ b/aeon/synthesis/scope.py
@@ -1,0 +1,69 @@
+"""Hiding fitness-relevant helpers from the synthesis scope by let-shadowing.
+
+The optimization decorators (``@minimize``, ``@example``, ``@cluster``, …) emit
+auxiliary top-level definitions holding the fitness/example/cluster expressions.
+They must stay in the program (so fitness evaluation can reach them), but must
+not be offered to the synthesizers as building blocks.
+
+This is the same problem the ``@hide`` decorator solved, and it is solved the
+same way: lexical shadowing. ``TypingContext.concrete_vars()`` keeps the
+innermost binding per surface name, so rebinding a helper to the inert ``Unit``
+type at the synthesis point — exactly what ``let helper = unit in <hole>`` does —
+hides its real (callable) type from the type-directed grammar and from every
+backend. We gather the helper names from the ``Metadata`` that already records
+them and append those ``Unit`` shadows to the context handed to synthesis.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from aeon.core.types import t_unit
+from aeon.typechecking.context import (
+    ReflectedBinder,
+    TypingContext,
+    UninterpretedBinder,
+    VariableBinder,
+)
+from aeon.utils.name import Name
+
+_VALUE_BINDERS = (VariableBinder, UninterpretedBinder, ReflectedBinder)
+
+
+def fitness_relevant_names(metadata) -> set[str]:
+    """The (surface) names of every fitness/example/cluster helper recorded in
+    ``metadata`` — the bindings that back ``@minimize``/``@maximize``,
+    ``@example`` and ``@cluster`` and so must not appear in the synthesis scope."""
+    names: set[str] = set()
+    for entry in metadata.values():
+        if not isinstance(entry, dict):
+            continue
+        for goal in entry.get("goals", []) or []:
+            fn = getattr(goal, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        for example in entry.get("examples", []) or []:
+            fn = getattr(example, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        cluster = entry.get("cluster")
+        if cluster is not None:
+            names.add(cluster.name)
+    return names
+
+
+def shadow_fitness_helpers(ctx: TypingContext, metadata) -> TypingContext:
+    """``ctx`` with every in-scope fitness/example/cluster helper let-shadowed to
+    ``Unit``, so the synthesizer never builds it. Returns ``ctx`` unchanged when
+    there is nothing to shadow. This mirrors a ``let helper = unit in <hole>``
+    wrapper, relying on :meth:`TypingContext.concrete_vars` keeping the innermost
+    (``Unit``) binding per name."""
+    hidden = fitness_relevant_names(metadata)
+    if not hidden:
+        return ctx
+    present = {e.name.name for e in ctx.entries if isinstance(e, _VALUE_BINDERS) and e.name.name in hidden}
+    if not present:
+        return ctx
+    entries = list(ctx.entries)
+    entries.extend(VariableBinder(Name(name, 0), t_unit) for name in sorted(present))
+    return dataclasses.replace(ctx, entries=entries)

--- a/tests/synthesis_scope_test.py
+++ b/tests/synthesis_scope_test.py
@@ -1,0 +1,98 @@
+"""The fitness/example/cluster helpers emitted by the optimization decorators
+must stay evaluable (in the program) but must be hidden from the synthesis scope
+by let-shadowing to ``Unit`` — not by a ``__internal__`` name prefix."""
+
+from __future__ import annotations
+
+from aeon.synthesis.identification import get_holes_info
+from aeon.synthesis.scope import fitness_relevant_names, shadow_fitness_helpers
+from aeon.core.types import top, t_int, t_unit
+from aeon.typechecking.context import TypingContext, TypeBinder, VariableBinder, UninterpretedBinder
+from aeon.utils.name import Name
+
+from tests.driver import check_and_return_core
+
+
+# --------------------------------------------------------------------------- #
+# Unit: shadowing recorded fitness helpers to Unit
+# --------------------------------------------------------------------------- #
+
+
+def _goal(name: Name):
+    from aeon.synthesis.decorators import Goal
+
+    return Goal(minimize=True, length=1, function=name, kind="expression")
+
+
+def test_fitness_relevant_names_gathers_all_kinds():
+    from aeon.synthesis.decorators import Example
+
+    md = {
+        Name("f", 0): {
+            "goals": [_goal(Name("_fitness_minimize_f_0", 5))],
+            "examples": [Example(Name("_example_f_0", 6), "f 1 == 1")],
+            "cluster": Name("_cluster_f", 7),
+        }
+    }
+    assert fitness_relevant_names(md) == {"_fitness_minimize_f_0", "_example_f_0", "_cluster_f"}
+
+
+def test_shadow_rebinds_only_in_scope_helpers_to_unit():
+    md = {Name("f", 0): {"goals": [_goal(Name("_fitness_minimize_f_0", 5))]}}
+    ctx = TypingContext(
+        entries=[
+            TypeBinder(Name("Int", 0)),
+            VariableBinder(Name("f", 0), t_int),
+            VariableBinder(Name("_fitness_minimize_f_0", 5), t_int),  # real (callable) type
+            UninterpretedBinder(Name("g", 0), t_int),
+        ]
+    )
+    shadowed = shadow_fitness_helpers(ctx, md)
+    vars_by_name = {n.name: t for n, t in shadowed.concrete_vars()}
+    # the helper is now seen as inert Unit, not its real type
+    assert vars_by_name["_fitness_minimize_f_0"] == t_unit
+    # real definitions are untouched
+    assert vars_by_name["f"] == t_int
+    # nothing to shadow -> same object back
+    assert shadow_fitness_helpers(ctx, {}) is ctx
+    # a recorded helper that is not in scope is not introduced
+    md2 = {Name("z", 0): {"goals": [_goal(Name("_fitness_minimize_z_0", 9))]}}
+    assert shadow_fitness_helpers(ctx, md2) is ctx
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through the real decorator + lowering pipeline
+# --------------------------------------------------------------------------- #
+
+SOURCE = """
+    @minimize(g(1.0) - 5.0)
+    def g(x:Float) : Float := x
+
+    def h(y:Float) : Float := ?hole
+"""
+
+
+def test_no_internal_prefix_in_generated_names():
+    _core, _ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    names = fitness_relevant_names(metadata)
+    assert names, "expected at least one fitness helper"
+    assert all(not n.startswith("__internal__") for n in names)
+
+
+def test_fitness_helper_shadowed_to_unit_at_later_hole():
+    core, ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    fitness = fitness_relevant_names(metadata)
+
+    holes = get_holes_info(ctx, core, top, [], refined_types=True)
+    shadowed_somewhere = False
+    for _ty, hole_ctx in holes.values():
+        in_scope = {n.name for n, _t in hole_ctx.concrete_vars()}
+        if fitness & in_scope:  # g's fitness helper is in scope at h's hole
+            shadowed_somewhere = True
+            shadowed = shadow_fitness_helpers(hole_ctx, metadata)
+            types_by_name = {n.name: t for n, t in shadowed.concrete_vars()}
+            for fn in fitness & in_scope:
+                # hidden by shadowing to the inert Unit type, not removed
+                assert types_by_name[fn] == t_unit
+            assert "g" in types_by_name  # the real definition stays available
+    assert shadowed_somewhere, "expected a fitness helper in scope at some hole"


### PR DESCRIPTION
Removes the `__internal__` name-prefix trick for the optimization decorators' fitness/example/cluster helpers, using the **same let-shadowing mechanism** that `@hide` was migrated to in #287/#333.

## Mechanism
`@hide` became `let helper = unit in <hole>`: `TypingContext.concrete_vars()` keeps the innermost binding per name, so rebinding a helper to inert `Unit` hides its real callable type from the type-directed grammar. This applies that to the auto-generated helpers:

- [`aeon/synthesis/scope.py`](aeon/synthesis/scope.py): `shadow_fitness_helpers(ctx, metadata)` rebinds every **in-scope** fitness helper (names from the `goals`/`examples`/`cluster` metadata) to `Unit` — the context equivalent of a `let helper = unit in` wrapper. Helpers not in scope are left alone (never introduced).
- Applied where holes are synthesized: `synthesize_holes` (SMT/tdsyn/synquid) and `gen_grammar_nodes` (grammar synthesizer **and** PBT input generation), so a helper that leaks into a *later* function's hole is shadowed too.
- The four `startswith("__internal__")` filters are **deleted**; generated helpers are named `_fitness_/_cluster_/_example_`.

Helpers remain in the program, so fitness/example **evaluation is unchanged**. No compiler changes.

## Tests
New `tests/synthesis_scope_test.py`: names carry no `__internal__` prefix; `shadow_fitness_helpers` rebinds only in-scope helpers to `Unit` (real defs and type binders untouched, no-op when nothing to hide); end-to-end, a helper in scope at a later function's hole is shadowed to `Unit` while the real definition stays.

Ran locally on macOS via uv (scipy built from source + the handful of non-loading Fortran solvers auto-stubbed): decorator, optimization, multi-objective, csv, pbt, sygus/SMT, tactic, lta, seed, and the new scope tests pass (63 + 74). `symetric` fails only under that local scipy stub (identical on a clean baseline; runs on CI).