### PR TITLE
fix: make canonicalize_type idempotent for refined types

### DIFF
--- a/aeon/core/equality.py
+++ b/aeon/core/equality.py
@@ -36,6 +36,29 @@ from aeon.core.types import (
 )
 
 
+def _rename_liquid_parallel(lq: LiquidTerm, mapping: dict[Name, Name]) -> LiquidTerm:
+    """Simultaneously rename every variable occurrence in a liquid term.
+
+    Each ``LiquidVar``/application head is rewritten according to ``mapping`` in a
+    single pass, so a name introduced by one entry is never re-substituted by
+    another (unlike chained single-variable substitutions). This is what makes
+    ``canonicalize_type`` safe to apply to an already-canonical type.
+    """
+    match lq:
+        case LiquidVar(name):
+            return LiquidVar(mapping.get(name, name))
+        case LiquidApp(fun, args):
+            return LiquidApp(mapping.get(fun, fun), [_rename_liquid_parallel(a, mapping) for a in args])
+        case LiquidHornApplication(fun, argtypes, loc):
+            return LiquidHornApplication(
+                mapping.get(fun, fun),
+                [(_rename_liquid_parallel(a, mapping), t) for (a, t) in argtypes],
+                loc=loc,
+            )
+        case _:
+            return lq
+
+
 def core_liquid_equality(lq1: LiquidTerm, lq2: LiquidTerm, rename_left: dict[Name, Name] | None = None) -> bool:
     "Equality of liquid terms up to alpha renaming"
     rename_left = rename_left or {}
@@ -100,8 +123,6 @@ def canonicalize_type(
     (and so compare equal / hash equal via the structural ``__eq__``/``__hash__``
     in ``aeon/core/types.py``).
     """
-    from aeon.core.substitutions import substitution_in_liquid
-
     rename = rename or {}
     if counter is None:
         counter = [0]
@@ -110,11 +131,6 @@ def canonicalize_type(
         n = Name(f"__c{counter[0]}__", 0)
         counter[0] += 1
         return n
-
-    def rename_liquid(lq: LiquidTerm, mapping: dict[Name, Name]) -> LiquidTerm:
-        for old, new in mapping.items():
-            lq = substitution_in_liquid(lq, LiquidVar(new), old)
-        return lq
 
     match ty:
         case TypeVar(name):
@@ -129,10 +145,17 @@ def canonicalize_type(
         case RefinedType(name, inner, refinement):
             c_inner = canonicalize_type(inner, rename, counter)
             fresh_name = fresh()
-            # Rebind the refinement's own bound variable to the fresh canonical name,
-            # then rewrite any free variables captured by enclosing binders.
-            c_ref = substitution_in_liquid(refinement, LiquidVar(fresh_name), name)
-            c_ref = rename_liquid(c_ref, rename)
+            # Rebind the refinement's own bound variable to the fresh canonical name
+            # and rewrite free variables captured by enclosing binders in a single
+            # parallel pass. The bound variable shadows any enclosing binder of the
+            # same name, so its mapping takes precedence. Doing this as two sequential
+            # substitutions is unsafe when the type is re-canonicalized: a freshly
+            # allocated ``__cN__`` name can collide with a stale ``__cN__`` key still
+            # present in ``rename``, chaining the bound variable through an unrelated
+            # rewrite and producing a refinement whose binder and body disagree.
+            body_map = {old: new for (old, new) in rename.items() if old != name}
+            body_map[name] = fresh_name
+            c_ref = _rename_liquid_parallel(refinement, body_map)
             assert isinstance(c_inner, (TypeConstructor, TypeVar))
             return RefinedType(fresh_name, c_inner, c_ref)
         case TypePolymorphism(name, kind, body):

--- a/examples/synthesis/dungeon.ae
+++ b/examples/synthesis/dungeon.ae
@@ -1,0 +1,142 @@
+# Dungeon Generator - Pure Aeon version
+# A procedural-content-generation example in the same spirit as supermario.ae:
+# nested inductive types with refined fields, a parametric List with a length
+# measure, match-based fitness helpers, and a multi-objective synthesis goal.
+
+# --- Generic list with length measure ---
+
+inductive List a
+| nil : {l: (List a) | len l = 0}
+| cons (hd: a) (tl: (List a)) : {l: (List a) | len l = len tl + 1}
++ len (l: (List a)) : Int
+
+# --- Atomic enumerations ---
+
+inductive FloorType
+| stone : FloorType
+| cave  : FloorType
+| crypt : FloorType
+
+inductive LootType
+| gold   : LootType
+| gem    : LootType
+| potion : LootType
+
+inductive MonsterType
+| rat      : MonsterType
+| skeleton : MonsterType
+| dragon   : MonsterType
+
+# --- Positioned elements ---
+# A 64 x 64 dungeon grid; rooms keep a margin from the border.
+
+inductive Loot
+| mk_loot (lt: LootType)
+          (x: Int | x >= 2 && x <= 62)
+          (y: Int | y >= 2 && y <= 62) : Loot
+
+inductive Monster
+| mk_monster (m: MonsterType)
+             (x: Int | x >= 2 && x <= 62)
+             (y: Int | y >= 2 && y <= 62) : Monster
+
+# --- Feature types (dungeon geometry) ---
+
+inductive Feature
+| room_feature (ft: FloorType)
+               (x: Int | x >= 2 && x <= 56)
+               (y: Int | y >= 2 && y <= 56)
+               (w: Int | w >= 4 && w <= 12)
+               (h: Int | h >= 4 && h <= 12) : Feature
+| corridor_feature (x: Int | x >= 2 && x <= 60)
+                   (y: Int | y >= 2 && y <= 60)
+                   (length: Int | length >= 3 && length <= 20) : Feature
+| treasure_feature (ls: (List Loot) | len ls >= 1 && len ls <= 5) : Feature
+| trap_feature (x: Int | x >= 2 && x <= 62)
+               (y: Int | y >= 2 && y <= 62)
+               (damage: Int | damage >= 1 && damage <= 10) : Feature
+
+# --- Dungeon ---
+# Minimum feature/monster counts are enforced by the fitness, not the type,
+# so that partial candidates can still be evaluated by the synthesizer.
+
+inductive Dungeon
+| mk_dungeon (fs: (List Feature)) (ms: (List Monster)) : Dungeon
+
+# --- Fitness helpers (pure Aeon, using match on inductive types) ---
+
+def max (a: Int) (b: Int) : Int := if a > b then a else b
+def min (a: Int) (b: Int) : Int := if a < b then a else b
+
+# Floor area occupied by a feature (proxy for explorable space)
+def feature_area (f: Feature) : Int :=
+    match f with
+    | room_feature ft x y w h => w * h
+    | corridor_feature x y length => length
+    | treasure_feature ls => 1
+    | trap_feature x y damage => 1;
+
+# Total explorable area across all features
+def coverage (fs: (List Feature)) : Int :=
+    match fs with
+    | nil => 0
+    | cons f rest => feature_area f + coverage rest;
+
+# Width of a feature's bounding box on the x-axis
+def feature_w (f: Feature) : Int :=
+    match f with
+    | room_feature ft x y w h => w
+    | corridor_feature x y length => length
+    | treasure_feature ls => 1
+    | trap_feature x y damage => 1;
+
+# X position of a feature
+def feature_x (f: Feature) : Int :=
+    match f with
+    | room_feature ft x y w h => x
+    | corridor_feature x y length => x
+    | treasure_feature ls => 0
+    | trap_feature x y damage => x;
+
+# 1-D overlap of two features projected on the x-axis (0 if disjoint)
+def overlap (f1: Feature) (f2: Feature) : Int :=
+    lo := max (feature_x f1) (feature_x f2);
+    hi := min (feature_x f1 + feature_w f1) (feature_x f2 + feature_w f2);
+    max 0 (hi - lo);
+
+# Total overlap of one feature against the rest
+def conflicts_one (f: Feature) (fs: (List Feature)) : Int :=
+    match fs with
+    | nil => 0
+    | cons f2 rest => overlap f f2 + conflicts_one f rest;
+
+# Total pairwise overlap across all features (cramped-layout penalty)
+def conflicts (fs: (List Feature)) : Int :=
+    match fs with
+    | nil => 0
+    | cons f rest => conflicts_one f rest + conflicts rest;
+
+# Extract features from a dungeon
+def dungeon_features (d: Dungeon) : (List Feature) :=
+    match d with
+    | mk_dungeon fs ms => fs;
+
+# --- Synthesis target ---
+# Maximize explorable area, minimize spatial conflicts between features.
+# The fitness helpers are shadowed by `unit` inside the hole so they are not
+# offered as synthesis building blocks (lexical shadowing replaced @hide).
+
+@maximize_int(coverage (dungeon_features new_dungeon))
+@minimize_int(conflicts (dungeon_features new_dungeon))
+def new_dungeon : Dungeon :=
+    (let max := unit in
+     let min := unit in
+     let feature_area := unit in
+     let coverage := unit in
+     let feature_w := unit in
+     let feature_x := unit in
+     let overlap := unit in
+     let conflicts_one := unit in
+     let conflicts := unit in
+     let dungeon_features := unit in
+     ?hole)


### PR DESCRIPTION
> Rebased onto the latest `master`. `aeon/core/equality.py` is untouched upstream, so the fix applies cleanly; the PR now contains a single commit.

## Problem

`canonicalize_type` (`aeon/core/equality.py`) is **not idempotent**. Its `RefinedType` branch rebuilt the refinement body in two *sequential* liquid passes:

1. `substitution_in_liquid` to rebind the refinement's own bound variable to the fresh `__cN__` name, then
2. `rename_liquid` to apply the enclosing rename map.

The synthesis grammar generator (`extract_all_types`) re-canonicalizes already-canonical constructor argument types at every arrow. On re-canonicalization, a freshly allocated `__cN__` name collides with a **stale `__cN__` key still present in the rename map**, so the two passes chain — dragging the just-rebound bound variable through an unrelated rewrite and producing a malformed refinement whose binder and body disagree (e.g. `{__c2__ | __c1__ >= 2}`).

This affects any inductive constructor with **two or more refined-integer fields** sharing canonical bounds (e.g. `room_feature` below, or `supermario.ae`'s chunk constructors).

### Symptom

Downstream, the grammar generator's `__self__`-normalization substitutes into the mismatched body and stores a corrupted key `{__c0__ | __self__ ...}` that never matches the well-formed lookup `{__c0__ | __c0__ ...}`.

- Before #354 this raised a hard `KeyError` and crashed synthesis.
- After #354 (current `master`), the `_has` guards in `create_var_apps_node`/`create_abstraction_node`/`create_application_node` turn that into a **silent skip**: the affected constructor is simply dropped from the grammar and the synthesizer can never emit it (and cannot synthesize at all when it is the only constructor).

Either way the constructor is unusable. Every other branch of `canonicalize_type` was already safe because it uses a single one-shot `rename.get(...)` lookup; the `RefinedType` branch was the lone offender.

## Fix

Replace the two sequential substitutions with a single capture-safe **parallel** rename (`_rename_liquid_parallel`) that rebinds the bound variable and applies the enclosing renames in one pass, with the bound variable shadowing any stale same-name entry. This matches the one-shot lookups used by the rest of `canonicalize_type`.

Also adds `examples/synthesis/dungeon.ae`, a procedural-content-generation example analogous to `supermario.ae` (parametric `List` with a `len` measure, constructors with multiple refined-int fields, `match`-based fitness helpers, `let … := unit` shadowing, and a multi-objective `@maximize_int`/`@minimize_int` hole) that exercises this path.

## Verification

On the rebased tree, with a `Feature` whose only constructor is `room_feature` (4 refined-int fields):

- **without the fix:** the constructor is unreachable — synthesis cannot build a `Feature`.
- **with the fix:** `Feature_room_feature FloorType_stone 56 26 10 4` is synthesized.

`dungeon.ae` and `supermario.ae` both synthesize. Full suite: **all tests pass** (`uv run pytest`, exit 0). Pre-commit (mypy, ruff, ruff-format) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)