### PR TITLE
perf(verification): one-point rule for `x == c` premises in VC flattening

### DIFF
--- a/aeon/verification/helpers.py
+++ b/aeon/verification/helpers.py
@@ -23,6 +23,7 @@ from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import Implication
 from aeon.verification.vcs import LiquidConstraint
 from aeon.verification.vcs import ReflectedFunctionDeclaration
+from aeon.verification.vcs import substitution_in_constraint
 from aeon.verification.vcs import UninterpretedFunctionDeclaration
 from aeon.utils.location import Location
 from aeon.utils.name import Name, fresh_counter
@@ -214,32 +215,6 @@ def constraint_free_variables(c: Constraint) -> list[Name]:
             return constraint_free_variables(c1) + constraint_free_variables(c2)
         case _:
             assert False, f"Unsupported Constraint: {c}"
-
-
-def substitution_in_constraint(c: Constraint, rep: LiquidTerm, name: Name) -> Constraint:
-    """Substitues a LiquidVar by another expression within a constraint."""
-    match c:
-        case LiquidConstraint(expr):
-            return LiquidConstraint(substitution_in_liquid(expr, rep, name), loc=c.loc)
-        case Conjunction(c1, c2):
-            left = substitution_in_constraint(c1, rep, name)
-            right = substitution_in_constraint(c2, rep, name)
-            return Conjunction(left, right, loc=c.loc)
-        case Implication(impl_name, base, pred, seq):
-            if name == impl_name:
-                return c
-            else:
-                nseq = substitution_in_constraint(seq, rep, name)
-                return Implication(impl_name, base, substitution_in_liquid(pred, rep, name), nseq, loc=c.loc)
-        case UninterpretedFunctionDeclaration(ufd_name, ufd_type, seq):
-            nseq = substitution_in_constraint(seq, rep, name)
-            return UninterpretedFunctionDeclaration(ufd_name, ufd_type, nseq)
-        case ReflectedFunctionDeclaration(rfd_name, rfd_type, params, body, seq):
-            nbody = substitution_in_liquid(body, rep, name)
-            nseq = substitution_in_constraint(seq, rep, name)
-            return ReflectedFunctionDeclaration(rfd_name, rfd_type, params, nbody, nseq)
-        case _:
-            assert False
 
 
 def used_variables(c: LiquidTerm) -> set[Name]:

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -41,6 +41,7 @@ from aeon.core.liquid import LiquidLiteralString
 from aeon.core.liquid import LiquidLiteralUnit
 from aeon.core.liquid import LiquidTerm
 from aeon.core.liquid import LiquidVar
+from aeon.core.liquid import liquid_free_vars
 from aeon.core.liquid_ops import mk_liquid_and
 from aeon.core.substitutions import substitution_in_liquid
 from aeon.core.types import AbstractionType, RefinedType, RefinementPolymorphism, Top, TypePolymorphism
@@ -54,6 +55,7 @@ from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import Implication
 from aeon.verification.vcs import LiquidConstraint
 from aeon.verification.vcs import ReflectedFunctionDeclaration
+from aeon.verification.vcs import substitution_in_constraint
 from aeon.verification.vcs import UninterpretedFunctionDeclaration
 from aeon.utils.name import Name, fresh_counter
 
@@ -508,6 +510,28 @@ def rename_constraint(c: Constraint, old_name: Name, new_name: Name) -> Constrai
             assert False, f"Unexpected case {c} ({type(c)})"
 
 
+def one_point_replacement(pred: LiquidTerm, name: Name) -> LiquidTerm | None:
+    """One-point rule for a universally quantified binder.
+
+    ``forall x:b, (x == c) => P`` is logically equivalent to ``P[x := c]``
+    whenever ``x`` does not occur free in ``c`` (which always holds here, since
+    ``x`` is a freshly introduced binder). When ``pred`` is exactly such an
+    equality this returns ``c``; otherwise ``None``.
+
+    Eliminating the binder removes one universally quantified variable *and* one
+    premise from the SMT query, shrinking the formula handed to Z3. The win is
+    modest in wall-clock terms (Z3 already eliminates trivial equalities during
+    preprocessing), but it keeps the emitted VCs smaller and is always sound.
+    """
+    if isinstance(pred, LiquidApp) and pred.fun == Name("==", 0) and len(pred.args) == 2:
+        left, right = pred.args
+        if left == LiquidVar(name) and name not in liquid_free_vars(right):
+            return right
+        if right == LiquidVar(name) and name not in liquid_free_vars(left):
+            return left
+    return None
+
+
 def flatten(c: Constraint, ctx: SMTContext | None = None) -> Generator[CanonicConstraint]:
     """Flattens a constraint into a list of SMT-valid constraints."""
     if ctx is None:
@@ -542,7 +566,14 @@ def flatten(c: Constraint, ctx: SMTContext | None = None) -> Generator[CanonicCo
                     pass
                 case _:
                     assert False, f"{base} ({type(base)}) is not a base type."
-            yield from flatten(seq, ctx.with_var(name, base).with_premise(pred))
+            # One-point rule: when the premise is just ``x == c`` we substitute
+            # ``c`` for ``x`` in the body and drop the binder entirely instead
+            # of handing the equality to Z3 as one more variable + premise.
+            rep = one_point_replacement(pred, name)
+            if rep is not None:
+                yield from flatten(substitution_in_constraint(seq, rep, name), ctx)
+            else:
+                yield from flatten(seq, ctx.with_var(name, base).with_premise(pred))
         case UninterpretedFunctionDeclaration(name, ty, seq):
             assert isinstance(c, UninterpretedFunctionDeclaration)
             nctx = _ctx_with_curried_formals(ctx, ty)

--- a/aeon/verification/vcs.py
+++ b/aeon/verification/vcs.py
@@ -10,6 +10,7 @@ from aeon.core.liquid import LiquidLiteralInt
 from aeon.core.liquid import LiquidLiteralString
 from aeon.core.liquid import LiquidTerm
 from aeon.core.liquid import LiquidVar
+from aeon.core.substitutions import substitution_in_liquid
 from aeon.core.types import AbstractionType, RefinedType, RefinementPolymorphism, Top, Type, TypePolymorphism, TypeVar
 from aeon.core.types import TypeConstructor
 from aeon.utils.location import Location
@@ -84,6 +85,34 @@ class TypeVarDeclaration(Constraint):
 
     def __repr__(self):
         return f"type {self.name}, {self.seq}"
+
+
+def substitution_in_constraint(c: Constraint, rep: LiquidTerm, name: Name) -> Constraint:
+    """Substitues a LiquidVar by another expression within a constraint."""
+    match c:
+        case LiquidConstraint(expr):
+            return LiquidConstraint(substitution_in_liquid(expr, rep, name), loc=c.loc)
+        case Conjunction(c1, c2):
+            left = substitution_in_constraint(c1, rep, name)
+            right = substitution_in_constraint(c2, rep, name)
+            return Conjunction(left, right, loc=c.loc)
+        case Implication(impl_name, base, pred, seq):
+            if name == impl_name:
+                return c
+            else:
+                nseq = substitution_in_constraint(seq, rep, name)
+                return Implication(impl_name, base, substitution_in_liquid(pred, rep, name), nseq, loc=c.loc)
+        case UninterpretedFunctionDeclaration(ufd_name, ufd_type, seq):
+            nseq = substitution_in_constraint(seq, rep, name)
+            return UninterpretedFunctionDeclaration(ufd_name, ufd_type, nseq)
+        case ReflectedFunctionDeclaration(rfd_name, rfd_type, params, body, seq):
+            nbody = substitution_in_liquid(body, rep, name)
+            nseq = substitution_in_constraint(seq, rep, name)
+            return ReflectedFunctionDeclaration(rfd_name, rfd_type, params, nbody, nseq)
+        case TypeVarDeclaration(tvd_name, seq):
+            return TypeVarDeclaration(tvd_name, substitution_in_constraint(seq, rep, name))
+        case _:
+            assert False
 
 
 def _alpha_name(name: Name, env: dict[tuple[str, int], int], counter: list[int]) -> str:


### PR DESCRIPTION
## What

When `flatten` introduces a fresh universally-quantified binder `x` whose premise is exactly `x == c`, apply the **one-point rule**: substitute `c` for `x` in the body and drop the binder + premise entirely, instead of handing Z3 one more variable and one more assumption.

`∀x:b, (x == c) ⇒ P` is logically equivalent to `P[x := c]` because the freshly-introduced `x` never occurs free in `c`, so the rewrite is **always sound**. The guard checks `x ∉ FV(c)` defensively anyway.

## Why this isn't already happening

`simplify_constraint` (in `helpers.py`) already does this kind of equality elimination — but it only runs in the **error-reporting** path (`constraint_to_parts`). The live verification path is `solve → smt_valid → flatten`, which never called it, so the actual SMT query still carried the `x == c` binder. This PR puts the rule where the VC is really lowered to Z3.

## Changes

- `aeon/verification/smt.py`: new `one_point_replacement` helper; `flatten`'s `Implication` case substitutes-and-drops when the premise is a bare `x == c`.
- `aeon/verification/vcs.py`: `substitution_in_constraint` moved here (next to the `Constraint` datatypes) so `smt.py` and `helpers.py` can both import it without an import cycle.
- `aeon/verification/helpers.py`: imports `substitution_in_constraint` from `vcs` instead of defining it.

## Speedup

Measured on the **isolated SMT verification path** (cache cleared each run, one-point rule ON vs. monkeypatched OFF):

| example | OFF (s) | ON (s) | speedup |
|---|---|---|---|
| super-mario (6 chunks) | 0.471 | 0.425 | **1.11x** |
| super-mario (8 chunks) | 0.641 | 0.603 | **1.06x** |
| AVL (depth 4, 15 nodes) | 2.30 | 2.29 | **1.00x** |
| AVL (depth 5, 31 nodes) | 10.60 | 10.56 | **1.00x** |

**Honest framing:** the win is modest.
- Z3 already eliminates trivial equalities during preprocessing, so removing them barely changes solve time.
- AVL is **1.00x** because only 72 of its 1390 binders (~5%) carry an `==` premise; its cost is dominated by the nested `if ah left >= ah right then …` height arithmetic, which this rule can't touch. Super-mario has 244 `==` premises (41%, 114 eliminated), so it sees a small constant-factor win.
- End-to-end (full typecheck) it's ~1.0x for both, since SMT is only ~18% of typecheck time (the rest is well-formedness checking + type lowering).

The real value here is a **sound, strictly smaller VC** (fewer quantified variables and premises emitted to Z3), not a large wall-clock gain. A larger speedup on these benchmarks would require relevance slicing (dropping VC content disconnected from the goal), which is out of scope for this PR.

## Tests

All 1263 tests pass (`uv run pytest`). The benchmark examples were constructed locally (hole-free super-mario `Level` values and perfect-balanced `Avl` trees) and are not included in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)