### PR TITLE
Synthesis: polymorphic ADT construction, SMT literals, perf + termination fixes

### DIFF
--- a/aeon/core/liquid.py
+++ b/aeon/core/liquid.py
@@ -148,7 +148,15 @@ class LiquidApp(LiquidTerm):
         )
 
     def __hash__(self) -> int:
-        return hash(self.fun) + sum(hash(a) for a in self.args)
+        # Cache the structural hash: liquid terms are immutable after
+        # construction, and substitution-built terms are DAGs with shared
+        # subterms -- without memoization, hashing re-visits every path and is
+        # exponential in the term's depth.
+        h = getattr(self, "_hash", None)
+        if h is None:
+            h = hash(self.fun) + sum(hash(a) for a in self.args)
+            object.__setattr__(self, "_hash", h)
+        return h
 
 
 def liquid_free_vars(e: LiquidTerm) -> list[Name]:

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -87,7 +87,11 @@ class AbstractionType(Type):
         )
 
     def __hash__(self) -> int:
-        return hash(self.var_name) + hash(self.var_type) + hash(self.type) + hash(self.multiplicity)
+        h = getattr(self, "_hash", None)
+        if h is None:
+            h = hash(self.var_name) + hash(self.var_type) + hash(self.type) + hash(self.multiplicity)
+            object.__setattr__(self, "_hash", h)
+        return h
 
 
 @dataclass
@@ -109,7 +113,11 @@ class RefinedType(Type):
         )
 
     def __hash__(self) -> int:
-        return hash(self.name) + hash(self.type) + hash(self.refinement)
+        h = getattr(self, "_hash", None)
+        if h is None:
+            h = hash(self.name) + hash(self.type) + hash(self.refinement)
+            object.__setattr__(self, "_hash", h)
+        return h
 
 
 @dataclass
@@ -123,7 +131,11 @@ class TypePolymorphism(Type):
         return f"forall {self.name}:{self.kind}, {self.body}"
 
     def __hash__(self) -> int:
-        return hash(self.name) + hash(self.kind) + hash(self.body)
+        h = getattr(self, "_hash", None)
+        if h is None:
+            h = hash(self.name) + hash(self.kind) + hash(self.body)
+            object.__setattr__(self, "_hash", h)
+        return h
 
 
 @dataclass
@@ -137,7 +149,11 @@ class RefinementPolymorphism(Type):
         return f"forall <{self.name}:{self.sort}>, {self.body}"
 
     def __hash__(self) -> int:
-        return hash(self.name) + hash(self.sort) + hash(self.body)
+        h = getattr(self, "_hash", None)
+        if h is None:
+            h = hash(self.name) + hash(self.sort) + hash(self.body)
+            object.__setattr__(self, "_hash", h)
+        return h
 
 
 @dataclass
@@ -154,7 +170,11 @@ class TypeConstructor(Type):
         return type(other) is TypeConstructor and other.name == self.name and self.args == other.args
 
     def __hash__(self) -> int:
-        return hash(self.name) + sum(hash(a) for a in self.args)
+        h = getattr(self, "_hash", None)
+        if h is None:
+            h = hash(self.name) + sum(hash(a) for a in self.args)
+            object.__setattr__(self, "_hash", h)
+        return h
 
 
 @dataclass

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -577,7 +577,22 @@ def resolve_qualified_names_in_definition(
         )
         for dec in d.decorators
     ]
-    if new_body is d.body and new_args == d.args and new_type is d.type and new_decorators == d.decorators:
+    # The termination-metric expressions reference the parameters and measures
+    # (e.g. ``size xs``) and must be qualified-name-resolved exactly like the
+    # body — otherwise a measure name (``size``) is left unresolved and the
+    # termination obligation is undischarged. ``arg_names`` is bound so the
+    # parameters are not captured by a same-named import.
+    new_decreasing = [
+        resolve_qualified_names_in_sterm(m, qualified_scope, unqualified_scope, constructor_defs, arg_names)
+        for m in d.decreasing_by
+    ]
+    if (
+        new_body is d.body
+        and new_args == d.args
+        and new_type is d.type
+        and new_decorators == d.decorators
+        and new_decreasing == list(d.decreasing_by)
+    ):
         return d
     return Definition(
         d.name,
@@ -587,7 +602,7 @@ def resolve_qualified_names_in_definition(
         new_body,
         new_decorators,
         d.rforalls,
-        d.decreasing_by,
+        new_decreasing,
         d.loc,
         arg_multiplicities=d.arg_multiplicities,
         instance_flags=d.instance_flags,

--- a/aeon/synthesis/modules/afta/pbe.py
+++ b/aeon/synthesis/modules/afta/pbe.py
@@ -247,10 +247,17 @@ def synthesize_pbe(
                 return None
         return None
 
+    # Depth is bounded by the time budget (and a fixpoint, when a full round adds
+    # no new terms), not a fixed number of rounds; ``synth.rounds``, when set,
+    # caps it explicitly. ``rounds`` defaults to ``None`` (unbounded), so a plain
+    # ``range(synth.rounds)`` would crash -- deepen with a budget-guarded loop
+    # mirroring the non-PBE path.
     solution = cegar_pass()
-    for _round in range(synth.rounds):
-        if solution is not None or time.time() >= deadline:
+    depth = 0
+    while solution is None and time.time() < deadline:
+        if synth.rounds is not None and depth >= synth.rounds:
             break
+        before = sum(len(v) for v in bank.values())
         snapshot = {k: list(v) for k, v in bank.items()}
         for comps in builders.values():
             for comp in comps:
@@ -258,6 +265,9 @@ def synthesize_pbe(
                     break
                 add_bank(comp.ret_key, synth._combos(comp, snapshot, deadline, rnd))
         solution = cegar_pass()
+        depth += 1
+        if sum(len(v) for v in bank.values()) == before:
+            break
 
     if solution is not None:
         ui.register(solution, [0.0], time.time() - start, True)
@@ -268,8 +278,8 @@ def synthesize_pbe(
         )
         return solution
     raise SynthesisNotSuccessful(
-        f"afta(pbe): no program consistent with all {n} example(s) of depth < {synth.rounds} "
-        f"found within the budget (enumerated {len(goal_terms)} goal terms, {refinements} refinements). "
+        f"afta(pbe): no program consistent with all {n} example(s) found within the budget "
+        f"(reached depth {depth}, enumerated {len(goal_terms)} goal terms, {refinements} refinements). "
         "Try a larger budget, more rounds, or a richer DSL in scope."
     )
 

--- a/aeon/synthesis/modules/afta/synthesizer.py
+++ b/aeon/synthesis/modules/afta/synthesizer.py
@@ -112,7 +112,7 @@ class AFTASynthesizer(Synthesizer):
         seed: int = 0,
         int_lo: int = -8,
         int_hi: int = 33,
-        rounds: int = 3,
+        rounds: int | None = None,
         combo_cap: int = 4096,
         max_bank: int = 512,
         max_refine: int = 16,
@@ -345,10 +345,16 @@ class AFTASynthesizer(Synthesizer):
         # -- interleave bottom-up growth with CEGAR refinement ----------------
         # Try to solve at the current depth (refining the abstraction to
         # convergence); only deepen the program bank when that depth is dry.
+        # Depth is bounded by the time budget, not a fixed number of rounds: keep
+        # deepening until a solution is found, the budget runs out, or the bank
+        # reaches a fixpoint (a full round adds no new terms). ``self.rounds``,
+        # when set, caps the depth explicitly.
         solution = cegar_pass()
-        for _round in range(self.rounds):
-            if solution is not None or time.time() >= deadline:
+        depth = 0
+        while solution is None and time.time() < deadline:
+            if self.rounds is not None and depth >= self.rounds:
                 break
+            before = sum(len(v) for v in bank.values())
             snapshot = {k: list(v) for k, v in bank.items()}
             for comps in builders.values():
                 for comp in comps:
@@ -358,6 +364,9 @@ class AFTASynthesizer(Synthesizer):
             solution = cegar_pass()
             # created = candidate terms banked; assessed = candidates validated.
             ui.progress(sum(len(v) for v in bank.values()), len(tried), time.time() - start)
+            depth += 1
+            if sum(len(v) for v in bank.values()) == before:
+                break
 
         if solution is not None:
             ui.register(solution, [0.0], time.time() - start, True)
@@ -370,8 +379,8 @@ class AFTASynthesizer(Synthesizer):
             )
             return solution
         raise SynthesisNotSuccessful(
-            f"afta: no spec-consistent program of depth < {self.rounds} found within budget={budget}s "
-            f"(after {refinements} refinement(s)). Try a larger budget or more rounds."
+            f"afta: no spec-consistent program found within budget={budget}s "
+            f"(reached depth {depth}, after {refinements} refinement(s)). Try a larger budget."
         )
 
 

--- a/aeon/synthesis/modules/cata/synthesizer.py
+++ b/aeon/synthesis/modules/cata/synthesizer.py
@@ -123,7 +123,7 @@ class CATASynthesizer(Synthesizer):
         seed: int = 0,
         int_lo: int = -2,
         int_hi: int = 5,
-        rounds: int = 3,
+        rounds: int | None = None,
         combo_cap: int = 2048,
         cond_cap: int = 4096,
         cond_head: int = 48,
@@ -307,25 +307,32 @@ class CATASynthesizer(Synthesizer):
             add_bank(key, list(vs))
         add_bank(int_key, [Literal(v, t_int) for v in range(self.int_lo, self.int_hi)])
 
-        # Rounds 1..k -- grow the automaton one operator deeper each round:
+        # Rounds 1.. -- grow the automaton one operator deeper each round:
         # application transitions (incl. recursive self-calls) and then the
-        # conditional split. Stop as soon as a state is accepted.
-        for _round in range(self.rounds):
-            if best is not None or time.time() >= deadline:
+        # conditional split. Depth is bounded by the time budget, not a fixed
+        # number of rounds: keep deepening until a state is accepted, the budget
+        # runs out, or the bank reaches a fixpoint (a full round adds no new
+        # terms). ``self.rounds``, when set, caps the depth explicitly.
+        depth = 0
+        while best is None and time.time() < deadline:
+            if self.rounds is not None and depth >= self.rounds:
                 break
+            before = sum(len(v) for v in bank.values())
             snapshot = {k: list(v) for k, v in bank.items()}
             for comps in builders.values():
                 for comp in comps:
                     if best is not None or time.time() >= deadline:
                         break
                     add_bank(comp.ret_key, self._app_combos(comp, snapshot, deadline, rnd))
-            if best is not None or time.time() >= deadline:
-                break
-            # Conditionals at the goal type, using the bank grown so far.
-            conds = self._cond_combos(bank.get(bool_key, []), bank.get(goal_key, []), deadline, rnd)
-            add_bank(goal_key, conds)
+            if best is None and time.time() < deadline:
+                # Conditionals at the goal type, using the bank grown so far.
+                conds = self._cond_combos(bank.get(bool_key, []), bank.get(goal_key, []), deadline, rnd)
+                add_bank(goal_key, conds)
             # created = candidate terms banked; assessed = candidates discharged.
             ui.progress(sum(len(v) for v in bank.values()), validated_count, time.time() - start)
+            depth += 1
+            if sum(len(v) for v in bank.values()) == before:
+                break
 
         if best is not None:
             shape = []
@@ -342,9 +349,9 @@ class CATASynthesizer(Synthesizer):
             )
             return wrap(best)
         raise SynthesisNotSuccessful(
-            f"cata: no spec-consistent program of depth < {self.rounds} found within budget={budget}s "
-            f"(discharged {validated_count} candidates). Try a larger budget, more rounds, or a wider "
-            "integer grid; recursive-datatype goals may need a tailored component set."
+            f"cata: no spec-consistent program found within budget={budget}s "
+            f"(reached depth {depth}, discharged {validated_count} candidates). Try a larger budget or a "
+            "wider integer grid; recursive-datatype goals may need a tailored component set."
         )
 
 

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -125,7 +125,7 @@ class FTASynthesizer(Synthesizer):
         seed: int = 0,
         int_lo: int = -8,
         int_hi: int = 33,
-        rounds: int = 3,
+        rounds: int | None = None,
         combo_cap: int = 4096,
         max_bank: int = 512,
         if_branch_cap: int = 20,
@@ -446,12 +446,17 @@ class FTASynthesizer(Synthesizer):
         add_bank(int_key, [Literal(v, t_int) for v in int_lits])
         add_bank(float_key, [Literal(v, t_float) for v in (0.0, 1.0, 2.0, -1.0)])
 
-        # Rounds 1..k -- apply every transition to the bank built so far, growing
-        # programs one operator deeper. Stop as soon as an accepting state is
-        # found: bottom-up construction reaches the smallest programs first.
-        for _round in range(self.rounds):
-            if best is not None or time.time() >= deadline:
+        # Rounds 1.. -- apply every transition to the bank built so far, growing
+        # programs one operator deeper. Depth is bounded by the time budget, not
+        # a fixed number of rounds: keep deepening until an accepting state is
+        # found (bottom-up construction reaches the smallest programs first), the
+        # budget runs out, or the bank reaches a fixpoint (a full round adds no
+        # new terms). ``self.rounds``, when set, caps the depth explicitly.
+        depth = 0
+        while best is None and time.time() < deadline:
+            if self.rounds is not None and depth >= self.rounds:
                 break
+            before = sum(len(v) for v in bank.values())
             snapshot = {k: list(v) for k, v in bank.items()}
             for comps in builders.values():
                 for comp in comps:
@@ -463,6 +468,9 @@ class FTASynthesizer(Synthesizer):
             # Report counts after each round: transitions are the candidates
             # generated; the validated goal states are those assessed.
             ui.progress(transitions, len(validated), time.time() - start)
+            depth += 1
+            if sum(len(v) for v in bank.values()) == before:
+                break
 
         states = len(rep)
         if best is not None:
@@ -474,9 +482,9 @@ class FTASynthesizer(Synthesizer):
             ui.register(best, [0.0], time.time() - start, True)
             return best
         raise SynthesisNotSuccessful(
-            f"fta: no spec-consistent program of depth < {self.rounds} found within budget={budget}s "
-            f"(explored {states} observational states / {transitions} transitions). Try a larger budget, "
-            "more rounds, or a backend that abstracts states (afta/lta)."
+            f"fta: no spec-consistent program found within budget={budget}s "
+            f"(reached depth {depth}, explored {states} observational states / {transitions} transitions). "
+            "Try a larger budget or a backend that abstracts states (afta/lta)."
         )
 
 

--- a/aeon/synthesis/modules/lta/synthesizer.py
+++ b/aeon/synthesis/modules/lta/synthesizer.py
@@ -68,10 +68,12 @@ class LTASynthesizer(Synthesizer):
     library `F` (the typing context's library functions) and a goal type
     `φ`, applying the rules of Fig. 7 and the reductions of Fig. 9.
 
-    The implementation simulates a single goal state at depth ≤ `max_depth`.
+    The implementation simulates a single goal state, deepening until the time
+    budget runs out or the LTA reaches a fixpoint (a transition step adds no new
+    states). `max_depth`, when set, caps the depth explicitly.
     """
 
-    def __init__(self, max_depth: int = 4):
+    def __init__(self, max_depth: int | None = None):
         self.max_depth = max_depth
 
     def synthesize(
@@ -143,9 +145,13 @@ class LTASynthesizer(Synthesizer):
         equiv_set: set[tuple[int, int]] = set()
         depth = 1
         created = 0
-        while depth < self.max_depth and (time.time() - start) < budget:
+        while (self.max_depth is None or depth < self.max_depth) and (time.time() - start) < budget:
             new_states = _transition_step(lta, tctx, inner_ctx)
             if not new_states:
+                break
+            # With the depth unbounded, the LTA can grow large; re-check the
+            # budget before the expensive minimization pipeline.
+            if (time.time() - start) >= budget:
                 break
             lta = prune(lta, inner_ctx)
             equiv_set = similarity(lta, inner_ctx, equiv_set)
@@ -161,7 +167,7 @@ class LTASynthesizer(Synthesizer):
                     return term
             depth += 1
 
-        raise SynthesisNotSuccessful(f"LTASynthesizer: no solution within depth={self.max_depth}, budget={budget}s")
+        raise SynthesisNotSuccessful(f"LTASynthesizer: no solution found (reached depth={depth}, budget={budget}s)")
 
     @staticmethod
     def _accept(term: Term, validate: Callable[[Term], bool]) -> bool:

--- a/aeon/synthesis/modules/synquid/engine.py
+++ b/aeon/synthesis/modules/synquid/engine.py
@@ -7,9 +7,11 @@ import itertools
 from typing import Callable
 
 from aeon.core.instantiation import type_substitution
+from aeon.core.liquid import LiquidVar, liquid_free_vars
+from aeon.core.substitutions import substitution_in_liquid, substitution_in_type
 from aeon.core.terms import Abstraction, Annotation, Application, If, Literal, Term, TypeApplication, Var
 from aeon.core.types import AbstractionType, RefinedType, Type, TypeConstructor, TypePolymorphism, TypeVar
-from aeon.core.types import refined_to_unrefined_type
+from aeon.core.types import refined_to_unrefined_type, type_free_term_vars
 from aeon.synthesis.modules.symetric.synthesizer import _match_type
 from aeon.synthesis.modules.synquid.decompose import synquid_application_arg_types, uncurry
 from aeon.synthesis.modules.synquid.guards import (
@@ -19,7 +21,7 @@ from aeon.synthesis.modules.synquid.guards import (
     bool_triple_conjunctions,
 )
 from aeon.typechecking.context import TypingContext
-from aeon.typechecking.typeinfer import check_type
+from aeon.typechecking.typeinfer import check_type, synth
 from aeon.typechecking.qualifiers import extract_qualifier_atoms
 from aeon.utils.name import Name
 
@@ -119,21 +121,78 @@ def _refined_adt_param(i: Type) -> bool:
     return isinstance(base, TypeConstructor) and base.name.name not in _PRIMITIVE_BASES
 
 
+def _refinements_consistent(actual: Type, goal: Type) -> bool:
+    """Synquid type-consistency ``∧:`` (PLDI'16, Fig 5): are the refinements of
+    ``actual`` and ``goal`` *jointly satisfiable*?
+
+    Consistency is the existential (``∃`` a valuation of the binder) counterpart
+    of subtyping (``∀``): it rejects only candidates whose type *contradicts* the
+    goal -- ``{v | v > 0}`` against ``{v | v < 0}`` -- while keeping any candidate
+    that could still be made to fit. It is therefore the right check when full
+    subtyping cannot be decided (a leftover predicate unknown). Only primitive
+    bases are SAT-checked (they map to a z3 sort); any doubt yields ``True``
+    (keep), so consistency never drops a valid term."""
+    ab = refined_to_unrefined_type(actual)
+    gb = refined_to_unrefined_type(goal)
+    if not (isinstance(ab, TypeConstructor) and isinstance(gb, TypeConstructor)):
+        return True
+    if ab.name.name != gb.name.name:
+        # Different base heads: aeon permits numeric coercions (Int/Float), so a
+        # name mismatch is not a definite contradiction -- keep, and let global
+        # validation decide. Consistency only ever prunes a same-base, jointly
+        # unsatisfiable refinement pair below.
+        return True
+    if ab.name.name not in _PRIMITIVE_BASES:
+        return True
+    binder = Name("_consist", 0)
+    refs = [
+        substitution_in_liquid(ty.refinement, LiquidVar(binder), ty.name)
+        for ty in (actual, goal)
+        if isinstance(ty, RefinedType)
+    ]
+    if not refs:
+        return True
+    try:
+        from z3 import Solver, sat
+
+        from aeon.verification.smt import make_variable, translate_liq
+
+        variables: dict[str, object] = {str(binder): make_variable(str(binder), ab)}
+        for r in refs:
+            for fv in liquid_free_vars(r):
+                # Free vars other than the binder are unconstrained context
+                # values; sorts are unknown here, so give them the base sort and
+                # let a sort clash raise -> caught -> keep (never a false prune).
+                variables.setdefault(str(fv), make_variable(str(fv), ab))
+        s = Solver()
+        for r in refs:
+            s.add(translate_liq(r, variables))
+        return s.check() == sat
+    except Exception:
+        return True
+
+
 def _local_check(ctx: TypingContext, term: Term, goal: Type) -> bool:
-    """Round-trip local refinement check (Synquid APPFO, PLDI'16 §3.2).
+    """Round-trip local refinement check (Synquid APPFO, PLDI'16 §3.2) plus the
+    type-consistency fallback (∧:, Fig 5).
 
     Keep an argument candidate unless it is *definitely* incompatible with the
-    refined parameter type ``goal``. ``check_type`` returns ``False`` only on a
-    genuine refinement contradiction -- e.g. ``nil : {List a | len >= 1}`` -- so
-    those candidates are pruned at the point of application instead of after a
-    full (and failing) program-level validation. A *raise* (an ill-sorted
-    intermediate, or a predicate unknown that only resolves in the global
-    context) means the local checker cannot decide: treat it as ``Unknown`` and
-    keep the candidate, so pruning never drops a valid term (soundness)."""
+    parameter type ``goal``. ``check_type`` (subtyping, the ``∀`` check) returns
+    ``False`` only on a genuine contradiction -- e.g. ``nil : {List a | len >=
+    1}`` -- so those are pruned at the application site instead of after a full,
+    failing program-level validation. When ``check_type`` cannot decide (a
+    raise: an ill-sorted intermediate or a predicate unknown that only resolves
+    globally), fall back to the weaker *consistency* check: keep only if the
+    candidate's inferred type is not outright contradictory with the goal. Both
+    tiers only ever prune definite failures, so a valid term is never dropped."""
     try:
         return bool(check_type(ctx, term, goal))
     except Exception:
-        return True
+        try:
+            _, actual = synth(ctx, term)
+        except Exception:
+            return True
+        return _refinements_consistent(actual, goal)
 
 
 def _pruned(gen, ctx: TypingContext, goal: Type):
@@ -155,6 +214,43 @@ def _arg_gen(ctx: TypingContext, level: int, i: Type, skip: Callable[[Name], boo
     return synthes_memory(ctx, 0, i, skip, mem)
 
 
+def _app_combos(
+    ctx: TypingContext,
+    level: int,
+    params: list[tuple[Name, Type]],
+    skip: Callable[[Name], bool],
+    mem: dict,
+):
+    """Incremental-unification argument synthesis (Synquid, PLDI'16 §3.6).
+
+    Rather than taking the independent cross-product of all argument candidate
+    sets, synthesize arguments left to right and *substitute each chosen
+    argument into the dependent parameter types that follow it*. A later
+    argument is therefore synthesized against an already-narrowed goal: for
+    ``f (x: Int) (y: {v: Int | v > x})`` the choice ``x := 3`` propagates so
+    ``y`` is synthesized against ``{v | v > 3}`` directly. For non-dependent
+    parameters the substitution is a no-op and this reduces to the plain
+    product, so it never enlarges the search space."""
+    if not params:
+        yield ()
+        return
+    # Fast path: when no parameter binder occurs free in a *later* parameter
+    # type, there is nothing to narrow, so incremental synthesis coincides with
+    # the plain cross-product -- take it directly and skip the per-argument
+    # substitution work. (Genuine dependencies, the case the incremental rule
+    # exists for, fall through to the recursive narrowing below.)
+    binders = {bn for bn, _ in params}
+    if not any(binders & set(type_free_term_vars(pt)) for _, pt in params):
+        gens = [_arg_gen(ctx, level, pt, skip, mem) for _, pt in params]
+        yield from itertools.product(*gens)
+        return
+    (binder, ptype), rest = params[0], params[1:]
+    for a in _arg_gen(ctx, level, ptype, skip, mem):
+        rest_narrowed = [(n, substitution_in_type(t, a, binder)) for (n, t) in rest]
+        for tail in _app_combos(ctx, level, rest_narrowed, skip, mem):
+            yield (a, *tail)
+
+
 def _peel_polymorphism(ty: Type) -> tuple[list[Name], Type]:
     """Strip the ``forall`` prefix, returning the bound type variables and body."""
     tyvars: list[Name] = []
@@ -165,15 +261,17 @@ def _peel_polymorphism(ty: Type) -> tuple[list[Name], Type]:
     return tyvars, cur
 
 
-def _uncurry_arrow(ty: Type) -> tuple[list[Type], Type]:
-    """Split an arrow type into argument types and return type, tolerating
-    type-variable domains (e.g. ``(hd: a) -> (tl: List a) -> List a``) -- which
-    arise before a polymorphic binding is instantiated, and which ``uncurry``
-    rejects."""
-    params: list[Type] = []
+def _uncurry_arrow_b(ty: Type) -> tuple[list[tuple[Name, Type]], Type]:
+    """Split an arrow type into ``(binder, argument-type)`` pairs and the return
+    type, tolerating type-variable domains (e.g. ``(hd: a) -> (tl: List a) ->
+    List a``) -- which arise before a polymorphic binding is instantiated, and
+    which ``uncurry`` rejects. The binder names let a chosen argument be
+    substituted into the dependent parameter types that follow it (incremental
+    unification)."""
+    params: list[tuple[Name, Type]] = []
     cur = ty
     while isinstance(cur, AbstractionType):
-        params.append(cur.var_type)
+        params.append((cur.var_name, cur.var_type))
         cur = cur.type
     return params, cur
 
@@ -272,7 +370,7 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
                 # containers get built -- and only the one relevant instantiation
                 # is tried (no universe enumeration, no combinatorial blow-up).
                 tyvars, inner = _peel_polymorphism(typ)
-                params_t, ret_template = _uncurry_arrow(inner)
+                param_bind, ret_template = _uncurry_arrow_b(inner)
                 # A binding whose return type is a *bare* bound type variable
                 # (e.g. ``+`` / ``Array_get`` : ``∀a. … -> a``) unifies with any
                 # goal, so it would be instantiated at every user datatype --
@@ -292,13 +390,12 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
                 head: Term = Var(name)
                 for tv in tyvars:
                     head = TypeApplication(head, sub[tv])
-                inst_params: list[Type] = []
-                for p in params_t:
+                inst_params: list[tuple[Name, Type]] = []
+                for binder, p in param_bind:
                     for tv in tyvars:
                         p = type_substitution(p, tv, sub[tv])
-                    inst_params.append(p)
-                params = [_arg_gen(ctx, level, i, skip, mem) for i in inst_params]
-                for combo in itertools.product(*params):
+                    inst_params.append((binder, p))
+                for combo in _app_combos(ctx, level, inst_params, skip, mem):
                     term: Term = head
                     for a in combo:
                         term = Application(term, a)
@@ -306,17 +403,25 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
             else:
                 if synquid_application_arg_types(typ, ret_t) is None:
                     continue
-                params_t, t = uncurry(typ)
+                _, t = uncurry(typ)
                 if refined_to_unrefined_type(t) != base_t:
                     continue
                 head_tc = _head_result_constructor(t)
                 if head_tc is None:
                     continue
-                params = [_arg_gen(ctx, level, i, skip, mem) for i in params_t]
-                params.insert(0, [Var(name)])
-                for i in itertools.product(*params):
-                    yield closing(i, head_tc)
-        bool_t = TypeConstructor(Name("Bool", 0), [])
+                param_bind, _ = _uncurry_arrow_b(typ)
+                for combo in _app_combos(ctx, level, param_bind, skip, mem):
+                    yield closing((Var(name), *combo), head_tc)
+        # Liquid abduction (Synquid IfAb, PLDI'16 §3.3): a branch guard is
+        # *abduced* from the qualifier-atom set ``atoms_q`` -- the abducibles Q
+        # derived from the goal and context -- and its boolean combinations,
+        # rather than enumerated as an arbitrary boolean term. Restricting the
+        # guard domain to Q is what Synquid does and is what makes conditional
+        # synthesis tractable: free-form boolean enumeration both diverges from
+        # the paper and, empirically, regresses the suite (the large boolean tail
+        # clogs the queue and pushes structural solutions past the budget). The
+        # IfAb premise -- each branch must satisfy the goal under the (negated)
+        # guard -- is discharged by the round-trip check on the assembled term.
         atoms_q = extract_qualifier_atoms(ctx, goal_type=ret_t)
         guard_quads = bool_quad_conjunctions(ctx, atoms_q)
         guard_triples = bool_triple_conjunctions(ctx, atoms_q)
@@ -327,7 +432,6 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
             iter(guard_triples),
             iter(guard_pairs),
             iter(guard_terms),
-            synthes_memory(ctx, level - 1, bool_t, skip, mem),
         )
         then = synthes_memory(ctx, level - 1, ret_t, skip, mem)
         otherwise = synthes_memory(ctx, level - 1, ret_t, skip, mem)

--- a/aeon/synthesis/modules/synquid/engine.py
+++ b/aeon/synthesis/modules/synquid/engine.py
@@ -19,6 +19,7 @@ from aeon.synthesis.modules.synquid.guards import (
     bool_triple_conjunctions,
 )
 from aeon.typechecking.context import TypingContext
+from aeon.typechecking.typeinfer import check_type
 from aeon.typechecking.qualifiers import extract_qualifier_atoms
 from aeon.utils.name import Name
 
@@ -99,6 +100,12 @@ def _head_result_constructor(t: Type) -> TypeConstructor | None:
 
 
 _PRIMITIVE_BASES = {"Int", "Bool", "Float", "String", "Unit"}
+# Goals at which a "returns-anything" operator (``∀a. … -> a``: ``+``, ``-``,
+# ``*``, ``Array_get``, ...) is meaningful: the Num/Ord arithmetic ops. Building
+# them at *non-numeric* primitives produces ill-typed junk -- in particular
+# ``True + False`` as a Bool guard, which makes the z3 backend raise an
+# int-where-bool sort error and so escapes the local refinement check below.
+_NUMERIC_BASES = {"Int", "Float"}
 
 
 def _refined_adt_param(i: Type) -> bool:
@@ -110,6 +117,42 @@ def _refined_adt_param(i: Type) -> bool:
         return False
     base = refined_to_unrefined_type(i)
     return isinstance(base, TypeConstructor) and base.name.name not in _PRIMITIVE_BASES
+
+
+def _local_check(ctx: TypingContext, term: Term, goal: Type) -> bool:
+    """Round-trip local refinement check (Synquid APPFO, PLDI'16 §3.2).
+
+    Keep an argument candidate unless it is *definitely* incompatible with the
+    refined parameter type ``goal``. ``check_type`` returns ``False`` only on a
+    genuine refinement contradiction -- e.g. ``nil : {List a | len >= 1}`` -- so
+    those candidates are pruned at the point of application instead of after a
+    full (and failing) program-level validation. A *raise* (an ill-sorted
+    intermediate, or a predicate unknown that only resolves in the global
+    context) means the local checker cannot decide: treat it as ``Unknown`` and
+    keep the candidate, so pruning never drops a valid term (soundness)."""
+    try:
+        return bool(check_type(ctx, term, goal))
+    except Exception:
+        return True
+
+
+def _pruned(gen, ctx: TypingContext, goal: Type):
+    for t in gen:
+        if _local_check(ctx, t, goal):
+            yield t
+
+
+def _arg_gen(ctx: TypingContext, level: int, i: Type, skip: Callable[[Name], bool], mem: dict):
+    """Candidate generator for one application argument of type ``i``.
+
+    Datatype / refined-container args are built one level deeper; primitive args
+    are level-0 leaves. A *refined* container arg additionally goes through the
+    round-trip local check, so e.g. an empty list is pruned against a
+    ``len >= 1`` parameter before the enclosing application is ever assembled."""
+    if isinstance(i, TypeConstructor) or _refined_adt_param(i):
+        g = synthes_memory(ctx, level - 1, i, skip, mem)
+        return _pruned(g, ctx, i) if _refined_adt_param(i) else g
+    return synthes_memory(ctx, 0, i, skip, mem)
 
 
 def _peel_polymorphism(ty: Type) -> tuple[list[Name], Type]:
@@ -241,7 +284,7 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
                 ret_unref = refined_to_unrefined_type(ret_template)
                 if isinstance(ret_unref, TypeVar) and ret_unref.name in set(tyvars):
                     goal_base = refined_to_unrefined_type(ret_t)
-                    if not (isinstance(goal_base, TypeConstructor) and goal_base.name.name in _PRIMITIVE_BASES):
+                    if not (isinstance(goal_base, TypeConstructor) and goal_base.name.name in _NUMERIC_BASES):
                         continue
                 sub = _match_type(ret_template, ret_t, set(tyvars))
                 if sub is None or any(tv not in sub for tv in tyvars):
@@ -254,12 +297,7 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
                     for tv in tyvars:
                         p = type_substitution(p, tv, sub[tv])
                     inst_params.append(p)
-                params = [
-                    synthes_memory(ctx, level - 1, i, skip, mem)
-                    if isinstance(i, TypeConstructor) or _refined_adt_param(i)
-                    else synthes_memory(ctx, 0, i, skip, mem)
-                    for i in inst_params
-                ]
+                params = [_arg_gen(ctx, level, i, skip, mem) for i in inst_params]
                 for combo in itertools.product(*params):
                     term: Term = head
                     for a in combo:
@@ -274,12 +312,7 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
                 head_tc = _head_result_constructor(t)
                 if head_tc is None:
                     continue
-                params = [
-                    synthes_memory(ctx, level - 1, i, skip, mem)
-                    if isinstance(i, TypeConstructor) or _refined_adt_param(i)
-                    else synthes_memory(ctx, 0, i, skip, mem)
-                    for i in params_t
-                ]
+                params = [_arg_gen(ctx, level, i, skip, mem) for i in params_t]
                 params.insert(0, [Var(name)])
                 for i in itertools.product(*params):
                     yield closing(i, head_tc)

--- a/aeon/synthesis/modules/synquid/engine.py
+++ b/aeon/synthesis/modules/synquid/engine.py
@@ -6,9 +6,11 @@ from itertools import chain, count, takewhile
 import itertools
 from typing import Callable
 
-from aeon.core.terms import Abstraction, Annotation, Application, If, Literal, TypeApplication, Var
+from aeon.core.instantiation import type_substitution
+from aeon.core.terms import Abstraction, Annotation, Application, If, Literal, Term, TypeApplication, Var
 from aeon.core.types import AbstractionType, RefinedType, Type, TypeConstructor, TypePolymorphism, TypeVar
 from aeon.core.types import refined_to_unrefined_type
+from aeon.synthesis.modules.symetric.synthesizer import _match_type
 from aeon.synthesis.modules.synquid.decompose import synquid_application_arg_types, uncurry
 from aeon.synthesis.modules.synquid.guards import (
     bool_pairwise_conjunctions,
@@ -46,6 +48,45 @@ def frange(start, stop, step):
     return takewhile(lambda x: x < stop, count(start, step))
 
 
+def _solve_literal(ret_t: Type, base_t: TypeConstructor):
+    """Synquid-faithful literal synthesis. Rather than enumerating a fixed range
+    of constants, emit a *symbolic* literal (``?intLit`` / ``?floatLit``) and let
+    z3 pick a value satisfying the verification condition present at this
+    position -- the refinement of the goal type, propagated here by round-trip
+    type checking. Yields the single solved literal, or nothing if the
+    refinement is unsatisfiable (no constant inhabits the goal type)."""
+    from z3 import Solver, sat
+
+    from aeon.core.liquid import LiquidLiteralBool, liquid_free_vars
+    from aeon.verification.smt import make_variable, translate_liq
+
+    if isinstance(ret_t, RefinedType):
+        binder, refinement = ret_t.name, ret_t.refinement
+    else:
+        binder, refinement = Name("_lit", 0), LiquidLiteralBool(True)
+
+    # The binder is the unknown to solve for; any other free variables in the VC
+    # are unknown context values, given fresh consts so the binder is solved
+    # relative to them.
+    variables: dict[str, object] = {str(binder): make_variable(str(binder), base_t)}
+    for fv in liquid_free_vars(refinement):
+        variables.setdefault(str(fv), make_variable(str(fv), base_t))
+
+    try:
+        s = Solver()
+        s.add(translate_liq(refinement, variables))
+        if s.check() != sat:
+            return
+        model_val = s.model()[variables[str(binder)]]
+    except Exception:
+        return
+
+    if base_t.name.name == "Int":
+        yield Literal(0 if model_val is None else model_val.as_long(), base_t)
+    else:  # Float
+        yield Literal(0.0 if model_val is None else float(model_val.as_fraction()), base_t)
+
+
 def _head_result_constructor(t: Type) -> TypeConstructor | None:
     """Head datatype for ``closing`` when the spine ends in ``TypeConstructor`` or ``RefinedType`` over one."""
     match t:
@@ -55,6 +96,43 @@ def _head_result_constructor(t: Type) -> TypeConstructor | None:
             return inner
         case _:
             return None
+
+
+_PRIMITIVE_BASES = {"Int", "Bool", "Float", "String", "Unit"}
+
+
+def _refined_adt_param(i: Type) -> bool:
+    """True for a refined argument whose base is a user datatype/container (e.g.
+    ``{cs: List Chunk | len cs >= 1}``). Such a parameter must be built by
+    *application* one level deeper, not as a level-0 leaf -- only primitive
+    refined params (refined Int/Bool/...) are satisfiable by literals at level 0."""
+    if not isinstance(i, RefinedType):
+        return False
+    base = refined_to_unrefined_type(i)
+    return isinstance(base, TypeConstructor) and base.name.name not in _PRIMITIVE_BASES
+
+
+def _peel_polymorphism(ty: Type) -> tuple[list[Name], Type]:
+    """Strip the ``forall`` prefix, returning the bound type variables and body."""
+    tyvars: list[Name] = []
+    cur = ty
+    while isinstance(cur, TypePolymorphism):
+        tyvars.append(cur.name)
+        cur = cur.body
+    return tyvars, cur
+
+
+def _uncurry_arrow(ty: Type) -> tuple[list[Type], Type]:
+    """Split an arrow type into argument types and return type, tolerating
+    type-variable domains (e.g. ``(hd: a) -> (tl: List a) -> List a``) -- which
+    arise before a polymorphic binding is instantiated, and which ``uncurry``
+    rejects."""
+    params: list[Type] = []
+    cur = ty
+    while isinstance(cur, AbstractionType):
+        params.append(cur.var_type)
+        cur = cur.type
+    return params, cur
 
 
 def closing(elems: tuple, typ: TypeConstructor):
@@ -114,9 +192,11 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
             case TypeConstructor(Name("Bool", 0)):
                 yield from [Literal(True, base_t), Literal(False, base_t)]
             case TypeConstructor(Name("Int", 0)):
-                yield from [Literal(value, base_t) for value in range(-100, 100)]
+                # ?intLit: solved by z3 against the VC (goal refinement) here.
+                yield from _solve_literal(ret_t, base_t)
             case TypeConstructor(Name("Float", 0)):
-                yield from [Literal(value, base_t) for value in frange(-100.0, 100.0, 0.00001)]
+                # ?floatLit: solved by z3 against the VC (goal refinement) here.
+                yield from _solve_literal(ret_t, base_t)
             case TypeConstructor(Name("String", 0)):
                 yield from (
                     Literal(s, base_t)
@@ -141,10 +221,54 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
         for name, typ in [
             (n, ty) for n, ty in ctx.concrete_vars() if not isinstance(ty, TypeConstructor) and not skip(n)
         ]:
-            for candidate in monomorfic(typ, ctx, {}) if isinstance(typ, TypePolymorphism) else [typ]:
-                if synquid_application_arg_types(candidate, ret_t) is None:
+            if isinstance(typ, TypePolymorphism):
+                # Synquid APP rule with polymorphic instantiation: instantiate the
+                # bound type variables by *unifying the function's return type with
+                # the goal* (Polikarpova et al., PLDI'16). Unifying ``List a`` with
+                # the goal ``List Enemy`` yields ``a := Enemy``, so the user's own
+                # containers get built -- and only the one relevant instantiation
+                # is tried (no universe enumeration, no combinatorial blow-up).
+                tyvars, inner = _peel_polymorphism(typ)
+                params_t, ret_template = _uncurry_arrow(inner)
+                # A binding whose return type is a *bare* bound type variable
+                # (e.g. ``+`` / ``Array_get`` : ``∀a. … -> a``) unifies with any
+                # goal, so it would be instantiated at every user datatype --
+                # ``chunk + chunk``, ``level + level`` -- and these nonsensical
+                # builders blow up the search combinatorially. Only build such
+                # "returns-anything" functions at primitive goals (where they are
+                # the actual arithmetic/relational ops); data constructors, whose
+                # return head is a concrete type constructor, are unaffected.
+                ret_unref = refined_to_unrefined_type(ret_template)
+                if isinstance(ret_unref, TypeVar) and ret_unref.name in set(tyvars):
+                    goal_base = refined_to_unrefined_type(ret_t)
+                    if not (isinstance(goal_base, TypeConstructor) and goal_base.name.name in _PRIMITIVE_BASES):
+                        continue
+                sub = _match_type(ret_template, ret_t, set(tyvars))
+                if sub is None or any(tv not in sub for tv in tyvars):
                     continue
-                params_t, t = uncurry(candidate)
+                head: Term = Var(name)
+                for tv in tyvars:
+                    head = TypeApplication(head, sub[tv])
+                inst_params: list[Type] = []
+                for p in params_t:
+                    for tv in tyvars:
+                        p = type_substitution(p, tv, sub[tv])
+                    inst_params.append(p)
+                params = [
+                    synthes_memory(ctx, level - 1, i, skip, mem)
+                    if isinstance(i, TypeConstructor) or _refined_adt_param(i)
+                    else synthes_memory(ctx, 0, i, skip, mem)
+                    for i in inst_params
+                ]
+                for combo in itertools.product(*params):
+                    term: Term = head
+                    for a in combo:
+                        term = Application(term, a)
+                    yield term
+            else:
+                if synquid_application_arg_types(typ, ret_t) is None:
+                    continue
+                params_t, t = uncurry(typ)
                 if refined_to_unrefined_type(t) != base_t:
                     continue
                 head_tc = _head_result_constructor(t)
@@ -152,14 +276,13 @@ def synthes(ctx: TypingContext, level: int, ret_t: Type, skip: Callable[[Name], 
                     continue
                 params = [
                     synthes_memory(ctx, level - 1, i, skip, mem)
-                    if isinstance(i, TypeConstructor)
+                    if isinstance(i, TypeConstructor) or _refined_adt_param(i)
                     else synthes_memory(ctx, 0, i, skip, mem)
                     for i in params_t
                 ]
                 params.insert(0, [Var(name)])
                 for i in itertools.product(*params):
-                    a = closing(i, head_tc)
-                    yield a
+                    yield closing(i, head_tc)
         bool_t = TypeConstructor(Name("Bool", 0), [])
         atoms_q = extract_qualifier_atoms(ctx, goal_type=ret_t)
         guard_quads = bool_quad_conjunctions(ctx, atoms_q)

--- a/aeon/synthesis/modules/synquid/guards.py
+++ b/aeon/synthesis/modules/synquid/guards.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidTerm, LiquidVar
 from aeon.core.terms import Annotation, Application, Literal, Var
 from aeon.core.terms import Term
-from aeon.core.types import TypeConstructor, t_bool
+from aeon.core.types import TypeConstructor, Type, refined_to_unrefined_type, t_bool
 from aeon.typechecking.context import TypingContext
 from aeon.utils.name import Name
 
@@ -23,18 +23,64 @@ def _liquid_to_int_term(t: LiquidTerm) -> Term | None:
             return None
 
 
+def _is_int_base(ty: Type) -> bool:
+    base = refined_to_unrefined_type(ty)
+    return isinstance(base, TypeConstructor) and base.name.name == "Int"
+
+
+def _relational_ops_in(atoms: frozenset[LiquidTerm]) -> list[Name]:
+    """Operators of every relational atom appearing *anywhere* in ``atoms`` --
+    including nested under ``&&`` / ``||`` (e.g. the ``<=`` of a sortedness
+    invariant ``ilen t = 0 || hd <= imin t``). These are the ``⋆ op ⋆``
+    qualifier *templates* of the abducible set Q (Polikarpova et al., PLDI'16
+    §2: ``⋆`` is a placeholder instantiated with program variables in scope)."""
+    ops: set[Name] = set()
+
+    def walk(t: LiquidTerm) -> None:
+        if isinstance(t, LiquidApp):
+            if t.fun in _REL:
+                ops.add(t.fun)
+            for a in t.args:
+                walk(a)
+
+    for a in atoms:
+        walk(a)
+    return sorted(ops, key=lambda n: (n.name, n.id))
+
+
 def bool_terms_from_qualifier_atoms(
     ctx: TypingContext,
     atoms: frozenset[LiquidTerm],
     *,
     max_terms: int = 48,
 ) -> list[Term]:
-    """Turn relational qualifier atoms into Bool-typed core terms using prelude ops."""
+    """Bool-typed core guards drawn from the qualifier set Q.
+
+    Two sources, both Synquid liquid abduction (PLDI'16 §2):
+    (a) relational atoms already present in Q whose operands are in scope; and
+    (b) *template instantiation* -- each relational operator appearing in Q is a
+    ``⋆ op ⋆`` qualifier template, re-instantiated with the program variables in
+    scope of matching (``Int``) sort, plus the literals ``0``/``1``. (b) is what
+    surfaces a discriminating guard such as ``hd <= p`` whose operands the
+    harvested atoms only mention over the datatype's own (out-of-scope) binders.
+    It fires only when Q carries a relational template *and* an ``Int`` variable
+    is in scope, so non-ordering goals pay nothing, and is bounded by
+    ``max_terms``."""
     in_ctx = {n for n, _ in ctx.concrete_vars()}
     out: list[Term] = []
+    seen: set[tuple[Name, str, str]] = set()
+
+    def emit(op: Name, lhs: Term, rhs: Term) -> None:
+        key = (op, repr(lhs), repr(rhs))
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(Annotation(Application(Application(Var(op), lhs), rhs), t_bool))
+
+    # (a) harvested atoms with in-scope operands
     for atom in atoms:
         if len(out) >= max_terms:
-            break
+            return out
         if not isinstance(atom, LiquidApp) or atom.fun not in _REL or len(atom.args) != 2:
             continue
         a0, a1 = atom.args
@@ -46,9 +92,23 @@ def bool_terms_from_qualifier_atoms(
             continue
         if isinstance(a1, LiquidVar) and a1.name not in in_ctx:
             continue
-        op = Var(atom.fun)
-        t = Application(Application(op, lhs), rhs)
-        out.append(Annotation(t, t_bool))
+        emit(atom.fun, lhs, rhs)
+
+    # (b) template instantiation over in-scope Int variables (+ 0/1)
+    ops = _relational_ops_in(atoms)
+    int_vars = [Var(n) for n, t in ctx.concrete_vars() if _is_int_base(t)]
+    if ops and int_vars:
+        operands: list[Term] = int_vars + [Literal(0, _INT), Literal(1, _INT)]
+        for op in ops:
+            for lhs in operands:
+                for rhs in operands:
+                    if len(out) >= max_terms:
+                        return out
+                    if lhs == rhs:
+                        continue
+                    if isinstance(lhs, Literal) and isinstance(rhs, Literal):
+                        continue  # constant guard (e.g. ``0 <= 1``) -- never discriminating
+                    emit(op, lhs, rhs)
     return out
 
 

--- a/aeon/synthesis/modules/synquid/search.py
+++ b/aeon/synthesis/modules/synquid/search.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import heapq
 import itertools
+from itertools import islice
 from collections.abc import Callable, Iterator
 
 from aeon.core.terms import Annotation, Application, Hole, If, Literal, Term, TypeApplication, Var
@@ -11,6 +12,15 @@ from aeon.core.types import Type
 from aeon.synthesis.modules.synquid.engine import synthes_memory
 from aeon.typechecking.context import TypingContext
 from aeon.utils.name import Name
+
+# When the depth is unbounded, treat this many consecutive empty deeper levels
+# as exhaustion of the candidate space (so the merge ends instead of probing
+# ever-deeper empty levels forever).
+_EMPTY_PROBE_LIMIT = 16
+
+# Cap on how many candidates of a single level are materialised+sorted at once,
+# so opening a deep (potentially huge) level can't blow past the time budget.
+_LEVEL_BATCH_CAP = 4000
 
 
 def term_size(t: Term) -> int:
@@ -41,8 +51,14 @@ def sorted_level_candidates(
     skip: Callable[[Name], bool],
     mem: dict,
 ) -> Iterator[Term]:
-    """Yield candidates from ``synthes_memory`` for this level, smallest ``term_size`` first."""
-    batch = list(synthes_memory(ctx, level, ret_t, skip, mem))
+    """Yield candidates from ``synthes_memory`` for this level, smallest ``term_size`` first.
+
+    The level is materialised so it can be sorted by size, but only up to
+    ``_LEVEL_BATCH_CAP`` candidates: a deep level can hold an enormous number of
+    terms, and materialising all of them (with no budget check) would blow past
+    the time budget. The cap keeps each level's setup bounded; the cross-level
+    merge still reaches deeper levels."""
+    batch = list(islice(synthes_memory(ctx, level, ret_t, skip, mem), _LEVEL_BATCH_CAP))
     batch.sort(key=term_size)
     yield from batch
 
@@ -53,7 +69,7 @@ def iter_candidates_size_then_level(
     skip: Callable[[Name], bool],
     mem: dict,
     *,
-    max_level: int = 128,
+    max_level: int | None = None,
     seed_levels: int = 2,
 ) -> Iterator[Term]:
     """Merge synthesis levels lazily: smaller ``term_size`` first; tie-break shallower ``level``.
@@ -61,17 +77,50 @@ def iter_candidates_size_then_level(
     Unlike strict iterative deepening (exhaust level *L* before *L+1*), this interleaves
     levels so a compact term at depth *L+1* can be tried before a bulky term at depth *L*.
     Deeper levels are opened when the previous frontier level is exhausted.
+
+    ``max_level`` defaults to ``None`` (unbounded): the search keeps deepening until
+    the caller's time budget stops consuming candidates, or the space is exhausted
+    (``_EMPTY_PROBE_LIMIT`` consecutive empty deeper levels). A concrete
+    ``max_level`` caps the depth explicitly.
     """
     tie = itertools.count()
     heap: list[tuple[int, int, int, Term]] = []
     itors: dict[int, Iterator[Term]] = {}
 
-    for L in range(min(seed_levels, max_level + 1)):
-        if L not in itors:
-            itors[L] = iter(sorted_level_candidates(ctx, L, ret_t, skip, mem))
-        first = next(itors[L], None)
-        if first is not None:
-            heapq.heappush(heap, (term_size(first), L, next(tie), first))
+    def push_from(level: int) -> bool:
+        """Open ``level`` (if needed) and push its next candidate; True if one was pushed."""
+        if level not in itors:
+            itors[level] = iter(sorted_level_candidates(ctx, level, ret_t, skip, mem))
+        cand = next(itors[level], None)
+        if cand is not None:
+            heapq.heappush(heap, (term_size(cand), level, next(tie), cand))
+            return True
+        return False
+
+    def open_deeper() -> None:
+        """Open the shallowest not-yet-opened level that yields a candidate, so the
+        merge keeps deepening. Bounded: stop at ``max_level``, or after a run of
+        empty levels (the space is exhausted -- never spin forever)."""
+        probe = max(itors.keys(), default=-1) + 1
+        empties = 0
+        while True:
+            if max_level is not None and probe > max_level:
+                return
+            if max_level is None and empties >= _EMPTY_PROBE_LIMIT:
+                return
+            if push_from(probe):
+                return
+            probe += 1
+            empties += 1
+
+    seed = seed_levels if max_level is None else min(seed_levels, max_level + 1)
+    for L in range(seed):
+        push_from(L)
+    # A goal whose constructor needs arguments has *no* candidates at the shallow
+    # seed levels (e.g. `Level`, only buildable at depth >= 2). Bootstrap by
+    # opening deeper levels until candidates appear, instead of returning empty.
+    if not heap:
+        open_deeper()
 
     while heap:
         _, lv, _, t = heapq.heappop(heap)
@@ -80,12 +129,4 @@ def iter_candidates_size_then_level(
         if nxt is not None:
             heapq.heappush(heap, (term_size(nxt), lv, next(tie), nxt))
             continue
-        probe = max(itors.keys(), default=-1) + 1
-        while probe <= max_level:
-            if probe not in itors:
-                itors[probe] = iter(sorted_level_candidates(ctx, probe, ret_t, skip, mem))
-            cand = next(itors[probe], None)
-            if cand is not None:
-                heapq.heappush(heap, (term_size(cand), probe, next(tie), cand))
-                break
-            probe += 1
+        open_deeper()

--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -64,20 +64,32 @@ class SynquidSynthesizer(Synthesizer):
         goals = current_metadata.get("goals", [])
         search_mode = current_metadata.get("synquid_search", "size_merge")
         typecheck_candidate_first = bool(current_metadata.get("synquid_typecheck_candidate_first", False))
-        max_level = max(0, int(current_metadata.get("synquid_max_level", 128)))
+        # Depth is unbounded by default: the search runs until the time budget
+        # (the budget check in `consider`) or the candidate space is exhausted.
+        # A concrete `synquid_max_level` caps the depth explicitly.
+        _max_level_raw = current_metadata.get("synquid_max_level")
+        max_level = None if _max_level_raw is None else max(0, int(_max_level_raw))
         seed_levels = max(1, int(current_metadata.get("synquid_seed_levels", 2)))
         max_candidates_raw = current_metadata.get("synquid_max_candidates")
         max_candidates = None if max_candidates_raw is None else max(0, int(max_candidates_raw))
         n_candidates = 0
 
+        def _safe_check(fn, *args) -> bool:
+            # A candidate that makes the typechecker/SMT raise (e.g. an
+            # ill-sorted intermediate term) is simply rejected, never fatal.
+            try:
+                return bool(fn(*args))
+            except Exception:
+                return False
+
         def consider(result: Term) -> bool:
             nonlocal best, done
-            if typecheck_candidate_first and not check_type(ctx, result, type):
+            if typecheck_candidate_first and not _safe_check(check_type, ctx, result, type):
                 ui.register(result, "Invalid (hole-local)", get_elapsed_time(start_time), False)
                 if get_elapsed_time(start_time) > budget:
                     done = False
                 return False
-            if validate(result):
+            if _safe_check(validate, result):
                 score = evaluate(result)
                 if not goals:
                     ui.register(result, score, get_elapsed_time(start_time), True)
@@ -94,7 +106,7 @@ class SynquidSynthesizer(Synthesizer):
             return False
 
         if search_mode == "iterative_deepening":
-            while done and level <= max_level:
+            while done and (max_level is None or level <= max_level):
                 cap_done = False
                 for result in sorted_level_candidates(ctx, level, type, skip, mem):
                     if max_candidates is not None and n_candidates >= max_candidates:

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -850,6 +850,183 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             assert False, f"Unhandled term {t} in synth. Type: {type(t)}"
 
 
+def _try_check_recursor(ctx: TypingContext, t: Term, ty: Type) -> Constraint | None:
+    """Path-sensitive checking of a fully-applied inductive eliminator.
+
+    Surface ``match`` lowers to ``T_rec[..] scrut h_1 … h_n``. Elaboration fixes
+    the eliminator's result *motive* to a bare base type, so the ordinary
+    synth-then-subtype path checks every branch against an unrefined ``ret`` and
+    proves the goal only on the (information-free) result -- dropping the matched
+    constructor's refinement. Here we instead bind the motive to the *expected*
+    type ``ty`` and check each handler against it. The dependent eliminator
+    carries the constructor's refinement in as a proof witness (see
+    ``expand_inductive_decls``), so each branch body is verified under that fact
+    -- recovering match path-sensitivity.
+
+    Returns the constraint, or ``None`` to fall back to the default rule when
+    ``t`` is not a recognisable, fully-applied eliminator on a variable
+    scrutinee.
+    """
+    # Only worth the extra work when the expected type carries a non-trivial
+    # refinement: that is the obligation the matched constructor's fact helps
+    # discharge. An unrefined motive is handled fine -- and far more cheaply --
+    # by the default synth-then-subtype path, so skip the whole machinery (and
+    # its per-branch re-checking) for the common case.
+    ty_r = ensure_refined(ty)
+    if not isinstance(ty_r, RefinedType) or (
+        isinstance(ty_r.refinement, LiquidLiteralBool) and ty_r.refinement.value is True
+    ):
+        return None
+
+    value_args: list[Term] = []
+    cur: Term = t
+    while isinstance(cur, Application):
+        value_args.append(cur.arg)
+        cur = cur.fun
+    value_args.reverse()
+    if not value_args:
+        return None
+    spine: list[tuple[str, object]] = []
+    head: Term = cur
+    while isinstance(head, (TypeApplication, RefinementApplication)):
+        spine.append(("T", head.type) if isinstance(head, TypeApplication) else ("R", head.refinement))
+        head = head.body
+    spine.reverse()
+    if not isinstance(head, Var) or not head.name.name.endswith("_rec"):
+        return None
+    from aeon.verification.constructor_registry import get_constructor_groups
+
+    if head.name.name[: -len("_rec")] not in get_constructor_groups():
+        return None
+    rec_type = ctx.type_of(head.name)
+    if rec_type is None:
+        return None
+    scrut = value_args[0]
+    handlers = value_args[1:]
+    scrut_inner = scrut.expr if isinstance(scrut, Annotation) else scrut
+    if not isinstance(scrut_inner, Var):
+        return None
+
+    # The motive is the type-variable returned after peeling binders and arrows.
+    peeled: Type = rec_type
+    while isinstance(peeled, (TypePolymorphism, RefinementPolymorphism)):
+        peeled = peeled.body
+    res: Type = peeled
+    while isinstance(res, AbstractionType):
+        res = res.type
+    if not isinstance(res, TypeVar):
+        return None
+    ret_var = res.name
+
+    # Re-instantiate the eliminator with the spine's args, but bind the motive to
+    # the expected type ``ty`` instead of its elaboration-erased base.
+    inst: Type = rec_type
+    for kind, val in spine:
+        if isinstance(inst, TypePolymorphism) and kind == "T":
+            assert isinstance(val, Type)
+            repl = ty if inst.name == ret_var else fresh(ctx, val)
+            inst = type_substitution(inst.body, inst.name, repl)
+        elif isinstance(inst, RefinementPolymorphism) and kind == "R":
+            if isinstance(val, ImplicitRefinementHole):
+                inst = instantiate_refinement_with_horn_in_type(
+                    inst.body, inst.name, inst.sort, Name("kappa", fresh_counter.fresh())
+                )
+            elif isinstance(val, Abstraction):
+                inst = instantiate_refinement_in_type(inst.body, inst.name, val)
+            else:
+                return None
+        else:
+            return None
+    if not isinstance(inst, AbstractionType):
+        return None
+
+    # ``inst`` is now ``(this: D) -> (case_1: CT_1) -> … -> ty``.
+    rest: Type = substitution_in_type(inst.type, scrut_inner, inst.var_name)
+    tyname = head.name.name[: -len("_rec")]
+    constraints: list[Constraint] = [check(ctx, scrut, inst.var_type)]
+    for h in handlers:
+        if not isinstance(rest, AbstractionType):
+            return None
+        case_name, case_type, rest = rest.var_name, rest.var_type, rest.type
+        constraints.append(_check_recursor_branch(ctx, h, case_type, tyname, case_name, scrut_inner))
+    out: Constraint = constraints[0]
+    for c in constraints[1:]:
+        out = Conjunction(out, c)
+    return out
+
+
+def _check_recursor_branch(
+    ctx: TypingContext,
+    handler: Term,
+    case_type: Type,
+    tyname: str,
+    case_name: Name,
+    scrut: Var,
+) -> Constraint:
+    """Check one eliminator branch under the matched constructor's refinement.
+
+    The branch handler ``λf₁ … f_k. body`` is checked against the case type
+    ``(f₁) → … → (f_k) → motive`` (already carrying the expected motive); on top
+    of the usual field hypotheses we add the constructor's *result* refinement,
+    specialised to the scrutinee (``size this = size tl + 1`` becomes
+    ``size scrut = size <field-for-tl> + 1``). That fact -- a pure measure
+    statement, which is all aeon's SMT logic models about a datatype -- is what
+    a non-dependent ``ret`` motive drops, and is exactly the match-branch
+    hypothesis. Falls back to a plain check (motive only, no constructor fact)
+    if the constructor's shape cannot be recovered."""
+    plain = lambda: check(ctx, handler, case_type)  # noqa: E731
+    ctor_full = f"{tyname}_{case_name.name[len('case_') :]}" if case_name.name.startswith("case_") else None
+    ctor_type = next((tt for n, tt in ctx.vars() if n.name == ctor_full), None) if ctor_full else None
+    if ctor_type is None:
+        return plain()
+    # Peel the constructor's binders/fields to reach its result refinement.
+    cur: Type = ctor_type
+    while isinstance(cur, (TypePolymorphism, RefinementPolymorphism)):
+        cur = cur.body
+    ctor_arg_names: list[Name] = []
+    while isinstance(cur, AbstractionType):
+        ctor_arg_names.append(cur.var_name)
+        cur = cur.type
+    res_ref = ensure_refined(cur)
+    if not isinstance(res_ref, RefinedType):
+        return plain()
+
+    # Peel the handler's field binders against the case type, recording the
+    # field types and the constructor-arg → handler-field name correspondence.
+    fields: list[tuple[Name, Type]] = []
+    ctor_to_field: dict[Name, LiquidTerm] = {}
+    hh: Term = handler
+    ct: Type = case_type
+    while isinstance(ct, AbstractionType) and isinstance(hh, Abstraction):
+        fn = hh.var_name
+        fields.append((fn, ct.var_type))
+        if len(fields) - 1 < len(ctor_arg_names):
+            ctor_to_field[ctor_arg_names[len(fields) - 1]] = LiquidVar(fn)
+        ct = substitution_in_type(ct.type, Var(fn), ct.var_name)
+        hh = hh.body
+    if isinstance(ct, AbstractionType):
+        return plain()  # handler under-applied for this case — leave it to the default
+
+    # fact = constructor result refinement, with the result binder set to the
+    # scrutinee and constructor field names mapped to the handler's binders.
+    fact: LiquidTerm = substitution_in_liquid(res_ref.refinement, LiquidVar(scrut.name), res_ref.name)
+    for cn, fv in ctor_to_field.items():
+        fact = substitution_in_liquid(fact, fv, cn)
+
+    ctx2 = ctx
+    for fn, ftype in fields:
+        ctx2 = ctx2.with_var(fn, ftype)
+    body_c = check(ctx2, hh, ct)
+    c = implication_constraint(
+        Name("_hyp", fresh_counter.fresh()),
+        RefinedType(Name("_hypu", fresh_counter.fresh()), t_unit, fact),
+        body_c,
+    )
+    for fn, ftype in reversed(fields):
+        c = implication_constraint(fn, ftype, c)
+    return c
+
+
 def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
     try:
         assert wellformed(ctx, ty)
@@ -1009,6 +1186,11 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
             # Return (fκ :: sort → bool) ⇒ c
             return UninterpretedFunctionDeclaration(fk_name, fk_type, c)
 
+        case _ if (rec_c := _try_check_recursor(ctx, t, ty)) is not None:
+            # Fully-applied inductive eliminator (lowered ``match``): check each
+            # branch against the expected motive so the matched constructor's
+            # refinement reaches the branch body (path-sensitivity).
+            return rec_c
         case _:
             (c, s) = synth(ctx, t)
             cp = sub(ctx, s, ty, t.loc)

--- a/examples/synthesis/supermario.ae
+++ b/examples/synthesis/supermario.ae
@@ -71,11 +71,14 @@ inductive Chunk
 | boxes_chunk (bs: (List Box) | len bs >= 2 && len bs <= 7) : Chunk
 
 # --- Level ---
-# Minimum chunk/enemy counts are enforced by the fitness, not the type,
-# so that partial candidates can still be evaluated by the synthesizer.
+# Both lists are required to be non-empty in the *type* of the constructor
+# (reusing the `len` measure on `List`): since `mk_level` is the only way to
+# build a `Level`, non-emptiness is an invariant of every `Level` value. This
+# rules out the degenerate empty level that a purely fitness-driven search
+# otherwise collapses to.
 
 inductive Level
-| mk_level (cs: (List Chunk)) (es: (List Enemy)) : Level
+| mk_level (cs: (List Chunk) | len cs >= 1) (es: (List Enemy) | len es >= 1) : Level
 
 # --- Fitness helpers (pure Aeon, using match on inductive types) ---
 

--- a/tests/match_path_sensitive_test.py
+++ b/tests/match_path_sensitive_test.py
@@ -1,0 +1,123 @@
+"""Path-sensitive ``match``: each branch should be checked under the matched
+constructor's refinement (specialised to the scrutinee).
+
+Surface ``match`` lowers to the generated ``<T>_rec`` eliminator. With a
+*non-dependent* motive the case bodies learn nothing about which constructor was
+matched, so a function whose refined return type depends on the scrutinee's
+constructor cannot be verified. These tests pin the desired behaviour: the
+constructor's refinement (a measure fact, the only thing aeon's SMT logic models
+about a datatype) must reach the branch body as a hypothesis.
+"""
+
+from __future__ import annotations
+
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import DesugaredProgram, desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_main_program
+from aeon.typechecking.typeinfer import check_type_errors
+
+
+def _type_errors(src: str) -> list:
+    prog = parse_main_program(src, filename="<path-sensitive-test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(
+        progt, ctx, desugared.metadata, desugared.constructor_to_type, desugared.constructor_defs
+    )
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    return list(check_type_errors(typing_ctx, core_ast, top))
+
+
+# A two-constructor datatype whose constructors pin the measure ``val`` to a
+# distinct literal. Both branch obligations discharge from the constructor's
+# measure value alone (no non-negativity reasoning needed), so this isolates
+# path-sensitivity from any measure-axiom concerns.
+_BIT = """
+inductive Bit
+| off : {b: Bit | val b = 0}
+| on : {b: Bit | val b = 1}
++ val (b: Bit) : Int
+"""
+
+
+def test_match_branch_sees_constructor_refinement() -> None:
+    """``isOn`` is correct only if each branch knows ``val x`` for that constructor."""
+    src = (
+        _BIT
+        + """
+def isOn (x: Bit) : {r: Bool | r = (val x = 1)} :=
+    match x with
+    | off => false
+    | on => true
+
+def main (args: Int) : Int := 0
+"""
+    )
+    errors = _type_errors(src)
+    assert errors == [], f"path-sensitive match should typecheck, got: {errors}"
+
+
+def test_match_branch_refinement_is_sound() -> None:
+    """The *wrong* body must still be rejected: assuming ``val x = 0`` in the
+    ``off`` branch does not let us prove a false claim about the ``on`` branch."""
+    src = (
+        _BIT
+        + """
+def wrong (x: Bit) : {r: Bool | r = (val x = 1)} :=
+    match x with
+    | off => true
+    | on => false
+
+def main (args: Int) : Int := 0
+"""
+    )
+    errors = _type_errors(src)
+    assert errors != [], "an incorrect match body must be rejected"
+
+
+def test_match_branch_constructor_field_refinement() -> None:
+    """A constructor *with a field* exposes its field-dependent refinement to
+    the branch: ``wrap n`` pins ``unwrap w = n``, so ``get`` returns ``n``."""
+    src = """
+inductive Wrap
+| wrap (k: Int) : {w: Wrap | unwrap w = k}
++ unwrap (w: Wrap) : Int
+
+def get (w: Wrap) : {r: Int | r = unwrap w} :=
+    match w with
+    | wrap n => n
+
+def main (args: Int) : Int := 0
+"""
+    errors = _type_errors(src)
+    assert errors == [], f"field-dependent constructor refinement should typecheck, got: {errors}"
+
+
+def test_match_branch_field_refinement_is_sound() -> None:
+    """The injected fact must not over-accept: a ``succ`` branch only knows
+    ``tonat n = tonat p + 1`` for an *arbitrary* ``p``, so claiming
+    ``tonat n = 1`` for every ``succ`` is rejected (it would need ``tonat p = 0``)."""
+    src = """
+inductive Nat2
+| z : {n: Nat2 | tonat n = 0}
+| s (p: Nat2) : {n: Nat2 | tonat n = tonat p + 1}
++ tonat (n: Nat2) : Int
+
+def bad (n: Nat2) : {r: Bool | r = (tonat n = 1)} :=
+    match n with
+    | z => false
+    | s p => true
+
+def main (args: Int) : Int := 0
+"""
+    errors = _type_errors(src)
+    assert errors != [], "a field-dependent claim true only for one constructor value must be rejected"

--- a/tests/synquid_guards_test.py
+++ b/tests/synquid_guards_test.py
@@ -1,5 +1,5 @@
 from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidVar
-from aeon.core.terms import Annotation, Application, Var
+from aeon.core.terms import Annotation, Application, Literal, Var
 from aeon.core.types import TypeConstructor
 from aeon.synthesis.modules.synquid.guards import (
     bool_pairwise_conjunctions,
@@ -20,22 +20,58 @@ def _is_and_annotation(t) -> bool:
 
 
 def test_bool_pairwise_conjunctions_requires_two_singles():
+    # With no in-scope Int variable, the harvested atom's operand is out of scope
+    # and template instantiation (which needs an Int operand in scope) cannot
+    # fire, so fewer than two singles exist and no pairwise guard is formed.
     x = Name("x", 0)
-    int_t = TypeConstructor(Name("Int", 0), [])
-    ctx = TypingContext().with_var(x, int_t)
+    empty_ctx = TypingContext()
     one = frozenset({LiquidApp(Name("<=", 0), [LiquidVar(x), LiquidLiteralInt(1)])})
-    assert bool_pairwise_conjunctions(ctx, one) == []
+    assert bool_terms_from_qualifier_atoms(empty_ctx, one) == []
+    assert bool_pairwise_conjunctions(empty_ctx, one) == []
+    x_int = TypingContext().with_var(x, TypeConstructor(Name("Int", 0), []))
     two = frozenset(
         {
             LiquidApp(Name("<=", 0), [LiquidVar(x), LiquidLiteralInt(10)]),
             LiquidApp(Name(">=", 0), [LiquidVar(x), LiquidLiteralInt(0)]),
         }
     )
-    singles = bool_terms_from_qualifier_atoms(ctx, two)
+    singles = bool_terms_from_qualifier_atoms(x_int, two)
     assert len(singles) >= 2
-    pairs = bool_pairwise_conjunctions(ctx, two, max_singles=12, max_pairs=24)
+    pairs = bool_pairwise_conjunctions(x_int, two, max_singles=12, max_pairs=24)
     assert len(pairs) >= 1
     assert all(_is_and_annotation(p) for p in pairs)
+
+
+def test_template_instantiation_over_in_scope_int_vars():
+    # Liquid-abduction qualifier templates (Synquid PLDI'16 §2): a single
+    # relational atom ``a <= 1`` is a ``⋆ <= ⋆`` template, re-instantiated over
+    # the in-scope Int variables (here ``a`` and ``b``) -- surfacing the
+    # cross-variable guard ``a <= b`` that the harvested atom never mentions.
+    a, b = Name("a", 0), Name("b", 0)
+    int_t = TypeConstructor(Name("Int", 0), [])
+    ctx = TypingContext().with_var(a, int_t).with_var(b, int_t)
+    atoms = frozenset({LiquidApp(Name("<=", 0), [LiquidVar(a), LiquidLiteralInt(1)])})
+    singles = bool_terms_from_qualifier_atoms(ctx, atoms)
+
+    def _rel(t, op, lhs, rhs):
+        match t:
+            case Annotation(Application(Application(Var(o), x), y), _):
+                return o.name == op and _leaf(x) == lhs and _leaf(y) == rhs
+            case _:
+                return False
+
+    def _leaf(t):
+        match t:
+            case Var(n):
+                return n.name
+            case Literal(v, _):
+                return v
+            case _:
+                return None
+
+    assert any(_rel(s, "<=", "a", "b") for s in singles), [str(s) for s in singles]
+    # constant-only guards (e.g. ``0 <= 1``) are excluded
+    assert not any(_rel(s, "<=", 0, 1) for s in singles)
 
 
 def _is_triple_and_annotation(t) -> bool:


### PR DESCRIPTION
## Summary

Synthesis improvements plus the core fixes that unblock them. Rebased on master.

### Core
- **perf(core): memoize structural hashing** on recursive `Type`/`LiquidTerm` nodes — was `O(paths)` (exponential) on shared-subterm DAGs; now `O(unique nodes)`. Fixes a hang in the synthesis memo.
- **fix(termination): resolve qualified names in `decreasing_by` metrics.** A measure name like `size` was left unresolved (never bound to `List_size`), leaving the obligation `size xs < size xs` undischarged and **silently admitting non-terminating ADT recursion**. Now rejected correctly.

### Synthesizers bounded only by search time
- **Tree-automata (fta/afta/cata/lta): remove the fixed depth cap** (`rounds=3` / `max_depth=4`); deepen until the time budget or a fixpoint.
- **Synquid: lift the default `max_level`** (was 128) to unbounded; the search runs until the budget or until the candidate space is exhausted. Caps can still be set explicitly.

### Synquid backend
- **APP rule with polymorphic instantiation by return-type unification** (PLDI'16): `List a` ⊔ `List Enemy` ⇒ `a := Enemy` — targeted, no universe enumeration.
- **Literals by SMT, not enumeration**: `?intLit`/`?floatLit` solved against the refinement (the VC); removes a 20M-element eager `Float` list.
- **Exception-safe candidate validation**.

### Examples
- **supermario**: require both chunk/enemy lists non-empty in the `Level` type.

## Testing
Targeted suites green: fta/afta/cata/lta (46), synquid+search, termination/soundness/decreasing/recursion, elaboration/typecheck/verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)