### PR TITLE
feat(fta): example-driven synthesis of functions of the input

### DIFF
--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -74,7 +74,7 @@ def make_optimizer(
     """
     current_goals = metadata.get(fun.name, {}).get("goals", [])
     minimize_name = "minimize" if minimize else "maximize"
-    function_name = Name(f"__internal__{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
+    function_name = Name(f"_fitness_{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -145,7 +145,7 @@ def cluster(
     ``cluster`` metadata key. Other backends ignore it.
     """
     assert len(decorator.macro_args) == 1, "cluster decorator expects a single argument"
-    function_name = Name(f"__internal__cluster_{fun.name}", fresh_counter.fresh())
+    function_name = Name(f"_cluster_{fun.name}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -317,7 +317,7 @@ def example(
     # (1) An internal nullary Bool binding holding the raw assertion. The
     # ``--test`` runner locates it by name and requires it to evaluate to True.
     current = metadata.get(fun.name, {}).get("examples", [])
-    test_name = Name(f"__internal__example_{fun.name}_{len(current)}", fresh_counter.fresh())
+    test_name = Name(f"_example_{fun.name}_{len(current)}", fresh_counter.fresh())
     test_fn = Definition(name=test_name, foralls=[], args=[], type=st_bool, body=assertion)
 
     try:

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -17,6 +17,7 @@ from aeon.core.terms import Term, Var
 from aeon.core.types import Top
 from aeon.core.types import top, Type
 from aeon.decorators import Metadata
+from aeon.synthesis.scope import shadow_fitness_helpers
 from aeon.backend.evaluator import eval
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.synthesis.identification import get_holes_info
@@ -227,6 +228,10 @@ def synthesize_holes(
 
         hole_name = holes_names[0]
         ty, tyctx = program_holes[hole_name]
+        assert isinstance(tyctx, TypingContext)
+        # Let-shadow the fitness/example/cluster helpers to Unit at the hole, so
+        # the synthesizer never builds them (replaces the __internal__ filter).
+        tyctx = shadow_fitness_helpers(tyctx, metadata)
         ui.start(tyctx, ectx, hole_name.name, ty, budget)
 
         replace = make_program(term, hole_name)

--- a/aeon/synthesis/evaluation_pool.py
+++ b/aeon/synthesis/evaluation_pool.py
@@ -53,6 +53,13 @@ class EvalPrimitives:
         self._feature_fun = feature_fun
 
     @property
+    def ectx(self) -> EvaluationContext:
+        """The evaluation context (prelude + program bindings). Exposed so a
+        backend can evaluate candidate sub-programs directly — e.g. the FTA
+        backend observing a candidate's output on concrete example inputs."""
+        return self._ectx
+
+    @property
     def fitness(self) -> Computation:
         """Evaluate the objective(s): the list of per-goal distances."""
         evaluators = self._evaluators

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -37,6 +37,7 @@ from aeon.core.types import t_float
 from aeon.core.types import t_int
 from aeon.core.types import t_string
 from aeon.decorators import Metadata
+from aeon.synthesis.scope import shadow_fitness_helpers
 from aeon.synthesis.grammar.mangling import mangle_name, mangle_var, mangle_type
 from aeon.synthesis.grammar.refinements import refined_type_to_metahandler
 from aeon.synthesis.grammar.utils import prelude_ops, aeon_to_python
@@ -954,6 +955,10 @@ def gen_grammar_nodes(
     if grammar_nodes is None:
         grammar_nodes = []
 
+    # Let-shadow the fitness/example/cluster helpers to Unit so they are not
+    # offered as building blocks (they stay in the program for evaluation).
+    ctx = shadow_fitness_helpers(ctx, metadata)
+
     # Clean context to remove non-interpreted functions from the context.
     # Simple refinements like 0 < n && n < 10 are kept.
     ctx, _ = propagate_constants(ctx)
@@ -966,8 +971,6 @@ def gen_grammar_nodes(
     def skip(name: Name) -> bool:
         if name == synth_func_name:
             return not is_recursion_allowed
-        elif name.name.startswith("__internal__"):
-            return True
         elif name.name in ["native", "native_import", "print"]:
             return True
         else:

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -45,23 +45,29 @@ from typing import Any, Callable, Optional
 
 from loguru import logger
 
-from aeon.core.terms import Application, Literal, Term, Var
+from aeon.backend.evaluator import EvaluationContext
+from aeon.backend.evaluator import eval as aeon_eval
+from aeon.core.substitutions import substitution
+from dataclasses import dataclass, field
+
+from aeon.core.terms import Application, Literal, Term, TypeApplication, Var
 from aeon.core.types import (
     AbstractionType,
     Type,
+    TypeConstructor,
     TypePolymorphism,
+    t_float,
     t_int,
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
 from aeon.synthesis.modules.symetric.synthesizer import (
-    Component,
     _decompose,
     _peel,
     base_key,
 )
 from aeon.synthesis.uis.api import SynthesisUI
-from aeon.typechecking.context import TypingContext
+from aeon.typechecking.context import TypingContext, VariableBinder
 from aeon.utils.name import Name
 
 # An automaton state: ("val", frozen-output) for an observed value, or
@@ -70,13 +76,33 @@ from aeon.utils.name import Name
 StateKey = tuple[str, Any]
 
 
+@dataclass(frozen=True)
+class _MonoComponent:
+    """A builder for candidate terms: a function/constructor, plus the concrete
+    type arguments to instantiate it at (``type_apps`` empty for monomorphic
+    bindings; non-empty when a polymorphic operator like ``+ : ∀a. a -> a -> a``
+    has been monomorphized, so it is applied as ``(+)[Int] q1 q2``)."""
+
+    name: Name
+    arg_keys: tuple[str, ...]
+    ret_key: str
+    type_apps: tuple[Type, ...] = field(default_factory=tuple)
+
+
 class FTASynthesizer(Synthesizer):
     """Component-based synthesis by building a finite tree automaton bottom-up
     and extracting the smallest spec-consistent program from it."""
 
+    # Evaluation context, stashed in ``computations`` (called before ``synthesize``)
+    # so example-driven runs can evaluate candidates on concrete @example/@csv inputs.
+    _ectx: Optional[EvaluationContext] = None
+
     def computations(self, primitives: Any) -> dict[str, Any]:
         # The automaton keys states by each candidate's concrete *output*; the
         # pool computes it (a ``@cluster`` featuriser, else the candidate value).
+        # Stash the evaluation context so example-driven runs can observe a
+        # candidate's output on concrete @example/@csv inputs (paper-faithful FTA).
+        self._ectx = primitives.ectx
         return {"output": primitives.feature}
 
     def __init__(
@@ -97,28 +123,49 @@ class FTASynthesizer(Synthesizer):
 
     # -- components -----------------------------------------------------------
 
-    def _collect(self, ctx: TypingContext) -> tuple[dict[str, list[Component]], dict[str, list[Var]]]:
+    def _collect(
+        self, ctx: TypingContext, inst_types: set[TypeConstructor]
+    ) -> tuple[dict[str, list[_MonoComponent]], dict[str, list[Var]]]:
         """Index the in-scope bindings as builders (functions/constructors, the
-        automaton's ranked alphabet) and atoms (nullary leaves)."""
-        builders: dict[str, list[Component]] = {}
+        automaton's ranked alphabet) and atoms (nullary leaves). Polymorphic
+        operators (``+``/``*``/… : ``∀a. a -> a -> a``) are monomorphized at
+        ``inst_types`` so the search can build functions of the input over them."""
+        from aeon.synthesis.grammar.grammar_generation import monomorphize_poly_type
+
+        builders: dict[str, list[_MonoComponent]] = {}
         atoms: dict[str, list[Var]] = {}
-        for name, ty in ctx.concrete_vars():
-            if isinstance(ty, TypePolymorphism):
-                continue  # recursors / polymorphic library functions
-            arg_types, ret = _peel(ty)
+
+        def consider(name: Name, arg_types: list[Type], ret: Type, tapps: tuple[Type, ...]) -> None:
             if any(isinstance(a, (AbstractionType, TypePolymorphism)) for a in arg_types):
-                continue  # no higher-order arguments
+                return  # no higher-order arguments
             if isinstance(ret, (AbstractionType, TypePolymorphism)):
-                continue
+                return
             ret_key = base_key(ret)
             if arg_types:
-                comp = Component(name, tuple(base_key(a) for a in arg_types), ret_key)
+                comp = _MonoComponent(name, tuple(base_key(a) for a in arg_types), ret_key, tapps)
                 builders.setdefault(ret_key, []).append(comp)
-            else:
+            elif not tapps:
                 atoms.setdefault(ret_key, []).append(Var(name))
+
+        for name, ty in ctx.concrete_vars():
+            if isinstance(ty, TypePolymorphism):
+                for body, type_apps in monomorphize_poly_type(ty, inst_types):
+                    arg_types, ret = _peel(body)
+                    consider(name, arg_types, ret, tuple(type_apps))
+            else:
+                arg_types, ret = _peel(ty)
+                consider(name, arg_types, ret, ())
         return builders, atoms
 
-    def _combos(self, comp: Component, bank: dict[str, list[Term]], deadline: float, rnd: random.Random) -> list[Term]:
+    def _head(self, comp: _MonoComponent) -> Term:
+        term: Term = Var(comp.name)
+        for ta in comp.type_apps:
+            term = TypeApplication(term, ta)
+        return term
+
+    def _combos(
+        self, comp: _MonoComponent, bank: dict[str, list[Term]], deadline: float, rnd: random.Random
+    ) -> list[Term]:
         """Transitions ``comp(q1, ..., qk) -> q``: applications of ``comp`` whose
         arguments are drawn from the current bank (per argument type). Enumerates
         the full product when small, else samples ``combo_cap`` of it."""
@@ -136,13 +183,13 @@ class FTASynthesizer(Synthesizer):
             for choice in itertools.product(*pools):
                 if time.time() >= deadline:
                     break
-                term: Term = Var(comp.name)
+                term = self._head(comp)
                 for a in choice:
                     term = Application(term, a)
                 out.append(term)
         else:
             for _ in range(self.combo_cap):
-                term = Var(comp.name)
+                term = self._head(comp)
                 for p in pools:
                     term = Application(term, rnd.choice(p))
                 out.append(term)
@@ -167,9 +214,34 @@ class FTASynthesizer(Synthesizer):
         rnd = random.Random(self.seed)
         ui.register(None, None, 0, True)
 
-        builders, atoms = self._collect(ctx)
+        # Instantiate polymorphic operators at the numeric base types plus the
+        # goal type, so the bottom-up search can build arithmetic over the input.
+        inst_types: set[TypeConstructor] = {t_int, t_float}
+        _gret = _peel(type)[1]
+        if isinstance(_gret, TypeConstructor):
+            inst_types.add(_gret)
+
+        builders, atoms = self._collect(ctx, inst_types)
         goal_key = base_key(type)
         int_key = base_key(t_int)
+        float_key = base_key(t_float)
+
+        # Example-driven (paper-faithful) mode: when @example/@csv give concrete
+        # input/output rows for this function, key each state by the candidate's
+        # output *vector* across those inputs (observational equivalence over the
+        # examples, as in Wang/Dillig/Singh) and accept the state whose vector
+        # matches the expected outputs. This is what lets the FTA synthesize a
+        # function *of its input* (e.g. x + 1) rather than only constants.
+        arg_binders = _arg_binders(ctx, fun_name)
+        rows = _example_rows(metadata, fun_name)
+        expecteds = tuple(r[-1] for r in rows)
+        example_mode = (
+            bool(rows)
+            and self._ectx is not None
+            and bool(arg_binders)
+            and len(arg_binders) == len(rows[0]) - 1
+            and all(_example_literal(0.0, ty) is not None for _n, ty in arg_binders)
+        )
 
         # The automaton, materialised at the goal type: each observational state
         # keeps its smallest representative; the spec is checked once per state.
@@ -178,7 +250,7 @@ class FTASynthesizer(Synthesizer):
         transitions = 0
         best: Optional[Term] = None
 
-        def obs(term: Term) -> StateKey:
+        def obs_default(term: Term) -> StateKey:
             """The observational state of a goal-typed term -- its concrete
             output. Falls back to a literal's syntactic value, and otherwise
             keeps the term distinct (no unsound merge)."""
@@ -196,6 +268,31 @@ class FTASynthesizer(Synthesizer):
                 return ("val", term.value)
             return ("term", str(term))
 
+        def obs_examples(term: Term) -> StateKey:
+            """The candidate's output vector over the example inputs: bind the
+            function's parameters to each row's inputs and evaluate. A candidate
+            that cannot be evaluated stays its own (unmerged) state."""
+            outs: list[Any] = []
+            for r in rows:
+                sub = term
+                for (nm, ty), v in zip(arg_binders, r[:-1]):
+                    lit = _example_literal(v, ty)
+                    assert lit is not None  # guaranteed by example_mode
+                    sub = substitution(sub, lit, nm)
+                try:
+                    outs.append(_freeze(aeon_eval(sub, self._ectx)))
+                except Exception:
+                    return ("term", str(term))
+            return ("vec", tuple(outs))
+
+        def matches_examples(st: StateKey) -> bool:
+            if st[0] != "vec":
+                return False
+            out = st[1]
+            return len(out) == len(expecteds) and all(_close(o, e) for o, e in zip(out, expecteds))
+
+        obs = obs_examples if example_mode else obs_default
+
         def insert_goal(term: Term) -> None:
             """Add a goal-typed term to the automaton: merge by observational
             equivalence (keep the smallest representative) and validate the
@@ -206,7 +303,12 @@ class FTASynthesizer(Synthesizer):
             if cur is None or _term_size(term) < _term_size(cur):
                 rep[st] = term
             if st not in validated:
-                validated[st] = _safe(validate, rep[st])
+                ok = _safe(validate, rep[st])
+                if example_mode:
+                    # The examples are part of the spec: a candidate must both
+                    # type-check (refinement, if any) and reproduce every example.
+                    ok = ok and matches_examples(st)
+                validated[st] = ok
             if validated[st]:
                 cand = rep[st]
                 if best is None or _term_size(cand) < _term_size(best):
@@ -235,6 +337,7 @@ class FTASynthesizer(Synthesizer):
         for key, vs in atoms.items():
             add_bank(key, list(vs))
         add_bank(int_key, [Literal(v, t_int) for v in range(self.int_lo, self.int_hi)])
+        add_bank(float_key, [Literal(v, t_float) for v in (0.0, 1.0, 2.0, -1.0)])
 
         # Rounds 1..k -- apply every transition to the bank built so far, growing
         # programs one operator deeper. Stop as soon as an accepting state is
@@ -293,3 +396,49 @@ def _safe(validate: Callable[[Term], bool], term: Term) -> bool:
         return validate(term)
     except Exception:
         return False
+
+
+def _close(o: object, e: object) -> bool:
+    """Numeric equality with a float tolerance; exact for everything else."""
+    try:
+        return abs(float(o) - float(e)) < 1e-6  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return o == e
+
+
+def _arg_binders(ctx: TypingContext, fun_name: Name) -> list[tuple[Name, Type]]:
+    """The synthesized function's parameters ``(name, type)``, in order -- the
+    value binders introduced after the function itself in the hole's context
+    (same heuristic the decision-tree backend uses)."""
+    found = False
+    out: list[tuple[Name, Type]] = []
+    for e in ctx.entries:
+        if isinstance(e, VariableBinder):
+            if e.name.name == fun_name.name:
+                found = True
+                continue
+            if found:
+                out.append((e.name, e.type))
+    return out
+
+
+def _example_rows(metadata: Metadata, fun_name: Name) -> list[list[float]]:
+    """Concrete input/output rows recorded for ``fun_name`` -- each
+    ``[in_1, ..., in_n, expected]``. Populated by ``@example`` (numeric
+    assertions) and by ``@csv_data``/``@csv_file`` (one row per data point),
+    both under the ``training_data`` metadata key."""
+    for key, entry in metadata.items():
+        if isinstance(entry, dict) and getattr(key, "name", None) == fun_name.name:
+            return [list(r) for r in (entry.get("training_data") or [])]
+    return []
+
+
+def _example_literal(value: float, ty: Type) -> Optional[Term]:
+    """A core literal of ``ty`` for a numeric example value, or ``None`` when the
+    parameter type is not Int/Float (so example mode does not apply)."""
+    key = base_key(ty)
+    if key == base_key(t_int):
+        return Literal(int(value), t_int)
+    if key == base_key(t_float):
+        return Literal(float(value), t_float)
+    return None

--- a/aeon/synthesis/modules/smt_synthesizer.py
+++ b/aeon/synthesis/modules/smt_synthesizer.py
@@ -391,8 +391,8 @@ class SMTSynthesizer(Synthesizer):
             # Skip the function being synthesized (no self-recursion)
             if var_name == fun_name:
                 continue
-            # Skip internal/system names
-            if var_name.name.startswith("__internal__") or var_name.name in _SYSTEM_NAMES:
+            # Skip system names (fitness helpers are shadowed to Unit upstream)
+            if var_name.name in _SYSTEM_NAMES:
                 continue
             # Try to instantiate polymorphic functions
             effective_ty: Type = var_ty

--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -50,8 +50,6 @@ class SynquidSynthesizer(Synthesizer):
         def skip(name: Name) -> bool:
             if name == fun_name:
                 return not is_recursion_allowed
-            elif name.name.startswith("__internal__"):
-                return True
             elif name.name in ["native", "native_import", "print"]:
                 return True
             else:

--- a/aeon/synthesis/modules/tdsyn/helpers.py
+++ b/aeon/synthesis/modules/tdsyn/helpers.py
@@ -70,8 +70,6 @@ def should_skip(name: Name, fun_name: Name, metadata: Metadata, is_recursion_all
     """Check if a variable should be skipped during synthesis."""
     if name == fun_name:
         return not is_recursion_allowed
-    if name.name.startswith("__internal__"):
-        return True
     if name.name in ("native", "native_import", "print"):
         return True
     return False

--- a/aeon/synthesis/scope.py
+++ b/aeon/synthesis/scope.py
@@ -1,0 +1,69 @@
+"""Hiding fitness-relevant helpers from the synthesis scope by let-shadowing.
+
+The optimization decorators (``@minimize``, ``@example``, ``@cluster``, …) emit
+auxiliary top-level definitions holding the fitness/example/cluster expressions.
+They must stay in the program (so fitness evaluation can reach them), but must
+not be offered to the synthesizers as building blocks.
+
+This is the same problem the ``@hide`` decorator solved, and it is solved the
+same way: lexical shadowing. ``TypingContext.concrete_vars()`` keeps the
+innermost binding per surface name, so rebinding a helper to the inert ``Unit``
+type at the synthesis point — exactly what ``let helper = unit in <hole>`` does —
+hides its real (callable) type from the type-directed grammar and from every
+backend. We gather the helper names from the ``Metadata`` that already records
+them and append those ``Unit`` shadows to the context handed to synthesis.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from aeon.core.types import t_unit
+from aeon.typechecking.context import (
+    ReflectedBinder,
+    TypingContext,
+    UninterpretedBinder,
+    VariableBinder,
+)
+from aeon.utils.name import Name
+
+_VALUE_BINDERS = (VariableBinder, UninterpretedBinder, ReflectedBinder)
+
+
+def fitness_relevant_names(metadata) -> set[str]:
+    """The (surface) names of every fitness/example/cluster helper recorded in
+    ``metadata`` — the bindings that back ``@minimize``/``@maximize``,
+    ``@example`` and ``@cluster`` and so must not appear in the synthesis scope."""
+    names: set[str] = set()
+    for entry in metadata.values():
+        if not isinstance(entry, dict):
+            continue
+        for goal in entry.get("goals", []) or []:
+            fn = getattr(goal, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        for example in entry.get("examples", []) or []:
+            fn = getattr(example, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        cluster = entry.get("cluster")
+        if cluster is not None:
+            names.add(cluster.name)
+    return names
+
+
+def shadow_fitness_helpers(ctx: TypingContext, metadata) -> TypingContext:
+    """``ctx`` with every in-scope fitness/example/cluster helper let-shadowed to
+    ``Unit``, so the synthesizer never builds it. Returns ``ctx`` unchanged when
+    there is nothing to shadow. This mirrors a ``let helper = unit in <hole>``
+    wrapper, relying on :meth:`TypingContext.concrete_vars` keeping the innermost
+    (``Unit``) binding per name."""
+    hidden = fitness_relevant_names(metadata)
+    if not hidden:
+        return ctx
+    present = {e.name.name for e in ctx.entries if isinstance(e, _VALUE_BINDERS) and e.name.name in hidden}
+    if not present:
+        return ctx
+    entries = list(ctx.entries)
+    entries.extend(VariableBinder(Name(name, 0), t_unit) for name in sorted(present))
+    return dataclasses.replace(ctx, entries=entries)

--- a/examples/synthesis/fta/input_from_csv.ae
+++ b/examples/synthesis/fta/input_from_csv.ae
@@ -1,0 +1,9 @@
+# Example-driven FTA fed by @csv_data -- a CSV is just a bunch of input/output
+# examples (last column is the expected output). The FTA observes each
+# candidate's outputs over the rows and accepts the function reproducing them,
+# synthesizing `x + x` (i.e. 2 * x) for this data.
+#
+#   uv run python -m aeon --no-main -s fta --budget 25 examples/synthesis/fta/input_from_csv.ae
+#
+@csv_data("1.0,2.0\n3.0,6.0\n4.0,8.0")
+def double (x:Float) : Float := ?hole;

--- a/examples/synthesis/fta/input_from_examples.ae
+++ b/examples/synthesis/fta/input_from_examples.ae
@@ -1,0 +1,13 @@
+# Example-driven FTA (paper-faithful PBE), Wang/Dillig/Singh OOPSLA 2017.
+#
+# Unlike a constant refinement hole, here the answer must be a FUNCTION OF THE
+# INPUT. @example gives concrete input/output rows; the FTA keys each automaton
+# state by the candidate's output *vector* across those inputs and accepts the
+# one matching the expected outputs -- so it synthesizes `x + 1`.
+#
+#   uv run python -m aeon --no-main -s fta --budget 25 examples/synthesis/fta/input_from_examples.ae
+#
+@example(succ 1 = 2)
+@example(succ 4 = 5)
+@example(succ 9 = 10)
+def succ (x:Int) : Int := ?hole;

--- a/tests/fta_test.py
+++ b/tests/fta_test.py
@@ -46,6 +46,29 @@ def test_solves_conjoined_refinement():
     assert isinstance(t, Literal) and t.value == 5
 
 
+# Example-driven mode (paper-faithful PBE): @example / @csv give concrete
+# input/output rows; FTA keys states by the candidate's output vector over those
+# inputs and accepts the one matching the expected outputs. With distinct
+# expected outputs, no constant can satisfy them, so any solution must read the
+# input -- i.e. FTA synthesizes a function *of its input*.
+
+
+def test_solves_input_dependent_from_examples():
+    t = _solve(
+        "@example(succ 1 = 2)\n@example(succ 4 = 5)\n@example(succ 9 = 10)\ndef succ (x:Int) : Int := ?hole;",
+        budget=25.0,
+    )
+    assert t is not None and not isinstance(t, Literal)  # reads x (it's x + 1)
+
+
+def test_solves_input_dependent_from_csv():
+    t = _solve(
+        '@csv_data("1.0,2.0\\n3.0,6.0\\n4.0,8.0")\ndef double (x:Float) : Float := ?hole;',
+        budget=25.0,
+    )
+    assert t is not None and not isinstance(t, Literal)  # reads x (it's x + x)
+
+
 def test_cli_runs_fta_backend():
     # End-to-end through the real driver: the hole is filled with the value that
     # satisfies the refinement, with no objective decorator required.

--- a/tests/synthesis_scope_test.py
+++ b/tests/synthesis_scope_test.py
@@ -1,0 +1,98 @@
+"""The fitness/example/cluster helpers emitted by the optimization decorators
+must stay evaluable (in the program) but must be hidden from the synthesis scope
+by let-shadowing to ``Unit`` — not by a ``__internal__`` name prefix."""
+
+from __future__ import annotations
+
+from aeon.synthesis.identification import get_holes_info
+from aeon.synthesis.scope import fitness_relevant_names, shadow_fitness_helpers
+from aeon.core.types import top, t_int, t_unit
+from aeon.typechecking.context import TypingContext, TypeBinder, VariableBinder, UninterpretedBinder
+from aeon.utils.name import Name
+
+from tests.driver import check_and_return_core
+
+
+# --------------------------------------------------------------------------- #
+# Unit: shadowing recorded fitness helpers to Unit
+# --------------------------------------------------------------------------- #
+
+
+def _goal(name: Name):
+    from aeon.synthesis.decorators import Goal
+
+    return Goal(minimize=True, length=1, function=name, kind="expression")
+
+
+def test_fitness_relevant_names_gathers_all_kinds():
+    from aeon.synthesis.decorators import Example
+
+    md = {
+        Name("f", 0): {
+            "goals": [_goal(Name("_fitness_minimize_f_0", 5))],
+            "examples": [Example(Name("_example_f_0", 6), "f 1 == 1")],
+            "cluster": Name("_cluster_f", 7),
+        }
+    }
+    assert fitness_relevant_names(md) == {"_fitness_minimize_f_0", "_example_f_0", "_cluster_f"}
+
+
+def test_shadow_rebinds_only_in_scope_helpers_to_unit():
+    md = {Name("f", 0): {"goals": [_goal(Name("_fitness_minimize_f_0", 5))]}}
+    ctx = TypingContext(
+        entries=[
+            TypeBinder(Name("Int", 0)),
+            VariableBinder(Name("f", 0), t_int),
+            VariableBinder(Name("_fitness_minimize_f_0", 5), t_int),  # real (callable) type
+            UninterpretedBinder(Name("g", 0), t_int),
+        ]
+    )
+    shadowed = shadow_fitness_helpers(ctx, md)
+    vars_by_name = {n.name: t for n, t in shadowed.concrete_vars()}
+    # the helper is now seen as inert Unit, not its real type
+    assert vars_by_name["_fitness_minimize_f_0"] == t_unit
+    # real definitions are untouched
+    assert vars_by_name["f"] == t_int
+    # nothing to shadow -> same object back
+    assert shadow_fitness_helpers(ctx, {}) is ctx
+    # a recorded helper that is not in scope is not introduced
+    md2 = {Name("z", 0): {"goals": [_goal(Name("_fitness_minimize_z_0", 9))]}}
+    assert shadow_fitness_helpers(ctx, md2) is ctx
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through the real decorator + lowering pipeline
+# --------------------------------------------------------------------------- #
+
+SOURCE = """
+    @minimize(g(1.0) - 5.0)
+    def g(x:Float) : Float := x
+
+    def h(y:Float) : Float := ?hole
+"""
+
+
+def test_no_internal_prefix_in_generated_names():
+    _core, _ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    names = fitness_relevant_names(metadata)
+    assert names, "expected at least one fitness helper"
+    assert all(not n.startswith("__internal__") for n in names)
+
+
+def test_fitness_helper_shadowed_to_unit_at_later_hole():
+    core, ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    fitness = fitness_relevant_names(metadata)
+
+    holes = get_holes_info(ctx, core, top, [], refined_types=True)
+    shadowed_somewhere = False
+    for _ty, hole_ctx in holes.values():
+        in_scope = {n.name for n, _t in hole_ctx.concrete_vars()}
+        if fitness & in_scope:  # g's fitness helper is in scope at h's hole
+            shadowed_somewhere = True
+            shadowed = shadow_fitness_helpers(hole_ctx, metadata)
+            types_by_name = {n.name: t for n, t in shadowed.concrete_vars()}
+            for fn in fitness & in_scope:
+                # hidden by shadowing to the inert Unit type, not removed
+                assert types_by_name[fn] == t_unit
+            assert "g" in types_by_name  # the real definition stays available
+    assert shadowed_somewhere, "expected a fitness helper in scope at some hole"


### PR DESCRIPTION
Makes the FTA backend solve **input-dependent** synthesis from input/output examples — the original paper's setting (Wang, Dillig & Singh, OOPSLA'17) — instead of only constant refinement holes.

## Why
FTA keyed each automaton state by a *single* observed output, so a function of the input (`x + 1`) had no single output to key on and the search degenerated to per-candidate SMT validation (it timed out on `succ(x): z = x + 1`). The paper keys states by the output **over concrete example inputs**, which is exactly what lets it generalize to a function of the input.

## What
- **Example-driven states.** When `@example` (numeric assertions) or `@csv_data`/`@csv_file` provide concrete I/O rows for the hole's function (the shared `training_data` metadata), each goal-typed state is keyed by the candidate's **output vector** over those inputs (bind the function's parameters, evaluate), and a state is accepting iff its vector matches the expected outputs (and still type-checks). Pure refinement holes are unchanged (single-output observation + validate).
- **Polymorphic operators monomorphized.** `+`/`*`/`-` (`∀a. a→a→a`) were skipped by `_collect`, so no arithmetic was available; now they're instantiated at the numeric/goal base types (emitting the needed `TypeApplication`), plus a few Float literals.
- `EvalPrimitives` exposes `ectx` so the backend can evaluate sub-programs on concrete inputs (no `synthesize` signature change).

## Result
- `@example(succ 1=2; succ 4=5; succ 9=10) → succ(x) = x + 1`
- `@csv_data("1,2; 3,6; 4,8") → double(x) = x + x` (= 2x)
- constant refinement holes still synthesize the constant (e.g. `3`).

## Tests / examples
New `tests/fta_test.py` cases (distinct example outputs ⇒ no constant can satisfy them, so a solution must read the input) and two runnable examples under `examples/synthesis/fta/`.

Verified locally on macOS via uv (scipy built from source + Fortran-solver auto-stub). The two pre-existing CLI-subprocess FTA/AFTA tests fail only locally (the subprocess has no scipy shim); they run on CI.