### PR TITLE
feat(synthesis): GenomicNG — Nevergrad grammatical-evolution backend

### DIFF
--- a/aeon/synthesis/grammar/genomic_ng.py
+++ b/aeon/synthesis/grammar/genomic_ng.py
@@ -1,0 +1,197 @@
+"""GenomicNG: Nevergrad-driven grammatical-evolution synthesis backend.
+
+The search space is a fixed-length integer *genome* (a codon list, exactly the
+representation geneticengine's :class:`GrammaticalEvolutionRepresentation`
+already uses). Nevergrad treats it as a bounded integer vector and optimises it
+with any of its derivative-free algorithms (NGOpt, CMA, DE, PSO, ...). Each
+genome is decoded into an Aeon ``Term`` by the *existing* grammatical-evolution
+mapper, and scored by the *existing* :func:`create_problem` fitness (the SMT
+``validate`` predicate plus any ``@minimize``/``@maximize`` objectives).
+
+This means GenomicNG reuses Aeon's whole synthesis stack — grammar generation,
+phenotype decoding, fitness — and only swaps the *search strategy* for
+Nevergrad's. The single design choice is the genome↔derivation encoding, and we
+borrow geneticengine's codon mapping rather than inventing our own.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+from aeon.core.terms import Term
+from aeon.core.types import Type
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import Synthesizer
+from aeon.synthesis.grammar.ge_synthesis import create_problem
+from aeon.synthesis.grammar.grammar_generation import create_grammar
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+
+from geneticengine.problems import Fitness, Problem
+from geneticengine.random.sources import NativeRandomSource
+from geneticengine.representations.grammatical_evolution.ge import (
+    Genotype,
+    GrammaticalEvolutionRepresentation,
+)
+from geneticengine.representations.tree.initializations import MaxDepthDecider
+
+# Upper bound on a codon. The decoder reduces each codon modulo the local choice
+# arity, so the exact ceiling only sets resolution: large enough that
+# ``codon % small_arity`` is close to uniform, small enough that Nevergrad's
+# continuous relaxation explores it well.
+CODON_MAX = 1 << 15
+GENE_LENGTH = 256
+MAX_DEPTH = 5
+
+# Finite penalty reported to Nevergrad for an invalid/un-evaluable candidate.
+# A large positive value keeps such candidates strictly worse than any real
+# (minimisation-oriented) loss without tripping Nevergrad's inf-clipping warning.
+INVALID_PENALTY = 1e12
+
+
+def _orient(components: list[float], minimize: list[bool]) -> list[float]:
+    """Re-orient a fitness vector so every objective is minimised.
+
+    Nevergrad always minimises; geneticengine records per-objective direction in
+    ``problem.minimize``. Maximise objectives are negated.
+    """
+    return [c if mini else -c for c, mini in zip(components, minimize)]
+
+
+def _knee_point(archive: list[tuple[Term, list[float]]], minimize: list[bool]) -> Term | None:
+    """Compromise selection over an archive of (term, oriented-loss) pairs.
+
+    Mirrors ``ge_synthesis._knee_point_individual``: per-objective min-max
+    normalisation, then the candidate closest to the utopia origin. Works for
+    the single-objective case too (one dimension → picks the lowest loss).
+    """
+    if not archive:
+        return None
+    if len(archive) == 1:
+        return archive[0][0]
+
+    n_obj = len(minimize)
+    losses = [loss for _, loss in archive]
+    mins = [min(l[d] for l in losses) for d in range(n_obj)]
+    maxs = [max(l[d] for l in losses) for d in range(n_obj)]
+    spreads = [maxs[d] - mins[d] for d in range(n_obj)]
+
+    def dist2(loss: list[float]) -> float:
+        total = 0.0
+        for d in range(n_obj):
+            if spreads[d] > 0:
+                norm = (loss[d] - mins[d]) / spreads[d]
+                total += norm * norm
+        return total
+
+    best = min(archive, key=lambda pair: dist2(pair[1]))
+    return best[0]
+
+
+class GenomicNGSynthesizer(Synthesizer):
+    """Synthesis by optimising a codon genome with Nevergrad.
+
+    Args:
+        optimizer: name of a Nevergrad optimiser class (e.g. ``"NGOpt"``,
+            ``"CMA"``, ``"DE"``, ``"PSO"``, ``"TBPSA"``).
+        seed: seed for both the Nevergrad optimiser and the codon decoder.
+        gene_length: number of codons in the genome.
+    """
+
+    def __init__(self, optimizer: str = "NGOpt", seed: int = 0, gene_length: int = GENE_LENGTH):
+        self.optimizer = optimizer
+        self.seed = seed
+        self.gene_length = gene_length
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], Any] | None = None,
+    ) -> Term:
+        assert isinstance(ctx, TypingContext)
+        assert isinstance(type, Type)
+
+        try:
+            import nevergrad as ng
+        except ImportError as e:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "GenomicNG requires the 'nevergrad' package. Install it with "
+                "`uv pip install nevergrad` (or the 'synthesis-ng' extra)."
+            ) from e
+
+        grammar = create_grammar(ctx, type, fun_name, metadata)
+        problem: Problem = create_problem(validate, evaluate, fun_name, metadata)
+        minimize = problem.minimize
+
+        representation = GrammaticalEvolutionRepresentation(
+            grammar,
+            decider=MaxDepthDecider(NativeRandomSource(self.seed), grammar, max_depth=MAX_DEPTH),
+            gene_length=self.gene_length,
+        )
+
+        # The genome: a fixed-length integer codon vector. Nevergrad mutates the
+        # continuous relaxation; integer casting + modulo decoding turn it back
+        # into a derivation.
+        parametrization = ng.p.Array(shape=(self.gene_length,)).set_bounds(0, CODON_MAX).set_integer_casting()
+        parametrization.random_state.seed(self.seed)
+
+        opt_cls = ng.optimizers.registry[self.optimizer]
+        # A generous evaluation cap; the real stop is the wall-clock budget below.
+        optimizer = opt_cls(parametrization=parametrization, budget=10**9, num_workers=1)
+
+        archive: list[tuple[Term, list[float]]] = []
+        best_term: Term | None = None
+        best_fitness: Fitness | None = None
+        start = time.monotonic()
+
+        while time.monotonic() - start < budget:
+            candidate = optimizer.ask()
+            dna = [int(x) for x in candidate.value]
+            phenotype = representation.genotype_to_phenotype(Genotype(dna))
+            core = phenotype.get_core()
+            assert isinstance(core, Term)
+
+            try:
+                fitness = problem.evaluate(phenotype)
+                oriented = _orient(fitness.fitness_components, minimize)
+                valid = fitness.valid
+            except Exception:
+                # A black-box search constantly proposes candidates the decoder
+                # turns into ill-typed or un-evaluable terms (e.g. validate/SMT
+                # throws). Treat any evaluation failure as an invalid candidate
+                # and penalise it rather than aborting the whole search.
+                fitness = problem.get_invalid_fitness()
+                oriented = [INVALID_PENALTY] * len(minimize)
+                valid = False
+
+            loss = oriented if len(oriented) > 1 else oriented[0]
+            optimizer.tell(candidate, loss)
+
+            ui.register(core, fitness, time.monotonic() - start, is_best=False)
+
+            if valid:
+                archive.append((core, oriented))
+                if best_fitness is None or problem.is_better(fitness, best_fitness):
+                    best_term, best_fitness = core, fitness
+                # Stop as soon as the goal is met (e.g. a validate-only target,
+                # or all objectives at/under their targets) instead of burning
+                # the rest of the time budget.
+                if problem.is_solved(fitness):
+                    break
+
+        # Single objective: ``best_term`` is already the optimum. Multi
+        # objective: ``is_better`` is only a partial order, so resolve the
+        # Pareto archive by knee-point compromise.
+        if len(minimize) > 1:
+            chosen = _knee_point(archive, minimize)
+            return chosen if chosen is not None else best_term
+        return best_term

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -2,6 +2,7 @@ import os
 
 from aeon.synthesis.api import Synthesizer
 from aeon.synthesis.grammar.ge_synthesis import GESynthesizer
+from aeon.synthesis.grammar.genomic_ng import GenomicNGSynthesizer
 from aeon.synthesis.modules.lta import LTASynthesizer
 from aeon.synthesis.modules.synquid.synthesizer import SynquidSynthesizer
 from aeon.synthesis.modules.llm import LLMSynthesizer
@@ -33,6 +34,10 @@ SYNTHESIZER_LABELS: dict[str, str] = {
     "tdsyn": "Type-directed Synthesis",
     "tdsyn_enumerative": "Type-directed Synthesis (enumerative)",
     "tdsyn_random": "Type-directed Synthesis (random)",
+    "ng": "Nevergrad grammatical-evolution (NGOpt)",
+    "ng_cma": "Nevergrad grammatical-evolution (CMA-ES)",
+    "ng_de": "Nevergrad grammatical-evolution (Differential Evolution)",
+    "ng_pso": "Nevergrad grammatical-evolution (PSO)",
     "tactics": "Tactic Search (Lean-style)",
     "lta": "Liquid Tree Automata",
     "symetric": "Metric Synthesis",
@@ -64,6 +69,14 @@ def make_synthesizer(module: str) -> Synthesizer:
             return GESynthesizer(seed=seed, method="one_plus_one")
         case "hc":
             return GESynthesizer(seed=seed, method="hill_climbing")
+        case "genomic_ng" | "ng":
+            return GenomicNGSynthesizer(optimizer="NGOpt", seed=seed)
+        case "ng_cma":
+            return GenomicNGSynthesizer(optimizer="CMA", seed=seed)
+        case "ng_de":
+            return GenomicNGSynthesizer(optimizer="DE", seed=seed)
+        case "ng_pso":
+            return GenomicNGSynthesizer(optimizer="PSO", seed=seed)
         case "synquid":
             return SynquidSynthesizer()
         case "llm":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ tests = [
     "pytest",
     "pytest-beartype"
 ]
+synthesis-ng = [
+    "nevergrad"
+]
 
 [project.urls]
 homepage = "https://github.com/alcides/aeon"

--- a/scripts/bench_genomic_ng.py
+++ b/scripts/bench_genomic_ng.py
@@ -1,0 +1,155 @@
+"""Benchmark GenomicNG (Nevergrad/NGOpt) against the GP backend.
+
+For each example we run both synthesizers with the same time budget and seed,
+recording every candidate the synthesizer evaluates through a SynthesisUI. We
+report:
+  - success: a valid completion was found
+  - best:    best (minimisation-oriented) objective sum among valid candidates
+             (0.0 for validate-only goals; lower is better)
+  - valid/total: how many evaluated candidates were valid
+
+Run: uv run python scripts/bench_genomic_ng.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.grammar.ge_synthesis import GESynthesizer
+from aeon.synthesis.grammar.genomic_ng import GenomicNGSynthesizer
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.uis.api import SynthesisUI
+from tests.driver import check_and_return_core
+
+setup_logger()
+
+BUDGET = 5.0
+SEEDS = [1, 2]
+EXAMPLES = [
+    "dummy",
+    "int",
+    "linear_equation",
+    "quadratic",
+    "system_equations",
+    "bank_deposit",
+    "coin",
+    "pizza",
+    "stock_profit",
+    "multiobjective",
+]
+ROOT = Path(__file__).resolve().parent.parent
+EX_DIR = ROOT / "examples" / "synthesis"
+
+
+class RecordingUI(SynthesisUI):
+    """Tracks best valid fitness and valid/total counts across a run."""
+
+    def __init__(self) -> None:
+        self.total = 0
+        self.valid = 0
+        self.best: float | None = None
+
+    def start(self, *a: Any, **k: Any) -> None:
+        pass
+
+    def register(self, solution: Any, quality: Any, elapsed_time: float, is_best: bool) -> None:
+        self.total += 1
+        comps = getattr(quality, "fitness_components", None)
+        is_valid = getattr(quality, "valid", True)
+        if not is_valid or comps is None:
+            return
+        self.valid += 1
+        score = float(sum(comps))
+        if self.best is None or score < self.best:
+            self.best = score
+
+    def end(self, *a: Any, **k: Any) -> None:
+        pass
+
+
+def run_one(source: str, make_synth: Any, seed: int) -> dict[str, Any]:
+    core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
+    incomplete = incomplete_functions_and_holes(ctx, core_ast_anf)
+    ui = RecordingUI()
+    t0 = time.monotonic()
+    mapping = synthesize_holes(
+        ctx, ectx, core_ast_anf, incomplete, metadata, synthesizer=make_synth(seed), budget=BUDGET, ui=ui
+    )
+    elapsed = time.monotonic() - t0
+    success = bool(mapping) and all(v is not None for v in mapping.values())
+    return {"success": success, "best": ui.best, "valid": ui.valid, "total": ui.total, "time": elapsed}
+
+
+def main() -> None:
+    backends = {
+        "gp": lambda seed: GESynthesizer(method="genetic_programming", seed=seed),
+        "ng(NGOpt)": lambda seed: GenomicNGSynthesizer(optimizer="NGOpt", seed=seed),
+    }
+
+    print(f"budget={BUDGET}s  seeds={SEEDS}\n")
+    header = f"{'example':<18} {'backend':<10} result"
+    print(header)
+    print("-" * len(header) + "-" * 20)
+
+    wins = {"gp": 0, "ng(NGOpt)": 0, "tie": 0}
+    for name in EXAMPLES:
+        src = (EX_DIR / f"{name}.ae").read_text()
+        agg: dict[str, dict[str, Any]] = {}
+        for bname, make in backends.items():
+            succ = 0
+            bests: list[float] = []
+            totals = 0
+            valids = 0
+            tsum = 0.0
+            for seed in SEEDS:
+                try:
+                    r = run_one(src, make, seed)
+                except Exception as e:  # noqa: BLE001 - benchmark should not abort on one cell
+                    print(f"{name:<18} {bname:<10} ERROR {type(e).__name__}: {e}")
+                    r = {"success": False, "best": None, "valid": 0, "total": 0, "time": 0.0}
+                succ += int(r["success"])
+                if r["best"] is not None:
+                    bests.append(r["best"])
+                totals += r["total"]
+                valids += r["valid"]
+                tsum += r["time"]
+            agg[bname] = {
+                "solved": succ,
+                "best": min(bests) if bests else None,
+                "valid": valids,
+                "total": totals,
+                "time": tsum / len(SEEDS),
+            }
+            ok = f"{succ}/{len(SEEDS)}"
+            best = "—" if agg[bname]["best"] is None else f"{agg[bname]['best']:.3g}"
+            print(
+                f"{name:<18} {bname:<10} solved={ok}  best={best:>8}  "
+                f"avg_time={agg[bname]['time']:.1f}s  (internal valid={valids}/{totals})"
+            )
+
+        # Winner: higher solve-rate; tie-break on average time, then objective.
+        g, n = agg["gp"], agg["ng(NGOpt)"]
+        if g["solved"] != n["solved"]:
+            winner = "gp" if g["solved"] > n["solved"] else "ng(NGOpt)"
+        elif g["solved"] == 0:
+            winner = "tie"  # neither solved
+        elif abs(g["time"] - n["time"]) > 0.2:
+            winner = "gp" if g["time"] < n["time"] else "ng(NGOpt)"
+        else:
+            winner = "tie"
+        wins[winner] += 1
+        print(f"{'':<18} {'-> winner':<10} {winner}\n")
+
+    print("=" * 40)
+    print(f"Wins: gp={wins['gp']}  ng(NGOpt)={wins['ng(NGOpt)']}  tie={wins['tie']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/genomic_ng_test.py
+++ b/tests/genomic_ng_test.py
@@ -1,0 +1,150 @@
+"""Unit tests for the GenomicNG (Nevergrad grammatical-evolution) synthesizer."""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.core.terms import Term
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.grammar.genomic_ng import (
+    GenomicNGSynthesizer,
+    _knee_point,
+    _orient,
+)
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+
+from tests.driver import check_and_return_core
+
+setup_logger()
+
+pytest.importorskip("nevergrad")
+
+
+# ---------------------------------------------------------------------------
+# _orient: re-orient fitness so every objective is minimised
+# ---------------------------------------------------------------------------
+
+
+def test_orient_minimize_unchanged():
+    assert _orient([3.0, -2.0], [True, True]) == [3.0, -2.0]
+
+
+def test_orient_maximize_negated():
+    assert _orient([3.0, -2.0], [False, False]) == [-3.0, 2.0]
+
+
+def test_orient_mixed():
+    assert _orient([3.0, 5.0], [True, False]) == [3.0, -5.0]
+
+
+# ---------------------------------------------------------------------------
+# _knee_point: compromise selection over an oriented-loss archive
+# ---------------------------------------------------------------------------
+
+
+def test_knee_point_empty_returns_none():
+    assert _knee_point([], [True]) is None
+
+
+def test_knee_point_single_returns_only():
+    term = object()
+    assert _knee_point([(term, [4.0])], [True]) is term
+
+
+def test_knee_point_single_objective_picks_lowest():
+    lo, hi = object(), object()
+    chosen = _knee_point([(hi, [9.0]), (lo, [1.0])], [True])
+    assert chosen is lo
+
+
+def test_knee_point_prefers_balanced_compromise():
+    # Two extreme points and one balanced one; the balanced candidate is the
+    # closest to the (normalised) utopia origin and should win.
+    a = object()  # extreme on objective 0
+    b = object()  # extreme on objective 1
+    knee = object()  # compromise
+    archive = [(a, [0.0, 10.0]), (b, [10.0, 0.0]), (knee, [2.0, 2.0])]
+    assert _knee_point(archive, [True, True]) is knee
+
+
+# ---------------------------------------------------------------------------
+# Factory routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,optimizer",
+    [
+        ("ng", "NGOpt"),
+        ("genomic_ng", "NGOpt"),
+        ("ng_cma", "CMA"),
+        ("ng_de", "DE"),
+        ("ng_pso", "PSO"),
+    ],
+)
+def test_factory_routes_to_genomic_ng(name, optimizer):
+    syn = make_synthesizer(name)
+    assert isinstance(syn, GenomicNGSynthesizer)
+    assert syn.optimizer == optimizer
+
+
+# ---------------------------------------------------------------------------
+# End-to-end synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_single_objective_synthesis_fills_hole():
+    source = """def year : Int := 2023;
+            @minimize_int( year - synth 7 )
+            def synth (i:Int) : Int := (?hole: Int) * i
+        """
+    core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
+    incomplete_functions = incomplete_functions_and_holes(ctx, core_ast_anf)
+    mapping = synthesize_holes(
+        ctx, ectx, core_ast_anf, incomplete_functions, metadata, synthesizer=GenomicNGSynthesizer(), budget=2.0
+    )
+    assert len(mapping) == 1
+    (term,) = mapping.values()
+    assert isinstance(term, Term)
+
+
+def test_multi_objective_synthesis_fills_hole():
+    # Two objectives and an unrefined return type: every well-typed candidate is
+    # valid, so the multi-objective knee-point selection path is exercised
+    # reliably (independent of search luck on a rare refinement).
+    source = """
+            def soft_a (n: Int) : Int := (n * n) - 5
+            def soft_b (n: Int) : Int := n + 4
+            @minimize_int(soft_a (func 10))
+            @minimize_int(soft_b (func 21))
+            def func (i:Int) : Int := ?hole
+        """
+    core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
+    incomplete_functions = incomplete_functions_and_holes(ctx, core_ast_anf)
+    mapping = synthesize_holes(
+        ctx, ectx, core_ast_anf, incomplete_functions, metadata, synthesizer=GenomicNGSynthesizer(), budget=3.0
+    )
+    assert len(mapping) == 1
+    (term,) = mapping.values()
+    assert isinstance(term, Term)
+
+
+def test_alternative_optimizer_runs():
+    source = """def year : Int := 2023;
+            @minimize_int( year - synth 7 )
+            def synth (i:Int) : Int := (?hole: Int) * i
+        """
+    core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
+    incomplete_functions = incomplete_functions_and_holes(ctx, core_ast_anf)
+    mapping = synthesize_holes(
+        ctx,
+        ectx,
+        core_ast_anf,
+        incomplete_functions,
+        metadata,
+        synthesizer=GenomicNGSynthesizer(optimizer="CMA"),
+        budget=2.0,
+    )
+    assert len(mapping) == 1


### PR DESCRIPTION
## Summary

Adds **GenomicNG**, a synthesis backend that drives Aeon's grammar-guided synthesis with [Nevergrad](https://github.com/facebookresearch/nevergrad) derivative-free optimizers.

A derivation is encoded as a **fixed-length integer codon genome** — exactly the representation geneticengine's `GrammaticalEvolutionRepresentation` already decodes. Nevergrad optimizes that integer vector; each genome is decoded into an Aeon `Term` by the existing GE mapper and scored by the existing `validate` + `@minimize` fitness. So the entire synthesis stack (grammar generation, phenotype decoding, fitness) is reused — only the *search strategy* changes.

### Flags
- `-s ng` / `-s genomic_ng` — NGOpt (Nevergrad's recommended meta-optimizer; default)
- `-s ng_cma`, `-s ng_de`, `-s ng_pso` — CMA-ES, Differential Evolution, PSO

All four route through one class differing only by optimizer name, so adding more is a one-line case.

### Behaviour
- Single- and multi-objective goals. Multi-objective resolves the Pareto archive by **knee-point compromise selection** (mirrors `GESynthesizer`).
- Robust to the ill-typed/un-evaluable candidates a black-box search constantly proposes: they are penalised, not fatal.
- **Early-stops** once `problem.is_solved` holds, instead of burning the rest of the budget.
- `nevergrad` is an optional `synthesis-ng` extra, imported lazily — the default install is unchanged.

### Tests
`tests/genomic_ng_test.py` (15 tests): objective re-orientation, knee-point selection, factory routing for all 5 flags, and end-to-end single/multi-objective + alternative-optimizer synthesis.

### Benchmark
`scripts/bench_genomic_ng.py` compares GenomicNG against GP. On a 10-example, validate-heavy suite **GP wins decisively** (8/10 solved vs 4/10) — the expected result, since grammar-guided tree search beats flat-vector black-box optimization for finding *valid typed programs*, especially on validate-only goals with no fitness gradient. GenomicNG's value is on problems with a strong continuous objective and high valid-candidate density.

## Test plan
- [x] `uv run pytest tests/genomic_ng_test.py` — 15 passed
- [x] `uvx ruff check` clean; pre-commit (incl. mypy) passes
- [x] End-to-end runs on `examples/synthesis/{dummy,multiobjective}.ae` with `-s ng` and `-s ng_cma`

🤖 Generated with [Claude Code](https://claude.com/claude-code)