### PR TITLE
feat(fta): reproduce the FTA paper's Section-2 examples via programming-by-example

### DIFF
--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -74,7 +74,7 @@ def make_optimizer(
     """
     current_goals = metadata.get(fun.name, {}).get("goals", [])
     minimize_name = "minimize" if minimize else "maximize"
-    function_name = Name(f"__internal__{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
+    function_name = Name(f"_fitness_{minimize_name}_{fun.name}_{len(current_goals)}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -145,7 +145,7 @@ def cluster(
     ``cluster`` metadata key. Other backends ignore it.
     """
     assert len(decorator.macro_args) == 1, "cluster decorator expects a single argument"
-    function_name = Name(f"__internal__cluster_{fun.name}", fresh_counter.fresh())
+    function_name = Name(f"_cluster_{fun.name}", fresh_counter.fresh())
     function = Definition(
         name=function_name,
         foralls=[],
@@ -317,7 +317,7 @@ def example(
     # (1) An internal nullary Bool binding holding the raw assertion. The
     # ``--test`` runner locates it by name and requires it to evaluate to True.
     current = metadata.get(fun.name, {}).get("examples", [])
-    test_name = Name(f"__internal__example_{fun.name}_{len(current)}", fresh_counter.fresh())
+    test_name = Name(f"_example_{fun.name}_{len(current)}", fresh_counter.fresh())
     test_fn = Definition(name=test_name, foralls=[], args=[], type=st_bool, body=assertion)
 
     try:

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -17,6 +17,7 @@ from aeon.core.terms import Term, Var
 from aeon.core.types import Top
 from aeon.core.types import top, Type
 from aeon.decorators import Metadata
+from aeon.synthesis.scope import shadow_fitness_helpers
 from aeon.backend.evaluator import eval
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.synthesis.identification import get_holes_info
@@ -227,6 +228,10 @@ def synthesize_holes(
 
         hole_name = holes_names[0]
         ty, tyctx = program_holes[hole_name]
+        assert isinstance(tyctx, TypingContext)
+        # Let-shadow the fitness/example/cluster helpers to Unit at the hole, so
+        # the synthesizer never builds them (replaces the __internal__ filter).
+        tyctx = shadow_fitness_helpers(tyctx, metadata)
         ui.start(tyctx, ectx, hole_name.name, ty, budget)
 
         replace = make_program(term, hole_name)

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -257,7 +257,7 @@ def synthesize_holes(
         # featuriser `f` (e.g. a rasterised scene), else the output is the
         # candidate's own value.
         feature_fun = _cluster_function(metadata, fun_name) or fun_name
-        primitives = EvalPrimitives(evaluators, ectx, feature_fun)
+        primitives = EvalPrimitives(evaluators, ectx, feature_fun, replace)
         pool = EvaluationPool(replace, syn_impl.computations(primitives), budget_eval=budget_eval)
         evaluator, output_evaluator = _pool_backed(pool)
 

--- a/aeon/synthesis/evaluation_pool.py
+++ b/aeon/synthesis/evaluation_pool.py
@@ -53,6 +53,13 @@ class EvalPrimitives:
         self._feature_fun = feature_fun
 
     @property
+    def ectx(self) -> EvaluationContext:
+        """The evaluation context (prelude + program bindings). Exposed so a
+        backend can evaluate candidate sub-programs directly — e.g. the FTA
+        backend observing a candidate's output on concrete example inputs."""
+        return self._ectx
+
+    @property
     def fitness(self) -> Computation:
         """Evaluate the objective(s): the list of per-goal distances."""
         evaluators = self._evaluators

--- a/aeon/synthesis/evaluation_pool.py
+++ b/aeon/synthesis/evaluation_pool.py
@@ -18,7 +18,7 @@ per-task timeout kills and replaces its worker.
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import multiprocess as mp
 
@@ -47,10 +47,17 @@ class EvalPrimitives:
     """The building blocks a backend composes its requested computations from,
     without ever touching the raw evaluation context directly."""
 
-    def __init__(self, evaluators: list[Callable[[Term], float]], ectx: EvaluationContext, feature_fun: Name):
+    def __init__(
+        self,
+        evaluators: list[Callable[[Term], float]],
+        ectx: EvaluationContext,
+        feature_fun: Name,
+        replace: Optional[Callable[[Term], Term]] = None,
+    ):
         self._evaluators = evaluators
         self._ectx = ectx
         self._feature_fun = feature_fun
+        self._replace = replace
 
     @property
     def ectx(self) -> EvaluationContext:
@@ -58,6 +65,14 @@ class EvalPrimitives:
         backend can evaluate candidate sub-programs directly — e.g. the FTA
         backend observing a candidate's output on concrete example inputs."""
         return self._ectx
+
+    @property
+    def replace(self) -> Optional[Callable[[Term], Term]]:
+        """Fills the hole in the whole program with a given term. Exposed so a
+        backend can evaluate a sub-program *in the program's context* (with all
+        top-level definitions, e.g. library primitives, in scope) by replacing
+        the program tail — see the FTA backend's example-driven observation."""
+        return self._replace
 
     @property
     def fitness(self) -> Computation:

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -37,6 +37,7 @@ from aeon.core.types import t_float
 from aeon.core.types import t_int
 from aeon.core.types import t_string
 from aeon.decorators import Metadata
+from aeon.synthesis.scope import shadow_fitness_helpers
 from aeon.synthesis.grammar.mangling import mangle_name, mangle_var, mangle_type
 from aeon.synthesis.grammar.refinements import refined_type_to_metahandler
 from aeon.synthesis.grammar.utils import prelude_ops, aeon_to_python
@@ -954,6 +955,10 @@ def gen_grammar_nodes(
     if grammar_nodes is None:
         grammar_nodes = []
 
+    # Let-shadow the fitness/example/cluster helpers to Unit so they are not
+    # offered as building blocks (they stay in the program for evaluation).
+    ctx = shadow_fitness_helpers(ctx, metadata)
+
     # Clean context to remove non-interpreted functions from the context.
     # Simple refinements like 0 < n && n < 10 are kept.
     ctx, _ = propagate_constants(ctx)
@@ -966,8 +971,6 @@ def gen_grammar_nodes(
     def skip(name: Name) -> bool:
         if name == synth_func_name:
             return not is_recursion_allowed
-        elif name.name.startswith("__internal__"):
-            return True
         elif name.name in ["native", "native_import", "print"]:
             return True
         else:

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -45,23 +45,29 @@ from typing import Any, Callable, Optional
 
 from loguru import logger
 
-from aeon.core.terms import Application, Literal, Term, Var
+from aeon.backend.evaluator import EvaluationContext
+from aeon.backend.evaluator import eval as aeon_eval
+from aeon.core.substitutions import substitution
+from dataclasses import dataclass, field
+
+from aeon.core.terms import Application, Literal, Term, TypeApplication, Var
 from aeon.core.types import (
     AbstractionType,
     Type,
+    TypeConstructor,
     TypePolymorphism,
+    t_float,
     t_int,
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
 from aeon.synthesis.modules.symetric.synthesizer import (
-    Component,
     _decompose,
     _peel,
     base_key,
 )
 from aeon.synthesis.uis.api import SynthesisUI
-from aeon.typechecking.context import TypingContext
+from aeon.typechecking.context import TypingContext, VariableBinder
 from aeon.utils.name import Name
 
 # An automaton state: ("val", frozen-output) for an observed value, or
@@ -70,13 +76,33 @@ from aeon.utils.name import Name
 StateKey = tuple[str, Any]
 
 
+@dataclass(frozen=True)
+class _MonoComponent:
+    """A builder for candidate terms: a function/constructor, plus the concrete
+    type arguments to instantiate it at (``type_apps`` empty for monomorphic
+    bindings; non-empty when a polymorphic operator like ``+ : ∀a. a -> a -> a``
+    has been monomorphized, so it is applied as ``(+)[Int] q1 q2``)."""
+
+    name: Name
+    arg_keys: tuple[str, ...]
+    ret_key: str
+    type_apps: tuple[Type, ...] = field(default_factory=tuple)
+
+
 class FTASynthesizer(Synthesizer):
     """Component-based synthesis by building a finite tree automaton bottom-up
     and extracting the smallest spec-consistent program from it."""
 
+    # Evaluation context, stashed in ``computations`` (called before ``synthesize``)
+    # so example-driven runs can evaluate candidates on concrete @example/@csv inputs.
+    _ectx: Optional[EvaluationContext] = None
+
     def computations(self, primitives: Any) -> dict[str, Any]:
         # The automaton keys states by each candidate's concrete *output*; the
         # pool computes it (a ``@cluster`` featuriser, else the candidate value).
+        # Stash the evaluation context so example-driven runs can observe a
+        # candidate's output on concrete @example/@csv inputs (paper-faithful FTA).
+        self._ectx = primitives.ectx
         return {"output": primitives.feature}
 
     def __init__(
@@ -97,28 +123,49 @@ class FTASynthesizer(Synthesizer):
 
     # -- components -----------------------------------------------------------
 
-    def _collect(self, ctx: TypingContext) -> tuple[dict[str, list[Component]], dict[str, list[Var]]]:
+    def _collect(
+        self, ctx: TypingContext, inst_types: set[TypeConstructor]
+    ) -> tuple[dict[str, list[_MonoComponent]], dict[str, list[Var]]]:
         """Index the in-scope bindings as builders (functions/constructors, the
-        automaton's ranked alphabet) and atoms (nullary leaves)."""
-        builders: dict[str, list[Component]] = {}
+        automaton's ranked alphabet) and atoms (nullary leaves). Polymorphic
+        operators (``+``/``*``/… : ``∀a. a -> a -> a``) are monomorphized at
+        ``inst_types`` so the search can build functions of the input over them."""
+        from aeon.synthesis.grammar.grammar_generation import monomorphize_poly_type
+
+        builders: dict[str, list[_MonoComponent]] = {}
         atoms: dict[str, list[Var]] = {}
-        for name, ty in ctx.concrete_vars():
-            if isinstance(ty, TypePolymorphism):
-                continue  # recursors / polymorphic library functions
-            arg_types, ret = _peel(ty)
+
+        def consider(name: Name, arg_types: list[Type], ret: Type, tapps: tuple[Type, ...]) -> None:
             if any(isinstance(a, (AbstractionType, TypePolymorphism)) for a in arg_types):
-                continue  # no higher-order arguments
+                return  # no higher-order arguments
             if isinstance(ret, (AbstractionType, TypePolymorphism)):
-                continue
+                return
             ret_key = base_key(ret)
             if arg_types:
-                comp = Component(name, tuple(base_key(a) for a in arg_types), ret_key)
+                comp = _MonoComponent(name, tuple(base_key(a) for a in arg_types), ret_key, tapps)
                 builders.setdefault(ret_key, []).append(comp)
-            else:
+            elif not tapps:
                 atoms.setdefault(ret_key, []).append(Var(name))
+
+        for name, ty in ctx.concrete_vars():
+            if isinstance(ty, TypePolymorphism):
+                for body, type_apps in monomorphize_poly_type(ty, inst_types):
+                    arg_types, ret = _peel(body)
+                    consider(name, arg_types, ret, tuple(type_apps))
+            else:
+                arg_types, ret = _peel(ty)
+                consider(name, arg_types, ret, ())
         return builders, atoms
 
-    def _combos(self, comp: Component, bank: dict[str, list[Term]], deadline: float, rnd: random.Random) -> list[Term]:
+    def _head(self, comp: _MonoComponent) -> Term:
+        term: Term = Var(comp.name)
+        for ta in comp.type_apps:
+            term = TypeApplication(term, ta)
+        return term
+
+    def _combos(
+        self, comp: _MonoComponent, bank: dict[str, list[Term]], deadline: float, rnd: random.Random
+    ) -> list[Term]:
         """Transitions ``comp(q1, ..., qk) -> q``: applications of ``comp`` whose
         arguments are drawn from the current bank (per argument type). Enumerates
         the full product when small, else samples ``combo_cap`` of it."""
@@ -136,13 +183,13 @@ class FTASynthesizer(Synthesizer):
             for choice in itertools.product(*pools):
                 if time.time() >= deadline:
                     break
-                term: Term = Var(comp.name)
+                term = self._head(comp)
                 for a in choice:
                     term = Application(term, a)
                 out.append(term)
         else:
             for _ in range(self.combo_cap):
-                term = Var(comp.name)
+                term = self._head(comp)
                 for p in pools:
                     term = Application(term, rnd.choice(p))
                 out.append(term)
@@ -167,9 +214,34 @@ class FTASynthesizer(Synthesizer):
         rnd = random.Random(self.seed)
         ui.register(None, None, 0, True)
 
-        builders, atoms = self._collect(ctx)
+        # Instantiate polymorphic operators at the numeric base types plus the
+        # goal type, so the bottom-up search can build arithmetic over the input.
+        inst_types: set[TypeConstructor] = {t_int, t_float}
+        _gret = _peel(type)[1]
+        if isinstance(_gret, TypeConstructor):
+            inst_types.add(_gret)
+
+        builders, atoms = self._collect(ctx, inst_types)
         goal_key = base_key(type)
         int_key = base_key(t_int)
+        float_key = base_key(t_float)
+
+        # Example-driven (paper-faithful) mode: when @example/@csv give concrete
+        # input/output rows for this function, key each state by the candidate's
+        # output *vector* across those inputs (observational equivalence over the
+        # examples, as in Wang/Dillig/Singh) and accept the state whose vector
+        # matches the expected outputs. This is what lets the FTA synthesize a
+        # function *of its input* (e.g. x + 1) rather than only constants.
+        arg_binders = _arg_binders(ctx, fun_name)
+        rows = _example_rows(metadata, fun_name)
+        expecteds = tuple(r[-1] for r in rows)
+        example_mode = (
+            bool(rows)
+            and self._ectx is not None
+            and bool(arg_binders)
+            and len(arg_binders) == len(rows[0]) - 1
+            and all(_example_literal(0.0, ty) is not None for _n, ty in arg_binders)
+        )
 
         # The automaton, materialised at the goal type: each observational state
         # keeps its smallest representative; the spec is checked once per state.
@@ -178,7 +250,7 @@ class FTASynthesizer(Synthesizer):
         transitions = 0
         best: Optional[Term] = None
 
-        def obs(term: Term) -> StateKey:
+        def obs_default(term: Term) -> StateKey:
             """The observational state of a goal-typed term -- its concrete
             output. Falls back to a literal's syntactic value, and otherwise
             keeps the term distinct (no unsound merge)."""
@@ -196,6 +268,31 @@ class FTASynthesizer(Synthesizer):
                 return ("val", term.value)
             return ("term", str(term))
 
+        def obs_examples(term: Term) -> StateKey:
+            """The candidate's output vector over the example inputs: bind the
+            function's parameters to each row's inputs and evaluate. A candidate
+            that cannot be evaluated stays its own (unmerged) state."""
+            outs: list[Any] = []
+            for r in rows:
+                sub = term
+                for (nm, ty), v in zip(arg_binders, r[:-1]):
+                    lit = _example_literal(v, ty)
+                    assert lit is not None  # guaranteed by example_mode
+                    sub = substitution(sub, lit, nm)
+                try:
+                    outs.append(_freeze(aeon_eval(sub, self._ectx)))
+                except Exception:
+                    return ("term", str(term))
+            return ("vec", tuple(outs))
+
+        def matches_examples(st: StateKey) -> bool:
+            if st[0] != "vec":
+                return False
+            out = st[1]
+            return len(out) == len(expecteds) and all(_close(o, e) for o, e in zip(out, expecteds))
+
+        obs = obs_examples if example_mode else obs_default
+
         def insert_goal(term: Term) -> None:
             """Add a goal-typed term to the automaton: merge by observational
             equivalence (keep the smallest representative) and validate the
@@ -206,7 +303,12 @@ class FTASynthesizer(Synthesizer):
             if cur is None or _term_size(term) < _term_size(cur):
                 rep[st] = term
             if st not in validated:
-                validated[st] = _safe(validate, rep[st])
+                ok = _safe(validate, rep[st])
+                if example_mode:
+                    # The examples are part of the spec: a candidate must both
+                    # type-check (refinement, if any) and reproduce every example.
+                    ok = ok and matches_examples(st)
+                validated[st] = ok
             if validated[st]:
                 cand = rep[st]
                 if best is None or _term_size(cand) < _term_size(best):
@@ -235,6 +337,7 @@ class FTASynthesizer(Synthesizer):
         for key, vs in atoms.items():
             add_bank(key, list(vs))
         add_bank(int_key, [Literal(v, t_int) for v in range(self.int_lo, self.int_hi)])
+        add_bank(float_key, [Literal(v, t_float) for v in (0.0, 1.0, 2.0, -1.0)])
 
         # Rounds 1..k -- apply every transition to the bank built so far, growing
         # programs one operator deeper. Stop as soon as an accepting state is
@@ -293,3 +396,49 @@ def _safe(validate: Callable[[Term], bool], term: Term) -> bool:
         return validate(term)
     except Exception:
         return False
+
+
+def _close(o: object, e: object) -> bool:
+    """Numeric equality with a float tolerance; exact for everything else."""
+    try:
+        return abs(float(o) - float(e)) < 1e-6  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return o == e
+
+
+def _arg_binders(ctx: TypingContext, fun_name: Name) -> list[tuple[Name, Type]]:
+    """The synthesized function's parameters ``(name, type)``, in order -- the
+    value binders introduced after the function itself in the hole's context
+    (same heuristic the decision-tree backend uses)."""
+    found = False
+    out: list[tuple[Name, Type]] = []
+    for e in ctx.entries:
+        if isinstance(e, VariableBinder):
+            if e.name.name == fun_name.name:
+                found = True
+                continue
+            if found:
+                out.append((e.name, e.type))
+    return out
+
+
+def _example_rows(metadata: Metadata, fun_name: Name) -> list[list[float]]:
+    """Concrete input/output rows recorded for ``fun_name`` -- each
+    ``[in_1, ..., in_n, expected]``. Populated by ``@example`` (numeric
+    assertions) and by ``@csv_data``/``@csv_file`` (one row per data point),
+    both under the ``training_data`` metadata key."""
+    for key, entry in metadata.items():
+        if isinstance(entry, dict) and getattr(key, "name", None) == fun_name.name:
+            return [list(r) for r in (entry.get("training_data") or [])]
+    return []
+
+
+def _example_literal(value: float, ty: Type) -> Optional[Term]:
+    """A core literal of ``ty`` for a numeric example value, or ``None`` when the
+    parameter type is not Int/Float (so example mode does not apply)."""
+    key = base_key(ty)
+    if key == base_key(t_int):
+        return Literal(int(value), t_int)
+    if key == base_key(t_float):
+        return Literal(float(value), t_float)
+    return None

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -50,12 +50,25 @@ from aeon.backend.evaluator import eval as aeon_eval
 from aeon.core.substitutions import substitution
 from dataclasses import dataclass, field
 
-from aeon.core.terms import Application, Literal, Term, TypeApplication, Var
+from aeon.core.terms import (
+    Abstraction,
+    Application,
+    If,
+    Let,
+    Literal,
+    Rec,
+    RefinementAbstraction,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+    Var,
+)
 from aeon.core.types import (
     AbstractionType,
     Type,
     TypeConstructor,
     TypePolymorphism,
+    t_bool,
     t_float,
     t_int,
 )
@@ -87,22 +100,24 @@ class _MonoComponent:
     arg_keys: tuple[str, ...]
     ret_key: str
     type_apps: tuple[Type, ...] = field(default_factory=tuple)
+    is_if: bool = False  # build If(cond, then, else) rather than an application
 
 
 class FTASynthesizer(Synthesizer):
     """Component-based synthesis by building a finite tree automaton bottom-up
     and extracting the smallest spec-consistent program from it."""
 
-    # Evaluation context, stashed in ``computations`` (called before ``synthesize``)
-    # so example-driven runs can evaluate candidates on concrete @example/@csv inputs.
+    # Stashed in ``computations`` (called before ``synthesize``) so example-driven
+    # runs can evaluate candidate sub-programs on concrete @example/@csv inputs,
+    # in the program's context (top-level defs / library primitives in scope).
     _ectx: Optional[EvaluationContext] = None
+    _replace: Optional[Callable[[Term], Term]] = None
 
     def computations(self, primitives: Any) -> dict[str, Any]:
         # The automaton keys states by each candidate's concrete *output*; the
         # pool computes it (a ``@cluster`` featuriser, else the candidate value).
-        # Stash the evaluation context so example-driven runs can observe a
-        # candidate's output on concrete @example/@csv inputs (paper-faithful FTA).
         self._ectx = primitives.ectx
+        self._replace = primitives.replace
         return {"output": primitives.feature}
 
     def __init__(
@@ -113,6 +128,8 @@ class FTASynthesizer(Synthesizer):
         rounds: int = 3,
         combo_cap: int = 4096,
         max_bank: int = 512,
+        if_branch_cap: int = 20,
+        enable_if: bool = True,
     ):
         self.seed = seed
         self.int_lo = int_lo
@@ -120,18 +137,28 @@ class FTASynthesizer(Synthesizer):
         self.rounds = rounds
         self.combo_cap = combo_cap
         self.max_bank = max_bank
+        # Whether to offer the conditional builder. Off avoids its cost/overfit
+        # when the target is known to be branch-free.
+        self.enable_if = enable_if
+        # then/else branches are restricted to the smallest reps so the
+        # conditional builder enumerates a bounded space (the condition pool is
+        # already tiny after observational compression).
+        self.if_branch_cap = if_branch_cap
 
     # -- components -----------------------------------------------------------
 
     def _collect(
-        self, ctx: TypingContext, inst_types: set[TypeConstructor]
+        self, ctx: TypingContext, inst_types: set[TypeConstructor], fun_name: Name
     ) -> tuple[dict[str, list[_MonoComponent]], dict[str, list[Var]]]:
         """Index the in-scope bindings as builders (functions/constructors, the
         automaton's ranked alphabet) and atoms (nullary leaves). Polymorphic
         operators (``+``/``*``/… : ``∀a. a -> a -> a``) are monomorphized at
-        ``inst_types`` so the search can build functions of the input over them."""
+        ``inst_types`` so the search can build functions of the input over them.
+        The function being synthesized (no self-recursion) and the ``native``
+        intrinsics are skipped, as in the grammar backend."""
         from aeon.synthesis.grammar.grammar_generation import monomorphize_poly_type
 
+        skip_names = {fun_name.name, "native", "native_import", "print"}
         builders: dict[str, list[_MonoComponent]] = {}
         atoms: dict[str, list[Var]] = {}
 
@@ -148,6 +175,8 @@ class FTASynthesizer(Synthesizer):
                 atoms.setdefault(ret_key, []).append(Var(name))
 
         for name, ty in ctx.concrete_vars():
+            if name.name in skip_names:
+                continue
             if isinstance(ty, TypePolymorphism):
                 for body, type_apps in monomorphize_poly_type(ty, inst_types):
                     arg_types, ret = _peel(body)
@@ -170,29 +199,41 @@ class FTASynthesizer(Synthesizer):
         arguments are drawn from the current bank (per argument type). Enumerates
         the full product when small, else samples ``combo_cap`` of it."""
         pools: list[list[Term]] = []
-        for ak in comp.arg_keys:
+        for idx, ak in enumerate(comp.arg_keys):
             pool = bank.get(ak, [])
             if not pool:
                 return []
+            if comp.is_if and idx >= 1:
+                # then/else: only the smallest representatives, so the product
+                # stays bounded and is enumerated exhaustively (below).
+                pool = sorted(pool, key=_term_size)[: self.if_branch_cap]
             pools.append(pool)
         total = 1
         for p in pools:
             total *= len(p)
+        # The conditional's space is already bounded by the branch cap, so
+        # enumerate it fully rather than sampling.
+        cap = max(self.combo_cap, total) if comp.is_if else self.combo_cap
+
+        def build(choice: tuple[Term, ...]) -> Term:
+            # If(cond, then, else) for the conditional builder; otherwise an
+            # application of the (possibly type-applied) component to its args.
+            if comp.is_if:
+                return If(choice[0], choice[1], choice[2])
+            term = self._head(comp)
+            for a in choice:
+                term = Application(term, a)
+            return term
+
         out: list[Term] = []
-        if total <= self.combo_cap:
+        if total <= cap:
             for choice in itertools.product(*pools):
                 if time.time() >= deadline:
                     break
-                term = self._head(comp)
-                for a in choice:
-                    term = Application(term, a)
-                out.append(term)
+                out.append(build(choice))
         else:
-            for _ in range(self.combo_cap):
-                term = self._head(comp)
-                for p in pools:
-                    term = Application(term, rnd.choice(p))
-                out.append(term)
+            for _ in range(cap):
+                out.append(build(tuple(rnd.choice(p) for p in pools)))
         return out
 
     # -- entry point ----------------------------------------------------------
@@ -214,17 +255,32 @@ class FTASynthesizer(Synthesizer):
         rnd = random.Random(self.seed)
         ui.register(None, None, 0, True)
 
-        # Instantiate polymorphic operators at the numeric base types plus the
-        # goal type, so the bottom-up search can build arithmetic over the input.
-        inst_types: set[TypeConstructor] = {t_int, t_float}
+        # Instantiate polymorphic operators at the goal type (so arithmetic over
+        # the input can be built) plus Int (for indices/literals). Keeping the set
+        # minimal avoids a blow-up of useless cross-type builders.
+        inst_types: set[TypeConstructor] = {t_int}
         _gret = _peel(type)[1]
         if isinstance(_gret, TypeConstructor):
             inst_types.add(_gret)
 
-        builders, atoms = self._collect(ctx, inst_types)
+        builders, atoms = self._collect(ctx, inst_types, fun_name)
         goal_key = base_key(type)
         int_key = base_key(t_int)
         float_key = base_key(t_float)
+        bool_key = base_key(t_bool)
+
+        # A conditional builder: If(cond:Bool, then:T, else:T) -> T at the goal
+        # type. Lets the FTA synthesize branching programs (the paper's switch /
+        # fallback), keyed by the branch's observed output like any other state.
+        # Prepended so it is explored first each round, before the wide arithmetic.
+        if self.enable_if:
+            builders.setdefault(goal_key, []).insert(
+                0, _MonoComponent(Name("if", 0), (bool_key, goal_key, goal_key), goal_key, is_if=True)
+            )
+        else:
+            # Without the conditional, Bool sub-programs have no consumer at the
+            # goal type, so don't waste the search generating them.
+            builders.pop(bool_key, None)
 
         # Example-driven (paper-faithful) mode: when @example/@csv give concrete
         # input/output rows for this function, key each state by the candidate's
@@ -242,6 +298,28 @@ class FTASynthesizer(Synthesizer):
             and len(arg_binders) == len(rows[0]) - 1
             and all(_example_literal(0.0, ty) is not None for _n, ty in arg_binders)
         )
+
+        # In example mode, restrict the symbolic operators to the additive and
+        # boolean ones (data-completion formulas are SUM/MINUS/COUNT-shaped);
+        # dropping ``*``/``/``/``%``/… curbs the bottom-up combinatorial blow-up
+        # while leaving the table primitives (alphabetic names) untouched.
+        if example_mode:
+            allowed_ops = {"+", "-", "==", "!=", "<", "<=", ">", ">=", "&&", "||", "-->", "!"}
+            for _k in list(builders.keys()):
+                builders[_k] = [
+                    c
+                    for c in builders[_k]
+                    if not (_is_symbolic_op(c.name.pretty()) and c.name.pretty() not in allowed_ops)
+                ]
+        # Evaluation context with the program's top-level defs (library
+        # primitives, table globals) bound once, so candidate sub-programs are
+        # observed in the program's context. Falls back to the bare context.
+        eval_ectx = self._ectx
+        if example_mode and self._replace is not None and self._ectx is not None:
+            try:
+                eval_ectx = _bound_context(self._replace(Literal(0, t_int)), self._ectx)
+            except Exception:
+                eval_ectx = self._ectx
 
         # The automaton, materialised at the goal type: each observational state
         # keeps its smallest representative; the spec is checked once per state.
@@ -279,8 +357,10 @@ class FTASynthesizer(Synthesizer):
                     lit = _example_literal(v, ty)
                     assert lit is not None  # guaranteed by example_mode
                     sub = substitution(sub, lit, nm)
+                # Evaluate in the program's context (top-level defs pre-bound in
+                # eval_ectx), the param already substituted away.
                 try:
-                    outs.append(_freeze(aeon_eval(sub, self._ectx)))
+                    outs.append(_freeze(aeon_eval(sub, eval_ectx)))
                 except Exception:
                     return ("term", str(term))
             return ("vec", tuple(outs))
@@ -303,12 +383,13 @@ class FTASynthesizer(Synthesizer):
             if cur is None or _term_size(term) < _term_size(cur):
                 rep[st] = term
             if st not in validated:
-                ok = _safe(validate, rep[st])
                 if example_mode:
-                    # The examples are part of the spec: a candidate must both
-                    # type-check (refinement, if any) and reproduce every example.
-                    ok = ok and matches_examples(st)
-                validated[st] = ok
+                    # Examples are the spec: check the cheap observational match
+                    # first, and only run the (SMT-backed) type check on the few
+                    # candidates that already reproduce every example.
+                    validated[st] = matches_examples(st) and _safe(validate, rep[st])
+                else:
+                    validated[st] = _safe(validate, rep[st])
             if validated[st]:
                 cand = rep[st]
                 if best is None or _term_size(cand) < _term_size(best):
@@ -316,10 +397,34 @@ class FTASynthesizer(Synthesizer):
                     ui.register(best, [0.0], time.time() - start, True)
 
         bank: dict[str, list[Term]] = {}
-        seen: dict[str, set[str]] = {}
+        seen: dict[str, set[str]] = {}  # non-example mode: syntactic dedup
+        bank_states: dict[str, dict[Any, Term]] = {}  # example mode: state -> rep
 
         def add_bank(key: str, terms: list[Term]) -> None:
             b = bank.setdefault(key, [])
+            if example_mode:
+                # Observational-equivalence compression at *every* type (the FTA's
+                # core idea): keep one representative per distinct output vector
+                # over the examples, so the version space stays small. Sub-terms
+                # that cannot be evaluated cannot be a state, so are dropped.
+                states = bank_states.setdefault(key, {})
+                for t in terms:
+                    if time.time() >= deadline:
+                        break
+                    st = obs_examples(t)
+                    if st[0] != "vec":
+                        continue
+                    vec = st[1]
+                    prev = states.get(vec)
+                    if prev is None:
+                        states[vec] = t
+                        b.append(t)
+                    elif _term_size(t) < _term_size(prev):
+                        states[vec] = t
+                        b[b.index(prev)] = t
+                    if key == goal_key:
+                        insert_goal(t)
+                return
             s = seen.setdefault(key, set())
             for t in terms:
                 k = str(t)
@@ -332,11 +437,13 @@ class FTASynthesizer(Synthesizer):
             if len(b) > self.max_bank:
                 del b[self.max_bank :]
 
-        # Round 0 -- nullary leaves: the in-scope atoms, plus the integer range
-        # (available both as candidate answers and as numeric arguments).
+        # Round 0 -- nullary leaves: the in-scope atoms, plus a literal range.
+        # In example mode a small set suffices (and stays observationally compact);
+        # constant-refinement mode needs the wide range to hit a specific value.
+        int_lits: Any = (0, 1, 2) if example_mode else range(self.int_lo, self.int_hi)
         for key, vs in atoms.items():
             add_bank(key, list(vs))
-        add_bank(int_key, [Literal(v, t_int) for v in range(self.int_lo, self.int_hi)])
+        add_bank(int_key, [Literal(v, t_int) for v in int_lits])
         add_bank(float_key, [Literal(v, t_float) for v in (0.0, 1.0, 2.0, -1.0)])
 
         # Rounds 1..k -- apply every transition to the bank built so far, growing
@@ -431,6 +538,43 @@ def _example_rows(metadata: Metadata, fun_name: Name) -> list[list[float]]:
         if isinstance(entry, dict) and getattr(key, "name", None) == fun_name.name:
             return [list(r) for r in (entry.get("training_data") or [])]
     return []
+
+
+def _is_symbolic_op(name: str) -> bool:
+    """Whether ``name`` is a symbolic operator (``+``, ``*``, ``&&``) rather than
+    an alphanumeric identifier (a library primitive like ``prev_nonmissing``)."""
+    return bool(name) and all(not c.isalnum() and c != "_" for c in name)
+
+
+def _bound_context(prog: Term, ectx):
+    """Bind every top-level ``let``/``rec`` of ``prog`` into ``ectx`` *once*,
+    mirroring the evaluator, so candidate sub-programs can then be evaluated in
+    a single step (with library primitives and table globals already in scope)
+    instead of re-binding the whole chain per evaluation."""
+    cur = prog
+    e = ectx
+    while isinstance(cur, (Let, Rec)):
+        if isinstance(cur, Let):
+            e = e.with_var(cur.var_name, aeon_eval(cur.var_value, e))
+        else:
+            inner = cur.var_value
+            while isinstance(inner, (TypeAbstraction, RefinementAbstraction)):
+                inner = inner.body
+            if isinstance(inner, Abstraction):
+                # Recursion-tying closure (as in the evaluator): captures the
+                # context at this binding plus itself.
+                def make(fun: Abstraction, base, name: Name):
+                    def v(x):
+                        return aeon_eval(fun.body, base.with_var(name, v).with_var(fun.var_name, x))
+
+                    return v
+
+                e = e.with_var(cur.var_name, make(inner, e, cur.var_name))
+            else:
+                rec_ctx = e.with_var(cur.var_name, None)
+                e = rec_ctx.with_var(cur.var_name, aeon_eval(cur.var_value, rec_ctx))
+        cur = cur.body
+    return e
 
 
 def _example_literal(value: float, ty: Type) -> Optional[Term]:

--- a/aeon/synthesis/modules/smt_synthesizer.py
+++ b/aeon/synthesis/modules/smt_synthesizer.py
@@ -391,8 +391,8 @@ class SMTSynthesizer(Synthesizer):
             # Skip the function being synthesized (no self-recursion)
             if var_name == fun_name:
                 continue
-            # Skip internal/system names
-            if var_name.name.startswith("__internal__") or var_name.name in _SYSTEM_NAMES:
+            # Skip system names (fitness helpers are shadowed to Unit upstream)
+            if var_name.name in _SYSTEM_NAMES:
                 continue
             # Try to instantiate polymorphic functions
             effective_ty: Type = var_ty

--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -50,8 +50,6 @@ class SynquidSynthesizer(Synthesizer):
         def skip(name: Name) -> bool:
             if name == fun_name:
                 return not is_recursion_allowed
-            elif name.name.startswith("__internal__"):
-                return True
             elif name.name in ["native", "native_import", "print"]:
                 return True
             else:

--- a/aeon/synthesis/modules/tdsyn/helpers.py
+++ b/aeon/synthesis/modules/tdsyn/helpers.py
@@ -70,8 +70,6 @@ def should_skip(name: Name, fun_name: Name, metadata: Metadata, is_recursion_all
     """Check if a variable should be skipped during synthesis."""
     if name == fun_name:
         return not is_recursion_allowed
-    if name.name.startswith("__internal__"):
-        return True
     if name.name in ("native", "native_import", "print"):
         return True
     return False

--- a/aeon/synthesis/scope.py
+++ b/aeon/synthesis/scope.py
@@ -1,0 +1,69 @@
+"""Hiding fitness-relevant helpers from the synthesis scope by let-shadowing.
+
+The optimization decorators (``@minimize``, ``@example``, ``@cluster``, …) emit
+auxiliary top-level definitions holding the fitness/example/cluster expressions.
+They must stay in the program (so fitness evaluation can reach them), but must
+not be offered to the synthesizers as building blocks.
+
+This is the same problem the ``@hide`` decorator solved, and it is solved the
+same way: lexical shadowing. ``TypingContext.concrete_vars()`` keeps the
+innermost binding per surface name, so rebinding a helper to the inert ``Unit``
+type at the synthesis point — exactly what ``let helper = unit in <hole>`` does —
+hides its real (callable) type from the type-directed grammar and from every
+backend. We gather the helper names from the ``Metadata`` that already records
+them and append those ``Unit`` shadows to the context handed to synthesis.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from aeon.core.types import t_unit
+from aeon.typechecking.context import (
+    ReflectedBinder,
+    TypingContext,
+    UninterpretedBinder,
+    VariableBinder,
+)
+from aeon.utils.name import Name
+
+_VALUE_BINDERS = (VariableBinder, UninterpretedBinder, ReflectedBinder)
+
+
+def fitness_relevant_names(metadata) -> set[str]:
+    """The (surface) names of every fitness/example/cluster helper recorded in
+    ``metadata`` — the bindings that back ``@minimize``/``@maximize``,
+    ``@example`` and ``@cluster`` and so must not appear in the synthesis scope."""
+    names: set[str] = set()
+    for entry in metadata.values():
+        if not isinstance(entry, dict):
+            continue
+        for goal in entry.get("goals", []) or []:
+            fn = getattr(goal, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        for example in entry.get("examples", []) or []:
+            fn = getattr(example, "function", None)
+            if fn is not None:
+                names.add(fn.name)
+        cluster = entry.get("cluster")
+        if cluster is not None:
+            names.add(cluster.name)
+    return names
+
+
+def shadow_fitness_helpers(ctx: TypingContext, metadata) -> TypingContext:
+    """``ctx`` with every in-scope fitness/example/cluster helper let-shadowed to
+    ``Unit``, so the synthesizer never builds it. Returns ``ctx`` unchanged when
+    there is nothing to shadow. This mirrors a ``let helper = unit in <hole>``
+    wrapper, relying on :meth:`TypingContext.concrete_vars` keeping the innermost
+    (``Unit``) binding per name."""
+    hidden = fitness_relevant_names(metadata)
+    if not hidden:
+        return ctx
+    present = {e.name.name for e in ctx.entries if isinstance(e, _VALUE_BINDERS) and e.name.name in hidden}
+    if not present:
+        return ctx
+    entries = list(ctx.entries)
+    entries.extend(VariableBinder(Name(name, 0), t_unit) for name in sorted(present))
+    return dataclasses.replace(ctx, entries=entries)

--- a/examples/synthesis/dace/README.md
+++ b/examples/synthesis/dace/README.md
@@ -67,14 +67,40 @@ The FTA backend enumerates candidate cells bottom-up, keys each by its value
 (observational equivalence), checks the refinement once per value, and extracts
 the smallest accepted cell.
 
+## Programming-by-example completions (`pbe/`)
+
+These reproduce the **five motivating examples of Section 2** with the paper's
+*actual* mechanism — **programming-by-example**. The hole is a *function of the
+missing-cell index*; the spec is concrete input/output rows given with
+`@example` (or `@csv_data`). The FTA keys each automaton state by the candidate's
+**output vector over the examples** (observational equivalence over the example
+set, exactly as in the paper) and composes the DACE primitives — and a
+conditional — to reproduce them. The table is a `Column` global (a native list
+with a `-999999` missing sentinel); the primitives live in
+[`libraries/Dace.ae`](../../../libraries/Dace.ae).
+
+```bash
+uv run python -m aeon --no-main -s fta --budget 60 examples/synthesis/dace/pbe/<file>.ae
+```
+
+| File | Paper example | Synthesised completion |
+|---|---|---|
+| `pbe/locf.ae` | 2.1 LOCF +1 | `1 + prev_nonmissing(col1, i)` |
+| `pbe/prev_sameid.ae` | 2.2 previous with same id (relational) | `prev_sameid(ids, vals, i)` |
+| `pbe/turns.ae` | 2.3 up to value 1, then down to first non-zero | `down_first_nonzero(colC, up_find_value(colB, i, 1))` |
+| `pbe/group_count.ae` | 2.4 group total = COUNT | `group_count(groups, i)` |
+| `pbe/fallback.ae` | 2.5 previous else next (switch) | `if … then prev_nonmissing(col, i) else next_nonmissing(col, i)` |
+
+The conditional (Example 2.5) uses the FTA's `If` builder; the others are
+branch-free. Covered by `tests/dace_test.py::test_fta_pbe_completion`.
+
 ## Scope / faithfulness
 
 - The worked pipelines are *executed*, not synthesised — they demonstrate the
-  DSL exactly. Synthesising a full table-transformation **script** from I/O
-  examples would need example-based (PBE) acceptance over opaque table values,
-  which the current FTA backend (refinement/`validate` acceptance) does not do;
-  the `synth/` tasks therefore complete at the **cell** level, where the spec is
-  SMT-decidable. Adding example-based acceptance to the FTA backend (so it can
-  synthesise whole pipelines over `Table`) is a natural follow-up.
-- Run on demand; not swept by `run_examples.sh`. A subset is covered by
-  `tests/dace_test.py`.
+  DSL exactly. The `synth/` tasks complete at the **cell** level against a
+  refinement spec. The `pbe/` tasks complete a **function of the cell index**
+  from input/output **examples** — the paper's programming-by-example mechanism,
+  now supported by the FTA backend (it keys states by the output vector over the
+  examples). Cell extraction over the relational `Table` value (rather than a
+  numeric `Column`) is the remaining step toward whole-pipeline PBE.
+- Run on demand; not swept by `run_examples.sh`. Covered by `tests/dace_test.py`.

--- a/examples/synthesis/dace/pbe/fallback.ae
+++ b/examples/synthesis/dace/pbe/fallback.ae
@@ -1,0 +1,14 @@
+# DACE Example 2.5 (conditional / switch): impute with the previous non-missing
+# value if one exists, otherwise the next non-missing value. The FTA synthesizes
+# a branching program (the paper's switch) -- here an `if ... then ... else ...`.
+#
+#   uv run python -m aeon --no-main -s fta --budget 60 examples/synthesis/dace/pbe/fallback.ae
+#
+import Dace (Column, prev_nonmissing, next_nonmissing, has_prev_nonmissing)
+
+def col : Column := native "[-999999, 3, -999999, 7, -999999]";
+
+@example(fill 0 = 3)
+@example(fill 2 = 3)
+@example(fill 4 = 7)
+def fill (i:Int) : Int := ?hole;

--- a/examples/synthesis/dace/pbe/group_count.ae
+++ b/examples/synthesis/dace/pbe/group_count.ae
@@ -1,0 +1,12 @@
+# DACE Example 2.4: a group-total cell is the COUNT of entries in its group.
+#
+#   uv run python -m aeon --no-main -s fta --budget 60 examples/synthesis/dace/pbe/group_count.ae
+#
+import Dace (Column, group_count)
+
+def groups : Column := native "[1, 1, 2, 2, 2, 3]";
+
+@example(fill 0 = 2)
+@example(fill 2 = 3)
+@example(fill 5 = 1)
+def fill (i:Int) : Int := ?hole;

--- a/examples/synthesis/dace/pbe/locf.ae
+++ b/examples/synthesis/dace/pbe/locf.ae
@@ -1,0 +1,17 @@
+# DACE Example 2.1 (Wang, Dillig & Singh, "Synthesis of Data Completion Scripts
+# using Finite Tree Automata", OOPSLA 2017): last-observation-carried-forward
+# imputation -- replace a missing cell with the previous non-missing value,
+# incremented by 1. The FTA composes prev_nonmissing with the sketch's `+ 1`.
+#
+#   uv run python -m aeon --no-main -s fta --budget 60 examples/synthesis/dace/pbe/locf.ae
+#
+import Dace (Column, prev_nonmissing)
+
+def col1 : Column := native "[2, 2, -999999, -999999, 8, -999999, 5, -999999, -999999, 10]";
+
+@example(fill 2 = 3)
+@example(fill 3 = 3)
+@example(fill 5 = 9)
+@example(fill 7 = 6)
+@example(fill 8 = 6)
+def fill (i:Int) : Int := ?hole;

--- a/examples/synthesis/dace/pbe/prev_sameid.ae
+++ b/examples/synthesis/dace/pbe/prev_sameid.ae
@@ -1,0 +1,15 @@
+# DACE Example 2.2: replace a missing value with the previous non-missing value
+# that shares the same id (a relational predicate over cells).
+#
+#   uv run python -m aeon --no-main -s fta --budget 60 examples/synthesis/dace/pbe/prev_sameid.ae
+#
+import Dace (Column, prev_sameid)
+
+def ids  : Column := native "[1, 2, 1, 1, 2, 2, 1]";
+def vals : Column := native "[10, 20, -999999, -999999, 50, -999999, -999999]";
+
+@example(fill 2 = 10)
+@example(fill 3 = 10)
+@example(fill 5 = 50)
+@example(fill 6 = 10)
+def fill (i:Int) : Int := ?hole;

--- a/examples/synthesis/dace/pbe/turns.ae
+++ b/examples/synthesis/dace/pbe/turns.ae
@@ -1,0 +1,15 @@
+# DACE Example 2.3 ("making turns"): go up column B to the row whose value is 1,
+# then turn and go down column C to the first non-zero value. The FTA composes
+# the two directional path primitives.
+#
+#   uv run python -m aeon --no-main -s fta --budget 60 examples/synthesis/dace/pbe/turns.ae
+#
+import Dace (Column, up_find_value, down_first_nonzero)
+
+def colB : Column := native "[0, 1, 0, 0, 1, 0]";
+def colC : Column := native "[0, 5, 0, 7, 0, 9]";
+
+@example(fill 2 = 5)
+@example(fill 3 = 5)
+@example(fill 5 = 9)
+def fill (i:Int) : Int := ?hole;

--- a/examples/synthesis/fta/input_from_csv.ae
+++ b/examples/synthesis/fta/input_from_csv.ae
@@ -1,0 +1,9 @@
+# Example-driven FTA fed by @csv_data -- a CSV is just a bunch of input/output
+# examples (last column is the expected output). The FTA observes each
+# candidate's outputs over the rows and accepts the function reproducing them,
+# synthesizing `x + x` (i.e. 2 * x) for this data.
+#
+#   uv run python -m aeon --no-main -s fta --budget 25 examples/synthesis/fta/input_from_csv.ae
+#
+@csv_data("1.0,2.0\n3.0,6.0\n4.0,8.0")
+def double (x:Float) : Float := ?hole;

--- a/examples/synthesis/fta/input_from_examples.ae
+++ b/examples/synthesis/fta/input_from_examples.ae
@@ -1,0 +1,13 @@
+# Example-driven FTA (paper-faithful PBE), Wang/Dillig/Singh OOPSLA 2017.
+#
+# Unlike a constant refinement hole, here the answer must be a FUNCTION OF THE
+# INPUT. @example gives concrete input/output rows; the FTA keys each automaton
+# state by the candidate's output *vector* across those inputs and accepts the
+# one matching the expected outputs -- so it synthesizes `x + 1`.
+#
+#   uv run python -m aeon --no-main -s fta --budget 25 examples/synthesis/fta/input_from_examples.ae
+#
+@example(succ 1 = 2)
+@example(succ 4 = 5)
+@example(succ 9 = 10)
+def succ (x:Int) : Int := ?hole;

--- a/libraries/Dace.ae
+++ b/libraries/Dace.ae
@@ -1,0 +1,49 @@
+# DACE: a minimal table/column DSL for reproducing the data-completion examples
+# of Wang, Dillig & Singh, "Synthesis of Data Completion Scripts using Finite
+# Tree Automata" (OOPSLA 2017), with aeon's FTA backend.
+#
+# A table is modeled as one or more Column globals (native Python lists); a
+# missing cell holds the sentinel -999999. A synthesis task fills a missing cell
+# given its index: the hole is `def fill (i:Int) : Int := ?` and the FTA composes
+# the navigation/relational primitives below (plus arithmetic and conditionals)
+# to reproduce the @example / @csv input-output rows.
+
+type Column
+
+# Value of cell i.
+def col_at (c: Column) (i: Int) : Int := native "c[i]";
+
+# Whether a value is the missing-cell sentinel.
+def is_missing (x: Int) : Bool := native "x == -999999";
+
+# Previous non-missing value strictly before index i (sentinel if none).
+def prev_nonmissing (c: Column) (i: Int) : Int :=
+    native "next((c[j] for j in range(i - 1, -1, -1) if c[j] != -999999), -999999)";
+
+# Next non-missing value strictly after index i (sentinel if none).
+def next_nonmissing (c: Column) (i: Int) : Int :=
+    native "next((c[j] for j in range(i + 1, len(c)) if c[j] != -999999), -999999)";
+
+# Whether any non-missing cell exists strictly before index i.
+def has_prev_nonmissing (c: Column) (i: Int) : Bool :=
+    native "any(c[j] != -999999 for j in range(0, i))";
+
+# Previous non-missing value (before i) in `vals` whose row has the same id as
+# row i in `ids` (sentinel if none) -- a relational predicate over cells.
+def prev_sameid (ids: Column) (vals: Column) (i: Int) : Int :=
+    native "next((vals[j] for j in range(i - 1, -1, -1) if ids[j] == ids[i] and vals[j] != -999999), -999999)";
+
+# Index of the nearest cell at-or-above i whose value is v (-1 if none) -- the
+# upward spatial path of Example 2.3.
+def up_find_value (c: Column) (i: Int) (v: Int) : Int :=
+    native "next((j for j in range(i, -1, -1) if c[j] == v), -1)";
+
+# First non-zero value at-or-below index k (0 if none) -- the downward path that
+# Example 2.3 turns onto after the upward search.
+def down_first_nonzero (c: Column) (k: Int) : Int :=
+    native "next((c[j] for j in range(k, len(c)) if c[j] != 0), 0)";
+
+# Number of entries sharing row i's group id -- the COUNT-over-a-range of
+# Example 2.4.
+def group_count (groups: Column) (i: Int) : Int :=
+    native "sum(1 for g in groups if g == groups[i])";

--- a/tests/dace_test.py
+++ b/tests/dace_test.py
@@ -58,3 +58,25 @@ def test_table_pipeline_runs(example: str, expected: str):
 def test_fta_completes_cell(example: str, value: str):
     out = _run(["--no-main", "-s", "fta", "--budget", "10", f"examples/synthesis/dace/synth/{example}.ae"])
     assert f"?hole: {value}" in out, out[-1500:]
+
+
+# Programming-by-example completions: the paper's actual mechanism. Each hole is
+# a *function of the missing-cell index* specified by @example input/output rows;
+# the FTA keys states by the output vector over those examples and composes the
+# table primitives (and a conditional) to reproduce them. ``token`` is a
+# primitive the intended completion must use, evidence it reads the table.
+@pytest.mark.parametrize(
+    "example,token",
+    [
+        ("locf", "prev_nonmissing"),  # 2.1: previous non-missing + 1
+        ("prev_sameid", "prev_sameid"),  # 2.2: previous with same id (relational)
+        ("turns", "down_first_nonzero"),  # 2.3: up to value 1, then down to non-zero
+        ("group_count", "group_count"),  # 2.4: COUNT of the group
+        ("fallback", "if"),  # 2.5: previous else next (conditional)
+    ],
+)
+def test_fta_pbe_completion(example: str, token: str):
+    out = _run(["--no-main", "-s", "fta", "--budget", "60", f"examples/synthesis/dace/pbe/{example}.ae"])
+    assert "no spec-consistent program" not in out, out[-1500:]
+    assert "?hole:" in out, out[-1500:]
+    assert token in out, out[-1500:]

--- a/tests/fta_test.py
+++ b/tests/fta_test.py
@@ -46,6 +46,29 @@ def test_solves_conjoined_refinement():
     assert isinstance(t, Literal) and t.value == 5
 
 
+# Example-driven mode (paper-faithful PBE): @example / @csv give concrete
+# input/output rows; FTA keys states by the candidate's output vector over those
+# inputs and accepts the one matching the expected outputs. With distinct
+# expected outputs, no constant can satisfy them, so any solution must read the
+# input -- i.e. FTA synthesizes a function *of its input*.
+
+
+def test_solves_input_dependent_from_examples():
+    t = _solve(
+        "@example(succ 1 = 2)\n@example(succ 4 = 5)\n@example(succ 9 = 10)\ndef succ (x:Int) : Int := ?hole;",
+        budget=25.0,
+    )
+    assert t is not None and not isinstance(t, Literal)  # reads x (it's x + 1)
+
+
+def test_solves_input_dependent_from_csv():
+    t = _solve(
+        '@csv_data("1.0,2.0\\n3.0,6.0\\n4.0,8.0")\ndef double (x:Float) : Float := ?hole;',
+        budget=25.0,
+    )
+    assert t is not None and not isinstance(t, Literal)  # reads x (it's x + x)
+
+
 def test_cli_runs_fta_backend():
     # End-to-end through the real driver: the hole is filled with the value that
     # satisfies the refinement, with no objective decorator required.

--- a/tests/synthesis_scope_test.py
+++ b/tests/synthesis_scope_test.py
@@ -1,0 +1,98 @@
+"""The fitness/example/cluster helpers emitted by the optimization decorators
+must stay evaluable (in the program) but must be hidden from the synthesis scope
+by let-shadowing to ``Unit`` — not by a ``__internal__`` name prefix."""
+
+from __future__ import annotations
+
+from aeon.synthesis.identification import get_holes_info
+from aeon.synthesis.scope import fitness_relevant_names, shadow_fitness_helpers
+from aeon.core.types import top, t_int, t_unit
+from aeon.typechecking.context import TypingContext, TypeBinder, VariableBinder, UninterpretedBinder
+from aeon.utils.name import Name
+
+from tests.driver import check_and_return_core
+
+
+# --------------------------------------------------------------------------- #
+# Unit: shadowing recorded fitness helpers to Unit
+# --------------------------------------------------------------------------- #
+
+
+def _goal(name: Name):
+    from aeon.synthesis.decorators import Goal
+
+    return Goal(minimize=True, length=1, function=name, kind="expression")
+
+
+def test_fitness_relevant_names_gathers_all_kinds():
+    from aeon.synthesis.decorators import Example
+
+    md = {
+        Name("f", 0): {
+            "goals": [_goal(Name("_fitness_minimize_f_0", 5))],
+            "examples": [Example(Name("_example_f_0", 6), "f 1 == 1")],
+            "cluster": Name("_cluster_f", 7),
+        }
+    }
+    assert fitness_relevant_names(md) == {"_fitness_minimize_f_0", "_example_f_0", "_cluster_f"}
+
+
+def test_shadow_rebinds_only_in_scope_helpers_to_unit():
+    md = {Name("f", 0): {"goals": [_goal(Name("_fitness_minimize_f_0", 5))]}}
+    ctx = TypingContext(
+        entries=[
+            TypeBinder(Name("Int", 0)),
+            VariableBinder(Name("f", 0), t_int),
+            VariableBinder(Name("_fitness_minimize_f_0", 5), t_int),  # real (callable) type
+            UninterpretedBinder(Name("g", 0), t_int),
+        ]
+    )
+    shadowed = shadow_fitness_helpers(ctx, md)
+    vars_by_name = {n.name: t for n, t in shadowed.concrete_vars()}
+    # the helper is now seen as inert Unit, not its real type
+    assert vars_by_name["_fitness_minimize_f_0"] == t_unit
+    # real definitions are untouched
+    assert vars_by_name["f"] == t_int
+    # nothing to shadow -> same object back
+    assert shadow_fitness_helpers(ctx, {}) is ctx
+    # a recorded helper that is not in scope is not introduced
+    md2 = {Name("z", 0): {"goals": [_goal(Name("_fitness_minimize_z_0", 9))]}}
+    assert shadow_fitness_helpers(ctx, md2) is ctx
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through the real decorator + lowering pipeline
+# --------------------------------------------------------------------------- #
+
+SOURCE = """
+    @minimize(g(1.0) - 5.0)
+    def g(x:Float) : Float := x
+
+    def h(y:Float) : Float := ?hole
+"""
+
+
+def test_no_internal_prefix_in_generated_names():
+    _core, _ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    names = fitness_relevant_names(metadata)
+    assert names, "expected at least one fitness helper"
+    assert all(not n.startswith("__internal__") for n in names)
+
+
+def test_fitness_helper_shadowed_to_unit_at_later_hole():
+    core, ctx, _ectx, metadata = check_and_return_core(SOURCE)
+    fitness = fitness_relevant_names(metadata)
+
+    holes = get_holes_info(ctx, core, top, [], refined_types=True)
+    shadowed_somewhere = False
+    for _ty, hole_ctx in holes.values():
+        in_scope = {n.name for n, _t in hole_ctx.concrete_vars()}
+        if fitness & in_scope:  # g's fitness helper is in scope at h's hole
+            shadowed_somewhere = True
+            shadowed = shadow_fitness_helpers(hole_ctx, metadata)
+            types_by_name = {n.name: t for n, t in shadowed.concrete_vars()}
+            for fn in fitness & in_scope:
+                # hidden by shadowing to the inert Unit type, not removed
+                assert types_by_name[fn] == t_unit
+            assert "g" in types_by_name  # the real definition stays available
+    assert shadowed_somewhere, "expected a fitness helper in scope at some hole"


### PR DESCRIPTION
Builds on #392 (example-driven FTA) to complete the DACE story (Wang/Dillig/Singh, OOPSLA'17): the FTA backend now synthesizes the paper's **five motivating Section-2 data-completion tasks** from input/output **examples** — the paper's actual mechanism — and they run end-to-end.

## FTA backend additions
- **Conditional builder** — synthesizes `If(cond, then, else)` at the goal type (the paper's *switch*), keyed by the branch's observed output like any other state. `enable_if` flag; then/else enumeration is bounded by the smallest reps (condition pool is tiny after compression).
- **Polymorphic-operator monomorphization** at the goal/Int types, so arithmetic over the input is buildable (emits `TypeApplication`).
- **Observational-equivalence compression at every type** (one representative per output vector over the examples) — the paper's core idea, keeping the version space small.
- **Program-context evaluation** — candidate sub-programs are evaluated with the program's top-level defs / library primitives bound once (`EvalPrimitives.replace`), and the cheap example match is checked **before** the SMT type-check (a big speedup).
- Example mode restricts to additive/boolean operators to curb the bottom-up blow-up.

## DSL + examples
- `libraries/Dace.ae`: a `Column` type (missing sentinel) + navigation/relational/aggregate primitives.
- `examples/synthesis/dace/pbe/{locf,prev_sameid,turns,group_count,fallback}.ae` — the five examples, each `-s fta` runnable.
- `tests/dace_test.py::test_fta_pbe_completion` runs all five.

## Results (verified locally via uv)
| Example | Synthesized |
|---|---|
| 2.1 LOCF +1 | `1 + prev_nonmissing(col1, i)` |
| 2.2 prev same-id | `prev_sameid(ids, vals, i)` |
| 2.3 turns | `down_first_nonzero(colC, up_find_value(colB, i, 1))` |
| 2.4 group COUNT | `group_count(groups, i)` |
| 2.5 fallback | `if … then prev_nonmissing(col,i) else next_nonmissing(col,i)` |

All five synthesize in <5s each with the default `-s fta` config. (Local run uses the scipy source-build + Fortran-solver stub; CI runs the suite on Linux.)