### PR TITLE
feat(synthesis): FloatHoleNG — joint Float-hole Nevergrad optimization

### DIFF
--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -1,8 +1,9 @@
 from abc import ABC
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Callable, Optional
 
 from aeon.typechecking.context import TypingContext
 
+from aeon.backend.evaluator import EvaluationContext
 from aeon.core.types import Type
 from aeon.core.terms import Term
 from aeon.utils.name import Name
@@ -62,3 +63,26 @@ class Synthesizer(ABC):
         ui: SynthesisUI = SynthesisUI(),
         output_value: Callable[[Term], object] | None = None,
     ) -> Term: ...
+
+
+class ProgramSynthesizer(ABC):
+    """A synthesizer that fills *all* of a program's holes jointly.
+
+    The per-hole :class:`Synthesizer` interface sees one hole at a time, so it
+    cannot optimise holes that interact (e.g. several ``Float`` constants that
+    jointly minimise one objective). A ``ProgramSynthesizer`` instead receives
+    the whole program and the full list of hole targets and returns a mapping
+    from every hole name to its synthesised term. ``synthesize_holes``
+    dispatches to this entry point when the chosen synthesizer is one.
+    """
+
+    def synthesize_program(
+        self,
+        ctx: TypingContext,
+        ectx: EvaluationContext,
+        term: Term,
+        targets: list[tuple[Name, list[Name]]],
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+    ) -> dict[Name, Optional[Term]]: ...

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -27,7 +27,13 @@ from aeon.typechecking.context import TypingContext
 from aeon.typechecking.typeinfer import check_type
 from aeon.utils.name import Name
 
-from aeon.synthesis.api import ErrorInSynthesis, InvalidIndividualException, Synthesizer, TimeoutInEvaluationException
+from aeon.synthesis.api import (
+    ErrorInSynthesis,
+    InvalidIndividualException,
+    ProgramSynthesizer,
+    Synthesizer,
+    TimeoutInEvaluationException,
+)
 from aeon.synthesis.evaluation_pool import EvalPrimitives, EvaluationPool, set_program_tail
 from aeon.synthesis.tactics.explicit_synth import ExplicitTacticSynthesizer
 
@@ -700,7 +706,7 @@ def synthesize_holes(
     term: Term,
     targets: list[tuple[Name, list[Name]]],
     metadata: Metadata,
-    synthesizer: Synthesizer,
+    synthesizer: Synthesizer | ProgramSynthesizer,
     budget: float = 60.0,
     ui: SynthesisUI = SynthesisUI(),
     budget_eval: Optional[float] = None,
@@ -710,6 +716,11 @@ def synthesize_holes(
     Independent functions are synthesised one at a time. Members of a Lean
     ``mutual ... end`` block are co-synthesised together (Contata's relational
     recursive synthesis), so a candidate for one member may call its siblings."""
+
+    # Program-level synthesizers (e.g. joint Float-hole optimisation) fill every
+    # hole at once rather than one function at a time.
+    if isinstance(synthesizer, ProgramSynthesizer):
+        return synthesizer.synthesize_program(ctx, ectx, term, targets, metadata, budget, ui)
 
     if budget_eval is None:
         budget_eval = max(budget / 1000, 1)

--- a/aeon/synthesis/grammar/genomic_ng.py
+++ b/aeon/synthesis/grammar/genomic_ng.py
@@ -17,7 +17,7 @@ borrow geneticengine's codon mapping rather than inventing our own.
 from __future__ import annotations
 
 import time
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar
 
 from aeon.core.terms import Term
 from aeon.core.types import Type
@@ -60,12 +60,17 @@ def _orient(components: list[float], minimize: list[bool]) -> list[float]:
     return [c if mini else -c for c, mini in zip(components, minimize)]
 
 
-def _knee_point(archive: list[tuple[Term, list[float]]], minimize: list[bool]) -> Term | None:
-    """Compromise selection over an archive of (term, oriented-loss) pairs.
+_Candidate = TypeVar("_Candidate")
+
+
+def _knee_point(archive: list[tuple[_Candidate, list[float]]], minimize: list[bool]) -> _Candidate | None:
+    """Compromise selection over an archive of (candidate, oriented-loss) pairs.
 
     Mirrors ``ge_synthesis._knee_point_individual``: per-objective min-max
     normalisation, then the candidate closest to the utopia origin. Works for
-    the single-objective case too (one dimension → picks the lowest loss).
+    the single-objective case too (one dimension → picks the lowest loss). The
+    candidate is opaque (a ``Term`` for GenomicNG, a float vector for
+    FloatHoleNG), so the function is generic over it.
     """
     if not archive:
         return None

--- a/aeon/synthesis/modules/float_ng.py
+++ b/aeon/synthesis/modules/float_ng.py
@@ -21,9 +21,10 @@ import time
 from typing import Optional
 
 from aeon.backend.evaluator import EvaluationContext
+from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidTerm
 from aeon.core.substitutions import substitution
 from aeon.core.terms import Literal, Term
-from aeon.core.types import TypeConstructor, t_float, top
+from aeon.core.types import RefinedType, Type, TypeConstructor, t_float, top
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import ProgramSynthesizer, SynthesisError
 from aeon.synthesis.decorators import Goal
@@ -50,8 +51,54 @@ DEFAULT_BOUND = 5.12
 OPTIMIZER_BUDGET = 1000
 
 
+def _unrefine(ty: Type) -> Type:
+    return ty.type if isinstance(ty, RefinedType) else ty
+
+
 def _is_float(ty: object) -> bool:
-    return isinstance(ty, TypeConstructor) and ty.name.name == "Float"
+    base = _unrefine(ty) if isinstance(ty, Type) else ty
+    return isinstance(base, TypeConstructor) and base.name.name == "Float"
+
+
+def _is_array_float(ty: object) -> bool:
+    base = _unrefine(ty) if isinstance(ty, Type) else ty
+    return (
+        isinstance(base, TypeConstructor)
+        and base.name.name == "Array"
+        and len(base.args) == 1
+        and _is_float(base.args[0])
+    )
+
+
+def _size_app(lt: LiquidTerm) -> bool:
+    """A liquid application of an array length measure (e.g. ``Array_size``)."""
+    return isinstance(lt, LiquidApp) and "size" in getattr(lt.fun, "name", str(lt.fun)).lower()
+
+
+def _array_length(ty: Type) -> int | None:
+    """Extract ``k`` from an ``Array`` hole refined by ``size a == k``.
+
+    Walks the refinement looking for an equality between an array-size
+    application and an integer literal (either operand order, anywhere in a
+    conjunction). Returns ``None`` if no such constraint is present.
+    """
+    if not isinstance(ty, RefinedType):
+        return None
+    found: list[int] = []
+
+    def walk(lt: LiquidTerm) -> None:
+        if isinstance(lt, LiquidApp):
+            fname = getattr(lt.fun, "name", str(lt.fun))
+            if fname == "==" and len(lt.args) == 2:
+                a, b = lt.args
+                for x, y in ((a, b), (b, a)):
+                    if _size_app(x) and isinstance(y, LiquidLiteralInt):
+                        found.append(y.value)
+            for a in lt.args:
+                walk(a)
+
+    walk(ty.refinement)
+    return found[0] if found else None
 
 
 class FloatHoleNGSynthesizer(ProgramSynthesizer):
@@ -87,16 +134,37 @@ class FloatHoleNGSynthesizer(ProgramSynthesizer):
                 "`uv pip install nevergrad` (or the 'synthesis-ng' extra)."
             ) from e
 
-        # One float dimension per hole, in a stable order taken from the targets.
+        # Map each hole to a contiguous slice of one flat float vector: a scalar
+        # ``Float`` hole takes one dimension, an ``(Array Float)`` hole takes one
+        # dimension per element (its length comes from a ``size a == k``
+        # refinement). Order is stable, taken from the targets.
         hole_names = [h for _, holes in targets for h in holes]
-        holes_info = get_holes_info(ctx, term, top, targets, refined_types=False)
-        non_float = [h for h in hole_names if not _is_float(holes_info[h][0])]
-        if len(hole_names) < 2 or non_float:
+        holes_info = get_holes_info(ctx, term, top, targets, refined_types=True)
+
+        # spec = (hole name, literal type to substitute, number of dimensions, is_array)
+        specs: list[tuple[Name, Type, int, bool]] = []
+        bad: list[str] = []
+        for h in hole_names:
+            ty = holes_info[h][0]
+            base = _unrefine(ty)
+            if _is_float(base):
+                specs.append((h, t_float, 1, False))
+            elif _is_array_float(base):
+                k = _array_length(ty)
+                if k is None or k < 1:
+                    bad.append(f"{h.pretty()} (Array Float without a 'size a == k' refinement)")
+                else:
+                    specs.append((h, base, k, True))
+            else:
+                bad.append(f"{h.pretty()} (type {base})")
+
+        total_dims = sum(k for _, _, k, _ in specs)
+        if bad or total_dims < 2:
             raise SynthesisError(
-                "FloatHoleNG only applies to programs with two or more holes, all of type Float. "
-                f"Got {len(hole_names)} hole(s)"
-                + (f"; non-Float: {[h.pretty() for h in non_float]}" if non_float else "")
-                + ". Use a grammar-based synthesizer (e.g. -s ng / gp) instead."
+                "FloatHoleNG only applies to holes that are Float or (Array Float) with a fixed "
+                "'size a == k' refinement, totalling at least two float dimensions. "
+                + (f"Unsupported holes: {bad}. " if bad else f"Only {total_dims} dimension(s). ")
+                + "Use a grammar-based synthesizer (e.g. -s ng / gp) instead."
             )
 
         # The objective(s) live on whichever function carries the @minimize/
@@ -107,12 +175,27 @@ class FloatHoleNGSynthesizer(ProgramSynthesizer):
             raise SynthesisError("FloatHoleNG requires at least one @minimize/@maximize objective on the program.")
         evaluators = [_make_fitness(g, ectx) for g in goals]
         minimize = [g.minimize for g in goals]
-        n = len(hole_names)
+        n = total_dims
+
+        def decode(vec: list[float]) -> dict[Name, Optional[Term]]:
+            """Split the flat vector into one term per hole (scalar → Float
+            literal, array slice → list-valued ``Array Float`` literal)."""
+            mapping: dict[Name, Optional[Term]] = {}
+            i = 0
+            for name, lit_type, k, is_array in specs:
+                chunk = vec[i : i + k]
+                i += k
+                if is_array:
+                    mapping[name] = Literal([float(x) for x in chunk], type=lit_type)
+                else:
+                    mapping[name] = Literal(float(chunk[0]), type=lit_type)
+            return mapping
 
         def fill(vec: list[float]) -> Term:
             prog = term
-            for name, val in zip(hole_names, vec):
-                prog = substitution(prog, Literal(float(val), type=t_float), name)
+            for name, rep in decode(vec).items():
+                assert rep is not None
+                prog = substitution(prog, rep, name)
             return prog
 
         def evaluate(vec: list[float]) -> list[float]:
@@ -168,4 +251,4 @@ class FloatHoleNGSynthesizer(ProgramSynthesizer):
                 best_vec = list(chosen)
 
         ui.end(fill(best_vec), None)
-        return {h: Literal(float(v), type=t_float) for h, v in zip(hole_names, best_vec)}
+        return decode(best_vec)

--- a/aeon/synthesis/modules/float_ng.py
+++ b/aeon/synthesis/modules/float_ng.py
@@ -1,0 +1,171 @@
+"""FloatHoleNG: joint Nevergrad optimisation of a program's Float holes.
+
+Where :class:`~aeon.synthesis.grammar.genomic_ng.GenomicNGSynthesizer` searches
+a *grammar* for one hole at a time, this synthesizer targets a narrower but very
+common shape: a program whose holes are **all of type ``Float``**, jointly
+driving one (or more) ``@minimize``/``@maximize`` objective. There the search
+space is simply an **array of floats — one dimension per hole** — and the
+problem is exactly the continuous black-box optimisation Nevergrad is built for
+(this is how Nevergrad's own benchmark functions — sphere, Rosenbrock,
+Rastrigin, Ackley — are posed).
+
+Each candidate float vector is substituted into the holes as ``Float`` literals;
+the resulting hole-free program is evaluated through the existing objective
+machinery (``_make_fitness``); Nevergrad minimises the (orientation-corrected)
+result.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from aeon.backend.evaluator import EvaluationContext
+from aeon.core.substitutions import substitution
+from aeon.core.terms import Literal, Term
+from aeon.core.types import TypeConstructor, t_float, top
+from aeon.decorators.api import Metadata
+from aeon.synthesis.api import ProgramSynthesizer, SynthesisError
+from aeon.synthesis.decorators import Goal
+from aeon.synthesis.entrypoint import _make_fitness
+from aeon.synthesis.grammar.genomic_ng import INVALID_PENALTY, _knee_point, _orient
+from aeon.synthesis.identification import get_holes_info
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+
+from geneticengine.problems import Fitness
+
+# Default symmetric search box for each float hole. Covers the standard domains
+# of the classic Nevergrad benchmark functions (sphere/Rastrigin/Ackley use
+# ±5.12, Rosenbrock ±2.048); overridable per synthesizer instance.
+DEFAULT_BOUND = 5.12
+
+# Evaluation budget declared to the Nevergrad optimiser. Several optimisers
+# (notably NGOpt) tune their internal strategy to this number; an over-large
+# value makes them pick heavy portfolio methods whose per-``ask`` overhead
+# dominates when each fitness evaluation is cheap (a few hundred microseconds
+# here). A moderate value keeps ``ask`` fast — the wall-clock budget is the real
+# stop, and Nevergrad happily accepts more asks than its declared budget.
+OPTIMIZER_BUDGET = 1000
+
+
+def _is_float(ty: object) -> bool:
+    return isinstance(ty, TypeConstructor) and ty.name.name == "Float"
+
+
+class FloatHoleNGSynthesizer(ProgramSynthesizer):
+    """Joint Float-hole optimisation with Nevergrad.
+
+    Args:
+        optimizer: name of a Nevergrad optimiser class (``"NGOpt"``, ``"CMA"``,
+            ``"DE"``, ``"PSO"``, ...).
+        seed: seed for the optimiser and its parametrization.
+        bound: each hole is searched in ``[-bound, bound]``.
+    """
+
+    def __init__(self, optimizer: str = "NGOpt", seed: int = 0, bound: float = DEFAULT_BOUND):
+        self.optimizer = optimizer
+        self.seed = seed
+        self.bound = bound
+
+    def synthesize_program(
+        self,
+        ctx: TypingContext,
+        ectx: EvaluationContext,
+        term: Term,
+        targets: list[tuple[Name, list[Name]]],
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+    ) -> dict[Name, Optional[Term]]:
+        try:
+            import nevergrad as ng
+        except ImportError as e:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "FloatHoleNG requires the 'nevergrad' package. Install it with "
+                "`uv pip install nevergrad` (or the 'synthesis-ng' extra)."
+            ) from e
+
+        # One float dimension per hole, in a stable order taken from the targets.
+        hole_names = [h for _, holes in targets for h in holes]
+        holes_info = get_holes_info(ctx, term, top, targets, refined_types=False)
+        non_float = [h for h in hole_names if not _is_float(holes_info[h][0])]
+        if len(hole_names) < 2 or non_float:
+            raise SynthesisError(
+                "FloatHoleNG only applies to programs with two or more holes, all of type Float. "
+                f"Got {len(hole_names)} hole(s)"
+                + (f"; non-Float: {[h.pretty() for h in non_float]}" if non_float else "")
+                + ". Use a grammar-based synthesizer (e.g. -s ng / gp) instead."
+            )
+
+        # The objective(s) live on whichever function carries the @minimize/
+        # @maximize decorator — not necessarily one of the hole-bearing
+        # functions — so collect goals across the whole program.
+        goals: list[Goal] = [g for d in metadata.values() for g in d.get("goals", [])]
+        if not goals:
+            raise SynthesisError("FloatHoleNG requires at least one @minimize/@maximize objective on the program.")
+        evaluators = [_make_fitness(g, ectx) for g in goals]
+        minimize = [g.minimize for g in goals]
+        n = len(hole_names)
+
+        def fill(vec: list[float]) -> Term:
+            prog = term
+            for name, val in zip(hole_names, vec):
+                prog = substitution(prog, Literal(float(val), type=t_float), name)
+            return prog
+
+        def evaluate(vec: list[float]) -> list[float]:
+            prog = fill(vec)
+            # _make_fitness raises InvalidIndividualException on an un-evaluable
+            # candidate; let it (and anything else) propagate to the penalty path.
+            return [ev(prog) for ev in evaluators]
+
+        parametrization = ng.p.Array(shape=(n,)).set_bounds(-self.bound, self.bound)
+        parametrization.random_state.seed(self.seed)
+        opt_cls = ng.optimizers.registry[self.optimizer]
+        optimizer = opt_cls(parametrization=parametrization, budget=OPTIMIZER_BUDGET, num_workers=1)
+
+        ui.start(ctx, ectx, "+".join(h.name for h in hole_names), top, budget)
+
+        archive: list[tuple[tuple[float, ...], list[float]]] = []
+        best_vec: list[float] | None = None
+        best_score: float | None = None
+        start = time.monotonic()
+
+        while time.monotonic() - start < budget:
+            candidate = optimizer.ask()
+            vec = [float(x) for x in candidate.value]
+            try:
+                components = evaluate(vec)
+                oriented = _orient(components, minimize)
+                valid = True
+            except Exception:
+                components = [INVALID_PENALTY] * len(minimize)
+                oriented = list(components)
+                valid = False
+
+            loss = oriented if len(oriented) > 1 else oriented[0]
+            optimizer.tell(candidate, loss)
+
+            if valid:
+                archive.append((tuple(vec), oriented))
+                score = sum(oriented)
+                if best_score is None or score < best_score:
+                    best_score, best_vec = score, vec
+                    ui.register(fill(vec), Fitness(components, valid=True), time.monotonic() - start, is_best=True)
+
+        if best_vec is None:
+            ui.end(None, None)
+            return {h: None for h in hole_names}
+
+        # For multiple objectives the scalar ``best_vec`` is just one Pareto
+        # point; resolve the archive by knee-point compromise to match the
+        # grammar backend's behaviour.
+        if len(minimize) > 1:
+            chosen = _knee_point(archive, minimize)
+            if chosen is not None:
+                best_vec = list(chosen)
+
+        ui.end(fill(best_vec), None)
+        return {h: Literal(float(v), type=t_float) for h, v in zip(hole_names, best_vec)}

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -1,8 +1,9 @@
 import os
 
-from aeon.synthesis.api import Synthesizer
+from aeon.synthesis.api import ProgramSynthesizer, Synthesizer
 from aeon.synthesis.grammar.ge_synthesis import GESynthesizer
 from aeon.synthesis.grammar.genomic_ng import GenomicNGSynthesizer
+from aeon.synthesis.modules.float_ng import FloatHoleNGSynthesizer
 from aeon.synthesis.modules.lta import LTASynthesizer
 from aeon.synthesis.modules.synquid.synthesizer import SynquidSynthesizer
 from aeon.synthesis.modules.llm import LLMSynthesizer
@@ -38,6 +39,8 @@ SYNTHESIZER_LABELS: dict[str, str] = {
     "ng_cma": "Nevergrad grammatical-evolution (CMA-ES)",
     "ng_de": "Nevergrad grammatical-evolution (Differential Evolution)",
     "ng_pso": "Nevergrad grammatical-evolution (PSO)",
+    "ng_float": "Nevergrad joint Float-hole optimisation (NGOpt)",
+    "ng_float_cma": "Nevergrad joint Float-hole optimisation (CMA-ES)",
     "tactics": "Tactic Search (Lean-style)",
     "lta": "Liquid Tree Automata",
     "symetric": "Metric Synthesis",
@@ -53,7 +56,7 @@ def synthesizer_label(module: str) -> str:
     return SYNTHESIZER_LABELS.get(module, module)
 
 
-def make_synthesizer(module: str) -> Synthesizer:
+def make_synthesizer(module: str) -> Synthesizer | ProgramSynthesizer:
     # The random seed for stochastic backends is taken from the AEON_SEED
     # environment variable (default 0), so experiments can vary it across runs
     # (e.g. multi-seed benchmarks) without a dedicated CLI flag.
@@ -77,6 +80,10 @@ def make_synthesizer(module: str) -> Synthesizer:
             return GenomicNGSynthesizer(optimizer="DE", seed=seed)
         case "ng_pso":
             return GenomicNGSynthesizer(optimizer="PSO", seed=seed)
+        case "ng_float" | "float_ng":
+            return FloatHoleNGSynthesizer(optimizer="NGOpt", seed=seed)
+        case "ng_float_cma":
+            return FloatHoleNGSynthesizer(optimizer="CMA", seed=seed)
         case "synquid":
             return SynquidSynthesizer()
         case "llm":

--- a/examples/synthesis/float_ng/ackley.ae
+++ b/examples/synthesis/float_ng/ackley.ae
@@ -1,0 +1,10 @@
+# Nevergrad benchmark: Ackley (2D). Nearly flat outer region, deep central well; global minimum 0 at the origin.
+# Note: in Aeon `+`/`-` are right-associative, so `a - b + c` parses as `a - (b + c)`;
+# the (term1 - term2) group below is parenthesised explicitly to get a - b + c.
+import Math (cos, exp, sqrtf, absf, PI, E)
+
+def x : Float := ?hx;
+def y : Float := ?hy;
+
+@minimize_float( (((0.0 - 20.0) * exp ((0.0 - 0.2) * sqrtf (absf (0.5 * ((x * x) + (y * y)))))) - (exp (0.5 * ((cos ((2.0 * PI) * x)) + (cos ((2.0 * PI) * y)))))) + (20.0 + E) )
+def ackley : Float := (((0.0 - 20.0) * exp ((0.0 - 0.2) * sqrtf (absf (0.5 * ((x * x) + (y * y)))))) - (exp (0.5 * ((cos ((2.0 * PI) * x)) + (cos ((2.0 * PI) * y)))))) + (20.0 + E);

--- a/examples/synthesis/float_ng/booth.ae
+++ b/examples/synthesis/float_ng/booth.ae
@@ -1,0 +1,6 @@
+# Booth function. f = (x + 2y - 7)^2 + (2x + y - 5)^2, global minimum 0 at (1, 3).
+def x : Float := ?hx;
+def y : Float := ?hy;
+
+@minimize_float( (((x + (2.0 * y)) - 7.0) * ((x + (2.0 * y)) - 7.0)) + ((((2.0 * x) + y) - 5.0) * (((2.0 * x) + y) - 5.0)) )
+def booth : Float := (((x + (2.0 * y)) - 7.0) * ((x + (2.0 * y)) - 7.0)) + ((((2.0 * x) + y) - 5.0) * (((2.0 * x) + y) - 5.0));

--- a/examples/synthesis/float_ng/matyas.ae
+++ b/examples/synthesis/float_ng/matyas.ae
@@ -1,0 +1,6 @@
+# Matyas function. f = 0.26*(x^2 + y^2) - 0.48*x*y, global minimum 0 at (0, 0).
+def x : Float := ?hx;
+def y : Float := ?hy;
+
+@minimize_float( (0.26 * ((x * x) + (y * y))) - (0.48 * (x * y)) )
+def matyas : Float := (0.26 * ((x * x) + (y * y))) - (0.48 * (x * y));

--- a/examples/synthesis/float_ng/rastrigin.ae
+++ b/examples/synthesis/float_ng/rastrigin.ae
@@ -1,0 +1,8 @@
+# Nevergrad benchmark: Rastrigin (2D). Highly multimodal; global minimum 0 at the origin.
+import Math (cos, PI)
+
+def x : Float := ?hx;
+def y : Float := ?hy;
+
+@minimize_float( (20.0 + ((x * x) - (10.0 * cos ((2.0 * PI) * x)))) + ((y * y) - (10.0 * cos ((2.0 * PI) * y))) )
+def rastrigin : Float := (20.0 + ((x * x) - (10.0 * cos ((2.0 * PI) * x)))) + ((y * y) - (10.0 * cos ((2.0 * PI) * y)));

--- a/examples/synthesis/float_ng/rosenbrock.ae
+++ b/examples/synthesis/float_ng/rosenbrock.ae
@@ -1,0 +1,7 @@
+# Nevergrad benchmark: Rosenbrock. f = 100*(y - x^2)^2 + (1 - x)^2,
+# global minimum 0 at (1, 1) — the classic curved valley.
+def x : Float := ?hx;
+def y : Float := ?hy;
+
+@minimize_float( (100.0 * ((y - (x * x)) * (y - (x * x)))) + ((1.0 - x) * (1.0 - x)) )
+def rosenbrock : Float := (100.0 * ((y - (x * x)) * (y - (x * x)))) + ((1.0 - x) * (1.0 - x));

--- a/examples/synthesis/float_ng/sphere.ae
+++ b/examples/synthesis/float_ng/sphere.ae
@@ -1,0 +1,7 @@
+# Nevergrad benchmark: Sphere. f(x) = sum x_i^2, global minimum 0 at the origin.
+def x0 : Float := ?h0;
+def x1 : Float := ?h1;
+def x2 : Float := ?h2;
+
+@minimize_float( (x0 * x0) + (x1 * x1) + (x2 * x2) )
+def sphere : Float := (x0 * x0) + (x1 * x1) + (x2 * x2);

--- a/examples/synthesis/float_ng/sphere_array.ae
+++ b/examples/synthesis/float_ng/sphere_array.ae
@@ -1,10 +1,11 @@
 # Sphere over an (Array Float) of fixed size 5: the synthesized *body* of
 # `sphere` IS the array. f(v) = sum v_i^2, global minimum 0 at the zero vector.
 # FloatHoleNG fills the function body with a 5-element float vector, one
-# optimisation dimension per element.
-import Array (size, get)
+# optimisation dimension per element. Elements are read with UFCS method
+# syntax (`sphere.get i`, issue #27), which dispatches to `Array.get`.
+import Array;
 
 @minimize_float(
-  ((get sphere 0) * (get sphere 0)) + ((get sphere 1) * (get sphere 1)) + ((get sphere 2) * (get sphere 2)) + ((get sphere 3) * (get sphere 3)) + ((get sphere 4) * (get sphere 4))
+  ((sphere.get 0) * (sphere.get 0)) + ((sphere.get 1) * (sphere.get 1)) + ((sphere.get 2) * (sphere.get 2)) + ((sphere.get 3) * (sphere.get 3)) + ((sphere.get 4) * (sphere.get 4))
 )
-def sphere : {a:(Array Float) | size a == 5} = ?h;
+def sphere : {a:(Array Float) | Array.size a = 5} := ?h;

--- a/examples/synthesis/float_ng/sphere_array.ae
+++ b/examples/synthesis/float_ng/sphere_array.ae
@@ -1,0 +1,12 @@
+# Sphere over a single (Array Float) hole of fixed size 5: f(v) = sum v_i^2,
+# global minimum 0 at the zero vector. The whole vector is one hole — FloatHoleNG
+# allocates one optimisation dimension per element.
+import Array (size, get)
+
+def v : {a:(Array Float) | size a == 5} = ?h;
+
+@minimize_float(
+  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4))
+)
+def sphere : Float =
+  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4));

--- a/examples/synthesis/float_ng/sphere_array.ae
+++ b/examples/synthesis/float_ng/sphere_array.ae
@@ -1,12 +1,10 @@
-# Sphere over a single (Array Float) hole of fixed size 5: f(v) = sum v_i^2,
-# global minimum 0 at the zero vector. The whole vector is one hole — FloatHoleNG
-# allocates one optimisation dimension per element.
+# Sphere over an (Array Float) of fixed size 5: the synthesized *body* of
+# `sphere` IS the array. f(v) = sum v_i^2, global minimum 0 at the zero vector.
+# FloatHoleNG fills the function body with a 5-element float vector, one
+# optimisation dimension per element.
 import Array (size, get)
 
-def v : {a:(Array Float) | size a == 5} = ?h;
-
 @minimize_float(
-  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4))
+  ((get sphere 0) * (get sphere 0)) + ((get sphere 1) * (get sphere 1)) + ((get sphere 2) * (get sphere 2)) + ((get sphere 3) * (get sphere 3)) + ((get sphere 4) * (get sphere 4))
 )
-def sphere : Float =
-  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4));
+def sphere : {a:(Array Float) | size a == 5} = ?h;

--- a/scripts/bench_float_ng.py
+++ b/scripts/bench_float_ng.py
@@ -41,7 +41,7 @@ BUDGET = 3.0
 SEEDS = [1, 2]
 SOLVED_THRESHOLD = 1e-3
 BENCH_DIR = Path(__file__).resolve().parent.parent / "examples" / "synthesis" / "float_ng"
-BENCHMARKS = ["sphere", "rosenbrock", "booth", "matyas", "rastrigin", "ackley"]
+BENCHMARKS = ["sphere", "rosenbrock", "booth", "matyas", "rastrigin", "ackley", "sphere_array"]
 BACKENDS = ["ng_float", "ng_float_cma", "gp"]
 
 

--- a/scripts/bench_float_ng.py
+++ b/scripts/bench_float_ng.py
@@ -1,0 +1,131 @@
+"""Benchmark FloatHoleNG on classic Nevergrad test functions.
+
+Each benchmark in ``examples/synthesis/float_ng/`` is a program whose holes are
+all ``Float`` constants jointly minimising a well-known optimisation surface
+(sphere, Rosenbrock, Booth, Matyas, Rastrigin, Ackley). Every function has
+global minimum value 0, so the *achieved objective value* is directly the
+quality (lower = better; 0 = optimum found).
+
+We compare:
+  - ng_float       FloatHoleNG with NGOpt
+  - ng_float_cma   FloatHoleNG with CMA-ES
+  - gp             the grammar-based GP backend
+
+gp is included to show the gap: the objective lives on a function without a
+hole, so the per-hole grammar search has no signal on these holes and cannot
+optimise them — exactly the niche FloatHoleNG fills.
+
+Run: uv run python scripts/bench_float_ng.py
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from aeon.core.substitutions import substitution
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.entrypoint import _make_fitness, synthesize_holes
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+from aeon.synthesis.uis.api import SilentSynthesisUI, SynthesisFormat
+
+setup_logger()
+
+BUDGET = 3.0
+SEEDS = [1, 2]
+SOLVED_THRESHOLD = 1e-3
+BENCH_DIR = Path(__file__).resolve().parent.parent / "examples" / "synthesis" / "float_ng"
+BENCHMARKS = ["sphere", "rosenbrock", "booth", "matyas", "rastrigin", "ackley"]
+BACKENDS = ["ng_float", "ng_float_cma", "gp"]
+
+
+def achieved_objective(driver: AeonDriver, mapping: dict) -> float | None:
+    """Objective value of the program with its holes filled by ``mapping``."""
+    goals = [g for d in driver.metadata.values() for g in d.get("goals", [])]
+    if not goals or any(v is None for v in mapping.values()):
+        return None
+    prog = driver.core
+    for name, term in mapping.items():
+        prog = substitution(prog, term, name)
+    try:
+        return float(sum(_make_fitness(g, driver.evaluation_ctx)(prog) for g in goals))
+    except Exception:
+        return None
+
+
+def run(name: str, backend: str, seed: int) -> dict[str, Any]:
+    src = (BENCH_DIR / f"{name}.ae").read_text()
+    cfg = AeonConfig(
+        synthesizer=backend,
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=int(BUDGET),
+        synthesis_format=SynthesisFormat.DEFAULT,
+    )
+    driver = AeonDriver(cfg)
+    try:
+        # parse() returns elaboration/type errors as a list, but a lexer/parser
+        # error is raised — guard both so one bad file can't abort the suite.
+        errs = list(driver.parse(aeon_code=src))
+    except Exception as e:  # noqa: BLE001
+        return {"obj": None, "time": 0.0, "error": f"parse: {type(e).__name__}: {e}"}
+    if errs:
+        return {"obj": None, "time": 0.0, "error": f"parse: {errs[0]}"}
+    targets = incomplete_functions_and_holes(driver.typing_ctx, driver.core)
+    synth = make_synthesizer(backend)
+    # FloatHoleNG seed is on the instance; set it for reproducibility.
+    if hasattr(synth, "seed"):
+        synth.seed = seed
+    t0 = time.monotonic()
+    try:
+        mapping = synthesize_holes(
+            driver.typing_ctx,
+            driver.evaluation_ctx,
+            driver.core,
+            targets,
+            driver.metadata,
+            synth,
+            BUDGET,
+            SilentSynthesisUI(),
+        )
+    except Exception as e:  # noqa: BLE001
+        return {"obj": None, "time": time.monotonic() - t0, "error": f"{type(e).__name__}: {e}"}
+    return {"obj": achieved_objective(driver, mapping), "time": time.monotonic() - t0, "error": None}
+
+
+def main() -> None:
+    print(f"budget={BUDGET}s  seeds={SEEDS}  solved if objective < {SOLVED_THRESHOLD}\n")
+    print(f"{'benchmark':<12} {'backend':<13} {'best objective':>16}  {'solved':>7}")
+    print("-" * 54)
+    wins = {b: 0 for b in BACKENDS}
+    for name in BENCHMARKS:
+        best_per_backend: dict[str, float | None] = {}
+        for backend in BACKENDS:
+            objs = []
+            for seed in SEEDS:
+                r = run(name, backend, seed)
+                if r["error"]:
+                    print(f"{name:<12} {backend:<13} {'ERROR':>16}  {r['error'][:30]}")
+                elif r["obj"] is not None:
+                    objs.append(r["obj"])
+            best = min(objs) if objs else None
+            best_per_backend[backend] = best
+            shown = "—" if best is None else f"{best:.3e}"
+            solved = "yes" if best is not None and best < SOLVED_THRESHOLD else "no"
+            print(f"{name:<12} {backend:<13} {shown:>16}  {solved:>7}")
+        # Winner = lowest achieved objective.
+        valid = {b: o for b, o in best_per_backend.items() if o is not None}
+        if valid:
+            wins[min(valid, key=valid.get)] += 1
+        print()
+    print("=" * 54)
+    print("Wins (lowest objective): " + "  ".join(f"{b}={wins[b]}" for b in BACKENDS))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/float_ng_test.py
+++ b/tests/float_ng_test.py
@@ -168,10 +168,10 @@ def test_is_array_float():
 
 
 ARRAY_SPHERE = """
-import Array (size, get)
-def v : {a:(Array Float) | size a == 3} = ?h;
-@minimize_float( ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) )
-def sphere : Float = ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2));
+import Array;
+def v : {a:(Array Float) | Array.size a = 3} := ?h;
+@minimize_float( ((v.get 0) * (v.get 0)) + ((v.get 1) * (v.get 1)) + ((v.get 2) * (v.get 2)) )
+def sphere : Float := ((v.get 0) * (v.get 0)) + ((v.get 1) * (v.get 1)) + ((v.get 2) * (v.get 2));
 """
 
 

--- a/tests/float_ng_test.py
+++ b/tests/float_ng_test.py
@@ -1,0 +1,148 @@
+"""Unit tests for the FloatHoleNG joint Float-hole synthesizer."""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.core.substitutions import substitution
+from aeon.core.terms import Literal
+from aeon.core.types import t_float, t_int
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.api import ProgramSynthesizer, SynthesisError
+from aeon.synthesis.entrypoint import _make_fitness, synthesize_holes
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.modules.float_ng import FloatHoleNGSynthesizer, _is_float
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+from aeon.synthesis.uis.api import SilentSynthesisUI, SynthesisFormat
+
+setup_logger()
+
+pytest.importorskip("nevergrad")
+
+
+def _parse(src: str) -> AeonDriver:
+    cfg = AeonConfig(
+        synthesizer="ng_float",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=1,
+        synthesis_format=SynthesisFormat.DEFAULT,
+    )
+    driver = AeonDriver(cfg)
+    errs = driver.parse(aeon_code=src)
+    assert not errs, f"parse/type errors: {errs}"
+    return driver
+
+
+def _synthesize(driver: AeonDriver, synth, budget: float = 2.0) -> dict:
+    targets = incomplete_functions_and_holes(driver.typing_ctx, driver.core)
+    return synthesize_holes(
+        driver.typing_ctx,
+        driver.evaluation_ctx,
+        driver.core,
+        targets,
+        driver.metadata,
+        synth,
+        budget,
+        SilentSynthesisUI(),
+    )
+
+
+def _objective(driver: AeonDriver, mapping: dict) -> float:
+    goals = [g for d in driver.metadata.values() for g in d.get("goals", [])]
+    prog = driver.core
+    for name, term in mapping.items():
+        prog = substitution(prog, term, name)
+    return float(sum(_make_fitness(g, driver.evaluation_ctx)(prog) for g in goals))
+
+
+SPHERE = """
+def x0 : Float := ?h0;
+def x1 : Float := ?h1;
+@minimize_float( (x0 * x0) + (x1 * x1) )
+def sphere : Float := (x0 * x0) + (x1 * x1);
+"""
+
+
+# ---------------------------------------------------------------------------
+# helpers / wiring
+# ---------------------------------------------------------------------------
+
+
+def test_is_float():
+    assert _is_float(t_float)
+    assert not _is_float(t_int)
+
+
+def test_is_program_synthesizer():
+    assert isinstance(FloatHoleNGSynthesizer(), ProgramSynthesizer)
+
+
+@pytest.mark.parametrize(
+    "name,optimizer",
+    [("ng_float", "NGOpt"), ("float_ng", "NGOpt"), ("ng_float_cma", "CMA")],
+)
+def test_factory_routing(name, optimizer):
+    syn = make_synthesizer(name)
+    assert isinstance(syn, FloatHoleNGSynthesizer)
+    assert syn.optimizer == optimizer
+
+
+# ---------------------------------------------------------------------------
+# end-to-end optimisation
+# ---------------------------------------------------------------------------
+
+
+def test_sphere_converges_near_optimum():
+    driver = _parse(SPHERE)
+    mapping = _synthesize(driver, FloatHoleNGSynthesizer(optimizer="CMA", seed=1), budget=2.0)
+    assert set(h.name for h in mapping) == {"h0", "h1"}
+    assert all(isinstance(v, Literal) and v.type == t_float for v in mapping.values())
+    # Sphere optimum is 0 at the origin; CMA should get comfortably close.
+    assert _objective(driver, mapping) < 0.1
+
+
+def test_dispatch_through_synthesize_holes():
+    # synthesize_holes must route a ProgramSynthesizer to synthesize_program
+    # (filling every hole), not the per-hole loop.
+    driver = _parse(SPHERE)
+    mapping = _synthesize(driver, FloatHoleNGSynthesizer(optimizer="CMA", seed=1), budget=1.0)
+    assert len(mapping) == 2
+
+
+# ---------------------------------------------------------------------------
+# precondition errors
+# ---------------------------------------------------------------------------
+
+
+def test_single_hole_rejected():
+    src = """
+    def x : Float := ?h0;
+    @minimize_float( x * x )
+    def f : Float := x * x;
+    """
+    driver = _parse(src)
+    with pytest.raises(SynthesisError, match="two or more holes"):
+        _synthesize(driver, FloatHoleNGSynthesizer())
+
+
+def test_non_float_hole_rejected():
+    src = """
+    def x : Float := ?h0;
+    def n : Int := ?h1;
+    @minimize_float( (x * x) + 1.0 )
+    def f : Float := (x * x) + 1.0;
+    """
+    driver = _parse(src)
+    with pytest.raises(SynthesisError, match="Float"):
+        _synthesize(driver, FloatHoleNGSynthesizer())
+
+
+def test_missing_objective_rejected():
+    src = """
+    def x0 : Float := ?h0;
+    def x1 : Float := ?h1;
+    """
+    driver = _parse(src)
+    with pytest.raises(SynthesisError, match="objective"):
+        _synthesize(driver, FloatHoleNGSynthesizer())

--- a/tests/float_ng_test.py
+++ b/tests/float_ng_test.py
@@ -6,13 +6,21 @@ import pytest
 
 from aeon.core.substitutions import substitution
 from aeon.core.terms import Literal
-from aeon.core.types import t_float, t_int
+from aeon.core.types import TypeConstructor, t_float, t_int
+from aeon.utils.name import Name
 from aeon.facade.driver import AeonConfig, AeonDriver
 from aeon.logger.logger import setup_logger
 from aeon.synthesis.api import ProgramSynthesizer, SynthesisError
 from aeon.synthesis.entrypoint import _make_fitness, synthesize_holes
 from aeon.synthesis.identification import incomplete_functions_and_holes
-from aeon.synthesis.modules.float_ng import FloatHoleNGSynthesizer, _is_float
+from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidVar
+from aeon.core.types import RefinedType
+from aeon.synthesis.modules.float_ng import (
+    FloatHoleNGSynthesizer,
+    _array_length,
+    _is_array_float,
+    _is_float,
+)
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.uis.api import SilentSynthesisUI, SynthesisFormat
 
@@ -122,7 +130,7 @@ def test_single_hole_rejected():
     def f : Float := x * x;
     """
     driver = _parse(src)
-    with pytest.raises(SynthesisError, match="two or more holes"):
+    with pytest.raises(SynthesisError, match="dimension"):
         _synthesize(driver, FloatHoleNGSynthesizer())
 
 
@@ -146,3 +154,61 @@ def test_missing_objective_rejected():
     driver = _parse(src)
     with pytest.raises(SynthesisError, match="objective"):
         _synthesize(driver, FloatHoleNGSynthesizer())
+
+
+# ---------------------------------------------------------------------------
+# Array Float holes
+# ---------------------------------------------------------------------------
+
+
+def test_is_array_float():
+    assert _is_array_float(TypeConstructor(Name("Array", 0), [t_float]))
+    assert not _is_array_float(TypeConstructor(Name("Array", 0), [t_int]))
+    assert not _is_array_float(t_float)
+
+
+ARRAY_SPHERE = """
+import Array (size, get)
+def v : {a:(Array Float) | size a == 3} = ?h;
+@minimize_float( ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) )
+def sphere : Float = ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2));
+"""
+
+
+def test_array_float_hole_converges():
+    driver = _parse(ARRAY_SPHERE)
+    mapping = _synthesize(driver, FloatHoleNGSynthesizer(optimizer="CMA", seed=1), budget=3.0)
+    assert len(mapping) == 1
+    (term,) = mapping.values()
+    # The single (Array Float) hole is filled with a length-3 list literal.
+    assert isinstance(term, Literal)
+    assert isinstance(term.value, list) and len(term.value) == 3
+    assert _objective(driver, mapping) < 0.1
+
+
+def _array_refined(refinement) -> RefinedType:
+    return RefinedType(Name("a", 0), TypeConstructor(Name("Array", 0), [t_float]), refinement)
+
+
+def _size_eq(left_int: bool, k: int) -> LiquidApp:
+    size = LiquidApp(Name("Array_size", 0), [LiquidVar(Name("a", 0))])
+    lit = LiquidLiteralInt(k)
+    args = [lit, size] if left_int else [size, lit]
+    return LiquidApp(Name("==", 0), args)
+
+
+def test_array_length_extracts_size():
+    assert _array_length(_array_refined(_size_eq(False, 4))) == 4
+
+
+def test_array_length_reversed_operands():
+    assert _array_length(_array_refined(_size_eq(True, 7))) == 7
+
+
+def test_array_length_none_without_fixed_size():
+    # `size a > 0` constrains but does not fix the length → no dimension count.
+    refinement = LiquidApp(
+        Name(">", 0),
+        [LiquidApp(Name("Array_size", 0), [LiquidVar(Name("a", 0))]), LiquidLiteralInt(0)],
+    )
+    assert _array_length(_array_refined(refinement)) is None


### PR DESCRIPTION
**Stacked on [#401](https://github.com/alcides/aeon/pull/401)** (base: `claude/genomic-ng-synthesizer`). Review/merge that first; this PR's diff is only the second commit.

## Summary

Where [GenomicNG (#401)](https://github.com/alcides/aeon/pull/401) searches a *grammar* one hole at a time, **FloatHoleNG** targets a narrower but common shape: a program whose holes are **all of type `Float`**, jointly driving an objective. There the search space is simply an **array of floats — one dimension per hole** — which is exactly the continuous black-box optimization Nevergrad is built for (and how Nevergrad's own benchmark functions are posed).

Each candidate float vector is substituted into the holes as `Float` literals; the resulting hole-free program is scored through the existing `@minimize` machinery; Nevergrad minimizes the result.

### Why a new abstraction
The per-hole `Synthesizer` interface sees one hole at a time, so it **cannot** optimize holes that interact (several Float constants minimizing one shared objective — the objective typically lives on a function with *no* hole). This PR adds a `ProgramSynthesizer` ABC that fills all holes at once; `synthesize_holes` dispatches to it via an `isinstance` check, leaving the existing per-hole path untouched.

### Flags
- `-s ng_float` / `-s float_ng` — NGOpt
- `-s ng_float_cma` — CMA-ES

Validates its precondition (≥2 holes, all `Float`, ≥1 objective) and raises a clear `SynthesisError` otherwise, pointing users at the grammar backends.

### A subtlety worth flagging
NGOpt sizes its strategy to the *declared* budget. Passing a huge budget (as the grammar backend does, where SMT-validated evals are slow anyway) makes NGOpt pick heavy portfolio methods whose per-`ask` overhead dominates when each float eval is sub-millisecond — it dropped to **~1 eval/sec**. FloatHoleNG declares a moderate budget so `ask` stays cheap (~6500 evals in 4s); the wall-clock budget remains the real stop, and Nevergrad accepts asks beyond its declared budget.

## Benchmarks — `examples/synthesis/float_ng/` (six classic Nevergrad functions)

`scripts/bench_float_ng.py`, budget 3s, 2 seeds, objective minimum = 0 for all:

| benchmark | ng_float (NGOpt) | ng_float_cma | gp |
|---|---|---|---|
| sphere | **0** | 5e-20 | 1.08 |
| rosenbrock | 1.5e-2 | 1.3e-2 | 149 |
| booth | **1.4e-19** | 1.4e-19 | 4.25 |
| matyas | **1.5e-17** | 1.5e-17 | 4.8e-2 |
| rastrigin | **0** | 0 | error\* |
| ackley | **1.4e-11** | 1.4e-11 | error\* |

FloatHoleNG reaches the optimum on 5/6 (Rosenbrock's curved valley is near-optimal at 3s). `gp` is included to show the gap: the objective lives on a hole-free function, so the grammar search has **no signal** on these holes and cannot optimize them.

\* `gp` errors on rastrigin/ackley are a pre-existing grammar-generation issue (KeyError on a refined-`Int` constructor) triggered by importing `Math` — orthogonal to this PR.

## Test plan
- [x] `uv run pytest tests/float_ng_test.py` — 10 passed (Float check, factory routing, `ProgramSynthesizer` dispatch, end-to-end convergence, precondition errors)
- [x] `tests/genomic_ng_test.py` + `tests/knee_point_selection_test.py` still green after generalizing `_knee_point`
- [x] Existing synthesis suites (`synth_fitness`, `tactic_synth`, `minimize_decorator`) pass — shared `api.py`/`entrypoint.py` changes are backward compatible
- [x] pre-commit (ruff + mypy) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)