### PR TITLE
feat(synthesis): support (Array Float) holes in FloatHoleNG

### DIFF
--- a/aeon/synthesis/modules/float_ng.py
+++ b/aeon/synthesis/modules/float_ng.py
@@ -21,9 +21,10 @@ import time
 from typing import Optional
 
 from aeon.backend.evaluator import EvaluationContext
+from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidTerm
 from aeon.core.substitutions import substitution
 from aeon.core.terms import Literal, Term
-from aeon.core.types import TypeConstructor, t_float, top
+from aeon.core.types import RefinedType, Type, TypeConstructor, t_float, top
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import ProgramSynthesizer, SynthesisError
 from aeon.synthesis.decorators import Goal
@@ -50,8 +51,54 @@ DEFAULT_BOUND = 5.12
 OPTIMIZER_BUDGET = 1000
 
 
+def _unrefine(ty: Type) -> Type:
+    return ty.type if isinstance(ty, RefinedType) else ty
+
+
 def _is_float(ty: object) -> bool:
-    return isinstance(ty, TypeConstructor) and ty.name.name == "Float"
+    base = _unrefine(ty) if isinstance(ty, Type) else ty
+    return isinstance(base, TypeConstructor) and base.name.name == "Float"
+
+
+def _is_array_float(ty: object) -> bool:
+    base = _unrefine(ty) if isinstance(ty, Type) else ty
+    return (
+        isinstance(base, TypeConstructor)
+        and base.name.name == "Array"
+        and len(base.args) == 1
+        and _is_float(base.args[0])
+    )
+
+
+def _size_app(lt: LiquidTerm) -> bool:
+    """A liquid application of an array length measure (e.g. ``Array_size``)."""
+    return isinstance(lt, LiquidApp) and "size" in getattr(lt.fun, "name", str(lt.fun)).lower()
+
+
+def _array_length(ty: Type) -> int | None:
+    """Extract ``k`` from an ``Array`` hole refined by ``size a == k``.
+
+    Walks the refinement looking for an equality between an array-size
+    application and an integer literal (either operand order, anywhere in a
+    conjunction). Returns ``None`` if no such constraint is present.
+    """
+    if not isinstance(ty, RefinedType):
+        return None
+    found: list[int] = []
+
+    def walk(lt: LiquidTerm) -> None:
+        if isinstance(lt, LiquidApp):
+            fname = getattr(lt.fun, "name", str(lt.fun))
+            if fname == "==" and len(lt.args) == 2:
+                a, b = lt.args
+                for x, y in ((a, b), (b, a)):
+                    if _size_app(x) and isinstance(y, LiquidLiteralInt):
+                        found.append(y.value)
+            for a in lt.args:
+                walk(a)
+
+    walk(ty.refinement)
+    return found[0] if found else None
 
 
 class FloatHoleNGSynthesizer(ProgramSynthesizer):
@@ -87,16 +134,37 @@ class FloatHoleNGSynthesizer(ProgramSynthesizer):
                 "`uv pip install nevergrad` (or the 'synthesis-ng' extra)."
             ) from e
 
-        # One float dimension per hole, in a stable order taken from the targets.
+        # Map each hole to a contiguous slice of one flat float vector: a scalar
+        # ``Float`` hole takes one dimension, an ``(Array Float)`` hole takes one
+        # dimension per element (its length comes from a ``size a == k``
+        # refinement). Order is stable, taken from the targets.
         hole_names = [h for _, holes in targets for h in holes]
-        holes_info = get_holes_info(ctx, term, top, targets, refined_types=False)
-        non_float = [h for h in hole_names if not _is_float(holes_info[h][0])]
-        if len(hole_names) < 2 or non_float:
+        holes_info = get_holes_info(ctx, term, top, targets, refined_types=True)
+
+        # spec = (hole name, literal type to substitute, number of dimensions, is_array)
+        specs: list[tuple[Name, Type, int, bool]] = []
+        bad: list[str] = []
+        for h in hole_names:
+            ty = holes_info[h][0]
+            base = _unrefine(ty)
+            if _is_float(base):
+                specs.append((h, t_float, 1, False))
+            elif _is_array_float(base):
+                k = _array_length(ty)
+                if k is None or k < 1:
+                    bad.append(f"{h.pretty()} (Array Float without a 'size a == k' refinement)")
+                else:
+                    specs.append((h, base, k, True))
+            else:
+                bad.append(f"{h.pretty()} (type {base})")
+
+        total_dims = sum(k for _, _, k, _ in specs)
+        if bad or total_dims < 2:
             raise SynthesisError(
-                "FloatHoleNG only applies to programs with two or more holes, all of type Float. "
-                f"Got {len(hole_names)} hole(s)"
-                + (f"; non-Float: {[h.pretty() for h in non_float]}" if non_float else "")
-                + ". Use a grammar-based synthesizer (e.g. -s ng / gp) instead."
+                "FloatHoleNG only applies to holes that are Float or (Array Float) with a fixed "
+                "'size a == k' refinement, totalling at least two float dimensions. "
+                + (f"Unsupported holes: {bad}. " if bad else f"Only {total_dims} dimension(s). ")
+                + "Use a grammar-based synthesizer (e.g. -s ng / gp) instead."
             )
 
         # The objective(s) live on whichever function carries the @minimize/
@@ -107,12 +175,27 @@ class FloatHoleNGSynthesizer(ProgramSynthesizer):
             raise SynthesisError("FloatHoleNG requires at least one @minimize/@maximize objective on the program.")
         evaluators = [_make_fitness(g, ectx) for g in goals]
         minimize = [g.minimize for g in goals]
-        n = len(hole_names)
+        n = total_dims
+
+        def decode(vec: list[float]) -> dict[Name, Optional[Term]]:
+            """Split the flat vector into one term per hole (scalar → Float
+            literal, array slice → list-valued ``Array Float`` literal)."""
+            mapping: dict[Name, Optional[Term]] = {}
+            i = 0
+            for name, lit_type, k, is_array in specs:
+                chunk = vec[i : i + k]
+                i += k
+                if is_array:
+                    mapping[name] = Literal([float(x) for x in chunk], type=lit_type)
+                else:
+                    mapping[name] = Literal(float(chunk[0]), type=lit_type)
+            return mapping
 
         def fill(vec: list[float]) -> Term:
             prog = term
-            for name, val in zip(hole_names, vec):
-                prog = substitution(prog, Literal(float(val), type=t_float), name)
+            for name, rep in decode(vec).items():
+                assert rep is not None
+                prog = substitution(prog, rep, name)
             return prog
 
         def evaluate(vec: list[float]) -> list[float]:
@@ -168,4 +251,4 @@ class FloatHoleNGSynthesizer(ProgramSynthesizer):
                 best_vec = list(chosen)
 
         ui.end(fill(best_vec), None)
-        return {h: Literal(float(v), type=t_float) for h, v in zip(hole_names, best_vec)}
+        return decode(best_vec)

--- a/examples/synthesis/float_ng/sphere_array.ae
+++ b/examples/synthesis/float_ng/sphere_array.ae
@@ -1,10 +1,11 @@
 # Sphere over an (Array Float) of fixed size 5: the synthesized *body* of
 # `sphere` IS the array. f(v) = sum v_i^2, global minimum 0 at the zero vector.
 # FloatHoleNG fills the function body with a 5-element float vector, one
-# optimisation dimension per element.
-import Array (size, get)
+# optimisation dimension per element. Elements are read with UFCS method
+# syntax (`sphere.get i`, issue #27), which dispatches to `Array.get`.
+import Array;
 
 @minimize_float(
-  ((get sphere 0) * (get sphere 0)) + ((get sphere 1) * (get sphere 1)) + ((get sphere 2) * (get sphere 2)) + ((get sphere 3) * (get sphere 3)) + ((get sphere 4) * (get sphere 4))
+  ((sphere.get 0) * (sphere.get 0)) + ((sphere.get 1) * (sphere.get 1)) + ((sphere.get 2) * (sphere.get 2)) + ((sphere.get 3) * (sphere.get 3)) + ((sphere.get 4) * (sphere.get 4))
 )
-def sphere : {a:(Array Float) | size a == 5} = ?h;
+def sphere : {a:(Array Float) | Array.size a = 5} := ?h;

--- a/examples/synthesis/float_ng/sphere_array.ae
+++ b/examples/synthesis/float_ng/sphere_array.ae
@@ -1,0 +1,12 @@
+# Sphere over a single (Array Float) hole of fixed size 5: f(v) = sum v_i^2,
+# global minimum 0 at the zero vector. The whole vector is one hole — FloatHoleNG
+# allocates one optimisation dimension per element.
+import Array (size, get)
+
+def v : {a:(Array Float) | size a == 5} = ?h;
+
+@minimize_float(
+  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4))
+)
+def sphere : Float =
+  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4));

--- a/examples/synthesis/float_ng/sphere_array.ae
+++ b/examples/synthesis/float_ng/sphere_array.ae
@@ -1,12 +1,10 @@
-# Sphere over a single (Array Float) hole of fixed size 5: f(v) = sum v_i^2,
-# global minimum 0 at the zero vector. The whole vector is one hole — FloatHoleNG
-# allocates one optimisation dimension per element.
+# Sphere over an (Array Float) of fixed size 5: the synthesized *body* of
+# `sphere` IS the array. f(v) = sum v_i^2, global minimum 0 at the zero vector.
+# FloatHoleNG fills the function body with a 5-element float vector, one
+# optimisation dimension per element.
 import Array (size, get)
 
-def v : {a:(Array Float) | size a == 5} = ?h;
-
 @minimize_float(
-  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4))
+  ((get sphere 0) * (get sphere 0)) + ((get sphere 1) * (get sphere 1)) + ((get sphere 2) * (get sphere 2)) + ((get sphere 3) * (get sphere 3)) + ((get sphere 4) * (get sphere 4))
 )
-def sphere : Float =
-  ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) + ((get v 3) * (get v 3)) + ((get v 4) * (get v 4));
+def sphere : {a:(Array Float) | size a == 5} = ?h;

--- a/scripts/bench_float_ng.py
+++ b/scripts/bench_float_ng.py
@@ -41,7 +41,7 @@ BUDGET = 3.0
 SEEDS = [1, 2]
 SOLVED_THRESHOLD = 1e-3
 BENCH_DIR = Path(__file__).resolve().parent.parent / "examples" / "synthesis" / "float_ng"
-BENCHMARKS = ["sphere", "rosenbrock", "booth", "matyas", "rastrigin", "ackley"]
+BENCHMARKS = ["sphere", "rosenbrock", "booth", "matyas", "rastrigin", "ackley", "sphere_array"]
 BACKENDS = ["ng_float", "ng_float_cma", "gp"]
 
 

--- a/tests/float_ng_test.py
+++ b/tests/float_ng_test.py
@@ -168,10 +168,10 @@ def test_is_array_float():
 
 
 ARRAY_SPHERE = """
-import Array (size, get)
-def v : {a:(Array Float) | size a == 3} = ?h;
-@minimize_float( ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) )
-def sphere : Float = ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2));
+import Array;
+def v : {a:(Array Float) | Array.size a = 3} := ?h;
+@minimize_float( ((v.get 0) * (v.get 0)) + ((v.get 1) * (v.get 1)) + ((v.get 2) * (v.get 2)) )
+def sphere : Float := ((v.get 0) * (v.get 0)) + ((v.get 1) * (v.get 1)) + ((v.get 2) * (v.get 2));
 """
 
 

--- a/tests/float_ng_test.py
+++ b/tests/float_ng_test.py
@@ -6,13 +6,21 @@ import pytest
 
 from aeon.core.substitutions import substitution
 from aeon.core.terms import Literal
-from aeon.core.types import t_float, t_int
+from aeon.core.types import TypeConstructor, t_float, t_int
+from aeon.utils.name import Name
 from aeon.facade.driver import AeonConfig, AeonDriver
 from aeon.logger.logger import setup_logger
 from aeon.synthesis.api import ProgramSynthesizer, SynthesisError
 from aeon.synthesis.entrypoint import _make_fitness, synthesize_holes
 from aeon.synthesis.identification import incomplete_functions_and_holes
-from aeon.synthesis.modules.float_ng import FloatHoleNGSynthesizer, _is_float
+from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidVar
+from aeon.core.types import RefinedType
+from aeon.synthesis.modules.float_ng import (
+    FloatHoleNGSynthesizer,
+    _array_length,
+    _is_array_float,
+    _is_float,
+)
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 from aeon.synthesis.uis.api import SilentSynthesisUI, SynthesisFormat
 
@@ -122,7 +130,7 @@ def test_single_hole_rejected():
     def f : Float := x * x;
     """
     driver = _parse(src)
-    with pytest.raises(SynthesisError, match="two or more holes"):
+    with pytest.raises(SynthesisError, match="dimension"):
         _synthesize(driver, FloatHoleNGSynthesizer())
 
 
@@ -146,3 +154,61 @@ def test_missing_objective_rejected():
     driver = _parse(src)
     with pytest.raises(SynthesisError, match="objective"):
         _synthesize(driver, FloatHoleNGSynthesizer())
+
+
+# ---------------------------------------------------------------------------
+# Array Float holes
+# ---------------------------------------------------------------------------
+
+
+def test_is_array_float():
+    assert _is_array_float(TypeConstructor(Name("Array", 0), [t_float]))
+    assert not _is_array_float(TypeConstructor(Name("Array", 0), [t_int]))
+    assert not _is_array_float(t_float)
+
+
+ARRAY_SPHERE = """
+import Array (size, get)
+def v : {a:(Array Float) | size a == 3} = ?h;
+@minimize_float( ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2)) )
+def sphere : Float = ((get v 0) * (get v 0)) + ((get v 1) * (get v 1)) + ((get v 2) * (get v 2));
+"""
+
+
+def test_array_float_hole_converges():
+    driver = _parse(ARRAY_SPHERE)
+    mapping = _synthesize(driver, FloatHoleNGSynthesizer(optimizer="CMA", seed=1), budget=3.0)
+    assert len(mapping) == 1
+    (term,) = mapping.values()
+    # The single (Array Float) hole is filled with a length-3 list literal.
+    assert isinstance(term, Literal)
+    assert isinstance(term.value, list) and len(term.value) == 3
+    assert _objective(driver, mapping) < 0.1
+
+
+def _array_refined(refinement) -> RefinedType:
+    return RefinedType(Name("a", 0), TypeConstructor(Name("Array", 0), [t_float]), refinement)
+
+
+def _size_eq(left_int: bool, k: int) -> LiquidApp:
+    size = LiquidApp(Name("Array_size", 0), [LiquidVar(Name("a", 0))])
+    lit = LiquidLiteralInt(k)
+    args = [lit, size] if left_int else [size, lit]
+    return LiquidApp(Name("==", 0), args)
+
+
+def test_array_length_extracts_size():
+    assert _array_length(_array_refined(_size_eq(False, 4))) == 4
+
+
+def test_array_length_reversed_operands():
+    assert _array_length(_array_refined(_size_eq(True, 7))) == 7
+
+
+def test_array_length_none_without_fixed_size():
+    # `size a > 0` constrains but does not fix the length → no dimension count.
+    refinement = LiquidApp(
+        Name(">", 0),
+        [LiquidApp(Name("Array_size", 0), [LiquidVar(Name("a", 0))]), LiquidLiteralInt(0)],
+    )
+    assert _array_length(_array_refined(refinement)) is None


### PR DESCRIPTION
**Stacked on [#403](https://github.com/alcides/aeon/pull/403)** (base: `claude/genomic-ng-float-holes`), which is itself stacked on [#401](https://github.com/alcides/aeon/pull/401). Review/merge those first; this PR's diff is only the third commit.

## Summary

Extends FloatHoleNG (#403) beyond scalar `Float` holes to holes of type **`(Array Float)`** — a single array hole becomes **one optimization dimension per element**, which is the most natural framing for vector-valued continuous optimization.

Each hole now maps to a contiguous slice of one flat float vector:
- a scalar `Float` hole → one dimension → substituted as a `Float` literal;
- an `(Array Float)` hole → its length k dimensions → substituted as a **list-valued `Array Float` literal** (`[v₀ … v_{k-1}]`, which the backend evaluates directly to a Python list).

### Determining the length
The length comes from a fixed-size refinement, `{a:(Array Float) | size a == k}` — the same `Array_size` measure the multi-objective decorators use. The extractor walks the refinement for an `Array_size == int` equality (either operand order, inside conjunctions). An array hole **without** a fixed-size refinement is rejected with a clear message (its length is unknowable).

### Precondition
Now stated in **float dimensions (≥ 2)** rather than hole count, so a single `(Array Float)` hole of size ≥ 2 qualifies, while a lone scalar `Float` hole still routes to the grammar backends.

## Benchmark — `examples/synthesis/float_ng/sphere_array.ae`
Sphere over a single size-5 `(Array Float)` hole (`scripts/bench_float_ng.py`, 3s, 2 seeds):

| benchmark | ng_float (NGOpt) | ng_float_cma | gp |
|---|---|---|---|
| sphere_array | **0** | 2.3e-18 | — |

Both float backends reach the optimum; `gp` cannot produce a usable array for this hole.

## Test plan
- [x] `uv run pytest tests/float_ng_test.py` — 15 passed, incl. `_is_array_float`, `_array_length` (size extraction / reversed operands / no-fixed-size), end-to-end array convergence, and the updated precondition message
- [x] `genomic_ng` / `knee_point` / `synth_fitness` suites still green
- [x] pre-commit (ruff + mypy) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)