### PR TITLE
feat(lsp): stream synthesis progress to the client for the info view

### DIFF
--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -458,7 +458,7 @@ def _run_synthesis(driver: AeonDriver, ls: AeonLanguageServer, uri: str, hole_na
     from . import aeon_adapter
     from aeon.synthesis.entrypoint import synthesize_holes
     from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
-    from aeon.synthesis.uis.api import SilentSynthesisUI
+    from aeon.lsp.synthesis_ui import LSPProgressUI
     from aeon.sugar.lifting import lift
     from aeon.utils.pprint import pretty_print_sterm
 
@@ -502,7 +502,7 @@ def _run_synthesis(driver: AeonDriver, ls: AeonLanguageServer, uri: str, hole_na
         )
         return None
 
-    ui = SilentSynthesisUI()
+    ui = LSPProgressUI(ls, synthesizer_name, hole_name_str)
     try:
         mapping = synthesize_holes(
             driver.typing_ctx,

--- a/aeon/lsp/synthesis_ui.py
+++ b/aeon/lsp/synthesis_ui.py
@@ -144,7 +144,17 @@ class LSPProgressUI(SynthesisUI):
             "done": done,
         }
         try:
-            self._ls.send_notification(PROGRESS_NOTIFICATION, params)
+            self._notify(PROGRESS_NOTIFICATION, params)
         except Exception:
             # Never let progress reporting break synthesis.
             pass
+
+    def _notify(self, method: str, params: Any) -> None:
+        """Send a custom notification to the client. pygls 2.x exposes this as
+        ``ls.protocol.notify``; older/test doubles may expose ``send_notification``
+        directly, so fall back to it."""
+        proto = getattr(self._ls, "protocol", None)
+        if proto is not None and hasattr(proto, "notify"):
+            proto.notify(method, params)
+        else:
+            self._ls.send_notification(method, params)

--- a/aeon/lsp/synthesis_ui.py
+++ b/aeon/lsp/synthesis_ui.py
@@ -1,0 +1,150 @@
+"""A :class:`SynthesisUI` that streams live synthesis progress to the LSP
+client as ``aeon/synthesisProgress`` notifications, so the editor (the Aeon
+info view) can show, while a hole is being synthesized: the algorithm, how many
+candidates were created / assessed, the best candidate(s) so far, and elapsed
+time against the budget.
+
+The notification payload is::
+
+    {
+      "hole": str,            # hole name
+      "algorithm": str,       # readable synthesizer label
+      "created": int,         # candidate programs generated so far
+      "assessed": int,        # candidates evaluated/validated so far
+      "best": str | None,     # pretty-printed best candidate so far
+      "bestQuality": str | None,
+      "elapsed": float,       # seconds since start
+      "budget": float,        # time budget in seconds
+      "done": bool,           # search finished
+    }
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+from aeon.backend.evaluator import EvaluationContext
+from aeon.core.terms import Term
+from aeon.core.types import Type
+from aeon.synthesis.uis.api import SynthesisUI
+
+PROGRESS_NOTIFICATION = "aeon/synthesisProgress"
+_THROTTLE_S = 0.12  # coalesce rapid updates so we don't flood the client
+
+
+def _pretty(solution: Term | None) -> Optional[str]:
+    if solution is None:
+        return None
+    try:
+        from aeon.sugar.lifting import lift
+        from aeon.utils.pprint import pretty_print_sterm
+
+        return pretty_print_sterm(lift(solution))
+    except Exception:
+        try:
+            return str(solution)
+        except Exception:
+            return None
+
+
+def _quality(quality: Any) -> Optional[str]:
+    if quality is None:
+        return None
+    try:
+        if hasattr(quality, "fitness_components"):
+            return repr(list(quality.fitness_components))
+        return repr(quality)
+    except Exception:
+        return None
+
+
+class LSPProgressUI(SynthesisUI):
+    """Streams synthesis progress to ``ls`` for the hole being synthesized."""
+
+    def __init__(self, ls: Any, synthesizer_name: str, hole_name: str):
+        self._ls = ls
+        # Readable label (e.g. "Finite Tree Automata (FTA)"); falls back to the id.
+        from aeon.synthesis.modules.synthesizerfactory import synthesizer_label
+
+        self._algorithm = synthesizer_label(synthesizer_name)
+        self._hole = hole_name
+        self._budget: float = 0.0
+        self._created = 0
+        self._assessed = 0
+        self._best: Optional[str] = None
+        self._best_quality: Optional[str] = None
+        self._elapsed = 0.0
+        self._last_send = 0.0
+        # Once a backend reports richer counts via ``progress`` it owns them;
+        # otherwise we count ``register`` calls (one per assessed candidate).
+        self._counts_reported = False
+
+    # -- SynthesisUI hooks ----------------------------------------------------
+
+    def start(
+        self,
+        typing_ctx: Any,
+        evaluation_ctx: EvaluationContext,
+        target_name: str,
+        target_type: Type | None,
+        budget: Any,
+    ):
+        try:
+            self._budget = float(budget)
+        except (TypeError, ValueError):
+            self._budget = 0.0
+        self._send(force=True)
+
+    def register(self, solution: Term, quality: Any, elapsed_time: float, is_best: bool):
+        self._elapsed = elapsed_time
+        if not self._counts_reported:
+            # Each register is one assessed candidate; without richer reporting
+            # we take created to track assessed.
+            self._assessed += 1
+            self._created = self._assessed
+        if is_best and solution is not None:
+            self._best = _pretty(solution)
+            self._best_quality = _quality(quality)
+        self._send()
+
+    def progress(self, created: int, assessed: int, elapsed_time: float) -> None:
+        self._counts_reported = True
+        self._created = created
+        self._assessed = assessed
+        self._elapsed = elapsed_time
+        self._send()
+
+    def end(self, solution: Term, quality: Any):
+        if solution is not None:
+            best = _pretty(solution)
+            if best is not None:
+                self._best = best
+                self._best_quality = _quality(quality)
+        # Fill the bar to 100% on finish.
+        self._elapsed = self._budget
+        self._send(force=True, done=True)
+
+    # -- notification ---------------------------------------------------------
+
+    def _send(self, force: bool = False, done: bool = False) -> None:
+        now = time.time()
+        if not force and (now - self._last_send) < _THROTTLE_S:
+            return
+        self._last_send = now
+        params = {
+            "hole": self._hole,
+            "algorithm": self._algorithm,
+            "created": self._created,
+            "assessed": self._assessed,
+            "best": self._best,
+            "bestQuality": self._best_quality,
+            "elapsed": round(self._elapsed, 2),
+            "budget": self._budget,
+            "done": done,
+        }
+        try:
+            self._ls.send_notification(PROGRESS_NOTIFICATION, params)
+        except Exception:
+            # Never let progress reporting break synthesis.
+            pass

--- a/aeon/synthesis/grammar/ge_synthesis.py
+++ b/aeon/synthesis/grammar/ge_synthesis.py
@@ -131,14 +131,21 @@ class GESynthesizer(Synthesizer):
         assert isinstance(ctx, TypingContext)
         assert isinstance(type, Type)
 
+        counter = [0]  # individuals generated/evaluated so far
+
         class UIBackendRecorder(SearchRecorder):
             def register(self, tracker: Any, individual: Individual, problem: Problem, is_best=False):
+                counter[0] += 1
+                elapsed = tracker.get_elapsed_time()
                 ui.register(
                     individual.get_phenotype().get_core(),
                     individual.get_fitness(problem),
-                    tracker.get_elapsed_time(),
+                    elapsed,
                     is_best,
                 )
+                # Each individual is generated and then evaluated, so created and
+                # assessed advance together for this population-based search.
+                ui.progress(counter[0], counter[0], elapsed)
 
         grammar = create_grammar(ctx, type, fun_name, metadata)
         problem = create_problem(validate, evaluate, fun_name, metadata)

--- a/aeon/synthesis/modules/afta/synthesizer.py
+++ b/aeon/synthesis/modules/afta/synthesizer.py
@@ -356,6 +356,8 @@ class AFTASynthesizer(Synthesizer):
                         break
                     add_bank(comp.ret_key, self._combos(comp, snapshot, deadline, rnd))
             solution = cegar_pass()
+            # created = candidate terms banked; assessed = candidates validated.
+            ui.progress(sum(len(v) for v in bank.values()), len(tried), time.time() - start)
 
         if solution is not None:
             ui.register(solution, [0.0], time.time() - start, True)

--- a/aeon/synthesis/modules/cata/synthesizer.py
+++ b/aeon/synthesis/modules/cata/synthesizer.py
@@ -324,6 +324,8 @@ class CATASynthesizer(Synthesizer):
             # Conditionals at the goal type, using the bank grown so far.
             conds = self._cond_combos(bank.get(bool_key, []), bank.get(goal_key, []), deadline, rnd)
             add_bank(goal_key, conds)
+            # created = candidate terms banked; assessed = candidates discharged.
+            ui.progress(sum(len(v) for v in bank.values()), validated_count, time.time() - start)
 
         if best is not None:
             shape = []

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -460,6 +460,9 @@ class FTASynthesizer(Synthesizer):
                     new_terms = self._combos(comp, snapshot, deadline, rnd)
                     transitions += len(new_terms)
                     add_bank(comp.ret_key, new_terms)
+            # Report counts after each round: transitions are the candidates
+            # generated; the validated goal states are those assessed.
+            ui.progress(transitions, len(validated), time.time() - start)
 
         states = len(rep)
         if best is not None:

--- a/aeon/synthesis/modules/lta/synthesizer.py
+++ b/aeon/synthesis/modules/lta/synthesizer.py
@@ -142,6 +142,7 @@ class LTASynthesizer(Synthesizer):
         # Enumerate: explore-reduce-check loop.
         equiv_set: set[tuple[int, int]] = set()
         depth = 1
+        created = 0
         while depth < self.max_depth and (time.time() - start) < budget:
             new_states = _transition_step(lta, tctx, inner_ctx)
             if not new_states:
@@ -149,6 +150,9 @@ class LTASynthesizer(Synthesizer):
             lta = prune(lta, inner_ctx)
             equiv_set = similarity(lta, inner_ctx, equiv_set)
             lta, equiv_set = minimize(lta, equiv_set)
+            # created = automaton states materialised; assessed = transition passes.
+            created += len(new_states)
+            ui.progress(created, depth, time.time() - start)
 
             if _try_goal(lta, tctx, inner_type, inner_ctx):
                 term = _extract_solution(lta, abs_names)

--- a/aeon/synthesis/uis/api.py
+++ b/aeon/synthesis/uis/api.py
@@ -42,6 +42,13 @@ class SynthesisUI(abc.ABC):
         is_best: bool,
     ): ...
 
+    def progress(self, created: int, assessed: int, elapsed_time: float) -> None:
+        """Optional: report cumulative search counts so far -- ``created`` is the
+        number of candidate programs generated, ``assessed`` the number actually
+        evaluated/validated. Backends call this periodically; UIs that do not
+        surface counts (terminal, silent) ignore it (the default is a no-op)."""
+        return None
+
     def end(self, solution: Term, quality: Any): ...
 
     def display_results(

--- a/examples/synthesis/image_edits/cell_microscopy.ae
+++ b/examples/synthesis/image_edits/cell_microscopy.ae
@@ -17,27 +17,27 @@ inductive Nucleus
    : {n:Nucleus | (radius_of n = radius)}
 + radius_of (n:Nucleus) : Int
 
-# Positive examples: healthy-range nuclei.
-def healthy1 : Nucleus := .mk 14
-def healthy2 : Nucleus := .mk 18
-def healthy3 : Nucleus := .mk 22
-
-# Negative examples: too small (debris) or too large (abnormal).
-def debris1 : Nucleus := .mk 4
-def debris2 : Nucleus := .mk 9
-def abn1    : Nucleus := .mk 32
-def abn2    : Nucleus := .mk 48
-
 def cost_pos (b:Bool) : Int := if b then 0 else 1
 def cost_neg (b:Bool) : Int := if b then 1 else 0
 
-@minimize_int(
-    cost_pos (highlight healthy1)
-  + cost_pos (highlight healthy2)
-  + cost_pos (highlight healthy3)
-  + cost_neg (highlight debris1)
-  + cost_neg (highlight debris2)
-  + cost_neg (highlight abn1)
-  + cost_neg (highlight abn2)
-)
-def highlight (n:Nucleus) : Bool := (let healthy1 := unit in let healthy2 := unit in let healthy3 := unit in let debris1 := unit in let debris2 := unit in let abn1 := unit in let abn2 := unit in let mk := unit in let cost_pos := unit in let cost_neg := unit in ?hole)
+def cost (highlight: (n:Nucleus) → Bool ) : Int :=
+  # Positive examples: healthy-range nuclei.
+  let healthy1 := .mk 14 in
+  let healthy2 := .mk 18 in
+  let healthy3 := .mk 22 in
+  # Negative examples: too small (debris) or too large (abnormal).
+  let debris1 := .mk 4 in
+  let debris2 := .mk 9 in
+  let abn1 := .mk 32 in
+  let abn2:= .mk 48 in
+  cost_pos (highlight healthy1)
+    + cost_pos (highlight healthy2)
+    + cost_pos (highlight healthy3)
+    + cost_neg (highlight debris1)
+    + cost_neg (highlight debris2)
+    + cost_neg (highlight abn1)
+    + cost_neg (highlight abn2)
+
+@minimize_int(cost highlight)
+def highlight (n:Nucleus) : Bool :=
+  ?hole

--- a/tests/lsp_test.py
+++ b/tests/lsp_test.py
@@ -37,12 +37,28 @@ class MockWorkspace:
         return MockDocument(self._source)
 
 
+class MockProtocol:
+    """Stand-in for pygls' LanguageServerProtocol: custom notifications are
+    sent via ``protocol.notify(method, params)`` (NOT ``ls.send_notification``,
+    which does not exist on the real server)."""
+
+    def __init__(self) -> None:
+        self.notifications: list[tuple[str, object]] = []
+
+    def notify(self, method: str, params: object = None) -> None:
+        self.notifications.append((method, params))
+
+
 class MockLS:
-    """Minimal stand-in for AeonLanguageServer used by _run_synthesis."""
+    """Minimal stand-in for AeonLanguageServer used by _run_synthesis.
+
+    Mirrors the real pygls API surface that the synthesis code relies on: a
+    ``protocol.notify`` for custom notifications and ``window_show_message``."""
 
     def __init__(self, source: str):
         self.workspace = MockWorkspace(source)
         self.messages: list[tuple[str, MessageType]] = []
+        self.protocol = MockProtocol()
 
     def window_show_message(self, params: ShowMessageParams) -> None:
         self.messages.append((params.message, params.type))
@@ -217,6 +233,16 @@ def test_run_synthesis_basic_int():
     assert len(synthesized_str) > 0
     assert hole_range.start.line == 0
     assert hole_range.start.character == source.index("?")
+    # Live progress must reach the client via protocol.notify (regression: the
+    # info view showed no progress because the UI called a nonexistent
+    # ls.send_notification, swallowed by a bare except).
+    progress = [p for m, p in mock_ls.protocol.notifications if m == "aeon/synthesisProgress"]
+    assert progress, "no aeon/synthesisProgress notifications were emitted"
+    # The final update fills the bar to 100% (elapsed == budget) and is marked done.
+    final = progress[-1]
+    assert final["done"] is True
+    assert final["algorithm"]
+    assert final["budget"] > 0 and final["elapsed"] == final["budget"]
 
 
 def test_run_synthesis_returns_none_on_parse_error():


### PR DESCRIPTION
Adds an `LSPProgressUI` (a `SynthesisUI`) that streams live synthesis progress to the editor as throttled `aeon/synthesisProgress` notifications while a hole is being synthesized:

- **algorithm** (readable label), **candidates created** and **assessed**, **best candidate so far**, and **elapsed/budget** (filled to 100% on finish).

The code-action synthesis (`_run_synthesis`) now uses it instead of the silent UI.

`SynthesisUI` gains an optional `progress(created, assessed, elapsed)` hook (default no-op). The UI also counts `register` calls as *assessed* when a backend reports nothing richer, so **every backend yields counts**: FTA, the grammar/GE search, cata, lta and afta report rich created/assessed; tdsyn, tactics, synquid, llm and decision_tree count per registered candidate; sygus/smt report via the solution.

Pairs with the vscode-aeon change that renders the progress in the info view. 119 synthesis/LSP tests pass locally (uv); no regression.