### PR TITLE
feat(synthesis): relational/k-safety `@property` as a co-synthesis oracle (#397)

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -113,6 +113,7 @@ def _parse_common_arguments(parser: ArgumentParser):
             "fta (Finite Tree Automata, OOPSLA'17), "
             "afta (abstraction-refinement FTA, POPL'18), "
             "cata (constraint-annotated tree automata, recursive/relational), "
+            "contata (cata version space, synthesises from @example I/O facts), "
             "symetric / xfta (metric program synthesis, arXiv:2206.06164)"
         ),
     )

--- a/aeon/backend/evaluator.py
+++ b/aeon/backend/evaluator.py
@@ -26,9 +26,14 @@ class EvaluationContext:
     pipeline: LLVMPipeline | None
     # Optional call-trace sink (instrumented semantics, Fig. 4 of the Contata
     # paper). When non-None, every ``Rec``-bound function call records a
-    # ``(name, args, result)`` fact here, so a synthesized candidate's behaviour
-    # can be observed and blamed. ``None`` (the default) means zero overhead.
+    # ``[name, args, result, parent_index]`` entry here, so a synthesized
+    # candidate's behaviour can be observed and its call tree reconstructed (the
+    # ``parent_index`` distinguishes a real callee from an unrelated call, e.g.
+    # an eagerly-evaluated ``@example`` binding). ``None`` ⇒ zero overhead.
+    # ``trace_stack`` holds the indices of the calls currently on the stack and
+    # is shared (by reference) with ``trace`` across ``with_var``.
     trace: list | None
+    trace_stack: list | None
 
     def __init__(
         self,
@@ -36,6 +41,7 @@ class EvaluationContext:
         metadata: Metadata | None = None,
         pipeline: LLVMPipeline | None = None,
         trace: list | None = None,
+        trace_stack: list | None = None,
     ):
         if prev:
             self.variables = {k: v for (k, v) in prev.items()}
@@ -44,12 +50,15 @@ class EvaluationContext:
         self.metadata = metadata
         self.pipeline = pipeline
         self.trace = trace
+        self.trace_stack = trace_stack
 
     def with_var(self, name: Name, value: Any):
         assert isinstance(name, Name)
         v = self.variables.copy()
         v.update({name: value})
-        return EvaluationContext(v, metadata=self.metadata, pipeline=self.pipeline, trace=self.trace)
+        return EvaluationContext(
+            v, metadata=self.metadata, pipeline=self.pipeline, trace=self.trace, trace_stack=self.trace_stack
+        )
 
     def get(self, name: Name):
         return self.variables[name]
@@ -117,7 +126,13 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                 cur = cur.body
             final_body = cur
 
-            group_ctx = EvaluationContext(ctx.variables, metadata=ctx.metadata, pipeline=ctx.pipeline, trace=ctx.trace)
+            group_ctx = EvaluationContext(
+                ctx.variables,
+                metadata=ctx.metadata,
+                pipeline=ctx.pipeline,
+                trace=ctx.trace,
+                trace_stack=ctx.trace_stack,
+            )
             for m in members:
                 inner_value = m.var_value
                 while isinstance(inner_value, (TypeAbstraction, RefinementAbstraction)):
@@ -126,9 +141,18 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
 
                     def make_closure(fun: Abstraction, fname: Name):
                         def v(x):
-                            result = eval(fun.body, group_ctx.with_var(fun.var_name, x))
-                            if group_ctx.trace is not None and not callable(result):
-                                group_ctx.trace.append((fname, (x,), result))
+                            tr = group_ctx.trace
+                            if tr is None:
+                                return eval(fun.body, group_ctx.with_var(fun.var_name, x))
+                            st = group_ctx.trace_stack
+                            idx = len(tr)
+                            tr.append([fname, (x,), None, st[-1] if st else -1])
+                            st.append(idx)
+                            try:
+                                result = eval(fun.body, group_ctx.with_var(fun.var_name, x))
+                            finally:
+                                st.pop()
+                            tr[idx][2] = result
                             return result
 
                         return v
@@ -169,10 +193,20 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                 fun = inner_value
 
                 def v(x):
-                    return eval(
-                        fun.body,
-                        ctx.with_var(var_name, v).with_var(fun.var_name, x),
-                    )
+                    rec_ctx = ctx.with_var(var_name, v).with_var(fun.var_name, x)
+                    tr = ctx.trace
+                    if tr is None:
+                        return eval(fun.body, rec_ctx)
+                    st = ctx.trace_stack
+                    idx = len(tr)
+                    tr.append([var_name, (x,), None, st[-1] if st else -1])
+                    st.append(idx)
+                    try:
+                        result = eval(fun.body, rec_ctx)
+                    finally:
+                        st.pop()
+                    tr[idx][2] = result
+                    return result
 
             else:
                 # General recursion for non-lambda values (e.g. instance
@@ -215,10 +249,12 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
 
 def eval_with_trace(t: Term, ctx: EvaluationContext = EvaluationContext()) -> tuple[Any, list]:
     """Instrumented evaluation (Contata, Fig. 4): evaluate ``t`` and return
-    ``(value, trace)`` where ``trace`` is the list of ``(name, args, result)``
-    facts for every ``Rec``-bound function call made during evaluation. Used by
-    co-synthesis to observe a candidate's behaviour and blame failing inputs."""
+    ``(value, trace)`` where ``trace`` is the list of ``[name, args, result,
+    parent_index]`` entries for every ``Rec``-bound function call made during
+    evaluation (``parent_index`` is the trace index of the enclosing call, or
+    ``-1`` for a top-level call). Used by co-synthesis to observe a candidate's
+    behaviour, reconstruct its call tree, and blame failing inputs."""
     sink: list = []
-    traced = EvaluationContext(ctx.variables, metadata=ctx.metadata, pipeline=ctx.pipeline, trace=sink)
+    traced = EvaluationContext(ctx.variables, metadata=ctx.metadata, pipeline=ctx.pipeline, trace=sink, trace_stack=[])
     value = eval(t, traced)
     return value, sink

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -196,6 +196,7 @@ class AeonDriver:
             synthesizer,
             self.cfg.synthesis_budget,
             ui,
+            constructor_names=self.constructor_names,
         )
 
         synthesized_core: Term = self.core

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -250,8 +250,8 @@ expression_b : "fun" ID _FATARROW expression                     -> abstraction_
 // application.
 %declare METHOD_DOT
 
-application_t : application_t TYPE_LBRACKET type "]"          -> type_application_e
-              | application_t "{" expression "}"              -> refinement_application_e
+application_t : application_t "{" type "}"                    -> type_application_e
+              | application_t _REFOPEN expression _REFCLOSE   -> refinement_application_e
               | method_recv                                  -> same
               | DOT_ID                                       -> anon_constructor
 
@@ -279,9 +279,8 @@ non_dot_simple : "(" expression ")"                          -> same
         | "?" ID                                             -> hole
         // Lean-style collection literals. ``[1, 2, 3]`` desugars to
         // ``List.cons``/``List.nil`` and ``#[1, 2, 3]`` to ``Array.new``/
-        // ``Array.append`` (element types are inferred). A *spaced* ``[`` is a
-        // list literal; an *attached* one (``f[Int]``) is a type application —
-        // disambiguated by the postlexer, Lean-style.
+        // ``Array.append`` (element types are inferred). ``[`` is unambiguously a
+        // list literal — type application uses ``{t}`` (e.g. ``List.nil{Int}``).
         | "[" list_items "]"                                 -> list_literal
         | "#[" list_items "]"                                -> array_literal
 
@@ -323,6 +322,12 @@ ID.0 : CNAME | /\([\+=\>\<!\*\-&\|\$]{1,3}\)/
 _PIPE.10 : "where" | "|"
 _DOUBLEPIPE.11 : "||"
 
+// Refinement-application brackets ``{| pred |}`` (supplying an abstract
+// refinement). Priority above ``_PIPE`` so ``{|``/``|}`` lex as one token rather
+// than ``{``/``}`` + ``|``; filtered (leading ``_``) so they stay out of the tree.
+_REFOPEN.20 : "{|"
+_REFCLOSE.20 : "|}"
+
 // Operators accept a Lean-style Unicode spelling in addition to their ASCII
 // form. These terminals are filtered (leading ``_``) so the parse-tree shape is
 // identical whichever spelling is used — ``a ≤ b`` and ``a <= b`` desugar to the
@@ -336,12 +341,6 @@ _FATARROW : "=>" | "⇒" | "↦"
 _NEQ : "!=" | "≠"
 _LE : "<=" | "≤"
 _GE : ">=" | "≥"
-
-// ``TYPE_LBRACKET`` has no pattern: it is produced by ``MethodDotPostLex`` from
-// an ``[`` that is *attached* to a receiver (``f[Int]``), marking a type
-// application. A spaced/standalone ``[`` stays ``LSQB`` (a list literal, or the
-// ``decreasing_by``/instance brackets, which are always spaced).
-%declare TYPE_LBRACKET
 
 // A comment runs ``#`` to end of line — but ``#[`` opens an Array literal, so a
 // ``#`` immediately followed by ``[`` is not a comment.

--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -250,7 +250,7 @@ expression_b : "fun" ID _FATARROW expression                     -> abstraction_
 // application.
 %declare METHOD_DOT
 
-application_t : application_t "[" type "]"                    -> type_application_e
+application_t : application_t TYPE_LBRACKET type "]"          -> type_application_e
               | application_t "{" expression "}"              -> refinement_application_e
               | method_recv                                  -> same
               | DOT_ID                                       -> anon_constructor
@@ -277,6 +277,16 @@ non_dot_simple : "(" expression ")"                          -> same
         | QUALIFIED_ID                                       -> qualified_var
         | ID                                                 -> var
         | "?" ID                                             -> hole
+        // Lean-style collection literals. ``[1, 2, 3]`` desugars to
+        // ``List.cons``/``List.nil`` and ``#[1, 2, 3]`` to ``Array.new``/
+        // ``Array.append`` (element types are inferred). A *spaced* ``[`` is a
+        // list literal; an *attached* one (``f[Int]``) is a type application —
+        // disambiguated by the postlexer, Lean-style.
+        | "[" list_items "]"                                 -> list_literal
+        | "#[" list_items "]"                                -> array_literal
+
+list_items :                                                 -> empty_list
+           | expression ("," expression)*                    -> list
 
 
 kind : "B" -> base_kind
@@ -327,7 +337,15 @@ _NEQ : "!=" | "≠"
 _LE : "<=" | "≤"
 _GE : ">=" | "≥"
 
-COMMENT: /\s*/ "#" /[^\n]/*
+// ``TYPE_LBRACKET`` has no pattern: it is produced by ``MethodDotPostLex`` from
+// an ``[`` that is *attached* to a receiver (``f[Int]``), marking a type
+// application. A spaced/standalone ``[`` stays ``LSQB`` (a list literal, or the
+// ``decreasing_by``/instance brackets, which are always spaced).
+%declare TYPE_LBRACKET
+
+// A comment runs ``#`` to end of line — but ``#[`` opens an Array literal, so a
+// ``#`` immediately followed by ``[`` is not a comment.
+COMMENT: /\s*#(?!\[)[^\n]*/
 
 %import common.ESCAPED_STRING
 %import common.WS

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -1915,14 +1915,24 @@ def apply_decorators_in_program(prog: Program) -> Program:
 
 def apply_decorators_in_definitions(definitions: list[Definition]) -> tuple[list[Definition], Metadata]:
     """We apply the decorators meta-programming code to each definition in the
-    program."""
+    program.
+
+    Decorator-generated helper bindings (``@example``/``@property``/fitness
+    helpers) are collected and appended *after* all primary definitions rather
+    than interleaved right after their owner. Interleaving would split a
+    ``mutual`` group — e.g. an ``@example`` on ``even`` inserts a helper between
+    ``even`` and ``odd`` — and the evaluator ties a mutual group's recursive knot
+    only over the contiguous run of members. Helpers are nullary and only
+    *reference* the primary definitions, so placing them last keeps them in scope
+    while preserving member contiguity."""
     metadata: Metadata = {}
-    new_definitions = []
+    primary: list[Definition] = []
+    helpers: list[Definition] = []
     for definition in definitions:
         new_def, other_defs, metadata = apply_decorators(definition, metadata)
-        new_definitions.append(new_def)
-        new_definitions.extend(other_defs)
-    return new_definitions, metadata
+        primary.append(new_def)
+        helpers.extend(other_defs)
+    return primary + helpers, metadata
 
 
 def update_program_and_context(

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -98,7 +98,8 @@ def _split_arg_multiplicities(fn_args):
 _RECEIVER_END_TOKENS = frozenset(
     {
         "RPAR",  # (e).m
-        "RSQB",  # [1,2,3].m  (list/array literal) and f[A][B] (chained type app)
+        "RSQB",  # [1,2,3].m  (list/array literal)
+        "RBRACE",  # f{Int}.m  (closing a type application)
         "INTLIT",  # 1.m
         "FLOATLIT",  # 1.5.m
         "BOOLLIT",
@@ -111,37 +112,32 @@ _RECEIVER_END_TOKENS = frozenset(
 
 
 class MethodDotPostLex(PostLex):
-    """Whitespace-driven token disambiguation, mirroring Lean (issue #27).
+    """Distinguish a method/projection dot from an anonymous-constructor dot by
+    whitespace, mirroring Lean (issue #27).
 
-    * A ``DOT_ID`` (``.name``) *attached* to the previous token — no whitespace,
-      and that token can end a receiver — is retagged ``METHOD_DOT`` and binds
-      tighter than application (``f 1.toString`` ≡ ``f (1.toString)``). A leading
-      or space-separated ``.name`` stays a ``DOT_ID`` anonymous constructor.
-    * An ``[`` (``LSQB``) *attached* to a receiver-ending token is retagged
-      ``TYPE_LBRACKET`` — a type application (``f[Int]``, ``List.nil[Int]``). A
-      spaced/standalone ``[`` stays ``LSQB``: a list literal (``f [1, 2, 3]``),
-      or the ``decreasing_by``/instance brackets (always spaced)."""
+    A ``DOT_ID`` (``.name``) that is *attached* to the previous token — no
+    whitespace, and that token can end a receiver — is retagged ``METHOD_DOT``
+    and binds tighter than application (``f 1.toString`` ≡ ``f (1.toString)``).
+    A leading or space-separated ``.name`` stays a ``DOT_ID`` anonymous
+    constructor (``.mk .sc_blue 40``)."""
 
-    # Ensure the contextual LALR lexer always offers ``DOT_ID`` / ``LSQB`` (the
-    # retagged ``METHOD_DOT`` / ``TYPE_LBRACKET`` have no pattern; they are
-    # produced only here), so an attached dot/bracket is lexable in states that
-    # expect the retagged token.
-    always_accept = ("DOT_ID", "LSQB")
+    # Ensure the contextual LALR lexer always offers ``DOT_ID`` (``METHOD_DOT``
+    # has no pattern; it is produced only here), so attached dots are lexable in
+    # states that expect a method dot.
+    always_accept = ("DOT_ID",)
 
     def process(self, stream):
         prev: Token | None = None
         for tok in stream:
-            attached = (
-                prev is not None
+            if (
+                tok.type == "DOT_ID"
+                and prev is not None
                 and prev.type in _RECEIVER_END_TOKENS
                 and prev.end_pos is not None
                 and tok.start_pos is not None
                 and prev.end_pos == tok.start_pos
-            )
-            if attached and tok.type == "DOT_ID":
+            ):
                 tok.type = "METHOD_DOT"
-            elif attached and tok.type == "LSQB":
-                tok.type = "TYPE_LBRACKET"
             prev = tok
             yield tok
 
@@ -432,8 +428,8 @@ class TreeToSugar(Transformer):
 
     @v_args(meta=True)
     def type_application_e(self, meta, args):
-        # ``args`` is ``[receiver, TYPE_LBRACKET?, type]``; the retagged bracket
-        # token may be kept, so take the receiver and the (last) type.
+        # ``receiver {type}`` — the ``{``/``}`` are filtered, so ``args`` is
+        # ``[receiver, type]``.
         return STypeApplication(args[0], args[-1], loc=self._loc(meta))
 
     @v_args(meta=True)

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -98,6 +98,7 @@ def _split_arg_multiplicities(fn_args):
 _RECEIVER_END_TOKENS = frozenset(
     {
         "RPAR",  # (e).m
+        "RSQB",  # [1,2,3].m  (list/array literal) and f[A][B] (chained type app)
         "INTLIT",  # 1.m
         "FLOATLIT",  # 1.5.m
         "BOOLLIT",
@@ -110,32 +111,37 @@ _RECEIVER_END_TOKENS = frozenset(
 
 
 class MethodDotPostLex(PostLex):
-    """Distinguish a method/projection dot from an anonymous-constructor dot by
-    whitespace, mirroring Lean (issue #27).
+    """Whitespace-driven token disambiguation, mirroring Lean (issue #27).
 
-    A ``DOT_ID`` (``.name``) that is *attached* to the previous token — no
-    whitespace, and that token can end a receiver — is retagged ``METHOD_DOT``
-    and binds tighter than application (``f 1.toString`` ≡ ``f (1.toString)``).
-    A leading or space-separated ``.name`` stays a ``DOT_ID`` anonymous
-    constructor (``.mk .sc_blue 40``)."""
+    * A ``DOT_ID`` (``.name``) *attached* to the previous token — no whitespace,
+      and that token can end a receiver — is retagged ``METHOD_DOT`` and binds
+      tighter than application (``f 1.toString`` ≡ ``f (1.toString)``). A leading
+      or space-separated ``.name`` stays a ``DOT_ID`` anonymous constructor.
+    * An ``[`` (``LSQB``) *attached* to a receiver-ending token is retagged
+      ``TYPE_LBRACKET`` — a type application (``f[Int]``, ``List.nil[Int]``). A
+      spaced/standalone ``[`` stays ``LSQB``: a list literal (``f [1, 2, 3]``),
+      or the ``decreasing_by``/instance brackets (always spaced)."""
 
-    # Ensure the contextual LALR lexer always offers ``DOT_ID`` (``METHOD_DOT``
-    # has no pattern; it is produced only here), so attached dots are lexable in
-    # states that expect a method dot.
-    always_accept = ("DOT_ID",)
+    # Ensure the contextual LALR lexer always offers ``DOT_ID`` / ``LSQB`` (the
+    # retagged ``METHOD_DOT`` / ``TYPE_LBRACKET`` have no pattern; they are
+    # produced only here), so an attached dot/bracket is lexable in states that
+    # expect the retagged token.
+    always_accept = ("DOT_ID", "LSQB")
 
     def process(self, stream):
         prev: Token | None = None
         for tok in stream:
-            if (
-                tok.type == "DOT_ID"
-                and prev is not None
+            attached = (
+                prev is not None
                 and prev.type in _RECEIVER_END_TOKENS
                 and prev.end_pos is not None
                 and tok.start_pos is not None
                 and prev.end_pos == tok.start_pos
-            ):
+            )
+            if attached and tok.type == "DOT_ID":
                 tok.type = "METHOD_DOT"
+            elif attached and tok.type == "LSQB":
+                tok.type = "TYPE_LBRACKET"
             prev = tok
             yield tok
 
@@ -426,7 +432,33 @@ class TreeToSugar(Transformer):
 
     @v_args(meta=True)
     def type_application_e(self, meta, args):
-        return STypeApplication(args[0], args[1], loc=self._loc(meta))
+        # ``args`` is ``[receiver, TYPE_LBRACKET?, type]``; the retagged bracket
+        # token may be kept, so take the receiver and the (last) type.
+        return STypeApplication(args[0], args[-1], loc=self._loc(meta))
+
+    @v_args(meta=True)
+    def list_literal(self, meta, args):
+        # ``[e1, ..., en]`` => ``List.cons e1 (... (List.cons en List.nil))``.
+        # Element type (and abstract refinement) are inferred by elaboration.
+        loc = self._loc(meta)
+        items = args[0] if args else []
+        result: STerm = SQualifiedVar("List", Name("nil"), loc=loc)
+        for e in reversed(items):
+            cons = SQualifiedVar("List", Name("cons"), loc=loc)
+            result = SApplication(SApplication(cons, e, loc=loc), result, loc=loc)
+        return result
+
+    @v_args(meta=True)
+    def array_literal(self, meta, args):
+        # ``#[e1, ..., en]`` => ``Array.append (... (Array.append Array.new e1)) en``
+        # (left fold, so element order is preserved).
+        loc = self._loc(meta)
+        items = args[0] if args else []
+        result: STerm = SQualifiedVar("Array", Name("new"), loc=loc)
+        for e in items:
+            app = SQualifiedVar("Array", Name("append"), loc=loc)
+            result = SApplication(SApplication(app, result, loc=loc), e, loc=loc)
+        return result
 
     @v_args(meta=True)
     def refinement_application_e(self, meta, args):

--- a/aeon/sugar/program.py
+++ b/aeon/sugar/program.py
@@ -385,7 +385,7 @@ class STypeApplication(STerm):
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __str__(self):
-        return f"({self.body})[{self.type}]"
+        return f"({self.body}){{{self.type}}}"
 
 
 @dataclass(frozen=True)
@@ -395,7 +395,7 @@ class SRefinementApplication(STerm):
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __str__(self):
-        return f"({self.body})[{self.refinement}]"
+        return f"({self.body}){{|{self.refinement}|}}"
 
 
 class Node:

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -527,24 +527,36 @@ def _partition_targets(
 
 
 def _joint_accepts(
-    ctx: TypingContext, ectx: EvaluationContext, term: Term, fills: dict[Name, Term], metadata: Metadata
+    ctx: TypingContext,
+    ectx: EvaluationContext,
+    term: Term,
+    fills: dict[Name, Term],
+    metadata: Metadata,
+    constructor_names: set[str] | None = None,
 ) -> bool:
     """Contata Algorithm 2, lines 11-13: does the *joint* candidate assignment
-    satisfy the spec? Fill every group hole, then (a) the whole program type
-    checks (the relational/refinement oracle), and (b) any ``@example``
-    assertions on the group's members all pass (the executable oracle)."""
+    satisfy the spec? Fill every group hole, then require:
+    (a) the whole program type checks (the relational/refinement oracle);
+    (b) any ``@example`` assertions on the group's members all pass; and
+    (c) any ``@property`` assertions hold under property-based testing — these
+        are the **relational / k-safety** specifications over *several* functions
+        or *several runs* of one function (e.g. ``even x == !(odd x)`` or
+        ``reverse (reverse x) == x``) that cannot be a single function's
+        refinement type (issue #397)."""
     filled = term
     for hole_name, cand in fills.items():
         filled = substitution(filled, cand, hole_name)
     if not check_type(ctx, filled, Top()):
         return False
-    from aeon.synthesis.pbt.runner import run_examples
+    from aeon.synthesis.pbt.runner import run_examples, run_properties
 
     try:
-        results = run_examples(ectx, filled, metadata)
+        if not all(r.passed for r in run_examples(ectx, filled, metadata)):
+            return False
+        prop_results = run_properties(ctx, ectx, filled, metadata, constructor_names=constructor_names or set())
     except Exception:
         return False
-    return all(r.passed for r in results)
+    return all(r.passed for r in prop_results)
 
 
 def _refine_obligations(
@@ -638,6 +650,7 @@ def _cosynthesize_group(
     ui: SynthesisUI,
     budget_eval: float,
     rounds: int = 3,
+    constructor_names: set[str] | None = None,
 ) -> dict[Name, Optional[Term]]:
     """Co-synthesize a mutual group, following Contata's lazy synthesis
     (Algorithm 2): each round pops a candidate for *every* member (with its
@@ -679,7 +692,9 @@ def _cosynthesize_group(
         # (no stubs left), and the joint assignment satisfies the spec.
         if synthesised == {h for _, h in members}:
             chosen = {h: fills[h] for _, h in members}
-            if all(c is not None for c in chosen.values()) and _joint_accepts(ctx, ectx, term, chosen, metadata):
+            if all(c is not None for c in chosen.values()) and _joint_accepts(
+                ctx, ectx, term, chosen, metadata, constructor_names
+            ):
                 return dict(fills)
         # Refinement phase (Algorithm 2, lines 11-16): blame the failing examples'
         # tail-callees and grow their per-function obligations, so the next round
@@ -704,12 +719,15 @@ def synthesize_holes(
     budget: float = 60.0,
     ui: SynthesisUI = SynthesisUI(),
     budget_eval: Optional[float] = None,
+    constructor_names: set[str] | None = None,
 ) -> dict[Name, Optional[Term]]:
     """Synthesizes code for multiple functions, each with one hole.
 
     Independent functions are synthesised one at a time. Members of a Lean
     ``mutual ... end`` block are co-synthesised together (Contata's relational
-    recursive synthesis), so a candidate for one member may call its siblings."""
+    recursive synthesis), so a candidate for one member may call its siblings.
+    ``constructor_names`` (data-constructor names) is forwarded to the
+    ``@property`` runner used as a relational/k-safety acceptance oracle."""
 
     if budget_eval is None:
         budget_eval = max(budget / 1000, 1)
@@ -733,7 +751,19 @@ def synthesize_holes(
         for fun_name, holes_names in group:
             assert len(holes_names) == 1, "Currently, we only support 1 hole per function"
         mapping.update(
-            _cosynthesize_group(ctx, ectx, term, group, program_holes, metadata, synthesizer, budget, ui, budget_eval)
+            _cosynthesize_group(
+                ctx,
+                ectx,
+                term,
+                group,
+                program_holes,
+                metadata,
+                synthesizer,
+                budget,
+                ui,
+                budget_eval,
+                constructor_names=constructor_names,
+            )
         )
 
     return mapping

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -881,6 +881,38 @@ def _refine_obligations(
     return added
 
 
+def _contata_version_space_group(
+    members: list[tuple[Name, Name]],
+    program_holes: dict[Name, tuple[Type, TypingContext]],
+    metadata: Metadata,
+    synthesizer: Synthesizer,
+) -> Optional[dict[Name, Optional[Term]]]:
+    """Try the ``contata`` version space over the whole mutual group, returning a
+    ``{hole_name: body}`` assignment or ``None`` (wrong backend, unsupported
+    member, or no solution). Pure synthesis — the caller still gates on
+    :func:`_joint_accepts`."""
+    from aeon.synthesis.modules.contata.synthesizer import (
+        ContataSynthesizer,
+        GroupMember,
+        cosynthesize_group,
+    )
+
+    if not isinstance(synthesizer, ContataSynthesizer):
+        return None
+    gms: list[GroupMember] = []
+    hole_of: dict[Name, Name] = {}
+    for fun_name, hole_name in members:
+        ty, tyctx = program_holes[hole_name]
+        if not isinstance(tyctx, TypingContext):
+            return None
+        gms.append(GroupMember(fun_name, ty, tyctx, metadata.get(fun_name, {})))
+        hole_of[fun_name] = hole_name
+    bodies = cosynthesize_group(gms, gms[0].hole_ctx, max_size=synthesizer.max_size)
+    if bodies is None:
+        return None
+    return {hole_of[fn]: body for fn, body in bodies.items()}
+
+
 def _cosynthesize_group(
     ctx: TypingContext,
     ectx: EvaluationContext,
@@ -906,6 +938,17 @@ def _cosynthesize_group(
     their concrete behaviour, so a failing joint check drives the next round
     toward a consistent assignment."""
     members = [(fun_name, holes[0]) for fun_name, holes in group]
+
+    # Fast path: the genuine CATA version space. When the backend is ``contata``
+    # and every member is a unary Int/Bool function with @example facts, discharge
+    # the *whole group* in one SMT query — a member's body may call its siblings
+    # (uninterpreted functions), so the assignment is mutually consistent by
+    # construction. This converges on the MR flagship (even/odd from examples)
+    # that the per-member sibling-as-typed-oracle loop below cannot.
+    vs = _contata_version_space_group(members, program_holes, metadata, synthesizer)
+    if vs is not None and _joint_accepts(ctx, ectx, term, vs, metadata, constructor_names):
+        return vs
+
     # Initialise each sibling to a trivial stub (the executable analog of the
     # accept-all CATA): keeps example evaluation total during the first round.
     fills: dict[Name, Optional[Term]] = {h: _trivial_stub(program_holes[h][0]) for _, h in members}

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -15,7 +15,19 @@ from aeon.core.substitutions import substitution
 
 import dataclasses
 
-from aeon.core.terms import Application, Let, Literal, Rec, Term, Var
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    If,
+    Let,
+    Literal,
+    Rec,
+    RefinementApplication,
+    Term,
+    TypeApplication,
+    Var,
+)
 from aeon.core.types import Top
 from aeon.core.types import top, Type
 from aeon.decorators import Metadata
@@ -373,6 +385,7 @@ def _smt_unsat_core_obligations(
     observed_facts: list[tuple[Name, tuple, Any]],
     symbolic_eqs: list[tuple[tuple[Name, tuple], tuple[Name, tuple]]],
     member_names: set[str],
+    relational: list | None = None,
 ) -> list[tuple[Name, tuple, Any]]:
     """Contata's joint validity check + unsat-core refinement (Algorithm 2,
     lines 11-16), discharged by z3.
@@ -380,13 +393,16 @@ def _smt_unsat_core_obligations(
     The functions under synthesis are modelled as **uninterpreted functions**.
     We assert (with tracking literals) the ground spec ``ψ`` (``spec_facts``),
     the candidate's observed calls ``θ`` on inputs *not* pinned by the spec
-    (``observed_facts``), and the symbolic relations the candidate's structure
-    induces between calls (``symbolic_eqs``, e.g. ``even(2) = odd(1)``). If
-    ``ψ ∧ θ ∧ structure`` is satisfiable the joint candidate is consistent
-    (no refinement). Otherwise z3's **unsat core** names the conflicting calls;
-    for each blamed call to a function under synthesis we read its
-    spec-consistent output from a model of ``ψ ∧ structure`` and return it as a
-    new obligation — the constraint to add to that callee's next-round search."""
+    (``observed_facts``), the symbolic relations the candidate's structure
+    induces between calls (``symbolic_eqs``, e.g. ``even(2) = odd(1)``), and any
+    ``relational`` constraints — a **relational/k-safety ``@property`` evaluated
+    at a counterexample**, encoded as a small IR over the same uninterpreted
+    functions (e.g. ``even(2) = !odd(2)``). If the conjunction is satisfiable the
+    joint candidate is consistent (no refinement). Otherwise z3's **unsat core**
+    names the conflicting calls; for each blamed call to a function under
+    synthesis we read its spec-consistent output from a model of
+    ``ψ ∧ structure ∧ relational`` and return it as a new obligation — the
+    constraint to add to that callee's next-round search."""
     import z3
 
     val_sort = z3.DeclareSort("Val")
@@ -408,6 +424,31 @@ def _smt_unsat_core_obligations(
 
     for fname, args, out in list(spec_facts) + list(observed_facts):
         func_of(fname, args, out)
+
+    def ir_to_z3(ir):
+        """Translate a relational-property IR node into a z3 expression over the
+        (already-declared) uninterpreted functions. Raises on an undeclared
+        function or unsupported node, so the caller can skip that constraint."""
+        tag = ir[0]
+        if tag == "val":
+            return _z3_value(ir[1], val_sort, consts, rev)
+        if tag == "app":
+            return funcs[ir[1]](*[_z3_value(a, val_sort, consts, rev) for a in ir[2]])
+        if tag == "not":
+            return z3.Not(ir_to_z3(ir[1]))
+        if tag == "bin":
+            op, a, b = ir[1], ir_to_z3(ir[2]), ir_to_z3(ir[3])
+            return {
+                "==": lambda: a == b,
+                "!=": lambda: a != b,
+                "&&": lambda: z3.And(a, b),
+                "||": lambda: z3.Or(a, b),
+                "<": lambda: a < b,
+                "<=": lambda: a <= b,
+                ">": lambda: a > b,
+                ">=": lambda: a >= b,
+            }[op]()
+        raise ValueError(f"unsupported relational IR: {ir}")
 
     pinned = {(f.name, args) for f, args, _ in spec_facts}
 
@@ -432,6 +473,14 @@ def _smt_unsat_core_obligations(
     for (f, fa), (g, ga) in symbolic_eqs:
         if f.name in funcs and g.name in funcs:
             track(app(f, fa) == app(g, ga), ("sym", f, fa, g, ga))
+    rel_z3: list = []
+    for ir in relational or []:
+        try:
+            rel_z3.append(ir_to_z3(ir))
+        except Exception:
+            pass  # references an undeclared function / unsupported shape: skip
+    for i, rz in enumerate(rel_z3):
+        track(rz, ("rel", i))
 
     if solver.check() != z3.unsat:
         return []  # consistent (or unknown): nothing to refine
@@ -441,13 +490,18 @@ def _smt_unsat_core_obligations(
     if not blamed:
         return []
 
-    # Read the spec-consistent intended outputs from a model of ψ ∧ structure.
+    # Read the spec-consistent intended outputs from a model of
+    # ψ ∧ structure ∧ relational (the relational property is part of the
+    # intended spec, so the model must satisfy it — that is what pins a blamed
+    # callee's output, e.g. ``odd(1) = true`` from ``even(1) = !odd(1)``).
     model_solver = z3.Solver()
     for fname, args, out in spec_facts:
         model_solver.add(app(fname, args) == _z3_value(out, val_sort, consts, rev))
     for (f, fa), (g, ga) in symbolic_eqs:
         if f.name in funcs and g.name in funcs:
             model_solver.add(app(f, fa) == app(g, ga))
+    for rz in rel_z3:
+        model_solver.add(rz)
     if model_solver.check() != z3.sat:
         return []
     model = model_solver.model()
@@ -559,21 +613,203 @@ def _joint_accepts(
     return all(r.passed for r in prop_results)
 
 
+def _accumulate_trace(
+    trace: list,
+    observed: list,
+    symbolic: list,
+    seen_obs: set,
+    seen_sym: set,
+) -> None:
+    """Fold an instrumented call trace into the observed-fact set ``θ`` and the
+    symbolic tail-edges, using the recorded call-tree parents.
+
+    Each entry is ``[name, args, result, parent_index]``. A call whose result
+    equals its parent's was the parent's *tail call* (e.g. ``even(2) = odd(1)``),
+    so we add the edge ``parent = child`` — and *only* genuine parent/child
+    pairs, so unrelated calls that merely share a value (e.g. an eagerly
+    evaluated ``@example`` binding) never forge a spurious edge that would
+    over-constrain the SMT model. Calls whose result is still a function
+    (multi-argument partial applications) are skipped."""
+    for entry in trace:
+        nm, a, res = entry[0], entry[1], entry[2]
+        if callable(res):
+            continue
+        k = (nm.name, repr(a), repr(res))
+        if k not in seen_obs:
+            seen_obs.add(k)
+            observed.append((nm, a, res))
+    for i, entry in enumerate(trace):
+        p = entry[3]
+        if p < 0:
+            continue
+        nm_i, a_i, res_i = entry[0], entry[1], entry[2]
+        nm_p, a_p, res_p = trace[p][0], trace[p][1], trace[p][2]
+        if callable(res_i) or callable(res_p):
+            continue
+        if res_p == res_i and (nm_p.name, repr(a_p)) != (nm_i.name, repr(a_i)):
+            key = (nm_p.name, repr(a_p), nm_i.name, repr(a_i))
+            if key not in seen_sym:
+                seen_sym.add(key)
+                symbolic.append(((nm_p, a_p), (nm_i, a_i)))
+
+
+def _contains_member(t: Term, names: set[str]) -> bool:
+    """Does ``t`` mention any function under synthesis?"""
+    match t:
+        case Var(nm):
+            return nm.name in names
+        case Application(fun, arg):
+            return _contains_member(fun, names) or _contains_member(arg, names)
+        case Annotation(expr, _):
+            return _contains_member(expr, names)
+        case If(c, th, el):
+            return _contains_member(c, names) or _contains_member(th, names) or _contains_member(el, names)
+        case _:
+            return False
+
+
+def _find_top_level_def(core: Term, name_str: str) -> tuple[list[Name], Term] | None:
+    """Return ``(value-param names, body)`` of a top-level binding, or ``None``."""
+    cur: Term = core
+    while isinstance(cur, Rec):
+        if cur.var_name.name == name_str:
+            val: Term = cur.var_value
+            params: list[Name] = []
+            while isinstance(val, Abstraction):
+                params.append(val.var_name)
+                val = val.body
+            return params, val
+        cur = cur.body
+    return None
+
+
+_REL_BINOPS = {"==", "!=", "&&", "||", "<", "<=", ">", ">="}
+
+
+def _property_to_ir(body: Term, filled_core: Term, ectx: EvaluationContext, member_names: set[str]):
+    """Translate a (counterexample-instantiated) property body into the relational
+    IR consumed by :func:`_smt_unsat_core_obligations`.
+
+    Sub-terms free of any function under synthesis are *evaluated* to concrete
+    values (``("val", v)``); applications of a function under synthesis become
+    symbolic ``("app", name, arg-values)`` nodes (their argument terms — already
+    closed, since the property's parameter has been substituted — are evaluated
+    in the program); boolean/relational operators are kept symbolic. Returns the
+    IR, or ``None`` for an unsupported shape."""
+    from aeon.backend.evaluator import eval as aeon_eval
+
+    def ev(t: Term):
+        return aeon_eval(set_program_tail(filled_core, t), ectx)
+
+    def go(t: Term):
+        if not _contains_member(t, member_names):
+            return ("val", ev(t))
+        # Peel the application spine, then strip type/refinement applications from
+        # the head (a polymorphic operator like ``==`` appears as ``(==)[Bool]``).
+        head: Term = t
+        args: list[Term] = []
+        while isinstance(head, Application):
+            args.append(head.arg)
+            head = head.fun
+        args.reverse()
+        while isinstance(head, (TypeApplication, RefinementApplication)):
+            head = head.body
+        if isinstance(head, Var):
+            nm = head.name.name
+            if nm in member_names:
+                try:
+                    return ("app", nm, tuple(ev(a) for a in args))
+                except Exception:
+                    return None
+            if nm == "!" and len(args) == 1:
+                inner = go(args[0])
+                return ("not", inner) if inner is not None else None
+            if nm in _REL_BINOPS and len(args) == 2:
+                ia, ib = go(args[0]), go(args[1])
+                return ("bin", nm, ia, ib) if ia is not None and ib is not None else None
+        return None
+
+    try:
+        return go(body)
+    except Exception:
+        return None
+
+
+def _member_apps_in_ir(ir, acc: set) -> None:
+    """Collect every ``("app", name, args)`` (call to a function under synthesis)
+    appearing in a relational IR."""
+    if not isinstance(ir, tuple) or not ir:
+        return
+    if ir[0] == "app":
+        acc.add((ir[1], ir[2]))
+    elif ir[0] == "not":
+        _member_apps_in_ir(ir[1], acc)
+    elif ir[0] == "bin":
+        _member_apps_in_ir(ir[2], acc)
+        _member_apps_in_ir(ir[3], acc)
+
+
+def _property_counterexamples(
+    filled_core: Term, metadata: Metadata, ectx: EvaluationContext, member_names: set[str], max_input: int = 8
+) -> tuple[list, set]:
+    """Drive each ``@property`` over a small integer domain; for every input on
+    which it *fails*, return its relational IR and the set of member calls it
+    makes.
+
+    A relational property (e.g. ``even n = !(odd n)``) is the only spec that sees
+    a *deep* input. Its IR states the relation the unsat-core engine needs to
+    detect the conflict, and re-running each of its member calls (separately, so
+    each trace is a single recursion chain) exercises the recursion down to the
+    example-anchored base cases — together letting the engine propagate
+    obligations up the call chain (property-as-guide, not just filter).
+    Properties with non-integer or multi-argument parameters are skipped."""
+    from aeon.backend.evaluator import eval as aeon_eval
+    from aeon.core.types import t_int
+
+    prop_names = [
+        key
+        for key, entry in metadata.items()
+        if isinstance(key, Name) and isinstance(entry, dict) and "property" in entry
+    ]
+    irs: list = []
+    member_calls: set = set()
+    for pn in prop_names:
+        found = _find_top_level_def(filled_core, pn.name)
+        if found is None or len(found[0]) != 1:
+            continue  # need exactly one (integer) parameter to drive
+        (param,), body = found
+        for v in range(0, max_input + 1):
+            call: Term = Application(Var(pn), Literal(v, t_int))
+            try:
+                result = aeon_eval(set_program_tail(filled_core, call), ectx)
+            except Exception:
+                break  # wrong arity / non-int param: this property isn't drivable here
+            if result is False:
+                ir = _property_to_ir(substitution(body, Literal(v, t_int), param), filled_core, ectx, member_names)
+                if ir is not None:
+                    irs.append(ir)
+                    _member_apps_in_ir(ir, member_calls)
+    return irs, member_calls
+
+
 def _refine_obligations(
     filled_core: Term,
     members: list[tuple[Name, Name]],
     ectx: EvaluationContext,
     metadata: Metadata,
 ) -> int:
-    """Contata's refinement phase (Algorithm 2, lines 11-16) for example specs.
+    """Contata's refinement phase (Algorithm 2, lines 11-16).
 
-    Execute the current joint candidate (``filled_core``) on every member's I/O
-    examples under the instrumented semantics, blame the tail-callee of each
-    failing example, and add the propagated ``callee(args) = expected`` fact to
-    that callee's ``io_examples`` — the lazy refinement that constrains the
-    callee's next-round search on exactly the input implicated by the conflict.
-    Returns how many new obligations were added (0 ⇒ fixpoint / nothing to
-    learn). Only group members are refined."""
+    Execute the current joint candidate (``filled_core``) under the instrumented
+    semantics — on every member's I/O examples *and* on the failing inputs of any
+    relational ``@property`` (property-as-guide) — then hand the ground spec
+    ``ψ`` (``@example`` facts), the observed calls ``θ`` and the candidate's
+    symbolic structure to z3. Its unsat core blames the conflicting calls and a
+    model yields each blamed callee's spec-consistent output, added to that
+    callee's ``io_examples``: the lazy refinement that constrains the callee's
+    next-round search on exactly the input implicated by the conflict. Returns
+    how many new obligations were added (0 ⇒ fixpoint). Only group members are
+    refined."""
     from aeon.backend.evaluator import eval_with_trace
 
     member_name_strs = {fun_name.name for fun_name, _ in members}
@@ -585,10 +821,8 @@ def _refine_obligations(
         for args, out in metadata.get(fun_name, {}).get("io_examples", []):
             spec_facts.append((fun_name, tuple(args), out))
 
-    # θ + structure: run the joint candidate on every spec input under the
-    # instrumented semantics, recording observed calls and the per-call symbolic
-    # relations (each call's result equals the nearest enclosing earlier call
-    # with the same result — the executed tail edge).
+    # θ + structure: from running the candidate on every example input, and on
+    # each relational property's failing inputs.
     observed: list[tuple[Name, tuple, Any]] = []
     symbolic: list[tuple[tuple[Name, tuple], tuple[Name, tuple]]] = []
     seen_obs: set = set()
@@ -609,23 +843,32 @@ def _refine_obligations(
                 _actual, trace = eval_with_trace(set_program_tail(filled_core, call), ectx)
             except Exception:
                 continue
-            for nm, a, res in trace:
-                k = (nm.name, repr(a), repr(res))
-                if k not in seen_obs:
-                    seen_obs.add(k)
-                    observed.append((nm, a, res))
-            for i in range(len(trace)):
-                nm_i, a_i, res_i = trace[i]
-                for j in range(i - 1, -1, -1):
-                    nm_j, a_j, res_j = trace[j]
-                    if res_j == res_i and (nm_j.name, repr(a_j)) != (nm_i.name, repr(a_i)):
-                        key = (nm_i.name, repr(a_i), nm_j.name, repr(a_j))
-                        if key not in seen_sym:
-                            seen_sym.add(key)
-                            symbolic.append(((nm_i, a_i), (nm_j, a_j)))
-                        break
+            _accumulate_trace(trace, observed, symbolic, seen_obs, seen_sym)
 
-    obligations = _smt_unsat_core_obligations(spec_facts, observed, symbolic, member_name_strs)
+    relational, prop_member_calls = _property_counterexamples(filled_core, metadata, ectx, member_name_strs)
+    # Re-run each member call the failing properties make, separately, so each
+    # trace is a single recursion chain (no spurious cross-call structure edges).
+    for fname_str, argvals in prop_member_calls:
+        target = name_to_fun.get(fname_str)
+        if target is None:
+            continue
+        call = Var(target)
+        ok = True
+        for v in argvals:
+            lit = _value_literal(v)
+            if lit is None:
+                ok = False
+                break
+            call = Application(call, lit)
+        if not ok:
+            continue
+        try:
+            _actual, trace = eval_with_trace(set_program_tail(filled_core, call), ectx)
+        except Exception:
+            continue
+        _accumulate_trace(trace, observed, symbolic, seen_obs, seen_sym)
+
+    obligations = _smt_unsat_core_obligations(spec_facts, observed, symbolic, member_name_strs, relational=relational)
 
     added = 0
     for fname, args, out in obligations:

--- a/aeon/synthesis/modules/contata/__init__.py
+++ b/aeon/synthesis/modules/contata/__init__.py
@@ -1,0 +1,23 @@
+"""Contata: a genuine Constraint-Annotated Tree Automaton (CATA) version space.
+
+Implements the core of Miltner, Wang, Chaudhuri & Dillig, *Relational Synthesis
+of Recursive Programs via Constraint Annotated Tree Automata* (CAV 2024) — as an
+actual symbolic version space, rather than the enumerate-each-tree-and-typecheck
+approximation of the ``cata`` backend.
+
+The defining idea (paper §4): a candidate body is represented **symbolically** as
+a tree over the DSL, where calls to the functions under synthesis are
+*uninterpreted functions*. A body therefore has a value that is a *formula* over
+those uninterpreted functions — no evaluation, so recursion and mutual recursion
+need no fixpoint and there is no circularity. A run is *accepted under a model*
+(Def. 6) iff the conjunction of its transition constraints together with the
+specification is satisfiable — checked by z3. For a whole ``mutual`` group all
+members' bodies and all example inputs are discharged in **one** SMT query, so a
+solution is mutually consistent by construction.
+
+See :mod:`aeon.synthesis.modules.contata.cata`.
+"""
+
+from aeon.synthesis.modules.contata.cata import synthesize_group, ContataResult
+
+__all__ = ["synthesize_group", "ContataResult"]

--- a/aeon/synthesis/modules/contata/cata.py
+++ b/aeon/synthesis/modules/contata/cata.py
@@ -107,28 +107,57 @@ def _is_recursive_shaped(term: Term, member_names: set[str]) -> bool:
     return False
 
 
+def _value_vector(term: Term, ty: str, inputs: list[Any]) -> Optional[tuple]:
+    """The concrete value of ``term`` at each input, or ``None`` if it is symbolic
+    (contains a call under synthesis). Used to merge observationally-equivalent
+    sub-programs of the *non-recursive* fragment (FTA-style compression)."""
+    out: list[Any] = []
+    for x in inputs:
+        v = _concrete_int(term, x) if ty == INT else _concrete_bool(term, x)
+        if v is None:
+            return None
+        out.append(v)
+    return tuple(out)
+
+
 def _enumerate_bodies(
-    members: list[MemberSig], goal_type: str, max_size: int, max_bank: int = 48, cond_head: int = 16
+    members: list[MemberSig],
+    goal_type: str,
+    max_size: int,
+    inputs: list[Any],
+    max_bank: int = 48,
+    cond_head: int = 16,
 ) -> list[Term]:
     """Bottom-up enumeration of the version space: grow the per-type bank one
     transition deeper each round (operators and members' calls), then form
     conditionals of the **base/recursive-case shape** ``if cond then a else b``
     where one branch is a recursive/mutual call — the structure every recursive
-    definition has. Each type's bank keeps its ``max_bank`` smallest terms *plus
-    every member-call term* (so a recursive branch like ``odd (x-1)`` is never
-    crowded out by smaller junk). Returns goal-typed terms ordered by size."""
+    definition has.
+
+    Two flavours of compression keep the version space small (paper §4): a
+    member-call-free sub-program is merged by its **observed value-vector** over
+    ``inputs`` (so the thousands of arithmetic terms collapse to one per distinct
+    behaviour); a symbolic term (one that calls a function under synthesis) is
+    merged syntactically. Each type's bank keeps its ``max_bank`` smallest terms
+    *plus every recursive-shaped term*, so a branch like ``odd (x-1)`` is never
+    crowded out. Returns goal-typed terms ordered by size."""
     arg_type = members[0].arg_type
     member_names = {m.name for m in members}
     bank = _atoms(arg_type)
-    seen: dict[str, set[str]] = {INT: set(), BOOL: set()}
+    seen: dict[str, set] = {INT: set(), BOOL: set()}
+
+    def key_of(ty: str, term: Term):
+        vec = _value_vector(term, ty, inputs)
+        return ("v", vec) if vec is not None else ("s", str(term))
+
     for ty in bank:
         for t in bank[ty]:
-            seen[ty].add(str(t))
+            seen[ty].add(key_of(ty, t))
 
     calls = [(m.name, [m.arg_type], m.ret_type) for m in members]
 
     def add(ty: str, term: Term) -> None:
-        k = str(term)
+        k = key_of(ty, term)
         if k not in seen[ty]:
             seen[ty].add(k)
             bank[ty].append(term)
@@ -350,10 +379,14 @@ def synthesize_group(
     by_member: dict[str, list[Example]] = {}
     for e in examples:
         by_member.setdefault(e.member, []).append(e)
+    # The example inputs (plus their predecessors, the values recursive calls
+    # reach) over which non-recursive sub-programs are merged by behaviour.
+    int_inputs = sorted({e.arg for e in examples if isinstance(e.arg, int) and not isinstance(e.arg, bool)})
+    inputs: list[Any] = sorted(set(int_inputs) | {v - 1 for v in int_inputs if v - 1 >= 0})
 
     bodies: dict[str, Term] = {}
     for m in members:
-        goal_bodies = _enumerate_bodies(members, m.ret_type, max_size)
+        goal_bodies = _enumerate_bodies(members, m.ret_type, max_size, inputs)
         chosen: Optional[Term] = None
         for body in goal_bodies:  # smallest first => MinTree
             mexs = by_member.get(m.name, [])

--- a/aeon/synthesis/modules/contata/cata.py
+++ b/aeon/synthesis/modules/contata/cata.py
@@ -1,0 +1,378 @@
+"""A genuine Constraint-Annotated Tree Automaton (CATA) version space (Contata).
+
+This is the paper's algorithm, not the enumerate-and-typecheck approximation:
+
+* A candidate body is a *tree* over a small Int/Bool DSL whose alphabet includes
+  the *functions under synthesis* (recursion + mutual recursion).
+* Each tree denotes, at a given input, a **z3 expression** over those functions
+  treated as **uninterpreted functions** (the constraint annotation): a call
+  ``g e`` becomes ``g_uf(⟦e⟧)``. No evaluation, so recursion never loops.
+* A tree is **accepted under a model** (Def. 6) iff the specification together
+  with the tree's denotation at every input is satisfiable — one z3 query.
+* The **smallest** accepted tree is returned (MinTree, Def. 11). For a ``mutual``
+  group every member is solved against the *same* complete spec, so the members
+  are mutually consistent by construction (the paper's product across inputs and
+  the global ``φ`` collapse to: be consistent with ``ψ``).
+
+Bounded: states range over a small Int/Bool value domain; the DSL is the integer
+/boolean fragment plus conditionals and the members' own calls — enough for the
+paper's mutual-recursion (MR) flagship (``even``/``odd``) and relational
+comparators over integers.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from aeon.core.terms import Application, If, Literal, Term, Var
+from aeon.core.types import t_bool, t_int
+from aeon.utils.name import Name
+
+INT = "Int"
+BOOL = "Bool"
+
+
+@dataclass(frozen=True)
+class MemberSig:
+    """A function under synthesis: ``name`` with a single ``arg_type`` argument
+    and ``ret_type`` result (the MR/RC benchmarks are unary)."""
+
+    name: str
+    arg_type: str
+    ret_type: str
+
+
+@dataclass(frozen=True)
+class Example:
+    """A ground spec fact ``member(arg) = out`` (from an ``@example``)."""
+
+    member: str
+    arg: Any
+    out: Any
+
+
+@dataclass
+class ContataResult:
+    bodies: dict[str, Term]  # member name -> synthesized body (a Term in the param)
+    param: Name  # the parameter the bodies are written in terms of
+
+
+# ---------------------------------------------------------------------------
+# DSL — the ranked alphabet of the tree automaton.
+# ---------------------------------------------------------------------------
+
+# Integer/boolean operators usable as transitions: (op-name, [arg types], ret).
+_OPS: list[tuple[str, list[str], str]] = [
+    ("-", [INT, INT], INT),
+    ("+", [INT, INT], INT),
+    ("==", [INT, INT], BOOL),
+    ("<", [INT, INT], BOOL),
+    ("<=", [INT, INT], BOOL),
+    (">", [INT, INT], BOOL),
+]
+
+_PARAM = Name("x", 0)
+
+
+def _op(name: str) -> Var:
+    return Var(Name(name, 0))
+
+
+def _atoms(arg_type: str) -> dict[str, list[Term]]:
+    """Nullary leaves per type: the parameter and a few constants."""
+    bank: dict[str, list[Term]] = {INT: [], BOOL: []}
+    bank[arg_type].append(Var(_PARAM))  # the parameter
+    bank[INT].extend([Literal(0, t_int), Literal(1, t_int)])
+    bank[BOOL].extend([Literal(True, t_bool), Literal(False, t_bool)])
+    return bank
+
+
+def _is_member_app(term: Term, member_names: set[str]) -> bool:
+    head = term
+    while isinstance(head, Application):
+        head = head.fun
+    return isinstance(head, Var) and head.name.name in member_names
+
+
+def _is_recursive_shaped(term: Term, member_names: set[str]) -> bool:
+    """A recursive/mutual call, or a conditional with one — the body shapes that
+    must survive bank-capping even though they are large, since a base/recursive
+    split is exactly what a recursive definition needs."""
+    if _is_member_app(term, member_names):
+        return True
+    if isinstance(term, If):
+        return _is_recursive_shaped(term.then, member_names) or _is_recursive_shaped(term.otherwise, member_names)
+    return False
+
+
+def _enumerate_bodies(
+    members: list[MemberSig], goal_type: str, max_size: int, max_bank: int = 48, cond_head: int = 16
+) -> list[Term]:
+    """Bottom-up enumeration of the version space: grow the per-type bank one
+    transition deeper each round (operators and members' calls), then form
+    conditionals of the **base/recursive-case shape** ``if cond then a else b``
+    where one branch is a recursive/mutual call — the structure every recursive
+    definition has. Each type's bank keeps its ``max_bank`` smallest terms *plus
+    every member-call term* (so a recursive branch like ``odd (x-1)`` is never
+    crowded out by smaller junk). Returns goal-typed terms ordered by size."""
+    arg_type = members[0].arg_type
+    member_names = {m.name for m in members}
+    bank = _atoms(arg_type)
+    seen: dict[str, set[str]] = {INT: set(), BOOL: set()}
+    for ty in bank:
+        for t in bank[ty]:
+            seen[ty].add(str(t))
+
+    calls = [(m.name, [m.arg_type], m.ret_type) for m in members]
+
+    def add(ty: str, term: Term) -> None:
+        k = str(term)
+        if k not in seen[ty]:
+            seen[ty].add(k)
+            bank[ty].append(term)
+
+    def cap(terms: list[Term]) -> list[Term]:
+        ordered = sorted(terms, key=_size)
+        kept = ordered[:max_bank]
+        kept_keys = {str(t) for t in kept}
+        for t in ordered[max_bank:]:
+            if _is_recursive_shaped(t, member_names):  # retain recursive/mutual calls + base/rec splits
+                kept.append(t)
+                kept_keys.add(str(t))
+        return kept
+
+    for _round in range(max_size):
+        snap = {ty: cap(ts) for ty, ts in bank.items()}
+        for name, arg_tys, ret in _OPS + calls:
+            pools = [snap.get(a, []) for a in arg_tys]
+            if any(not p for p in pools):
+                continue
+            for combo in itertools.product(*pools):
+                term: Term = _op(name)
+                for a in combo:
+                    term = Application(term, a)
+                add(ret, term)
+        # Base/recursive-case conditionals at every type.
+        for ret in (INT, BOOL):
+            conds = sorted(snap.get(BOOL, []), key=_size)[:cond_head]
+            bases = sorted(snap.get(ret, []), key=_size)[:cond_head]
+            recs = [t for t in bank.get(ret, []) if _is_member_app(t, member_names)]
+            for c in conds:
+                for base in bases:
+                    for rec in recs:
+                        if base is not rec:
+                            add(ret, If(c, base, rec))
+                            add(ret, If(c, rec, base))
+        for ty in bank:
+            bank[ty] = cap(bank[ty])
+
+    return sorted(bank.get(goal_type, []), key=_size)
+
+
+def _size(t: Term) -> int:
+    match t:
+        case Application(fun, arg):
+            return _size(fun) + _size(arg)
+        case If(c, th, el):
+            return 1 + _size(c) + _size(th) + _size(el)
+        case _:
+            return 1
+
+
+# ---------------------------------------------------------------------------
+# Constraint-annotation denotation: a body's value at an input as a z3 term.
+# ---------------------------------------------------------------------------
+
+
+def _z3_const(v: Any):
+    import z3
+
+    if isinstance(v, bool):
+        return z3.BoolVal(v)
+    if isinstance(v, int):
+        return z3.IntVal(v)
+    raise ValueError(f"unsupported constant {v!r}")
+
+
+def _concrete_int(term: Term, x_value: Any) -> Optional[int]:
+    """Evaluate a member-call-free integer term at ``x = x_value`` to a concrete
+    ``int``, or ``None`` if it is symbolic (contains a call under synthesis)."""
+    match term:
+        case Literal(value, _) if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        case Var(name) if name == _PARAM and isinstance(x_value, int):
+            return x_value
+        case Application():
+            head: Term = term
+            args: list[Term] = []
+            while isinstance(head, Application):
+                args.append(head.arg)
+                head = head.fun
+            args.reverse()
+            if isinstance(head, Var) and head.name.name in {"-", "+"} and len(args) == 2:
+                a, b = _concrete_int(args[0], x_value), _concrete_int(args[1], x_value)
+                if a is None or b is None:
+                    return None
+                return a - b if head.name.name == "-" else a + b
+            return None
+        case _:
+            return None
+
+
+def _concrete_bool(term: Term, x_value: Any) -> Optional[bool]:
+    """Evaluate a member-call-free boolean term at ``x = x_value`` to a concrete
+    ``bool``, or ``None`` if symbolic. Lets a conditional with a concrete guard
+    fold to the taken branch (so the *untaken* branch — which may make an
+    out-of-range recursive call — is never required well-founded)."""
+    match term:
+        case Literal(value, _) if isinstance(value, bool):
+            return value
+        case Application():
+            head: Term = term
+            args: list[Term] = []
+            while isinstance(head, Application):
+                args.append(head.arg)
+                head = head.fun
+            args.reverse()
+            if isinstance(head, Var) and len(args) == 2:
+                a, b = _concrete_int(args[0], x_value), _concrete_int(args[1], x_value)
+                if a is None or b is None:
+                    return None
+                cmp = {
+                    "==": lambda: a == b,
+                    "<": lambda: a < b,
+                    "<=": lambda: a <= b,
+                    ">": lambda: a > b,
+                    ">=": lambda: a >= b,
+                }.get(head.name.name)
+                return cmp() if cmp else None
+            return None
+        case _:
+            return None
+
+
+def _denote(term: Term, x_value: Any, member_ufs: dict[str, Any]):
+    """⟦term⟧ at ``x = x_value`` as a z3 expression. Calls to members become
+    uninterpreted-function applications (the constraint annotation); everything
+    else folds concretely where possible. Raises on an unsupported shape, or on a
+    recursive call whose argument is not provably *smaller* than the current
+    input (the Function-Call rule's well-foundedness side condition ``v' ≺ v_in``,
+    Fig. 5) — without which a self-consistent non-terminating body such as
+    ``even(x) = even(x)`` would be wrongly accepted."""
+    import z3
+
+    match term:
+        case Literal(value, _):
+            return _z3_const(value)
+        case Var(name) if name == _PARAM:
+            return _z3_const(x_value)
+        case If(c, th, el):
+            cb = _concrete_bool(c, x_value)
+            if cb is True:
+                return _denote(th, x_value, member_ufs)
+            if cb is False:
+                return _denote(el, x_value, member_ufs)
+            cz = _denote(c, x_value, member_ufs)
+            return z3.If(cz, _denote(th, x_value, member_ufs), _denote(el, x_value, member_ufs))
+        case Application():
+            head: Term = term
+            args: list[Term] = []
+            while isinstance(head, Application):
+                args.append(head.arg)
+                head = head.fun
+            args.reverse()
+            if not isinstance(head, Var):
+                raise ValueError(f"unsupported head {head}")
+            nm = head.name.name
+            if nm in member_ufs and len(args) == 1:
+                # Well-foundedness: the argument must be a concrete value strictly
+                # smaller (in the natural order on the bounded Nat domain) than the
+                # current input. This both rules out non-terminating bodies and
+                # keeps the call's argument concrete so the spec can pin it.
+                arg_val = _concrete_int(args[0], x_value)
+                if arg_val is None or not (isinstance(x_value, int) and 0 <= arg_val < x_value):
+                    raise ValueError("recursive call not on a strictly smaller input")
+                return member_ufs[nm](_z3_const(arg_val))
+            az = [_denote(a, x_value, member_ufs) for a in args]
+            ops = {
+                "-": lambda: az[0] - az[1],
+                "+": lambda: az[0] + az[1],
+                "==": lambda: az[0] == az[1],
+                "<": lambda: az[0] < az[1],
+                "<=": lambda: az[0] <= az[1],
+                ">": lambda: az[0] > az[1],
+                ">=": lambda: az[0] >= az[1],
+            }
+            if nm in ops and len(az) == 2:
+                return ops[nm]()
+            raise ValueError(f"unsupported operator {nm}")
+        case _:
+            raise ValueError(f"unsupported term {term}")
+
+
+def _sort(ty: str):
+    import z3
+
+    return z3.IntSort() if ty == INT else z3.BoolSort()
+
+
+def _build_ufs(members: list[MemberSig]):
+    import z3
+
+    return {m.name: z3.Function(m.name, _sort(m.arg_type), _sort(m.ret_type)) for m in members}
+
+
+def _spec_assertions(ufs, examples: list[Example]):
+    return [ufs[e.member](_z3_const(e.arg)) == _z3_const(e.out) for e in examples]
+
+
+def synthesize_group(
+    members: list[MemberSig],
+    examples: list[Example],
+    max_size: int = 4,
+    on_candidate: Optional[Callable[[str, Term], None]] = None,
+) -> Optional[ContataResult]:
+    """Synthesize every member of a (mutually-recursive) group from a ground
+    relational/example spec, via the CATA version space.
+
+    Each member is solved against the *complete* spec ``ψ`` (all members'
+    examples): the smallest body whose constraint-annotated denotation agrees
+    with the member's examples — under *some* model of ``ψ`` — at every example
+    input. Because every member is consistent with the same ``ψ``, the group is
+    mutually consistent. Returns ``None`` if any member has no accepted body
+    within ``max_size``."""
+    import z3
+
+    ufs = _build_ufs(members)
+    spec = _spec_assertions(ufs, examples)
+    by_member: dict[str, list[Example]] = {}
+    for e in examples:
+        by_member.setdefault(e.member, []).append(e)
+
+    bodies: dict[str, Term] = {}
+    for m in members:
+        goal_bodies = _enumerate_bodies(members, m.ret_type, max_size)
+        chosen: Optional[Term] = None
+        for body in goal_bodies:  # smallest first => MinTree
+            mexs = by_member.get(m.name, [])
+            if not mexs:
+                continue
+            solver = z3.Solver()
+            for s in spec:
+                solver.add(s)
+            try:
+                for e in mexs:
+                    solver.add(_denote(body, e.arg, ufs) == _z3_const(e.out))
+            except ValueError:
+                continue  # body uses an unsupported shape; skip
+            if solver.check() == z3.sat:
+                chosen = body
+                if on_candidate is not None:
+                    on_candidate(m.name, body)
+                break
+        if chosen is None:
+            return None
+        bodies[m.name] = chosen
+    return ContataResult(bodies=bodies, param=_PARAM)

--- a/aeon/synthesis/modules/contata/cata.py
+++ b/aeon/synthesis/modules/contata/cata.py
@@ -14,10 +14,18 @@ This is the paper's algorithm, not the enumerate-and-typecheck approximation:
   are mutually consistent by construction (the paper's product across inputs and
   the global ``φ`` collapse to: be consistent with ``ψ``).
 
-Bounded: states range over a small Int/Bool value domain; the DSL is the integer
-/boolean fragment plus conditionals and the members' own calls — enough for the
-paper's mutual-recursion (MR) flagship (``even``/``odd``) and relational
-comparators over integers.
+Bounded: states range over a small Int/Bool/List value domain; the DSL is the
+integer/boolean fragment, the ``List Int`` destructors (``isEmpty``/``head``/
+``tail``), conditionals, and the members' own calls — enough for the paper's
+mutual-recursion (MR) flagship (``even``/``odd``), relational comparators over
+integers, and the partial-data-structure (PDS) category (e.g. ``length`` over a
+list, recovered as ``if isEmpty xs then 0 else 1 + length (tail xs)``).
+
+List values are opaque constants of an uninterpreted z3 sort: their *structure*
+is folded concretely by the destructors (so ``length`` recurses on the
+strictly-shorter ``tail``, the well-founded measure being list length), while the
+constant only serves to pin a recursive call's result in the spec (e.g.
+``length(const_[2,3]) = 2``). This sidesteps z3's list theory entirely.
 """
 
 from __future__ import annotations
@@ -32,6 +40,7 @@ from aeon.utils.name import Name
 
 INT = "Int"
 BOOL = "Bool"
+LIST = "List"  # List Int — the algebraic-datatype fragment (PDS category)
 
 
 @dataclass(frozen=True)
@@ -63,7 +72,9 @@ class ContataResult:
 # DSL — the ranked alphabet of the tree automaton.
 # ---------------------------------------------------------------------------
 
-# Integer/boolean operators usable as transitions: (op-name, [arg types], ret).
+# Operators usable as transitions: (op-name, [arg types], ret). Includes the
+# List-Int destructors so recursive list functions (the PDS category) are
+# buildable: ``isEmpty``/``head``/``tail`` of a list.
 _OPS: list[tuple[str, list[str], str]] = [
     ("-", [INT, INT], INT),
     ("+", [INT, INT], INT),
@@ -71,8 +82,12 @@ _OPS: list[tuple[str, list[str], str]] = [
     ("<", [INT, INT], BOOL),
     ("<=", [INT, INT], BOOL),
     (">", [INT, INT], BOOL),
+    ("isEmpty", [LIST], BOOL),
+    ("head", [LIST], INT),
+    ("tail", [LIST], LIST),
 ]
 
+_TYPES = (INT, BOOL, LIST)
 _PARAM = Name("x", 0)
 
 
@@ -82,7 +97,7 @@ def _op(name: str) -> Var:
 
 def _atoms(arg_type: str) -> dict[str, list[Term]]:
     """Nullary leaves per type: the parameter and a few constants."""
-    bank: dict[str, list[Term]] = {INT: [], BOOL: []}
+    bank: dict[str, list[Term]] = {INT: [], BOOL: [], LIST: []}
     bank[arg_type].append(Var(_PARAM))  # the parameter
     bank[INT].extend([Literal(0, t_int), Literal(1, t_int)])
     bank[BOOL].extend([Literal(True, t_bool), Literal(False, t_bool)])
@@ -96,15 +111,27 @@ def _is_member_app(term: Term, member_names: set[str]) -> bool:
     return isinstance(head, Var) and head.name.name in member_names
 
 
-def _is_recursive_shaped(term: Term, member_names: set[str]) -> bool:
-    """A recursive/mutual call, or a conditional with one — the body shapes that
-    must survive bank-capping even though they are large, since a base/recursive
-    split is exactly what a recursive definition needs."""
+def _contains_member_app(term: Term, member_names: set[str]) -> bool:
+    """A member/recursive call anywhere inside ``term`` — so a recursive branch
+    like ``1 + length (tail xs)`` (call under an operator) is recognised, not
+    only a bare ``odd (x-1)``."""
     if _is_member_app(term, member_names):
         return True
-    if isinstance(term, If):
-        return _is_recursive_shaped(term.then, member_names) or _is_recursive_shaped(term.otherwise, member_names)
-    return False
+    match term:
+        case Application(fun, arg):
+            return _contains_member_app(fun, member_names) or _contains_member_app(arg, member_names)
+        case If(c, th, el):
+            return any(_contains_member_app(t, member_names) for t in (c, th, el))
+        case _:
+            return False
+
+
+def _is_recursive_shaped(term: Term, member_names: set[str]) -> bool:
+    """A term that carries a recursive/mutual call anywhere — the body shapes that
+    must survive bank-capping even though they are large, since a base/recursive
+    split (``odd (x-1)``, ``1 + length (tail xs)``) is exactly what a recursive
+    definition needs."""
+    return _contains_member_app(term, member_names)
 
 
 def _value_vector(term: Term, ty: str, inputs: list[Any]) -> Optional[tuple]:
@@ -113,7 +140,12 @@ def _value_vector(term: Term, ty: str, inputs: list[Any]) -> Optional[tuple]:
     sub-programs of the *non-recursive* fragment (FTA-style compression)."""
     out: list[Any] = []
     for x in inputs:
-        v = _concrete_int(term, x) if ty == INT else _concrete_bool(term, x)
+        if ty == INT:
+            v: Any = _concrete_int(term, x)
+        elif ty == BOOL:
+            v = _concrete_bool(term, x)
+        else:
+            v = _concrete_list(term, x)
         if v is None:
             return None
         out.append(v)
@@ -127,6 +159,8 @@ def _enumerate_bodies(
     inputs: list[Any],
     max_bank: int = 48,
     cond_head: int = 16,
+    rec_head: int = 64,
+    rec_keep: int = 64,
 ) -> list[Term]:
     """Bottom-up enumeration of the version space: grow the per-type bank one
     transition deeper each round (operators and members' calls), then form
@@ -144,7 +178,7 @@ def _enumerate_bodies(
     arg_type = members[0].arg_type
     member_names = {m.name for m in members}
     bank = _atoms(arg_type)
-    seen: dict[str, set] = {INT: set(), BOOL: set()}
+    seen: dict[str, set] = {ty: set() for ty in _TYPES}
 
     def key_of(ty: str, term: Term):
         vec = _value_vector(term, ty, inputs)
@@ -162,14 +196,29 @@ def _enumerate_bodies(
             seen[ty].add(k)
             bank[ty].append(term)
 
+    # Conditionals are *terminal* goal candidates (the body is a base/recursive
+    # split). They are collected here and NOT fed back into ``bank`` — otherwise
+    # the large ``if … else 1 + length (tail xs)`` shapes compete for the bank's
+    # capped slots against many smaller distractors and are dropped before
+    # reaching the goal list.
+    results: dict[str, list[Term]] = {ty: [] for ty in _TYPES}
+    results_seen: dict[str, set] = {ty: set() for ty in _TYPES}
+
+    def add_result(ty: str, term: Term) -> None:
+        s = str(term)
+        if s not in results_seen[ty]:
+            results_seen[ty].add(s)
+            results[ty].append(term)
+
     def cap(terms: list[Term]) -> list[Term]:
         ordered = sorted(terms, key=_size)
         kept = ordered[:max_bank]
-        kept_keys = {str(t) for t in kept}
-        for t in ordered[max_bank:]:
-            if _is_recursive_shaped(t, member_names):  # retain recursive/mutual calls + base/rec splits
-                kept.append(t)
-                kept_keys.add(str(t))
+        # Retain the *smallest* recursive-shaped terms beyond the cap so a branch
+        # like ``odd (x-1)`` or ``1 + length (tail xs)`` is never crowded out —
+        # but bounded (``rec_keep``), or the list destructors make the set of
+        # call-bearing terms grow combinatorially each round.
+        extra = [t for t in ordered[max_bank:] if _is_recursive_shaped(t, member_names)]
+        kept.extend(extra[:rec_keep])
         return kept
 
     for _round in range(max_size):
@@ -184,20 +233,32 @@ def _enumerate_bodies(
                     term = Application(term, a)
                 add(ret, term)
         # Base/recursive-case conditionals at every type.
-        for ret in (INT, BOOL):
+        for ret in _TYPES:
             conds = sorted(snap.get(BOOL, []), key=_size)[:cond_head]
+            # Base branch: a non-recursive expression, or a previously-formed
+            # conditional (so two-level base/rec splits are reachable).
             bases = sorted(snap.get(ret, []), key=_size)[:cond_head]
-            recs = [t for t in bank.get(ret, []) if _is_member_app(t, member_names)]
+            bases = bases + sorted(results[ret], key=_size)[:cond_head]
+            # Recursive branch: a bare member call (``odd (x-1)``) *or* a call
+            # under an operator (``1 + length (tail xs)``), smallest first. Drawn
+            # from a wider pool than the base/guard, since the call-under-operator
+            # shapes are larger and easily crowded out by arithmetic distractors.
+            recs = sorted(
+                (t for t in bank.get(ret, []) if _contains_member_app(t, member_names)),
+                key=_size,
+            )[:rec_head]
             for c in conds:
                 for base in bases:
                     for rec in recs:
                         if base is not rec:
-                            add(ret, If(c, base, rec))
-                            add(ret, If(c, rec, base))
+                            add_result(ret, If(c, base, rec))
+                            add_result(ret, If(c, rec, base))
         for ty in bank:
             bank[ty] = cap(bank[ty])
 
-    return sorted(bank.get(goal_type, []), key=_size)
+    # Goal candidates: the simple (non-conditional) sub-programs of the goal type
+    # plus every conditional formed, smallest first (MinTree order).
+    return sorted(bank.get(goal_type, []) + results[goal_type], key=_size)
 
 
 def _size(t: Term) -> int:
@@ -215,14 +276,48 @@ def _size(t: Term) -> int:
 # ---------------------------------------------------------------------------
 
 
+_list_sort_cache: list = []  # lazily-built singleton z3 sort for List Int
+_list_consts: dict[tuple, Any] = {}  # concrete list value -> opaque z3 constant
+
+
+def _list_sort():
+    import z3
+
+    if not _list_sort_cache:
+        _list_sort_cache.append(z3.DeclareSort("ContataList"))
+    return _list_sort_cache[0]
+
+
 def _z3_const(v: Any):
+    """A z3 term for a concrete value. Lists are opaque constants of an
+    uninterpreted sort (their *structure* is folded concretely by the DSL
+    destructors; the constant only has to make a recursive call's argument a
+    distinct, spec-pinnable key, e.g. ``length(const_[2,3]) = 2``)."""
     import z3
 
     if isinstance(v, bool):
         return z3.BoolVal(v)
     if isinstance(v, int):
         return z3.IntVal(v)
+    if isinstance(v, (tuple, list)):
+        key = tuple(v)
+        if key not in _list_consts:
+            _list_consts[key] = z3.Const(f"lst_{len(_list_consts)}", _list_sort())
+        return _list_consts[key]
     raise ValueError(f"unsupported constant {v!r}")
+
+
+def _concrete_list(term: Term, x_value: Any) -> Optional[tuple]:
+    """Evaluate a member-call-free list term at ``x = x_value`` to a concrete
+    tuple, or ``None`` if symbolic / ill-defined (``tail`` of ``[]``)."""
+    match term:
+        case Var(name) if name == _PARAM and isinstance(x_value, (tuple, list)):
+            return tuple(x_value)
+        case Application(Var(Name("tail", _)), e):
+            inner = _concrete_list(e, x_value)
+            return inner[1:] if inner else None
+        case _:
+            return None
 
 
 def _concrete_int(term: Term, x_value: Any) -> Optional[int]:
@@ -245,6 +340,9 @@ def _concrete_int(term: Term, x_value: Any) -> Optional[int]:
                 if a is None or b is None:
                     return None
                 return a - b if head.name.name == "-" else a + b
+            if isinstance(head, Var) and head.name.name == "head" and len(args) == 1:
+                cl = _concrete_list(args[0], x_value)
+                return cl[0] if cl else None
             return None
         case _:
             return None
@@ -265,6 +363,9 @@ def _concrete_bool(term: Term, x_value: Any) -> Optional[bool]:
                 args.append(head.arg)
                 head = head.fun
             args.reverse()
+            if isinstance(head, Var) and head.name.name == "isEmpty" and len(args) == 1:
+                cl = _concrete_list(args[0], x_value)
+                return None if cl is None else len(cl) == 0
             if isinstance(head, Var) and len(args) == 2:
                 a, b = _concrete_int(args[0], x_value), _concrete_int(args[1], x_value)
                 if a is None or b is None:
@@ -315,15 +416,41 @@ def _denote(term: Term, x_value: Any, member_ufs: dict[str, Any]):
             if not isinstance(head, Var):
                 raise ValueError(f"unsupported head {head}")
             nm = head.name.name
+            # List destructors fold concretely (the structure is known; only
+            # member-call *results* stay symbolic). isEmpty/head/tail mirror the
+            # PDS datatype operations of the paper's partial-data-structure cat.
+            if nm == "isEmpty" and len(args) == 1:
+                cl = _concrete_list(args[0], x_value)
+                if cl is None:
+                    raise ValueError("isEmpty of a non-concrete list")
+                return z3.BoolVal(len(cl) == 0)
+            if nm == "head" and len(args) == 1:
+                cl = _concrete_list(args[0], x_value)
+                if not cl:
+                    raise ValueError("head of an empty/non-concrete list")
+                return z3.IntVal(cl[0])
+            if nm == "tail" and len(args) == 1:
+                cl = _concrete_list(term, x_value)
+                if cl is None:
+                    raise ValueError("tail of an empty/non-concrete list")
+                return _z3_const(cl)
             if nm in member_ufs and len(args) == 1:
                 # Well-foundedness: the argument must be a concrete value strictly
-                # smaller (in the natural order on the bounded Nat domain) than the
-                # current input. This both rules out non-terminating bodies and
-                # keeps the call's argument concrete so the spec can pin it.
-                arg_val = _concrete_int(args[0], x_value)
-                if arg_val is None or not (isinstance(x_value, int) and 0 <= arg_val < x_value):
-                    raise ValueError("recursive call not on a strictly smaller input")
-                return member_ufs[nm](_z3_const(arg_val))
+                # smaller than the current input under the member's measure (the
+                # value itself on the bounded Nat domain, or list length for a
+                # List argument). Rules out non-terminating bodies and keeps the
+                # call's argument concrete so the spec can pin it (Fig. 5).
+                iarg = _concrete_int(args[0], x_value)
+                if iarg is not None:
+                    if not (isinstance(x_value, int) and 0 <= iarg < x_value):
+                        raise ValueError("recursive call not on a strictly smaller input")
+                    return member_ufs[nm](_z3_const(iarg))
+                larg = _concrete_list(args[0], x_value)
+                if larg is not None:
+                    if not (isinstance(x_value, (tuple, list)) and len(larg) < len(x_value)):
+                        raise ValueError("recursive call not on a strictly smaller list")
+                    return member_ufs[nm](_z3_const(larg))
+                raise ValueError("recursive call argument is not concrete")
             az = [_denote(a, x_value, member_ufs) for a in args]
             ops = {
                 "-": lambda: az[0] - az[1],
@@ -344,7 +471,11 @@ def _denote(term: Term, x_value: Any, member_ufs: dict[str, Any]):
 def _sort(ty: str):
     import z3
 
-    return z3.IntSort() if ty == INT else z3.BoolSort()
+    if ty == INT:
+        return z3.IntSort()
+    if ty == BOOL:
+        return z3.BoolSort()
+    return _list_sort()
 
 
 def _build_ufs(members: list[MemberSig]):
@@ -380,9 +511,21 @@ def synthesize_group(
     for e in examples:
         by_member.setdefault(e.member, []).append(e)
     # The example inputs (plus their predecessors, the values recursive calls
-    # reach) over which non-recursive sub-programs are merged by behaviour.
+    # reach) over which non-recursive sub-programs are merged by behaviour. For
+    # Int that is each input and its decrement; for List, every suffix reachable
+    # by ``tail`` (the trace closure under the well-founded measure).
     int_inputs = sorted({e.arg for e in examples if isinstance(e.arg, int) and not isinstance(e.arg, bool)})
     inputs: list[Any] = sorted(set(int_inputs) | {v - 1 for v in int_inputs if v - 1 >= 0})
+    list_inputs: set[tuple] = set()
+    for e in examples:
+        if isinstance(e.arg, (tuple, list)):
+            t = tuple(e.arg)
+            while True:
+                list_inputs.add(t)
+                if not t:
+                    break
+                t = t[1:]
+    inputs.extend(sorted(list_inputs, key=len))
 
     bodies: dict[str, Term] = {}
     for m in members:

--- a/aeon/synthesis/modules/contata/synthesizer.py
+++ b/aeon/synthesis/modules/contata/synthesizer.py
@@ -7,18 +7,24 @@ synthesis as uninterpreted functions) and is accepted under an SMT model against
 the ground ``@example`` spec, with the well-foundedness side condition and
 MinTree extraction (see :mod:`aeon.synthesis.modules.contata.cata`).
 
-This adapter wires that version space into the single-hole ``Synthesizer`` API:
-it reads the hole's ``@example`` I/O facts, runs :func:`synthesize_group` for the
-one member, maps the resulting DSL body onto the real in-scope names
-(parameter, the recursive self-call, and the arithmetic/comparison operators),
-and discharges the mapped term through ``validate`` as a final soundness gate.
-A whole ``mutual`` block is co-synthesised jointly by the entrypoint
-(:func:`aeon.synthesis.entrypoint._cosynthesize_group`); this backend is the
-per-member engine that path drives.
+Two entry points share the body-mapping machinery here:
+
+* :class:`ContataSynthesizer` (the single-hole ``Synthesizer`` API) reads one
+  hole's ``@example`` I/O facts, runs :func:`synthesize_group` for that member,
+  maps the DSL body onto the real in-scope names (parameter, recursive self-call,
+  operators monomorphised at ``Int``), and discharges it through ``validate``.
+* :func:`cosynthesize_group` co-synthesises a whole ``mutual`` block: *all*
+  members' facts go into one :func:`synthesize_group` query, so a body may call
+  its siblings (uninterpreted functions) and the assignment is mutually
+  consistent by construction. The entrypoint
+  (:func:`aeon.synthesis.entrypoint._cosynthesize_group`) calls this as a fast
+  path before its per-member sibling-as-typed-oracle loop — it converges on the
+  MR flagship (even/odd from examples) that the loop cannot.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from loguru import logger
@@ -87,7 +93,7 @@ class ContataSynthesizer(Synthesizer):
             )
         param_name = io_params[0]
 
-        arg_key = _dsl_type(self._param_type(ctx, param_name))
+        arg_key = _dsl_type(_param_type(ctx, param_name))
         ret_key = _dsl_type(type)
         if arg_key is None or ret_key is None:
             raise SynthesisNotSuccessful(
@@ -108,7 +114,7 @@ class ContataSynthesizer(Synthesizer):
             )
 
         op_names = _operator_names(ctx)
-        body = _to_core(result.bodies[fun_name.name], param_name, fun_name, op_names)
+        body = _to_core(result.bodies[fun_name.name], param_name, {fun_name.name: fun_name}, op_names)
         if body is None:
             raise SynthesisNotSuccessful(
                 f"contata: synthesised body uses an operator not in scope for {fun_name.name}."
@@ -125,12 +131,69 @@ class ContataSynthesizer(Synthesizer):
         )
         return body
 
-    @staticmethod
-    def _param_type(ctx: TypingContext, param_name: Name) -> Optional[Type]:
-        for n, ty in ctx.vars():
-            if n == param_name:
-                return ty
+
+def _param_type(ctx: TypingContext, param_name: Name) -> Optional[Type]:
+    for n, ty in ctx.vars():
+        if n == param_name:
+            return ty
+    return None
+
+
+@dataclass(frozen=True)
+class GroupMember:
+    """One member of a mutual group, as the version space needs it: its real
+    ``Name``, hole type, hole context, and the spec entry that holds its
+    ``@example`` I/O facts and value-parameter names."""
+
+    fun_name: Name
+    hole_type: Type
+    hole_ctx: TypingContext
+    entry: dict
+
+
+def cosynthesize_group(
+    members: list[GroupMember], op_ctx: TypingContext, max_size: int = 4
+) -> Optional[dict[Name, Term]]:
+    """Co-synthesise a whole ``mutual`` group with the genuine version space:
+    *all* members' ``@example`` facts are discharged in **one** SMT query
+    (:func:`synthesize_group`), so a member's body may call its siblings (each an
+    uninterpreted function) and the group is mutually consistent by construction
+    — the paper's MR flagship, which the per-member sibling-as-typed-oracle loop
+    cannot converge on. Returns the per-member core bodies, or ``None`` if any
+    member is outside the unary Int/Bool fragment, has no examples, or no
+    example-consistent body exists. Operators are rebound from ``op_ctx``."""
+    specs = []
+    for m in members:
+        io_examples = m.entry.get("io_examples", [])
+        io_params = m.entry.get("io_params", [])
+        if not io_examples or len(io_params) != 1:
+            return None
+        arg_key = _dsl_type(_param_type(m.hole_ctx, io_params[0]))
+        ret_key = _dsl_type(m.hole_type)
+        if arg_key is None or ret_key is None:
+            return None
+        exs = []
+        for args, out in io_examples:
+            if len(args) != 1:
+                return None
+            exs.append(Example(m.fun_name.name, args[0], out))
+        specs.append((m.fun_name, io_params[0], arg_key, ret_key, exs))
+
+    sigs = [MemberSig(fn.name, ak, rk) for (fn, _p, ak, rk, _e) in specs]
+    all_examples = [e for (_fn, _p, _ak, _rk, exs) in specs for e in exs]
+    result = synthesize_group(sigs, all_examples, max_size=max_size)
+    if result is None:
         return None
+
+    op_names = _operator_names(op_ctx)
+    member_map = {fn.name: fn for (fn, _p, _ak, _rk, _e) in specs}
+    bodies: dict[Name, Term] = {}
+    for fn, param_name, _ak, _rk, _e in specs:
+        body = _to_core(result.bodies[fn.name], param_name, member_map, op_names)
+        if body is None:
+            return None
+        bodies[fn] = body
+    return bodies
 
 
 def _dsl_type(ty: Optional[Type]) -> Optional[str]:
@@ -165,27 +228,27 @@ def _operator_names(ctx: TypingContext) -> dict[str, Term]:
     return found
 
 
-def _to_core(term: Term, param_name: Name, fun_name: Name, op_names: dict[str, Term]) -> Optional[Term]:
+def _to_core(term: Term, param_name: Name, member_map: dict[str, Name], op_names: dict[str, Term]) -> Optional[Term]:
     """Rebind the version-space body's id-0 placeholder names to the real ones:
-    the parameter, the recursive self-call, and the (monomorphised) operators.
-    Returns ``None`` if an operator is not in scope."""
+    the parameter, the (self or sibling) member calls via ``member_map``, and the
+    (monomorphised) operators. Returns ``None`` if an operator is not in scope."""
     match term:
         case Literal(_, _):
             return term
         case Var(name) if name == _PARAM:
             return Var(param_name)
-        case Var(name) if name.name == fun_name.name:
-            return Var(fun_name)
+        case Var(name) if name.name in member_map:
+            return Var(member_map[name.name])
         case Var(name):
             return op_names.get(name.name)
         case Application(fun, arg):
-            f = _to_core(fun, param_name, fun_name, op_names)
-            a = _to_core(arg, param_name, fun_name, op_names)
+            f = _to_core(fun, param_name, member_map, op_names)
+            a = _to_core(arg, param_name, member_map, op_names)
             return Application(f, a, _loc) if f is not None and a is not None else None
         case If(c, th, el):
-            cc = _to_core(c, param_name, fun_name, op_names)
-            tt = _to_core(th, param_name, fun_name, op_names)
-            ee = _to_core(el, param_name, fun_name, op_names)
+            cc = _to_core(c, param_name, member_map, op_names)
+            tt = _to_core(th, param_name, member_map, op_names)
+            ee = _to_core(el, param_name, member_map, op_names)
             if cc is None or tt is None or ee is None:
                 return None
             return If(cc, tt, ee, _loc)

--- a/aeon/synthesis/modules/contata/synthesizer.py
+++ b/aeon/synthesis/modules/contata/synthesizer.py
@@ -1,0 +1,193 @@
+"""``-s contata`` — the example-driven Constraint-Annotated Tree Automaton.
+
+Where the ``cata`` backend discharges a *refinement-type* spec one candidate at
+a time with the liquid typechecker, ``contata`` is the paper-faithful **version
+space**: a candidate body denotes (symbolically, over the functions under
+synthesis as uninterpreted functions) and is accepted under an SMT model against
+the ground ``@example`` spec, with the well-foundedness side condition and
+MinTree extraction (see :mod:`aeon.synthesis.modules.contata.cata`).
+
+This adapter wires that version space into the single-hole ``Synthesizer`` API:
+it reads the hole's ``@example`` I/O facts, runs :func:`synthesize_group` for the
+one member, maps the resulting DSL body onto the real in-scope names
+(parameter, the recursive self-call, and the arithmetic/comparison operators),
+and discharges the mapped term through ``validate`` as a final soundness gate.
+A whole ``mutual`` block is co-synthesised jointly by the entrypoint
+(:func:`aeon.synthesis.entrypoint._cosynthesize_group`); this backend is the
+per-member engine that path drives.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from loguru import logger
+
+from aeon.core.terms import Application, If, Literal, Term, Var
+from aeon.core.types import Type, t_bool, t_int
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.modules.fta.synthesizer import _safe
+from aeon.synthesis.modules.contata.cata import (
+    BOOL,
+    INT,
+    Example,
+    MemberSig,
+    _PARAM,
+    synthesize_group,
+)
+from aeon.synthesis.modules.lta.polymorphism import is_polymorphic, monomorphize
+from aeon.synthesis.modules.symetric.synthesizer import base_key
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.location import SynthesizedLocation
+from aeon.utils.name import Name
+
+_loc = SynthesizedLocation("contata")
+
+
+class ContataSynthesizer(Synthesizer):
+    """Example-driven CATA version space, single-hole adapter."""
+
+    def __init__(self, max_size: int = 4):
+        self.max_size = max_size
+
+    def computations(self, primitives: Any) -> dict[str, Any]:
+        # Acceptance is by the SMT version space + ``validate``, not by a fitness
+        # value over a single ground input. Nothing extra to compute.
+        return {}
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
+    ) -> Term:
+        ui.register(None, None, 0, True)
+        entry = metadata.get(fun_name, {})
+        io_examples = entry.get("io_examples", [])
+        io_params = entry.get("io_params", [])
+
+        # The version space synthesises *unary* members from a ground spec.
+        if not io_examples:
+            raise SynthesisNotSuccessful(
+                f"contata: no @example I/O facts for {fun_name.name}; this backend synthesises from "
+                "ground examples (e.g. @example(f 0 = true))."
+            )
+        if len(io_params) != 1:
+            raise SynthesisNotSuccessful(
+                f"contata: {fun_name.name} is not unary ({len(io_params)} value parameters); the "
+                "version space currently handles single-argument members."
+            )
+        param_name = io_params[0]
+
+        arg_key = _dsl_type(self._param_type(ctx, param_name))
+        ret_key = _dsl_type(type)
+        if arg_key is None or ret_key is None:
+            raise SynthesisNotSuccessful(
+                f"contata: {fun_name.name} has a type outside the Int/Bool DSL; not supported."
+            )
+
+        examples: list[Example] = []
+        for args, out in io_examples:
+            if len(args) != 1:
+                raise SynthesisNotSuccessful("contata: expected exactly one argument per example.")
+            examples.append(Example(fun_name.name, args[0], out))
+
+        members = [MemberSig(fun_name.name, arg_key, ret_key)]
+        result = synthesize_group(members, examples, max_size=self.max_size)
+        if result is None:
+            raise SynthesisNotSuccessful(
+                f"contata: no example-consistent body for {fun_name.name} within size {self.max_size}."
+            )
+
+        op_names = _operator_names(ctx)
+        body = _to_core(result.bodies[fun_name.name], param_name, fun_name, op_names)
+        if body is None:
+            raise SynthesisNotSuccessful(
+                f"contata: synthesised body uses an operator not in scope for {fun_name.name}."
+            )
+        if not _safe(validate, body):
+            raise SynthesisNotSuccessful(
+                f"contata: synthesised body for {fun_name.name} did not discharge against its type."
+            )
+        ui.register(body, [0.0], 0, True)
+        logger.log(
+            "SYNTHESIZER",
+            f"contata: version-space body for {fun_name.name} accepted under SMT over "
+            f"{len(examples)} example(s) and discharged by the typechecker.",
+        )
+        return body
+
+    @staticmethod
+    def _param_type(ctx: TypingContext, param_name: Name) -> Optional[Type]:
+        for n, ty in ctx.vars():
+            if n == param_name:
+                return ty
+        return None
+
+
+def _dsl_type(ty: Optional[Type]) -> Optional[str]:
+    """The DSL key for an Aeon type, or ``None`` if outside the supported fragment."""
+    if ty is None:
+        return None
+    key = base_key(ty)
+    if key == base_key(t_int):
+        return INT
+    if key == base_key(t_bool):
+        return BOOL
+    return None
+
+
+def _operator_names(ctx: TypingContext) -> dict[str, Term]:
+    """Map each DSL operator string to a concrete in-scope **head term**. The
+    prelude's arithmetic/comparison operators are polymorphic (``forall a:B, …``),
+    so the bare ``Var`` the version space emits will not typecheck — each is
+    monomorphised at ``Int`` (a ``TypeApplication`` nest), exactly as the ``cata``
+    backend does, so ``x == 0`` / ``x - 1`` discharge."""
+    wanted = {"+", "-", "==", "<", "<=", ">", ">="}
+    found: dict[str, Term] = {}
+    for n, ty in ctx.vars():
+        if n.name not in wanted or n.name in found:
+            continue
+        if is_polymorphic(ty):
+            insts = monomorphize(n, ty, [t_int], max_instantiations=4)
+            if insts:
+                found[n.name] = insts[0].term
+        else:
+            found[n.name] = Var(n)
+    return found
+
+
+def _to_core(term: Term, param_name: Name, fun_name: Name, op_names: dict[str, Term]) -> Optional[Term]:
+    """Rebind the version-space body's id-0 placeholder names to the real ones:
+    the parameter, the recursive self-call, and the (monomorphised) operators.
+    Returns ``None`` if an operator is not in scope."""
+    match term:
+        case Literal(_, _):
+            return term
+        case Var(name) if name == _PARAM:
+            return Var(param_name)
+        case Var(name) if name.name == fun_name.name:
+            return Var(fun_name)
+        case Var(name):
+            return op_names.get(name.name)
+        case Application(fun, arg):
+            f = _to_core(fun, param_name, fun_name, op_names)
+            a = _to_core(arg, param_name, fun_name, op_names)
+            return Application(f, a, _loc) if f is not None and a is not None else None
+        case If(c, th, el):
+            cc = _to_core(c, param_name, fun_name, op_names)
+            tt = _to_core(th, param_name, fun_name, op_names)
+            ee = _to_core(el, param_name, fun_name, op_names)
+            if cc is None or tt is None or ee is None:
+                return None
+            return If(cc, tt, ee, _loc)
+        case _:
+            return None

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -13,6 +13,7 @@ from aeon.synthesis.modules.symetric import SymetricSynthesizer
 from aeon.synthesis.modules.fta import FTASynthesizer
 from aeon.synthesis.modules.afta import AFTASynthesizer
 from aeon.synthesis.modules.cata import CATASynthesizer
+from aeon.synthesis.modules.contata.synthesizer import ContataSynthesizer
 from aeon.synthesis.tactics import TacticRandomSynthesizer
 
 
@@ -39,6 +40,7 @@ SYNTHESIZER_LABELS: dict[str, str] = {
     "fta": "Finite Tree Automata (FTA)",
     "afta": "Abstraction-refinement FTA",
     "cata": "Constraint-annotated Tree Automata",
+    "contata": "Constraint-annotated Tree Automata (version space, from examples)",
 }
 
 
@@ -90,5 +92,7 @@ def make_synthesizer(module: str) -> Synthesizer:
             return AFTASynthesizer()
         case "cata":
             return CATASynthesizer()
+        case "contata":
+            return ContataSynthesizer()
         case _:
             assert False, f"Not supported synthesizer with name {module}"

--- a/aeon/utils/pprint.py
+++ b/aeon/utils/pprint.py
@@ -609,6 +609,10 @@ def sterm_pretty(sterm: STerm, context: ParenthesisContext = None, depth: int = 
             )
 
         case STypeApplication(body=body, type=_type):
+            # Inferred type arguments are elided from surface output for
+            # readability (they are reconstructed by elaboration). When a type
+            # application *is* rendered textually it uses ``{t}`` (see
+            # ``STypeApplication.__str__``).
             pretty_body = sterm_pretty(body, ParenthesisContext(Precedence.APPLICATION, Side.LEFT), depth + 1)
             return group(pretty_body)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,8 @@ Main returns Unit, which is the singleton type. It can be used like void in C.
 
 ### Comments
 
-Just like in Python, any line starting with # is a comment.
+Just like in Python, any line starting with # is a comment. (The one exception
+is `#[`, which opens an array literal — see below.)
 
 ### Literals
 
@@ -102,6 +103,22 @@ Just like in Python, any line starting with # is a comment.
 |    Int | ..., -2, -1, 0, 1, 2, ...           |
 |  Float | ..., -2.0, -1.0, 0.0, 1.0, 2.0, ... |
 | String | "", "a", "ab", ...                  |
+|   List | `[]`, `[1, 2, 3]`, `[[1, 2], [3]]`  |
+|  Array | `#[]`, `#[1, 2, 3]`                  |
+
+#### Collection literals
+
+Following Lean, `[1, 2, 3]` is a `List` literal and `#[1, 2, 3]` an `Array`
+literal (`import List` / `import Array` to bring the types into scope). They
+desugar to the library constructors — `[1, 2, 3]` to
+`List.cons 1 (List.cons 2 (List.cons 3 List.nil))` and `#[1, 2, 3]` to
+`Array.append (Array.append (Array.append Array.new 1) 2) 3` — and element types
+are inferred. An empty literal (`[]` / `#[]`) is fine where the element type is
+known (e.g. from an annotation: `let e : (List Int) := []`).
+
+As in Lean, the bracket is whitespace-sensitive: a **spaced** `[` is a list
+literal, while an **attached** `[` is a type application. So `f [1, 2]` applies
+`f` to a list, whereas `f[Int]` instantiates the polymorphic `f` at `Int`.
 
 ### Expressions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ The list below covers the ideas you'll meet first, with just enough context to g
 | **No exceptions, no `null`** | Errors are not raised. Failure is modelled with inductive types (`Maybe a`, `Either a b`) or, when possible, ruled out by refinement types so the failure case becomes unrepresentable. |
 | **Inductive types and pattern matching** | Data is defined with `inductive` (a sum of named constructors, each carrying typed fields), and destructured with `match ... with`. All constructors must be covered. |
 | **Functional, not object-oriented** | There are no classes, methods, or inheritance — only functions and inductive types. Behaviour is composed by passing functions, not by overriding. |
-| **Explicit polymorphism** | Generics are introduced with `forall t : B, ...` and applied at the call site, e.g. `id[Int]`. Type abstractions in the body use `Λ` (capital lambda). |
+| **Explicit polymorphism** | Generics are introduced with `forall t : B, ...` and applied at the call site with braces, e.g. `id{Int}`. Type abstractions in the body use `Λ` (capital lambda). |
 | **Parametric refinements** | A function can be polymorphic over a refinement *predicate*, not just over a type. This lets one definition preserve whatever invariant the caller's arguments happen to satisfy. |
 | **Synthesis is a language feature** | `?hole` is a legal expression. The compiler can search for an expression of the surrounding type, optionally guided by `@minimize` / `@maximize` decorators, training data, or natural-language prompts. |
 | **Surface syntax** | Top-level definitions use `def`; local bindings use `let`. Function types use `->` (or the Unicode `→`). Comments begin with `#`. |
@@ -116,9 +116,8 @@ desugar to the library constructors — `[1, 2, 3]` to
 are inferred. An empty literal (`[]` / `#[]`) is fine where the element type is
 known (e.g. from an annotation: `let e : (List Int) := []`).
 
-As in Lean, the bracket is whitespace-sensitive: a **spaced** `[` is a list
-literal, while an **attached** `[` is a type application. So `f [1, 2]` applies
-`f` to a list, whereas `f[Int]` instantiates the polymorphic `f` at `Int`.
+`[` is always a list literal — type application uses braces (`f{Int}`), so the
+two never collide.
 
 ### Expressions
 
@@ -335,16 +334,18 @@ def wrap : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} 
 
 def main (args:Int) : Unit :=
     score : Int | score > 0 := 42;
-    safe_score : Int | safe_score > 0 := wrap[Int]{fun n => n > 0} score;
+    safe_score : Int | safe_score > 0 := wrap{Int}{|fun n => n > 0|} score;
     print safe_score;
 ```
 
-#### Refinement application
+#### Type and refinement application
 
-When calling a function with an explicit refinement parameter, use `{predicate}` to supply the refinement:
+Type application uses braces: `f{Int}` instantiates a `forall t : B` parameter at
+`Int`. A refinement parameter (`forall <p : T -> Bool>`) is supplied with
+`{|predicate|}`:
 
 ```
-wrap[Int]{fun n => n > 0} score
+wrap{Int}{|fun n => n > 0|} score
 ```
 
 ### Inductive types with parametric refinements

--- a/docs/os-subprocess.md
+++ b/docs/os-subprocess.md
@@ -114,14 +114,14 @@ An `Array String` is a Python `list[str]` at runtime, so it flows directly into
 
 ```aeon
 def echoArgs : {a: (Array String) | Array.size a >= 1} :=
-    Array.append (Array.append (Array.new[String]) "echo") "hello"
+    Array.append (Array.append (Array.new{String}) "echo") "hello"
 ```
 
 An empty argv — which would raise `IndexError` inside `subprocess` — is a type
 error:
 
 ```aeon
-def bad : CompletedProcess := Subprocess.run (Array.new[String])
+def bad : CompletedProcess := Subprocess.run (Array.new{String})
 ```
 
 ```

--- a/examples/99problems/p01_last.ae
+++ b/examples/99problems/p01_last.ae
@@ -6,5 +6,5 @@ open Array
 def Array.last (l: {x:(Array a) | Array.size x > 0}) : a := native "l[-1]"
 
 def main (args:Int) : Unit :=
-    xs := (((Array.new[Int]).append 1).append 2).append 3;
+    xs := (((Array.new{Int}).append 1).append 2).append 3;
     print xs.last;

--- a/examples/99problems/p02_secondLast.ae
+++ b/examples/99problems/p02_secondLast.ae
@@ -6,5 +6,5 @@ open Array
 def Array.secondLast (l: {x:(Array a) | Array.size x > 1}) : a := native "l[-2]"
 
 def main (args:Int) : Unit :=
-    xs := (((Array.new[Int]).append 1).append 2).append 3;
+    xs := (((Array.new{Int}).append 1).append 2).append 3;
     print xs.secondLast;

--- a/examples/99problems/p03_kth.ae
+++ b/examples/99problems/p03_kth.ae
@@ -6,5 +6,5 @@ open Array
 def kth (l: (Array a)) (k: {n:Int | n >= 0 && n < Array.size l}) : a := native "l[k]"
 
 def main (args:Int) : Unit :=
-    xs := ((((Array.new[Int]).append 10).append 20).append 30).append 40;
+    xs := ((((Array.new{Int}).append 10).append 20).append 30).append 40;
     print (kth xs 2);

--- a/examples/99problems/p04_length.ae
+++ b/examples/99problems/p04_length.ae
@@ -6,5 +6,5 @@ open Array
 def Array.len (l: (Array a)) : {n:Int | n = Array.size l} := l.length
 
 def main (args:Int) : Unit :=
-    xs := (((Array.new[Int]).append 1).append 2).append 3;
+    xs := (((Array.new{Int}).append 1).append 2).append 3;
     print xs.len;

--- a/examples/99problems/p05_reverse.ae
+++ b/examples/99problems/p05_reverse.ae
@@ -6,6 +6,6 @@ open Array
 def Array.rev (l: (Array a)) : {r:(Array a) | Array.size r = Array.size l} := native "l[::-1]"
 
 def main (args:Int) : Unit :=
-    xs := (((Array.new[Int]).append 1).append 2).append 3;
+    xs := (((Array.new{Int}).append 1).append 2).append 3;
     rs : (Array Int) := xs.rev;
     print rs;

--- a/examples/99problems/p06_palindrome.ae
+++ b/examples/99problems/p06_palindrome.ae
@@ -8,7 +8,7 @@ def listEq (xs: (Array Int)) (ys: (Array Int)) : Bool := native "xs == ys"
 def Array.isPalindrome (l: (Array Int)) : Bool := listEq l l.reversed
 
 def main (args:Int) : Unit :=
-    pal := (((Array.new[Int]).append 1).append 2).append 1;
-    notpal := (((Array.new[Int]).append 1).append 2).append 3;
+    pal := (((Array.new{Int}).append 1).append 2).append 1;
+    notpal := (((Array.new{Int}).append 1).append 2).append 3;
     _ := print pal.isPalindrome;
     print notpal.isPalindrome

--- a/examples/99problems/p07_flatten.ae
+++ b/examples/99problems/p07_flatten.ae
@@ -6,10 +6,10 @@ open Array
 def flatten (l: (Array (Array Int))) : (Array Int) := native "[x for sub in l for x in sub]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((Array.new[Int]).append 1).append 2;
-    b : (Array Int) := (Array.new[Int]).append 3;
-    c : (Array Int) := ((Array.new[Int]).append 4).append 5;
-    n1 : (Array (Array Int)) := (Array.new[(Array Int)]).append a;
+    a : (Array Int) := ((Array.new{Int}).append 1).append 2;
+    b : (Array Int) := (Array.new{Int}).append 3;
+    c : (Array Int) := ((Array.new{Int}).append 4).append 5;
+    n1 : (Array (Array Int)) := (Array.new{(Array Int)}).append a;
     n2 : (Array (Array Int)) := n1.append b;
     nested : (Array (Array Int)) := n2.append c;
     print (flatten nested)

--- a/examples/99problems/p08_compress.ae
+++ b/examples/99problems/p08_compress.ae
@@ -7,5 +7,5 @@ def Array.compress (l: (Array Int)) : {r:(Array Int) | Array.size r <= Array.siz
     native "[x for i, x in enumerate(l) if i == 0 or x != l[i-1]]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := (((((Array.new[Int]).append 1).append 1).append 2).append 3).append 3;
+    a : (Array Int) := (((((Array.new{Int}).append 1).append 1).append 2).append 3).append 3;
     print a.compress

--- a/examples/99problems/p09_pack.ae
+++ b/examples/99problems/p09_pack.ae
@@ -8,5 +8,5 @@ def pack (l: (Array Int)) : (Array (Array Int)) :=
     native "[list(g) for k, g in itertools.groupby(l)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
+    a : (Array Int) := ((((((Array.new{Int}).append 1).append 1).append 1).append 2).append 3).append 3;
     print (pack a)

--- a/examples/99problems/p10_encode.ae
+++ b/examples/99problems/p10_encode.ae
@@ -9,5 +9,5 @@ def encode (l: (Array Int)) : (Array (Array Int)) :=
     native "[[len(list(g)), k] for k, g in itertools.groupby(l)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
+    a : (Array Int) := ((((((Array.new{Int}).append 1).append 1).append 1).append 2).append 3).append 3;
     print (encode a)

--- a/examples/99problems/p11_encode_modified.ae
+++ b/examples/99problems/p11_encode_modified.ae
@@ -10,5 +10,5 @@ def encode_modified (l: (Array Int)) : (Array (Array Int)) :=
     native "[(lambda gl: [k] if len(gl) == 1 else [len(gl), k])(list(g)) for k, g in itertools.groupby(l)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
+    a : (Array Int) := ((((((Array.new{Int}).append 1).append 1).append 1).append 2).append 3).append 3;
     print (encode_modified a)

--- a/examples/99problems/p12_decode.ae
+++ b/examples/99problems/p12_decode.ae
@@ -7,10 +7,10 @@ def decode (l: (Array (Array Int))) : (Array Int) :=
     native "[pair[1] for pair in l for _ in range(pair[0])]"
 
 def main (args:Int) : Unit :=
-    p1 : (Array Int) := ((Array.new[Int]).append 3).append 1;
-    p2 : (Array Int) := ((Array.new[Int]).append 1).append 2;
-    p3 : (Array Int) := ((Array.new[Int]).append 2).append 3;
-    enc1 : (Array (Array Int)) := (Array.new[(Array Int)]).append p1;
+    p1 : (Array Int) := ((Array.new{Int}).append 3).append 1;
+    p2 : (Array Int) := ((Array.new{Int}).append 1).append 2;
+    p3 : (Array Int) := ((Array.new{Int}).append 2).append 3;
+    enc1 : (Array (Array Int)) := (Array.new{(Array Int)}).append p1;
     enc2 : (Array (Array Int)) := enc1.append p2;
     enc : (Array (Array Int)) := enc2.append p3;
     print (decode enc)

--- a/examples/99problems/p13_encode_direct.ae
+++ b/examples/99problems/p13_encode_direct.ae
@@ -9,5 +9,5 @@ def encode_direct (l: (Array Int)) : (Array (Array Int)) :=
     native "functools.reduce(lambda acc, x: acc + [[1, x]] if not acc or acc[-1][1] != x else acc[:-1] + [[acc[-1][0]+1, x]], l, [])"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((((((Array.new[Int]).append 1).append 1).append 1).append 2).append 3).append 3;
+    a : (Array Int) := ((((((Array.new{Int}).append 1).append 1).append 1).append 2).append 3).append 3;
     print (encode_direct a)

--- a/examples/99problems/p14_duplicate.ae
+++ b/examples/99problems/p14_duplicate.ae
@@ -7,5 +7,5 @@ def duplicate (l: (Array Int)) : {r:(Array Int) | Array.size r = 2 * Array.size 
     native "[x for x in l for _ in range(2)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := (((Array.new[Int]).append 1).append 2).append 3;
+    a : (Array Int) := (((Array.new{Int}).append 1).append 2).append 3;
     print (duplicate a)

--- a/examples/99problems/p15_replicate.ae
+++ b/examples/99problems/p15_replicate.ae
@@ -7,5 +7,5 @@ def replicate (l: (Array Int)) (n: {k:Int | k >= 0}) : {r:(Array Int) | Array.si
     native "[x for x in l for _ in range(n)]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((Array.new[Int]).append 1).append 2;
+    a : (Array Int) := ((Array.new{Int}).append 1).append 2;
     print (replicate a 3)

--- a/examples/99problems/p16_drop_every.ae
+++ b/examples/99problems/p16_drop_every.ae
@@ -7,5 +7,5 @@ def drop_every (l: (Array Int)) (n: {k:Int | k >= 1}) : (Array Int) :=
     native "[x for i, x in enumerate(l) if (i + 1) % n != 0]"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6).append 7).append 8;
+    a : (Array Int) := ((((((((Array.new{Int}).append 1).append 2).append 3).append 4).append 5).append 6).append 7).append 8;
     print (drop_every a 3)

--- a/examples/99problems/p17_split.ae
+++ b/examples/99problems/p17_split.ae
@@ -8,5 +8,5 @@ def split (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array.size l}) : (Array (
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array.size x = 5} :=
-        (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
+        (((((Array.new{Int}).append 1).append 2).append 3).append 4).append 5;
     print (split a 2)

--- a/examples/99problems/p18_slice.ae
+++ b/examples/99problems/p18_slice.ae
@@ -10,5 +10,5 @@ def slice (l: (Array Int))
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array.size x = 7} :=
-        (((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6).append 7;
+        (((((((Array.new{Int}).append 1).append 2).append 3).append 4).append 5).append 6).append 7;
     print (slice a 3 5)

--- a/examples/99problems/p19_rotate.ae
+++ b/examples/99problems/p19_rotate.ae
@@ -7,5 +7,5 @@ def rotate (l: (Array Int)) (n: Int) : {r:(Array Int) | Array.size r = Array.siz
     native "l[n % len(l):] + l[:n % len(l)] if l else l"
 
 def main (args:Int) : Unit :=
-    a : (Array Int) := ((((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6).append 7).append 8;
+    a : (Array Int) := ((((((((Array.new{Int}).append 1).append 2).append 3).append 4).append 5).append 6).append 7).append 8;
     print (rotate a 3)

--- a/examples/99problems/p20_remove_at.ae
+++ b/examples/99problems/p20_remove_at.ae
@@ -9,5 +9,5 @@ def remove_at (l: (Array Int)) (k: {x:Int | x >= 0 && x < Array.size l}) :
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array.size x = 5} :=
-        (((((Array.new[Int]).append 10).append 20).append 30).append 40).append 50;
+        (((((Array.new{Int}).append 10).append 20).append 30).append 40).append 50;
     print (remove_at a 2)

--- a/examples/99problems/p21_insert_at.ae
+++ b/examples/99problems/p21_insert_at.ae
@@ -9,5 +9,5 @@ def insert_at (x: Int) (l: (Array Int)) (k: {n:Int | n >= 0 && n <= Array.size l
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array.size x = 4} :=
-        ((((Array.new[Int]).append 1).append 2).append 4).append 5;
+        ((((Array.new{Int}).append 1).append 2).append 4).append 5;
     print (insert_at 3 a 2)

--- a/examples/99problems/p23_random_select.ae
+++ b/examples/99problems/p23_random_select.ae
@@ -12,5 +12,5 @@ def rndSelect (l: (Array Int)) (n: {k:Int | k >= 0 && k <= Array.size l}) :
 def main (args:Int) : Unit :=
     _ := native "random.seed(42)";
     a : {x:(Array Int) | Array.size x = 6} :=
-        ((((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5).append 6;
+        ((((((Array.new{Int}).append 1).append 2).append 3).append 4).append 5).append 6;
     print (rndSelect a 3)

--- a/examples/99problems/p25_random_permutation.ae
+++ b/examples/99problems/p25_random_permutation.ae
@@ -10,5 +10,5 @@ def rndPermutation (l: (Array Int)) : {r:(Array Int) | Array.size r = Array.size
 
 def main (args:Int) : Unit :=
     _ := native "random.seed(7)";
-    a : (Array Int) := (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
+    a : (Array Int) := (((((Array.new{Int}).append 1).append 2).append 3).append 4).append 5;
     print (rndPermutation a)

--- a/examples/99problems/p26_combinations.ae
+++ b/examples/99problems/p26_combinations.ae
@@ -10,5 +10,5 @@ def combinations (k: {n:Int | n >= 0}) (l: {x:(Array Int) | Array.size x >= k}) 
 
 def main (args:Int) : Unit :=
     a : {x:(Array Int) | Array.size x = 5} :=
-        (((((Array.new[Int]).append 1).append 2).append 3).append 4).append 5;
+        (((((Array.new{Int}).append 1).append 2).append 3).append 4).append 5;
     print (combinations 3 a)

--- a/examples/imports/subprocess_example.ae
+++ b/examples/imports/subprocess_example.ae
@@ -6,7 +6,7 @@ open Array
 # `Array.size` postconditions of `append` discharge that automatically.
 
 def echoArgs : {a: (Array String) | Array.size a >= 1} :=
-    ((Array.new[String]).append "echo").append "hello"
+    ((Array.new{String}).append "echo").append "hello"
 
 # Inspect the exit code before trusting the output. `succeeded` ties the
 # boolean to the `exitCode` measure, so the branch reads cleanly.

--- a/examples/list/test_list_main.ae
+++ b/examples/list/test_list_main.ae
@@ -2,10 +2,10 @@ open List
 
 def consume : (l:(List Int)) -> Int := fun n => 0;
 
-def pos : Int := consume (List.snoc (List.nil[Int]) 1)
+def pos : Int := consume (List.snoc (List.nil{Int}) 1)
 
 def main (x:Int) : Unit :=
-    nil0 : (List Int) := List.nil[Int];
+    nil0 : (List Int) := List.nil{Int};
     one : (List Int) := nil0.snoc 3;
     two : (List Int) := one.snoc 2;
     three : (List Int) := two.snoc 1;

--- a/examples/llvm/gpu/busy.ae
+++ b/examples/llvm/gpu/busy.ae
@@ -2,10 +2,10 @@ open Array
 
 @gpu(target:="cuda", debug:=true)
 def multiply_by_ten (v:(Array Int)) : (Array Int) :=
-    Array.map[Int][Int] (fun (x : Int) => x * 10) v;
+    Array.map{Int}{Int} (fun (x : Int) => x * 10) v;
 
 def main (args:Int) : Unit :=
     let size : Int := 1000000 in
     let v : (Array Int) := native "[0] * size" in
     let res : (Array Int) := multiply_by_ten v in
-    print (Array.get[Int] res 1);
+    print (Array.get{Int} res 1);

--- a/examples/llvm/gpu/vector_map.ae
+++ b/examples/llvm/gpu/vector_map.ae
@@ -2,12 +2,12 @@ open Array
 
 @gpu(target:="cuda", block_size:=256)
 def multiply_by_ten (v:(Array Int)) : (Array Int) :=
-    Array.map[Int][Int] (fun (x : Int) => x * 10) v;
+    Array.map{Int}{Int} (fun (x : Int) => x * 10) v;
 
 def main (args:Int) : Unit :=
-    let v : (Array Int) := Array.new[Int] in
-    let v1 : (Array Int) := Array.append[Int] v 1 in
-    let v2 : (Array Int) := Array.append[Int] v1 2 in
-    let v3 : (Array Int) := Array.append[Int] v2 3 in
+    let v : (Array Int) := Array.new{Int} in
+    let v1 : (Array Int) := Array.append{Int} v 1 in
+    let v2 : (Array Int) := Array.append{Int} v1 2 in
+    let v3 : (Array Int) := Array.append{Int} v2 3 in
     let res : (Array Int) := multiply_by_ten v3 in
-    print (Array.get[Int] res 1);
+    print (Array.get{Int} res 1);

--- a/examples/pbt/props_args.ae
+++ b/examples/pbt/props_args.ae
@@ -36,7 +36,7 @@ def argvModeSlow : (Array String) := native "['--mode', 'slow']"
 # Built by chaining .append so its size (2 > 0) is provable — addChoice requires
 # a statically non-empty list of options.
 def choicesModes : {l : (Array String) | Array.size l > 0} :=
-    ((Array.new[String]).append "fast").append "slow"
+    ((Array.new{String}).append "fast").append "slow"
 
 def singleton (x : String) : (Array String) := native "[x]"
 

--- a/examples/syntax/collection_literals.ae
+++ b/examples/syntax/collection_literals.ae
@@ -3,9 +3,8 @@
 #   [1, 2, 3]    a List  (desugars to List.cons 1 (List.cons 2 (List.cons 3 List.nil)))
 #   #[1, 2, 3]   an Array (desugars to Array.append (Array.append (Array.append Array.new 1) 2) 3)
 #
-# Element types are inferred. Following Lean, a *spaced* bracket is a list literal
-# while an *attached* one is a type application: `f [x]` applies `f` to a list,
-# `f[Int]` instantiates `f` at `Int`. `#[` opens an array — it is never a comment.
+# Element types are inferred. `[` is always a list literal; type application uses
+# braces — `f{Int}` instantiates `f` at `Int`. `#[` opens an array — never a comment.
 
 import List
 import Array

--- a/examples/syntax/collection_literals.ae
+++ b/examples/syntax/collection_literals.ae
@@ -1,0 +1,27 @@
+# Lean-style collection literals.
+#
+#   [1, 2, 3]    a List  (desugars to List.cons 1 (List.cons 2 (List.cons 3 List.nil)))
+#   #[1, 2, 3]   an Array (desugars to Array.append (Array.append (Array.append Array.new 1) 2) 3)
+#
+# Element types are inferred. Following Lean, a *spaced* bracket is a list literal
+# while an *attached* one is a type application: `f [x]` applies `f` to a list,
+# `f[Int]` instantiates `f` at `Int`. `#[` opens an array — it is never a comment.
+
+import List
+import Array
+
+# A list literal, and a method-dot directly on it.
+def xs : (List Int) := [1, 2, 3]
+def three : Int := [1, 2, 3].length
+
+# An array literal; element order is preserved.
+def ys : (Array Int) := #[10, 20, 30, 40]
+
+# Nested lists and the empty list (annotated, so its element type is known).
+def grid : (List (List Int)) := [[1, 2], [3], []]
+
+# Literals are ordinary expressions: pass them as arguments, fold over them.
+def add (x:Int) (y:Int) : Int := x + y
+def total : Int := List.foldr add 0 [1, 2, 3, 4]
+
+def main (args:Int) : Int := three + List.length xs + Array.length ys + total

--- a/examples/syntax/implicit_id.ae
+++ b/examples/syntax/implicit_id.ae
@@ -2,5 +2,5 @@ def id : forall t : B, forall <p : t -> Bool>,(x : t | p x) -> {v : t | p v} := 
 
 def main (args:Int) : Unit :=
     x : Int | x > 0 := 3;
-    y : Int | y > 0 := id[Int] x;
+    y : Int | y > 0 := id{Int} x;
     print (y);

--- a/examples/synthesis/cata/README.md
+++ b/examples/synthesis/cata/README.md
@@ -53,5 +53,39 @@ So the single-function files here are a **feasible reconstruction** in the spiri
 of the RC category: functions whose *relational refinement* (parameters ↔
 result) pins down the implementation, which aeon's CATA discharges via the liquid
 typechecker. `mutual_cosynth.ae` exercises MR co-synthesis, and
-`relational_property.ae` a k-safety property over a mutual group. Full
-benchmark-suite coverage and property-driven CEGIS guidance remain future work.
+`relational_property.ae` a k-safety property over a mutual group.
+
+## `-s contata` — the paper-faithful version space
+
+The `cata` backend above *discharges* a refinement-type spec one candidate at a
+time. The `contata` backend is the paper's actual **version space** (the CATA of
+the title): a candidate body denotes **symbolically** as a z3 expression over the
+functions under synthesis treated as *uninterpreted functions* (the constraint
+annotation), and is **accepted under a model** (Def. 6) iff the ground `@example`
+specification together with the body's denotation at every example input is
+satisfiable — one SMT query. Recursion and mutual recursion need no fixpoint
+(the calls are uninterpreted), the well-foundedness side condition `v' ≺ v_in`
+(Fig. 5) rejects non-terminating bodies, and the **smallest** accepted tree is
+returned (MinTree, Def. 11). Observationally-equivalent member-call-free
+sub-programs are merged by their value-vector (FTA-style compression).
+
+```bash
+uv run python -m aeon --no-main -s contata examples/synthesis/cata/contata_pbe.ae
+```
+
+The version space genuinely synthesises the paper's flagships from examples:
+
+- **MR** — `even`/`odd` co-synthesised from `@example` facts, each body a
+  base/recursive conditional that calls its *sibling* (the mutually-recursive
+  solution, accepted jointly under one model).
+- **PDS** — `length : List Int -> Int` recovered as
+  `if isEmpty xs then 0 else 1 + length (tail xs)` from trace-closed examples;
+  list values are opaque SMT constants, the `isEmpty`/`head`/`tail` destructors
+  fold concretely, and the well-founded measure is list length.
+
+See `tests/contata_test.py`. The single-hole `-s contata` CLI path covers the
+Int/Bool fragment (it rebinds the version-space body onto the real in-scope
+parameter, recursive self-call, and operators monomorphised at `Int`, then
+discharges it through the typechecker); the richer mutual/list version space is
+exercised through its API. Full benchmark-suite coverage (deeper integer
+accumulators, trees) and property-driven CEGIS guidance remain future work.

--- a/examples/synthesis/cata/README.md
+++ b/examples/synthesis/cata/README.md
@@ -40,13 +40,14 @@ a time and discharged by the liquid typechecker.
   where evaluating one member's `@example` requires the sibling to already be
   filled — true co-search rather than sibling-as-typed-oracle.
 - **Relational / k-safety specs** relating *multiple* functions or multiple runs
-  of one function (much of RC and all of SO, e.g. `f (f x) = x`) — *now expressible*
-  as a `@property`, which the co-synthesis acceptance oracle checks (under
-  property-based testing) alongside the per-function refinement types and any
-  `@example`s. See `relational_property.ae`. What remains: using a failing
-  property as a *counterexample-driven guide* (CEGIS) — feeding the failing
-  input through the z3 unsat-core machinery to derive per-function obligations —
-  rather than only as an accept/reject filter.
+  of one function (much of RC and all of SO, e.g. `f (f x) = x`) — expressible as
+  a `@property`, which is both (a) a co-synthesis acceptance oracle, checked
+  under property-based testing alongside the per-function refinement types and
+  `@example`s, and (b) a **counterexample-driven guide** (CEGIS): a failing
+  property's input is run under the instrumented semantics, the property is
+  encoded as a relational constraint, and z3's unsat core blames the conflicting
+  calls while a model derives concrete per-function obligations — propagated down
+  the call chain to the example-anchored base cases. See `relational_property.ae`.
 
 So the single-function files here are a **feasible reconstruction** in the spirit
 of the RC category: functions whose *relational refinement* (parameters ↔

--- a/examples/synthesis/cata/README.md
+++ b/examples/synthesis/cata/README.md
@@ -19,7 +19,7 @@ The paper evaluates Contata on **30 benchmarks** in four categories (Table 1):
 | Mutual recursion (MR) | 7 | even/odd (`evens`/`odds`) | ◐ co-synthesis of `mutual` holes |
 | Recursive comparators (RC) | 7 | int-tuple list equality | ◐ relational subset |
 | Partial data structures (PDS) | 12 | binary-tree removal | ◐ partial |
-| Stack Overflow (SO) | 4 | reverse a list twice | ✗ relational/k-safety |
+| Stack Overflow (SO) | 4 | reverse a list twice | ◐ `@property` k-safety oracle |
 
 The benchmarks are **not individually published** in the paper (only category
 counts plus one example each; sourced from Stack Overflow, FP textbooks, and
@@ -40,12 +40,17 @@ a time and discharged by the liquid typechecker.
   where evaluating one member's `@example` requires the sibling to already be
   filled — true co-search rather than sibling-as-typed-oracle.
 - **Relational / k-safety specs** relating *multiple* functions or multiple runs
-  of one function (much of RC and all of SO, e.g. `f (f x) = x`) still cannot be
-  stated as a single function's refinement.
+  of one function (much of RC and all of SO, e.g. `f (f x) = x`) — *now expressible*
+  as a `@property`, which the co-synthesis acceptance oracle checks (under
+  property-based testing) alongside the per-function refinement types and any
+  `@example`s. See `relational_property.ae`. What remains: using a failing
+  property as a *counterexample-driven guide* (CEGIS) — feeding the failing
+  input through the z3 unsat-core machinery to derive per-function obligations —
+  rather than only as an accept/reject filter.
 
 So the single-function files here are a **feasible reconstruction** in the spirit
 of the RC category: functions whose *relational refinement* (parameters ↔
 result) pins down the implementation, which aeon's CATA discharges via the liquid
-typechecker. `mutual_cosynth.ae` additionally exercises MR co-synthesis. The
-genuinely k-safety/relational multi-function benchmarks remain future work tied
-to extending the backend.
+typechecker. `mutual_cosynth.ae` exercises MR co-synthesis, and
+`relational_property.ae` a k-safety property over a mutual group. Full
+benchmark-suite coverage and property-driven CEGIS guidance remain future work.

--- a/examples/synthesis/cata/README.md
+++ b/examples/synthesis/cata/README.md
@@ -77,15 +77,20 @@ The version space genuinely synthesises the paper's flagships from examples:
 
 - **MR** — `even`/`odd` co-synthesised from `@example` facts, each body a
   base/recursive conditional that calls its *sibling* (the mutually-recursive
-  solution, accepted jointly under one model).
+  solution, accepted jointly under one model). This runs **from the CLI**: a
+  `mutual` block of holes specified only by `@example`s is discharged in one SMT
+  query by the version-space fast path in `_cosynthesize_group`. See
+  `mutual_pbe.ae`.
 - **PDS** — `length : List Int -> Int` recovered as
   `if isEmpty xs then 0 else 1 + length (tail xs)` from trace-closed examples;
   list values are opaque SMT constants, the `isEmpty`/`head`/`tail` destructors
   fold concretely, and the well-founded measure is list length.
 
-See `tests/contata_test.py`. The single-hole `-s contata` CLI path covers the
-Int/Bool fragment (it rebinds the version-space body onto the real in-scope
-parameter, recursive self-call, and operators monomorphised at `Int`, then
-discharges it through the typechecker); the richer mutual/list version space is
-exercised through its API. Full benchmark-suite coverage (deeper integer
-accumulators, trees) and property-driven CEGIS guidance remain future work.
+See `tests/contata_test.py`. The single-hole `-s contata` CLI path and the
+`mutual` group path both cover the Int/Bool fragment (rebinding the version-space
+body onto the real in-scope parameter, sibling/self calls, and operators
+monomorphised at `Int`, then discharging through the typechecker). The list/PDS
+version space is exercised through its API (aeon's `@example` literals are scalar,
+so list I/O facts are supplied programmatically). Full benchmark-suite coverage
+(deeper integer accumulators, trees, list I/O in `@example` syntax) and
+property-driven CEGIS guidance remain future work.

--- a/examples/synthesis/cata/contata_pbe.ae
+++ b/examples/synthesis/cata/contata_pbe.ae
@@ -1,0 +1,16 @@
+# Example-driven CATA version space (`-s contata`).
+#
+# Unlike `-s cata` (which discharges a *refinement-type* spec with the liquid
+# typechecker), `contata` is the paper-faithful version space: each candidate
+# body denotes symbolically over the function under synthesis (an uninterpreted
+# function) and is accepted under an SMT model against these ground @example
+# facts, with the well-foundedness side condition and MinTree extraction. Here it
+# recovers the predicate `x == 0`.
+#
+#   uv run python -m aeon --no-main -s contata examples/synthesis/cata/contata_pbe.ae
+#
+@example(isZero 0 = true)
+@example(isZero 1 = false)
+@example(isZero 2 = false)
+@example(isZero 3 = false)
+def isZero (x: {v:Int | v >= 0}) : Bool := ?hole;

--- a/examples/synthesis/cata/mutual_pbe.ae
+++ b/examples/synthesis/cata/mutual_pbe.ae
@@ -1,0 +1,22 @@
+# Mutual co-synthesis from examples via the `-s contata` version space (MR).
+#
+# Both `even` and `odd` are holes, specified only by ground @example I/O facts.
+# The version space discharges the WHOLE group in one SMT query: each body may
+# call its sibling (an uninterpreted function), so the assignment is mutually
+# consistent by construction. This is the paper's MR flagship — recovered here
+# as `even x = if x = 0 then true else odd (x-1)` and the dual for `odd`.
+#
+#   uv run python -m aeon --no-main -s contata examples/synthesis/cata/mutual_pbe.ae
+#
+mutual
+  @example(even 0 = true)
+  @example(even 1 = false)
+  @example(even 2 = true)
+  @example(even 3 = false)
+  def even (x: {v:Int | v >= 0}) : Bool decreasing_by [x] := ?he;
+  @example(odd 0 = false)
+  @example(odd 1 = true)
+  @example(odd 2 = false)
+  @example(odd 3 = true)
+  def odd (x: {v:Int | v >= 0}) : Bool decreasing_by [x] := ?ho;
+end

--- a/examples/synthesis/cata/relational_property.ae
+++ b/examples/synthesis/cata/relational_property.ae
@@ -1,0 +1,25 @@
+# Relational / k-safety specification over several functions (issue #397).
+#
+# A `@property` relates the two mutually-recursive functions to each other
+# (`even n = !(odd n)`) — a k-safety spec that is NOT a single function's
+# refinement type. aeon now uses such properties as a co-synthesis acceptance
+# oracle: a candidate assignment for the whole `mutual` group is accepted only
+# if every relational property holds (under property-based testing), alongside
+# the per-function refinement types and any `@example`s.
+#
+# The property domain is bounded so PBT samples small Nats (the recursive
+# even/odd would otherwise be evaluated on huge random inputs).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/relational_property.ae
+
+mutual
+  def even (n: {x:Int | x >= 0}) : Bool decreasing_by [n] :=
+    if n = 0 then true else odd (n - 1)
+
+  def odd (n: {x:Int | x >= 0}) : Bool decreasing_by [n] :=
+    if n = 0 then false else even (n - 1)
+end
+
+@property(50)
+def even_odd_complementary (n: {x:Int | 0 <= x && x < 12}) : Bool :=
+  even n = !(odd n);

--- a/tests/collection_literal_test.py
+++ b/tests/collection_literal_test.py
@@ -1,10 +1,10 @@
 """Lean-style collection literals: ``[1, 2, 3]`` (List) and ``#[1, 2, 3]`` (Array).
 
-A *spaced* ``[`` is a list literal; an *attached* ``[`` (``f[Int]``) stays a type
-application — disambiguated by the postlexer, mirroring Lean's ``f[i]`` vs
-``f [i]``. ``#[…]`` is an array literal (the COMMENT lexer carves out ``#[`` so it
-is not read as a comment). Literals desugar to ``List.cons``/``List.nil`` and
-``Array.new``/``Array.append``; element types are inferred by elaboration.
+``[`` is unambiguously a list literal: type application uses ``{t}`` (e.g.
+``List.nil{Int}``), so the two never collide. ``#[…]`` is an array literal (the
+COMMENT lexer carves out ``#[`` so it is not read as a comment). Literals desugar
+to ``List.cons``/``List.nil`` and ``Array.new``/``Array.append``; element types
+are inferred by elaboration.
 """
 
 from __future__ import annotations
@@ -55,10 +55,10 @@ def test_nested_list_literal():
     assert _run("import List;\ndef main (u:Int) : Int := List.length [[1, 2], [3]];") == 2
 
 
-def test_attached_bracket_is_still_type_application():
-    # Regression: ``List.nil[Int]`` (attached ``[``) must remain a type
-    # application, not a list literal.
-    assert _run("import List;\ndef main (u:Int) : Int := List.length (List.nil[Int]);") == 0
+def test_type_application_uses_braces():
+    # Type application is ``{t}`` (``[`` is reserved for list literals), so
+    # ``List.nil{Int}`` instantiates the empty list at ``Int``.
+    assert _run("import List;\ndef main (u:Int) : Int := List.length (List.nil{Int});") == 0
 
 
 def test_list_literal_elements_evaluate():

--- a/tests/collection_literal_test.py
+++ b/tests/collection_literal_test.py
@@ -1,0 +1,71 @@
+"""Lean-style collection literals: ``[1, 2, 3]`` (List) and ``#[1, 2, 3]`` (Array).
+
+A *spaced* ``[`` is a list literal; an *attached* ``[`` (``f[Int]``) stays a type
+application — disambiguated by the postlexer, mirroring Lean's ``f[i]`` vs
+``f [i]``. ``#[…]`` is an array literal (the COMMENT lexer carves out ``#[`` so it
+is not read as a comment). Literals desugar to ``List.cons``/``List.nil`` and
+``Array.new``/``Array.append``; element types are inferred by elaboration.
+"""
+
+from __future__ import annotations
+
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _run(src: str) -> object:
+    cfg = AeonConfig(synthesizer="gp", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=False)
+    d = AeonDriver(cfg)
+    assert d.parse(aeon_code=src, filename="<t>") == [], "expected no parse/type errors"
+    return d.run()
+
+
+def test_list_literal_length():
+    assert _run("import List;\ndef main (u:Int) : Int := List.length [10, 20, 30];") == 3
+
+
+def test_array_literal_length():
+    assert _run("import Array;\ndef main (u:Int) : Int := Array.length #[5, 6, 7, 8];") == 4
+
+
+def test_empty_list_literal_with_annotation():
+    src = "import List;\ndef main (u:Int) : Int := let e : (List Int) := [] in List.length e;"
+    assert _run(src) == 0
+
+
+def test_empty_array_literal():
+    assert _run("import Array;\ndef main (u:Int) : Int := Array.length #[];") == 0
+
+
+def test_list_literal_as_spaced_application_argument():
+    src = """
+import List;
+def f (l: (List Int)) : Int := List.length l;
+def main (u:Int) : Int := f [1, 2];
+"""
+    assert _run(src) == 2
+
+
+def test_method_dot_on_list_literal():
+    # ``.length`` attached to the closing ``]`` is a method call on the literal.
+    assert _run("import List;\ndef main (u:Int) : Int := [1, 2, 3, 4, 5].length;") == 5
+
+
+def test_nested_list_literal():
+    assert _run("import List;\ndef main (u:Int) : Int := List.length [[1, 2], [3]];") == 2
+
+
+def test_attached_bracket_is_still_type_application():
+    # Regression: ``List.nil[Int]`` (attached ``[``) must remain a type
+    # application, not a list literal.
+    assert _run("import List;\ndef main (u:Int) : Int := List.length (List.nil[Int]);") == 0
+
+
+def test_list_literal_elements_evaluate():
+    # Elements are arbitrary expressions; sum the list via a fold.
+    src = """
+import List;
+def add (x:Int) (y:Int) : Int := x + y;
+def main (u:Int) : Int := List.foldr add 0 [1, 2, 3, 4];
+"""
+    assert _run(src) == 10

--- a/tests/contata_test.py
+++ b/tests/contata_test.py
@@ -1,0 +1,106 @@
+"""Tests for the Contata CATA version space (issue #397).
+
+A genuine Constraint-Annotated Tree Automaton: candidate bodies are denoted
+symbolically as z3 expressions over the functions under synthesis (uninterpreted
+functions = the constraint annotation), accepted by SMT against the spec, with
+the well-foundedness side condition and MinTree extraction. Unlike
+enumerate-and-typecheck, this synthesizes genuinely mutually-recursive programs
+(even/odd) from a relational/example spec.
+"""
+
+from __future__ import annotations
+
+from aeon.core.terms import Application, If, Term, Var
+from aeon.synthesis.modules.contata import synthesize_group
+from aeon.synthesis.modules.contata.cata import BOOL, INT, Example, MemberSig
+
+
+def _mentions(term: Term, name: str) -> bool:
+    match term:
+        case Var(n):
+            return n.name == name
+        case Application(fun, arg):
+            return _mentions(fun, name) or _mentions(arg, name)
+        case If(c, th, el):
+            return _mentions(c, name) or _mentions(th, name) or _mentions(el, name)
+        case _:
+            return False
+
+
+def _even_odd_examples(upto: int) -> list[Example]:
+    ex: list[Example] = []
+    for n in range(upto):
+        ex.append(Example("even", n, n % 2 == 0))
+        ex.append(Example("odd", n, n % 2 == 1))
+    return ex
+
+
+def test_cata_synthesizes_mutual_even_odd():
+    """The MR flagship: co-synthesize even/odd from examples. Each body must be a
+    base/recursive conditional that calls its *sibling* — the genuinely
+    mutually-recursive solution the version space accepts under SMT."""
+    members = [MemberSig("even", INT, BOOL), MemberSig("odd", INT, BOOL)]
+    res = synthesize_group(members, _even_odd_examples(5), max_size=3)
+    assert res is not None
+    even, odd = res.bodies["even"], res.bodies["odd"]
+    assert isinstance(even, If) and isinstance(odd, If)
+    assert _mentions(even, "odd"), even  # even calls odd (mutual)
+    assert _mentions(odd, "even"), odd  # odd calls even (mutual)
+
+
+def test_cata_recovers_evaluable_definitions():
+    """The synthesized bodies, assembled into a real mutual program, evaluate to
+    the specified outputs (the version space's solution is genuinely correct, not
+    just SMT-consistent)."""
+    members = [MemberSig("even", INT, BOOL), MemberSig("odd", INT, BOOL)]
+    res = synthesize_group(members, _even_odd_examples(5), max_size=3)
+    assert res is not None
+    # Render and evaluate via the full driver to confirm behaviour.
+    from aeon.facade.driver import AeonConfig, AeonDriver
+    from aeon.synthesis.uis.api import SilentSynthesisUI
+    from aeon.core.pprint import pretty_print  # noqa: F401  (ensure import path exists)
+
+    def render(body: Term) -> str:
+        match body:
+            case If(c, th, el):
+                return f"if {render(c)} then {render(th)} else {render(el)}"
+            case Application(Application(Var(op), a), b):
+                surface = {"==": "=", "!=": "!="}.get(op.name, op.name)
+                return f"({render(a)} {surface} {render(b)})"
+            case Application(Var(f), a):
+                return f"{f.name} ({render(a)})"
+            case Var(n):
+                return n.name
+            case _:
+                from aeon.core.terms import Literal
+
+                assert isinstance(body, Literal)
+                return str(body.value).lower()
+
+    src = f"""
+mutual
+  def even (x: {{v:Int | v >= 0}}) : Bool decreasing_by [x] := {render(res.bodies["even"])}
+  def odd  (x: {{v:Int | v >= 0}}) : Bool decreasing_by [x] := {render(res.bodies["odd"])}
+end
+def main (a: Int) : Int := if even 6 then (if odd 5 then 1 else 0) else 0;
+"""
+    cfg = AeonConfig(synthesizer="gp", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=False)
+    d = AeonDriver(cfg)
+    assert d.parse(aeon_code=src, filename="<t>") == []
+    assert d.run() == 1  # even 6 and odd 5
+
+
+def test_cata_synthesizes_predicate():
+    """A non-recursive relational predicate: f(0)=true, else false ⇒ ``x == 0``."""
+    members = [MemberSig("f", INT, BOOL)]
+    ex = [Example("f", 0, True)] + [Example("f", n, False) for n in range(1, 4)]
+    res = synthesize_group(members, ex, max_size=3)
+    assert res is not None
+    assert _mentions(res.bodies["f"], "x")
+
+
+def test_cata_none_when_out_of_size_budget():
+    """No body within the size budget ⇒ ``None`` (mutual even/odd needs the
+    base/recursive conditional, unreachable at ``max_size=1``)."""
+    members = [MemberSig("even", INT, BOOL), MemberSig("odd", INT, BOOL)]
+    assert synthesize_group(members, _even_odd_examples(4), max_size=1) is None

--- a/tests/contata_test.py
+++ b/tests/contata_test.py
@@ -146,6 +146,40 @@ def main (a: Int) : Int := if isZero 0 then (if isZero 3 then 1 else 0) else 9;
     assert d.run() == 0  # isZero 0 = true and isZero 3 = false
 
 
+def test_contata_cosynthesizes_mutual_group_from_examples():
+    """The MR flagship through the CLI: a ``mutual`` block whose members are
+    holes specified only by ``@example`` facts is co-synthesised by the version
+    space in one SMT query — each body calls its sibling. The old per-member
+    loop could not converge on this; the version-space fast path does."""
+    from aeon.core.types import Top
+    from aeon.facade.driver import AeonConfig, AeonDriver
+    from aeon.synthesis.uis.api import SilentSynthesisUI
+    from aeon.typechecking.typeinfer import check_type
+
+    src = """
+mutual
+  @example(even 0 = true)
+  @example(even 1 = false)
+  @example(even 2 = true)
+  @example(even 3 = false)
+  def even (x: {v:Int | v >= 0}) : Bool decreasing_by [x] := ?he;
+  @example(odd 0 = false)
+  @example(odd 1 = true)
+  @example(odd 2 = false)
+  @example(odd 3 = true)
+  def odd (x: {v:Int | v >= 0}) : Bool decreasing_by [x] := ?ho;
+end
+def main (a: Int) : Int := if even 6 then (if odd 5 then 1 else 0) else 0;
+"""
+    cfg = AeonConfig(synthesizer="contata", synthesis_ui=SilentSynthesisUI(), synthesis_budget=10, no_main=False)
+    d = AeonDriver(cfg)
+    assert d.parse(aeon_code=src, filename="<t>") == []
+    assert d.has_synth()
+    d.synth()
+    assert check_type(d.typing_ctx, d.core, Top())  # both holes filled, group well-typed
+    assert d.run() == 1  # even 6 and odd 5 both hold
+
+
 def test_cata_none_when_out_of_size_budget():
     """No body within the size budget ⇒ ``None`` (mutual even/odd needs the
     base/recursive conditional, unreachable at ``max_size=1``)."""

--- a/tests/contata_test.py
+++ b/tests/contata_test.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from aeon.core.terms import Application, If, Term, Var
 from aeon.synthesis.modules.contata import synthesize_group
-from aeon.synthesis.modules.contata.cata import BOOL, INT, Example, MemberSig
+from aeon.synthesis.modules.contata.cata import BOOL, INT, LIST, Example, MemberSig
 
 
 def _mentions(term: Term, name: str) -> bool:
@@ -97,6 +97,53 @@ def test_cata_synthesizes_predicate():
     res = synthesize_group(members, ex, max_size=3)
     assert res is not None
     assert _mentions(res.bodies["f"], "x")
+
+
+def test_cata_synthesizes_list_length_pds():
+    """The PDS (partial-data-structure) category: synthesize ``length`` over
+    ``List Int`` from trace-closed examples. The version space must form the
+    base/recursive conditional ``if isEmpty xs then 0 else 1 + length (tail xs)``
+    — a recursive call under an operator, on the structurally-smaller tail (the
+    well-founded measure is list length)."""
+    members = [MemberSig("length", LIST, INT)]
+    ex = [
+        Example("length", (), 0),
+        Example("length", (3,), 1),
+        Example("length", (2, 3), 2),
+        Example("length", (1, 2, 3), 3),
+    ]
+    res = synthesize_group(members, ex, max_size=4)
+    assert res is not None
+    body = res.bodies["length"]
+    assert isinstance(body, If)
+    assert _mentions(body, "length"), body  # genuinely recursive
+    assert _mentions(body, "isEmpty"), body  # base/recursive split on emptiness
+
+
+def test_contata_backend_fills_predicate_from_examples():
+    """The ``-s contata`` CLI backend: the version space synthesises a hole from
+    its ``@example`` I/O facts, rebinds the body onto real in-scope names
+    (parameter, operators monomorphised at Int), discharges it through the liquid
+    typechecker, and the filled program type checks and evaluates."""
+    from aeon.core.types import Top
+    from aeon.facade.driver import AeonConfig, AeonDriver
+    from aeon.synthesis.uis.api import SilentSynthesisUI
+    from aeon.typechecking.typeinfer import check_type
+
+    src = """
+@example(isZero 0 = true)
+@example(isZero 1 = false)
+@example(isZero 2 = false)
+def isZero (x: {v:Int | v >= 0}) : Bool := ?hole;
+def main (a: Int) : Int := if isZero 0 then (if isZero 3 then 1 else 0) else 9;
+"""
+    cfg = AeonConfig(synthesizer="contata", synthesis_ui=SilentSynthesisUI(), synthesis_budget=5, no_main=False)
+    d = AeonDriver(cfg)
+    assert d.parse(aeon_code=src, filename="<t>") == []
+    assert d.has_synth()
+    d.synth()
+    assert check_type(d.typing_ctx, d.core, Top())  # hole filled, program well-typed
+    assert d.run() == 0  # isZero 0 = true and isZero 3 = false
 
 
 def test_cata_none_when_out_of_size_budget():

--- a/tests/elaboration_test.py
+++ b/tests/elaboration_test.py
@@ -55,7 +55,7 @@ def test_elaboration_unification():
     t = bind_sterm(t, subs)
     v = elaborate_check(ectx, t, parse_type("Int"))
     v2 = elaborate_remove_unification(ectx, v)
-    expected = parse_expression("let x : forall a:B, (x:a) -> a := (Λ a:B => (fun x => x)); let y:Int := x[Int] 3; 1")
+    expected = parse_expression("let x : forall a:B, (x:a) -> a := (Λ a:B => (fun x => x)); let y:Int := x{Int} 3; 1")
     expected = bind_sterm(expected, subs)
     assert term_equality(v2, expected)
 

--- a/tests/infer_test.py
+++ b/tests/infer_test.py
@@ -222,4 +222,4 @@ def test_capture_avoiding_subs():
 
 def test_max():
     max_type = "forall a:B, (x:a) -> (y:a) -> a"
-    assert tt("let r := max[{x:Int | ?hole }] 0 5 in r + 1", "Int", {"max": max_type})
+    assert tt("let r := max{{x:Int | ?hole }} 0 5 in r + 1", "Int", {"max": max_type})

--- a/tests/llvm_e2e_test.py
+++ b/tests/llvm_e2e_test.py
@@ -74,7 +74,7 @@ def test_e2e_llvm_matrix_sum():
     def add(acc:Int) (curr:Int) : Int := acc + curr;
 
     @llvm
-    def sum_matrix(m:(Vector Int)) (s:Int) : Int := Vector.reduce[Int][Int] add 0 m s;
+    def sum_matrix(m:(Vector Int)) (s:Int) : Int := Vector.reduce{Int}{Int} add 0 m s;
 
     def main (i:Int) : Int := sum_matrix (native "[1, 2, 3, 4]") 4;
     """
@@ -91,12 +91,12 @@ def test_e2e_llvm_matrix_filter():
 
     @llvm
     def filter_even(m:(Vector Int)) (s:Int) : (Vector Int) :=
-        Vector.filter[Int] (fun (x : Int) => x % 2 = 0) m s;
+        Vector.filter{Int} (fun (x : Int) => x % 2 = 0) m s;
 
     def main (i:Int) : Int :=
         let m : (Vector Int) := native "[1, 2, 3, 4, 5, 6]" in
         let filtered : (Vector Int) := filter_even m 6 in
-        Vector.get[Int] filtered 0;
+        Vector.get{Int} filtered 0;
     """
     res = compile_and_run(source)
     assert res == 2
@@ -111,13 +111,13 @@ def test_e2e_llvm_matrix_zip_with():
 
     @llvm
     def vec_add(v1:(Vector Int)) (v2:(Vector Int)) (s:Int) : (Vector Int) :=
-        Vector.zipWith[Int][Int][Int] (fun (x : Int) => fun (y : Int) => x + y) v1 v2 s;
+        Vector.zipWith{Int}{Int}{Int} (fun (x : Int) => fun (y : Int) => x + y) v1 v2 s;
 
     def main (i:Int) : Int :=
         let v1 : (Vector Int) := native "[1, 2, 3]" in
         let v2 : (Vector Int) := native "[10, 20, 30]" in
         let v3 : (Vector Int) := vec_add v1 v2 3 in
-        Vector.get[Int] v3 1;
+        Vector.get{Int} v3 1;
     """
     res = compile_and_run(source)
     assert res == 22
@@ -132,7 +132,7 @@ def test_e2e_llvm_matrix_count():
 
     @llvm
     def count_gt_10(v:(Vector Int)) (s:Int) : Int :=
-        Vector.count[Int] (fun (x : Int) => x > 10) v s;
+        Vector.count{Int} (fun (x : Int) => x > 10) v s;
 
     def main (i:Int) : Int :=
         let v : (Vector Int) := native "[5, 15, 8, 25, 3]" in
@@ -151,12 +151,12 @@ def test_e2e_llvm_matrix_map():
 
     @llvm
     def vec_inc(v:(Vector Int)) (s:Int) : (Vector Int) :=
-        Vector.map[Int][Int] (fun (x : Int) => x + 1) v s;
+        Vector.map{Int}{Int} (fun (x : Int) => x + 1) v s;
 
     def main (i:Int) : Int :=
         let v : (Vector Int) := native "[1, 2, 3, 4, 5]" in
         let v2 : (Vector Int) := vec_inc v 5 in
-        Vector.get[Int] v2 2;
+        Vector.get{Int} v2 2;
     """
     res = compile_and_run(source)
     assert res == 4

--- a/tests/llvm_gpu_test.py
+++ b/tests/llvm_gpu_test.py
@@ -15,14 +15,14 @@ def test_gpu_fallback():
 
         @gpu(target:="cuda", debug:=false, cache:=false, block_size:=32, thread_count:=1024)
         def multiply_by_two (v:(Vector Int)) (size:Int) : (Vector Int) :=
-            Vector.map[Int][Int] (fun (x : Int) => x * 2) v size;
+            Vector.map{Int}{Int} (fun (x : Int) => x * 2) v size;
 
         def main (args:Int) : Int :=
-            let v : (Vector Int) := Vector.new[Int] in
-            let v2 : (Vector Int) := Vector.append[Int] v 10 in
-            let v3 : (Vector Int) := Vector.append[Int] v2 20 in
+            let v : (Vector Int) := Vector.new{Int} in
+            let v2 : (Vector Int) := Vector.append{Int} v 10 in
+            let v3 : (Vector Int) := Vector.append{Int} v2 20 in
             let res : (Vector Int) := multiply_by_two v3 2 in
-            Vector.get[Int] res 0;
+            Vector.get{Int} res 0;
     """
     config = AeonConfig(synthesizer="none", synthesis_ui=SynthesisUI(), synthesis_budget=0)
     driver = AeonDriver(config)

--- a/tests/mutual_synthesis_test.py
+++ b/tests/mutual_synthesis_test.py
@@ -170,3 +170,64 @@ def test_smt_consistent_no_obligation():
     observed = [(odd, (1,), True)]
     symbolic = [((even, (2,)), (odd, (1,)))]
     assert _smt_unsat_core_obligations(spec, observed, symbolic, {"even", "odd"}) == []
+
+
+# --- Relational / k-safety specs as a co-synthesis oracle (issue #397, item 2) ---
+
+# A complete mutual group plus a *relational* property that relates the two
+# functions (``even n = !(odd n)``) — the kind of k-safety spec over several
+# functions that cannot be a single function's refinement type. The domain is
+# bounded so property-based testing samples small Nats (recursion-friendly).
+_EVEN_ODD = """
+mutual
+  def even (n: {{x:Int | x >= 0}}) : Bool decreasing_by [n] := if n = 0 then true else odd (n - 1)
+  def odd (n: {{x:Int | x >= 0}}) : Bool decreasing_by [n] := if n = 0 then {odd_base} else even (n - 1)
+end
+@property(15)
+def complementary (n: {{x:Int | 0 <= x && x < 6}}) : Bool := even n = !(odd n);
+"""
+
+
+def _joint_accepts_complete(odd_base: str) -> bool:
+    from aeon.synthesis.entrypoint import _joint_accepts
+
+    d = _driver()
+    assert d.parse(aeon_code=_EVEN_ODD.format(odd_base=odd_base), filename="<t>") == []
+    # No holes: the program is complete, so fills is empty and the oracle checks
+    # the whole program (type check + @example + @property).
+    return _joint_accepts(d.typing_ctx, d.evaluation_ctx, d.core, {}, d.metadata, d.constructor_names)
+
+
+def test_relational_property_accepts_consistent_group():
+    """A relational @property over the group is part of the acceptance oracle:
+    a correct even/odd satisfies ``even n = !(odd n)``."""
+    assert _joint_accepts_complete("false") is True
+
+
+def test_relational_property_rejects_inconsistent_group():
+    """The same relational property rejects an inconsistent pair (odd's base case
+    flipped), even though each function type checks in isolation."""
+    assert _joint_accepts_complete("true") is False
+
+
+def test_cosynthesis_satisfies_relational_property():
+    """End-to-end: co-synthesize a mutual group under a relational property that
+    the trivial assignment satisfies (``f n = g n``); the synthesized group both
+    type checks and passes the property."""
+    src = """
+    mutual
+      def f (n: {x:Int | x >= 0}) : {r:Int | r >= 0} decreasing_by [n] := ?hf
+      def g (n: {x:Int | x >= 0}) : {r:Int | r >= 0} decreasing_by [n] := ?hg
+    end
+    @property(10)
+    def agree (n: {x:Int | 0 <= x && x < 6}) : Bool := f n = g n;
+    """
+    d = _driver()
+    assert d.parse(aeon_code=src, filename="<t>") == []
+    assert d.has_synth()
+    d.synth()
+    from aeon.synthesis.pbt.runner import run_properties
+
+    assert check_type(d.typing_ctx, d.core, Top())
+    results = run_properties(d.typing_ctx, d.evaluation_ctx, d.core, d.metadata, constructor_names=d.constructor_names)
+    assert results and all(r.passed for r in results)

--- a/tests/mutual_synthesis_test.py
+++ b/tests/mutual_synthesis_test.py
@@ -133,12 +133,19 @@ def test_instrumented_trace_records_mutual_calls():
     assert d.parse(aeon_code=src, filename="<t>") == []
     value, trace = eval_with_trace(d.core, d.evaluation_ctx)
     assert value == 1  # even 2 == true
-    names = [(n.name, args, res) for (n, args, res) in trace]
-    # even(2) -> odd(1) -> even(0); recorded child-first (post order).
+    # Each entry is [name, args, result, parent_index]; entries are appended when
+    # a call is entered, so the outermost call is first.
+    names = [(e[0].name, e[1], e[2]) for e in trace]
+    # even(2) -> odd(1) -> even(0) (main calls even 2).
     assert ("even", (0,), True) in names
     assert ("odd", (1,), True) in names
     assert ("even", (2,), True) in names
-    assert names[-1][0] == "even" and names[-1][1] == (2,)
+    # The call tree links each member to the sibling it tail-called.
+    by_call = {(e[0].name, e[1]): e for e in trace}
+    odd1 = by_call[("odd", (1,))]
+    even0 = by_call[("even", (0,))]
+    assert trace[odd1[3]][0].name == "even" and trace[odd1[3]][1] == (2,)  # parent of odd(1) is even(2)
+    assert trace[even0[3]][0].name == "odd" and trace[even0[3]][1] == (1,)  # parent of even(0) is odd(1)
 
 
 def test_smt_unsat_core_blames_unspecified_callee():
@@ -231,3 +238,44 @@ def test_cosynthesis_satisfies_relational_property():
     assert check_type(d.typing_ctx, d.core, Top())
     results = run_properties(d.typing_ctx, d.evaluation_ctx, d.core, d.metadata, constructor_names=d.constructor_names)
     assert results and all(r.passed for r in results)
+
+
+def test_property_guides_refinement():
+    """Property-as-guide (Contata refinement, Algorithm 2 lines 11-16): with only
+    base-case ``@example`` anchors, a *wrong* sibling candidate that violates a
+    relational ``@property`` is blamed via z3's unsat core, and the property's
+    counterexample propagates a concrete obligation for the unspecified callee.
+
+    Here ``odd`` is deliberately wrong (constant ``false``); the property
+    ``even n = !(odd n)`` plus the base anchors forces, e.g., ``odd 1 = true``,
+    which ``_refine_obligations`` must add to ``odd``'s obligations."""
+    from aeon.synthesis.entrypoint import _refine_obligations
+
+    src = """
+    mutual
+      @example(even 0 = true)
+      def even (n: {x:Int | x >= 0}) : Bool decreasing_by [n] := if n = 0 then true else odd (n - 1)
+      @example(odd 0 = false)
+      def odd (n: {x:Int | x >= 0}) : Bool decreasing_by [n] := false
+    end
+    @property(10)
+    def comp (n: {x:Int | 0 <= x && x < 6}) : Bool := even n = !(odd n);
+    """
+    d = _driver()
+    assert d.parse(aeon_code=src, filename="<t>") == []
+    names = {
+        r.var_name.name: r.var_name
+        for r in __import__("aeon.synthesis.identification", fromlist=["iterate_top_level"]).iterate_top_level(d.core)
+    }
+    members = [(names["even"], names["even"]), (names["odd"], names["odd"])]
+    odd_io_before = list(d.metadata.get(names["odd"], {}).get("io_examples", []))
+    added = _refine_obligations(d.core, members, d.evaluation_ctx, d.metadata)
+    assert added >= 1, "the relational property should have driven at least one obligation"
+    # A new obligation for a non-base input must have appeared on a member.
+    new_obls = [
+        (fn.name, args, out)
+        for fn in (names["even"], names["odd"])
+        for (args, out) in d.metadata.get(fn, {}).get("io_examples", [])
+        if (args, out) not in (odd_io_before if fn is names["odd"] else [([0], True)])
+    ]
+    assert any(args != [0] for _f, args, _o in new_obls), new_obls

--- a/tests/parametric_refinements_test.py
+++ b/tests/parametric_refinements_test.py
@@ -11,7 +11,7 @@ def test_parametric_explicit_type_implicit_refinement_compiles():
 def id : forall t : B, (x : t<p>) -> t<p> := Λ t : B => Λ < p : t -> Bool > => fun x => x;
 def main (args:Int) : Unit :=
     x : Int | x > 0 := 3;
-    y : Int | y > 0 := id[Int] x;
+    y : Int | y > 0 := id{Int} x;
     print (y)
 """
     assert check_compile(source, st_top)
@@ -22,7 +22,7 @@ def test_parametric_explicit_type_explicit_refinement_compiles():
 def id : forall t : B, forall <p : t -> Bool>, (x : t<p>) -> t<p> := Λ t : B => Λ < p : t -> Bool > => fun x => x;
 def main (args:Int) : Unit :=
     x : Int | x > 0 := 3;
-    y : Int | y > 0 := id[Int]{fun n => n > 0} x;
+    y : Int | y > 0 := id{Int}{|fun n => n > 0|} x;
     print (y)
 """
     assert check_compile(source, st_top)
@@ -38,7 +38,7 @@ def wrap : forall t : B, forall <p : t -> Bool>, (x : t | p x) -> {v : t | p v} 
 
 def main (args:Int) : Unit :=
     score : Int | score > 0 := 42;
-    safe_score : Int | safe_score > 0 := wrap[Int] score;
+    safe_score : Int | safe_score > 0 := wrap{Int} score;
     print safe_score
 """
     assert check_compile(source, st_top)
@@ -156,7 +156,7 @@ def main (args:Int) : Unit :=
     assert not check_compile(source, st_top)
 
 
-WRAP_DEF = "def wrap : (x : t<p>) -> t<p> := fun x => id[t]{fun v => v = x} x;"
+WRAP_DEF = "def wrap : (x : t<p>) -> t<p> := fun x => id{t}{|fun v => v = x|} x;"
 
 
 def test_wrapper_around_explicit_type_id():

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -242,7 +242,7 @@ class TestQualifiedNamesInBodyAnnotations:
         source = (
             "import Array;\n"
             "def main (i:Int) : Int :=\n"
-            "    a : {x:(Array Int) | Array.size x = 2} := ((Array.new[Int]).append 1).append 2;\n"
+            "    a : {x:(Array Int) | Array.size x = 2} := ((Array.new{Int}).append 1).append 2;\n"
             "    a.length;\n"
         )
         assert check_compile(source, st_top, 2)


### PR DESCRIPTION
## What

Follow-up to #398 (merged), addressing #397's second direction: **"accept relational specifications over several functions (k-safety), not just a single function's refinement type."**

A `@property` is aeon's vehicle for specs that span *several functions* or *several runs* of one function — e.g. `even n = !(odd n)` (two functions) or `reverse (reverse x) = x` (2-safety, one function) — which cannot be a single function's refinement type. This PR makes such properties part of the **co-synthesis acceptance oracle**.

## How

- `_joint_accepts` (Contata Algorithm 2, lines 11–13) now accepts a joint candidate for a `mutual` group only if: the per-function refinement types check, all `@example`s pass, **and** all relational `@property`s hold under property-based testing.
- `constructor_names` is threaded from the driver through `synthesize_holes` → `_cosynthesize_group` → `_joint_accepts` (needed by the `@property` generators).

## Tests / example

- A relational property over a mutual group **accepts** a correct even/odd and **rejects** an inconsistent pair (odd's base flipped) — deterministic.
- End-to-end co-synthesis under a relational property yields a group that passes it.
- `examples/synthesis/cata/relational_property.ae` (runs green with `--test`).

## Reviewer notes / remaining

- The property is currently an **accept/reject filter**. The natural next layer is property-driven **CEGIS guidance**: feed a failing property's counterexample through the z3 unsat-core machinery (already in the tree from #398) to derive per-function obligations. Noted in the cata README.
- PBT over recursive-on-`Nat` functions samples huge ints (recursion blow-up), so property domains should be bounded (`{x:Int | 0 <= x && x < N}`); the example/tests do this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)