### PR TITLE
examples(cata): complete the Contata benchmark transcription (remaining 23)

### DIFF
--- a/examples/synthesis/cata/contata/README.md
+++ b/examples/synthesis/cata/contata/README.md
@@ -55,29 +55,86 @@ the transcription:
 
 ## What is here
 
-Faithful transcriptions over the **original datatype shapes** (`nat`↦`Int`,
-plus `inductive` list/tree), each = the datatype + helpers + the **reference
-solution** + Contata's spec as `@property(N)`/`@example`. All verified with
-`uv run python -m aeon --test <file>` (master):
+The **complete 30-benchmark suite**, over the **original datatype shapes**
+(`nat`/`A`/`B` ↦ `Int`, plus `inductive` list/tree/forest/trie). Each file =
+the datatype(s) + helpers + the **reference solution** + Contata's spec as
+`@property(N)` (the `test forall …`) and `@example` (the `io …`). Unless noted
+`(plain)`, each is verified with `uv run python -m aeon --test <file>`:
 
-| File | Contata source | Category | Spec checked | Status |
-| --- | --- | --- | --- | --- |
-| [`mutrec/even_odd.ae`](mutrec/even_odd.ae) | `even_odd.mls` | MR | `is_odd(inc x)=is_even x`; alternation | true `mutual` group ✔ |
-| [`mutrec/evens_odds.ae`](mutrec/evens_odds.ae) | `evens_odds.mls` | MR | length-partition; unfolding eqn + IO | true `mutual` group ✔ |
-| [`reccomp/list_eq.ae`](reccomp/list_eq.ae) | `list_eq.mls` | RC | reflexivity; singleton-diff; length-mismatch + 3 IO | ✔ |
-| [`reccomp/binary_tree_depth.ae`](reccomp/binary_tree_depth.ae) | `binary_tree_depth.mls` | RC | node unfolding; deeper-than-children + 2 IO | ✔ |
-| [`ds/mirror_tree.ae`](ds/mirror_tree.ae) | `mirror_tree_test.mls` | PDS | involutivity `mirror∘mirror=id`; subtree swap | ✔ |
-| [`ds/list_insertion.ae`](ds/list_insertion.ae) | `list_insertion.mls` | PDS | membership added; sortedness preserved + IO | ✔ |
-| [`stackoverflow/list_rev_twice.ae`](stackoverflow/list_rev_twice.ae) | `list_rev_twice.mls` | SO | k-safety `reverse∘reverse=id` + IO | ✔ |
+**MR — Mutual Recursion (7)**
 
-Run all:
+| File | Source | Spec checked |
+| --- | --- | --- |
+| [`mutrec/even_odd.ae`](mutrec/even_odd.ae) | `even_odd.mls` | `is_odd(inc x)=is_even x`; alternation — true `mutual` group |
+| [`mutrec/even_odd2.ae`](mutrec/even_odd2.ae) | `even_odd2.mls` | variant properties — true `mutual` group |
+| [`mutrec/evens_odds.ae`](mutrec/evens_odds.ae) | `evens_odds.mls` | length-partition; unfolding eqn — true `mutual` group |
+| [`mutrec/nested_list_eq.ae`](mutrec/nested_list_eq.ae) | `nested_list_eq.mls` | reflexivity; inner-diff; length-mismatch |
+| [`mutrec/parenthesis_match.ae`](mutrec/parenthesis_match.ae) | `parenthesis_match.mls` | `is_open = not is_close` + 6 io |
+| [`mutrec/tree_forest_size.ae`](mutrec/tree_forest_size.ae) | `tree_forest_size.mls` | mutual tree/forest size; growth props **(plain)** |
+| [`mutrec/tree_forest_leaves.ae`](mutrec/tree_forest_leaves.ae) | `tree_forest_leaves.mls` | mutual tree/forest leaf count **(plain)** |
+
+**RC — Recursive Comparators (7)**
+
+| File | Source | Spec checked |
+| --- | --- | --- |
+| [`reccomp/list_eq.ae`](reccomp/list_eq.ae) | `list_eq.mls` | reflexivity; singleton-diff; length-mismatch + 3 io |
+| [`reccomp/list_cmp.ae`](reccomp/list_cmp.ae) | `list_cmp.mls` | three-way (Eq/Lt/Gt) reflexivity; longer/shorter + io |
+| [`reccomp/binary_tree_depth.ae`](reccomp/binary_tree_depth.ae) | `binary_tree_depth.mls` | node unfolding; deeper-than-children + 2 io |
+| [`reccomp/binary_tree_eq.ae`](reccomp/binary_tree_eq.ae) | `binary_tree_eq.mls` | reflexivity; symmetry; proper-subtree + io |
+| [`reccomp/ternary_tree_depth.ae`](reccomp/ternary_tree_depth.ae) | `ternary_tree_depth.mls` | depth unfolding (×3); `tt_cmp` reflexivity + io |
+| [`reccomp/ternary_tree_eq.ae`](reccomp/ternary_tree_eq.ae) | `ternary_tree_eq.mls` | reflexivity; symmetry + io |
+| [`reccomp/trie_eq.ae`](reccomp/trie_eq.ae) | `trie_eq.mls` | reflexivity; value-differs; subtrie; leaf-vs-node |
+
+**PDS — Partial Data Structures (12)**
+
+| File | Source | Spec checked |
+| --- | --- | --- |
+| [`ds/list_insertion.ae`](ds/list_insertion.ae) | `list_insertion.mls` | membership added; sortedness preserved + io |
+| [`ds/list_insertion2.ae`](ds/list_insertion2.ae) | `list_insertion2.mls` | membership preserved (append-to-end) + io |
+| [`ds/list_insertion3.ae`](ds/list_insertion3.ae) | `list_insertion3.mls` | no-new-elements (intended; see note) + io |
+| [`ds/list_removal.ae`](ds/list_removal.ae) | `list_removal.mls` | removed element absent + io |
+| [`ds/list_removal2.ae`](ds/list_removal2.ae) | `list_removal2.mls` | keeps exactly the others + io |
+| [`ds/list_sort.ae`](ds/list_sort.ae) | `list_sort.mls` | ordered insert preserves sortedness + io |
+| [`ds/bst_insertion.ae`](ds/bst_insertion.ae) | `bst_insertion.mls` | inserted found; existing preserved + io |
+| [`ds/mirror_tree.ae`](ds/mirror_tree.ae) | `mirror_tree_test.mls` | involutivity `mirror∘mirror=id`; subtree swap |
+| [`ds/mirror_tree_test2.ae`](ds/mirror_tree_test2.ae) | `mirror_tree_test2.mls` | period-2 group laws (binary, bool) + io |
+| [`ds/mirror_ternary_test.ae`](ds/mirror_ternary_test.ae) | `mirror_ternary_test.mls` | involutivity (ternary, bool) + io |
+| [`ds/mirror_ternary_test2.ae`](ds/mirror_ternary_test2.ae) | `mirror_ternary_test2.mls` | period-2 group laws (ternary) + io |
+| [`ds/sized_list.ae`](ds/sized_list.ae) | `sized_list.mls` | size-cache invariant preserved + 2 io |
+
+**SO — Stack Overflow / k-safety (4)**
+
+| File | Source | Spec checked |
+| --- | --- | --- |
+| [`stackoverflow/list_rev_twice.ae`](stackoverflow/list_rev_twice.ae) | `list_rev_twice.mls` | k-safety `reverse∘reverse=id` + io |
+| [`stackoverflow/pairs.ae`](stackoverflow/pairs.ae) | `pairs.mls` | even-length round-trip `flatten∘pairs=id` + io |
+| [`stackoverflow/split_on.ae`](stackoverflow/split_on.ae) | `split_on.mls` | round-trip `concat∘split=id` + 2 io (exact shape) |
+| [`stackoverflow/zip_same_len.ae`](stackoverflow/zip_same_len.ae) | `zip_same_len.mls` | `length(zip xs ys) = min(len xs, len ys)` + io |
+
+Run them all (the two `(plain)` files via a plain run that prints `True`):
 
 ```bash
-for f in examples/synthesis/cata/contata/**/*.ae; do uv run python -m aeon --test "$f"; done
+for f in examples/synthesis/cata/contata/**/*.ae; do
+  case "$f" in
+    *tree_forest_*) uv run python -m aeon "$f" ;;   # prints True
+    *)              uv run python -m aeon --test "$f" ;;
+  esac
+done
 ```
 
-These seven span all four categories; the remaining 23 follow the same recipe
-(their datatypes and properties are in the artifact above).
+### Two transcription notes
+
+- **`tree_forest_{size,leaves}` use a plain run, not `--test`.** Their mutual
+  group spans *two* datatype sorts (`Tree`, `Forest`); aeon's `--test` reflects
+  called functions into z3, and reflecting a mutual group across distinct ADT
+  sorts currently raises a z3 *“Sort mismatch”* (an aeon bug — the definitions
+  themselves typecheck and run). So these verify by evaluating every io example
+  and both properties in `main`, which prints `True`. (Single-sort mutual groups,
+  e.g. `even_odd`, reflect fine.)
+- **`list_insertion3`** transcribes the *intended* property (“insertion adds no
+  element other than the one inserted”). The original `.mls` test, read
+  literally, is contradicted by its own io, so the literal de-Morgan form is
+  unsatisfiable; the file documents this.
 
 ## Honest status vs. the paper
 

--- a/examples/synthesis/cata/contata/ds/bst_insertion.ae
+++ b/examples/synthesis/cata/contata/ds/bst_insertion.ae
@@ -1,0 +1,38 @@
+# Contata benchmark: ds/bst_insertion.mls  (category PDS -- Partial Data Structures)
+#
+# Original: synth insert : [tree * t] -> tree calling [insert], insertion into a
+# binary search tree. Spec:
+#     test forall tr x.   lookup (insert (tr, x), x) == True
+#     test forall tr x y. lookup (tr, x) --> lookup (insert (tr, y), x)
+#     io insert (Node(Leaf,1,Leaf), 0) -> Node(Node(Leaf,0,Leaf),1,Leaf) ; ...
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/bst_insertion.ae
+
+inductive BST
+| leaf : BST
+| node (l: BST) (v: Int) (r: BST) : BST
+
+# --- reference solution ---
+def insert (t: BST) (x: Int) : BST :=
+    match t with
+    | .leaf => .node .leaf x .leaf
+    | .node l v r =>
+        if x = v then .node l v r else (if x < v then .node (insert l x) v r else .node l v (insert r x))
+
+def lookup (t: BST) (x: Int) : Bool :=
+    match t with
+    | .leaf => false
+    | .node l v r => if x = v then true else (if x < v then lookup l x else lookup r x)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_inserts (t: BST) (x: Int) : Bool := lookup (insert t x) x
+
+@property(30)
+def prop_preserves (t: BST) (x: Int) (y: Int) : Bool :=
+    if lookup t x then lookup (insert t y) x else true
+
+@example(lookup (insert (.node .leaf 1 .leaf) 0) 0 = true)
+def main (z: Int) : Unit := print (lookup (insert (.node .leaf 0 .leaf) 1) 1)

--- a/examples/synthesis/cata/contata/ds/list_insertion2.ae
+++ b/examples/synthesis/cata/contata/ds/list_insertion2.ae
@@ -1,0 +1,29 @@
+# Contata benchmark: ds/list_insertion2.mls  (category PDS)
+#
+# Original: synth insert : [(A * list)] -> list calling [insert]. The io
+# (insert (0, [0,1]) -> [0,1,0]) fixes insert as append-to-end. Spec:
+#     test forall x y xs. contains (x, xs) --> contains (x, insert (y, xs))
+#  (insertion preserves membership of existing elements).
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/list_insertion2.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+def contains (x: Int) (xs: IntList) : Bool :=
+    match xs with | .nil => false | .cons h t => if x = h then true else contains x t
+
+# --- reference solution: append to the end ---
+def insert (y: Int) (xs: IntList) : IntList :=
+    match xs with | .nil => .cons y .nil | .cons h t => .cons h (insert y t)
+
+# --- specification as PBT property ---
+@property(40)
+def prop_preserves_membership (x: Int) (y: Int) (xs: IntList) : Bool :=
+    if contains x xs then contains x (insert y xs) else true
+
+@example(contains 0 (insert 0 (.cons 0 (.cons 1 .nil))) = true)
+def main (z: Int) : Unit := print (contains 5 (insert 5 (.cons 1 .nil)))

--- a/examples/synthesis/cata/contata/ds/list_insertion3.ae
+++ b/examples/synthesis/cata/contata/ds/list_insertion3.ae
@@ -1,0 +1,37 @@
+# Contata benchmark: ds/list_insertion3.mls  (category PDS)
+#
+# Original: synth insert : [(A * list)] -> list calling [insert], with io
+# insert (0,[0,1]) -> [0,1,0] (append-to-end) and the comment "insertion will
+# not add other elements than the one inserted". The *intended* property is:
+#     contains (x, insert (y, xs)) --> (contains (x, xs) || x == y)
+#
+# Faithful note. The original test is written
+#     implies(not(and(contains(x,xs), not(x==y))), not(contains(x, insert(y,xs))))
+# whose literal de-Morgan reading is contradicted by the benchmark's own io
+# (with x=y=0, xs=[0,1]: insert gives [0,1,0], which contains 0, yet the literal
+# test demands it must not) — i.e. as written it is inconsistent with the io.
+# We transcribe the evident intent ("no new elements except the inserted one"),
+# which append-to-end satisfies.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/list_insertion3.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+def orB (a: Bool) (b: Bool) : Bool := if a then true else b
+
+def contains (x: Int) (xs: IntList) : Bool :=
+    match xs with | .nil => false | .cons h t => if x = h then true else contains x t
+
+# --- reference solution: append to the end ---
+def insert (y: Int) (xs: IntList) : IntList :=
+    match xs with | .nil => .cons y .nil | .cons h t => .cons h (insert y t)
+
+# --- specification (intended): inserting y adds no element other than y ---
+@property(40)
+def prop_no_new_elements (x: Int) (y: Int) (xs: IntList) : Bool :=
+    if contains x (insert y xs) then orB (contains x xs) (x = y) else true
+
+@example(contains 0 (insert 0 (.cons 0 (.cons 1 .nil))) = true)
+def main (z: Int) : Unit := print (contains 9 (insert 5 (.cons 1 .nil)))

--- a/examples/synthesis/cata/contata/ds/list_removal.ae
+++ b/examples/synthesis/cata/contata/ds/list_removal.ae
@@ -1,0 +1,28 @@
+# Contata benchmark: ds/list_removal.mls  (category PDS)
+#
+# Original: synth remove : [(A * list)] -> list calling [remove]. Spec:
+#     test forall x xs. contains (x, remove (x, xs)) == False
+#     io remove (0, [1,0]) -> [1] ; remove (0, [0,1]) -> [1]
+#  (remove deletes all occurrences of x).
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/list_removal.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+def contains (x: Int) (xs: IntList) : Bool :=
+    match xs with | .nil => false | .cons h t => if x = h then true else contains x t
+
+# --- reference solution: delete every occurrence ---
+def remove (x: Int) (xs: IntList) : IntList :=
+    match xs with | .nil => .nil | .cons h t => if h = x then remove x t else .cons h (remove x t)
+
+# --- specification as PBT property ---
+@property(40)
+def prop_removed_absent (x: Int) (xs: IntList) : Bool := contains x (remove x xs) = false
+
+@example(contains 0 (remove 0 (.cons 1 (.cons 0 .nil))) = false)
+def main (z: Int) : Unit := print (contains 0 (remove 0 (.cons 0 (.cons 1 .nil))))

--- a/examples/synthesis/cata/contata/ds/list_removal2.ae
+++ b/examples/synthesis/cata/contata/ds/list_removal2.ae
@@ -1,0 +1,32 @@
+# Contata benchmark: ds/list_removal2.mls  (category PDS)
+#
+# Original: synth remove : [(A * list)] -> list calling [remove], with the
+# stronger element-wise spec:
+#     test forall x y xs.
+#       contains (y, remove (x, xs)) == (not (x == y) && contains (y, xs))
+#  (remove (x, xs) keeps exactly the elements of xs other than x).
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/list_removal2.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+def andB (a: Bool) (b: Bool) : Bool := if a then b else false
+
+def contains (x: Int) (xs: IntList) : Bool :=
+    match xs with | .nil => false | .cons h t => if x = h then true else contains x t
+
+# --- reference solution: delete every occurrence ---
+def remove (x: Int) (xs: IntList) : IntList :=
+    match xs with | .nil => .nil | .cons h t => if h = x then remove x t else .cons h (remove x t)
+
+# --- specification as PBT property ---
+@property(40)
+def prop_keeps_others (x: Int) (y: Int) (xs: IntList) : Bool :=
+    contains y (remove x xs) = andB (!(x = y)) (contains y xs)
+
+@example(contains 1 (remove 0 (.cons 1 (.cons 0 .nil))) = true)
+def main (z: Int) : Unit := print (contains 0 (remove 0 (.cons 0 (.cons 1 .nil))))

--- a/examples/synthesis/cata/contata/ds/list_sort.ae
+++ b/examples/synthesis/cata/contata/ds/list_sort.ae
@@ -1,0 +1,33 @@
+# Contata benchmark: ds/list_sort.mls  (category PDS)
+#
+# Original: synth insert_sort : [(A * list)] -> list calling [insert_sort], the
+# ordered-insertion step of insertion sort. Spec:
+#     test forall x xs. sorted xs --> sorted (insert_sort (x, xs))
+#     io insert_sort (2, [0,1]) -> [0,1,2] ; insert_sort (0,[1]) -> [0,1] ; ...
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/list_sort.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+# --- reference solution: ordered insertion ---
+def insertSorted (x: Int) (xs: IntList) : IntList :=
+    match xs with
+    | .nil => .cons x .nil
+    | .cons h t => if x <= h then .cons x (.cons h t) else .cons h (insertSorted x t)
+
+def sortedFrom (lo: Int) (xs: IntList) : Bool :=
+    match xs with | .nil => true | .cons h t => if lo <= h then sortedFrom h t else false
+def sorted (xs: IntList) : Bool :=
+    match xs with | .nil => true | .cons h t => sortedFrom h t
+
+# --- specification as PBT property ---
+@property(40)
+def prop_keeps_sorted (x: Int) (xs: IntList) : Bool :=
+    if sorted xs then sorted (insertSorted x xs) else true
+
+@example(sorted (insertSorted 2 (.cons 0 (.cons 1 .nil))) = true)
+def main (z: Int) : Unit := print (sorted (insertSorted 2 (.cons 0 (.cons 1 .nil))))

--- a/examples/synthesis/cata/contata/ds/mirror_ternary_test.ae
+++ b/examples/synthesis/cata/contata/ds/mirror_ternary_test.ae
@@ -1,0 +1,43 @@
+# Contata benchmark: ds/mirror_ternary_test.mls  (category PDS)
+#
+# Original: synth mirror : [tree] -> tree calling [mirror] on a ternary tree
+# (Leaf | Node of t*bool*t*t). Spec:
+#     test forall x. mirror (mirror x) == x        -- involutivity
+#     io mirror Leaf -> Leaf ;
+#        mirror Node(Node(Leaf,False,Leaf,Leaf), True, Leaf, Leaf)
+#             -> Node(Leaf, True, Leaf, Node(Leaf,False,Leaf,Leaf))
+#  (mirror swaps the outer children l and r, recursively).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/mirror_ternary_test.ae
+
+inductive TTree
+| leaf : TTree
+| node (l: TTree) (v: Bool) (m: TTree) (r: TTree) : TTree
+
+def boolEq (a: Bool) (b: Bool) : Bool := if a then b else !b
+def and (a: Bool) (b: Bool) : Bool := if a then b else false
+
+# --- reference solution: swap outer children ---
+def mirror (t: TTree) : TTree :=
+    match t with
+    | .leaf => .leaf
+    | .node l v m r => .node (mirror r) v (mirror m) (mirror l)
+
+def treeEq (a: TTree) (b: TTree) : Bool :=
+    match a with
+    | .leaf => (match b with | .leaf => true | .node lb vb mb rb => false)
+    | .node la va ma ra =>
+        (match b with
+         | .leaf => false
+         | .node lb vb mb rb =>
+            if boolEq va vb then and (treeEq la lb) (and (treeEq ma mb) (treeEq ra rb)) else false)
+
+# --- specification as PBT property ---
+@property(30)
+def prop_involutive (x: TTree) : Bool := treeEq (mirror (mirror x)) x
+
+@example(treeEq (mirror (.node (.node .leaf false .leaf .leaf) true .leaf .leaf))
+                (.node .leaf true .leaf (.node .leaf false .leaf .leaf)) = true)
+def main (z: Int) : Unit :=
+    print (treeEq (mirror (mirror (.node .leaf true (.node .leaf false .leaf .leaf) .leaf)))
+                  (.node .leaf true (.node .leaf false .leaf .leaf) .leaf))

--- a/examples/synthesis/cata/contata/ds/mirror_ternary_test2.ae
+++ b/examples/synthesis/cata/contata/ds/mirror_ternary_test2.ae
@@ -1,0 +1,46 @@
+# Contata benchmark: ds/mirror_ternary_test2.mls  (category PDS)
+#
+# Original: synth mirror : [tree] -> tree on a ternary tree (Leaf | Node of
+# t*A*t*t). Spec (period-2 group laws):
+#     test forall x. mirror (mirror (mirror (mirror x))) == x
+#     test forall x. mirror (mirror (mirror x)) == mirror x
+#     io mirror Leaf -> Leaf ; mirror Node(Node(Leaf,1,Leaf,Leaf),0,Leaf,Leaf)
+#                                   -> Node(Leaf,0,Leaf,Node(Leaf,1,Leaf,Leaf))
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/mirror_ternary_test2.ae
+
+inductive TTree
+| leaf : TTree
+| node (l: TTree) (v: Int) (m: TTree) (r: TTree) : TTree
+
+def and (a: Bool) (b: Bool) : Bool := if a then b else false
+
+# --- reference solution: swap outer children ---
+def mirror (t: TTree) : TTree :=
+    match t with
+    | .leaf => .leaf
+    | .node l v m r => .node (mirror r) v (mirror m) (mirror l)
+
+def treeEq (a: TTree) (b: TTree) : Bool :=
+    match a with
+    | .leaf => (match b with | .leaf => true | .node lb vb mb rb => false)
+    | .node la va ma ra =>
+        (match b with
+         | .leaf => false
+         | .node lb vb mb rb =>
+            if va = vb then and (treeEq la lb) (and (treeEq ma mb) (treeEq ra rb)) else false)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_period_4 (x: TTree) : Bool := treeEq (mirror (mirror (mirror (mirror x)))) x
+
+@property(30)
+def prop_period_2 (x: TTree) : Bool := treeEq (mirror (mirror (mirror x))) (mirror x)
+
+@example(treeEq (mirror (.node (.node .leaf 1 .leaf .leaf) 0 .leaf .leaf))
+                (.node .leaf 0 .leaf (.node .leaf 1 .leaf .leaf)) = true)
+def main (z: Int) : Unit :=
+    print (treeEq (mirror (mirror (.node .leaf 0 (.node .leaf 1 .leaf .leaf) .leaf)))
+                  (.node .leaf 0 (.node .leaf 1 .leaf .leaf) .leaf))

--- a/examples/synthesis/cata/contata/ds/mirror_tree_test2.ae
+++ b/examples/synthesis/cata/contata/ds/mirror_tree_test2.ae
@@ -1,0 +1,43 @@
+# Contata benchmark: ds/mirror_tree_test2.mls  (category PDS)
+#
+# Original: synth mirror : [tree] -> tree on a binary tree (Leaf | Node of
+# t*bool*t). Spec (period-2 group laws):
+#     test forall x. mirror (mirror (mirror (mirror x))) == x
+#     test forall x. mirror (mirror (mirror x)) == mirror x
+#     io mirror Leaf -> Leaf ; mirror (Node(Node(Leaf,True,Leaf),True,Leaf))
+#                                   -> Node(Leaf,True,Node(Leaf,True,Leaf))
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/mirror_tree_test2.ae
+
+inductive BTreeB
+| leaf : BTreeB
+| node (l: BTreeB) (v: Bool) (r: BTreeB) : BTreeB
+
+def boolEq (a: Bool) (b: Bool) : Bool := if a then b else !b
+
+# --- reference solution: swap children ---
+def mirror (t: BTreeB) : BTreeB :=
+    match t with
+    | .leaf => .leaf
+    | .node l v r => .node (mirror r) v (mirror l)
+
+def treeEq (a: BTreeB) (b: BTreeB) : Bool :=
+    match a with
+    | .leaf => (match b with | .leaf => true | .node lb vb rb => false)
+    | .node la va ra =>
+        (match b with
+         | .leaf => false
+         | .node lb vb rb => if boolEq va vb then (if treeEq la lb then treeEq ra rb else false) else false)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_period_4 (x: BTreeB) : Bool := treeEq (mirror (mirror (mirror (mirror x)))) x
+
+@property(30)
+def prop_period_2 (x: BTreeB) : Bool := treeEq (mirror (mirror (mirror x))) (mirror x)
+
+@example(treeEq (mirror (.node (.node .leaf true .leaf) true .leaf))
+                (.node .leaf true (.node .leaf true .leaf)) = true)
+def main (z: Int) : Unit :=
+    print (treeEq (mirror (mirror (.node (.node .leaf true .leaf) true .leaf)))
+                  (.node (.node .leaf true .leaf) true .leaf))

--- a/examples/synthesis/cata/contata/ds/sized_list.ae
+++ b/examples/synthesis/cata/contata/ds/sized_list.ae
@@ -1,0 +1,46 @@
+# Contata benchmark: ds/sized_list.mls  (category PDS)
+#
+# Original: a list that caches its own length at every node
+#     list = Nil of nat | Cons of (A * nat * list)
+# and (the one non-recursive synth in the suite) insert : [tapair] -> t calling []
+# that prepends an element and refreshes the cached size. Spec:
+#     test forall s i. invariant s --> invariant (insert (s, i))
+#     io insert (Nil O, 0) -> Cons(0, 1, Nil O)
+#        insert (Cons(0,1,Nil O), 1) -> Cons(1, 2, Cons(0,1,Nil O))
+# where `invariant` says every node's cached size is one more than its tail's.
+#
+# aeon transcription (A,nat ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/ds/sized_list.ae
+
+inductive SList
+| snil (sz: Int) : SList
+| scons (x: Int) (sz: Int) (rest: SList) : SList
+
+def storedLen (l: SList) : Int :=
+    match l with | .snil s => s | .scons x s xs => s
+
+# --- reference solution (non-recursive): prepend with refreshed size ---
+def insert (l: SList) (x: Int) : SList := .scons x (storedLen l + 1) l
+
+def invariant (l: SList) : Bool :=
+    match l with
+    | .snil s => true
+    | .scons x s xs => if invariant xs then (storedLen xs < s) else false
+
+def slEq (a: SList) (b: SList) : Bool :=
+    match a with
+    | .snil sa => (match b with | .snil sb => sa = sb | .scons x s xs => false)
+    | .scons xa sa ta =>
+        (match b with
+         | .snil sb => false
+         | .scons xb sb tb => if xa = xb then (if sa = sb then slEq ta tb else false) else false)
+
+# --- specification as PBT property + io ---
+@property(40)
+def prop_preserves_invariant (s: SList) (i: Int) : Bool :=
+    if invariant s then invariant (insert s i) else true
+
+@example(slEq (insert (.snil 0) 0) (.scons 0 1 (.snil 0)) = true)
+@example(slEq (insert (.scons 0 1 (.snil 0)) 1) (.scons 1 2 (.scons 0 1 (.snil 0))) = true)
+def main (z: Int) : Unit := print (invariant (insert (.scons 0 1 (.snil 0)) 1))

--- a/examples/synthesis/cata/contata/mutrec/even_odd2.ae
+++ b/examples/synthesis/cata/contata/mutrec/even_odd2.ae
@@ -1,0 +1,32 @@
+# Contata benchmark: mutrec/even_odd2.mls  (category MR -- Mutual Recursion)
+#
+# A variant of even_odd.mls with different relational properties:
+#     test forall x. is_odd (inc (inc x)) == is_even (inc x)
+#     test forall x. is_even x            == not (is_even (inc x))
+#     io   is_odd O -> False
+# (`inc` is succ.) Same true `mutual ... end` group as even_odd.ae.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/mutrec/even_odd2.ae
+
+inductive Nat
+| zero : Nat
+| succ (n: Nat) : Nat
+
+def not (b: Bool) : Bool := if b then false else true
+def bIff (a: Bool) (b: Bool) : Bool := if a then b else not b
+
+mutual
+  def isEven (n: Nat) : Bool :=
+    match n with | .zero => true  | .succ m => isOdd m
+  def isOdd (n: Nat) : Bool :=
+    match n with | .zero => false | .succ m => isEven m
+end
+
+@property(40)
+def prop_odd_succ_succ (x: Nat) : Bool := bIff (isOdd (.succ (.succ x))) (isEven (.succ x))
+
+@property(40)
+def prop_even_alternates (x: Nat) : Bool := bIff (isEven x) (not (isEven (.succ x)))
+
+@example(isOdd .zero = false)
+def main (z: Int) : Unit := print (isOdd (.succ .zero))

--- a/examples/synthesis/cata/contata/mutrec/nested_list_eq.ae
+++ b/examples/synthesis/cata/contata/mutrec/nested_list_eq.ae
@@ -1,0 +1,53 @@
+# Contata benchmark: mutrec/nested_list_eq.mls  (category MR)
+#
+# Original: synth nested_list_cmp : [(nested_list * nested_list)] -> bool, where
+# a nested_list is a list of lists; equality compares inner lists element-wise
+# (via list_cmp) and is itself recursive. Spec:
+#     test forall ns. nested_list_cmp (ns, ns) == True
+#     test forall xs ys. not (list_cmp xs ys) --> not (nested_list_cmp ([xs],[ys]))
+#     test forall xs. not (nested_list_cmp ([xs], []))
+#
+# aeon (A ↦ Int): inner `listEq` plus the recursive `nlEq`.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/mutrec/nested_list_eq.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+inductive NestedList
+| nnil : NestedList
+| ncons (hd: IntList) (tl: NestedList) : NestedList
+
+def not (b: Bool) : Bool := if b then false else true
+
+def listEq (a: IntList) (b: IntList) : Bool :=
+    match a with
+    | .nil => (match b with | .nil => true | .cons hb tb => false)
+    | .cons ha ta =>
+        (match b with
+         | .nil => false
+         | .cons hb tb => if ha = hb then listEq ta tb else false)
+
+# --- reference solution ---
+def nlEq (a: NestedList) (b: NestedList) : Bool :=
+    match a with
+    | .nnil => (match b with | .nnil => true | .ncons hb tb => false)
+    | .ncons ha ta =>
+        (match b with
+         | .nnil => false
+         | .ncons hb tb => if listEq ha hb then nlEq ta tb else false)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_reflexive (ns: NestedList) : Bool := nlEq ns ns
+
+@property(30)
+def prop_inner_diff (xs: IntList) (ys: IntList) : Bool :=
+    if not (listEq xs ys) then not (nlEq (.ncons xs .nnil) (.ncons ys .nnil)) else true
+
+@property(30)
+def prop_length_mismatch (xs: IntList) : Bool := not (nlEq (.ncons xs .nnil) .nnil)
+
+def main (z: Int) : Unit :=
+    print (nlEq (.ncons (.cons 1 .nil) .nnil) (.ncons (.cons 1 .nil) .nnil))

--- a/examples/synthesis/cata/contata/mutrec/parenthesis_match.ae
+++ b/examples/synthesis/cata/contata/mutrec/parenthesis_match.ae
@@ -1,0 +1,53 @@
+# Contata benchmark: mutrec/parenthesis_match.mls  (category MR)
+#
+# Original: synth is_open : [list] -> bool calling [is_close] and is_close
+# calling [is_open], over a list of parentheses (Left/Right). Spec:
+#     test forall xs. is_open xs == not (is_close xs)
+#     io is_open Nil -> True ; is_close Nil -> False ;
+#        is_close [Right] -> True ; is_open [Left] -> False ;
+#        is_open [Left,Right] -> True ; is_open [Left,Right,Right] -> False ; ...
+#
+# Faithful note. The spec forces `is_close = not is_open` for ALL inputs, so the
+# pair collapses: the only real content is `is_open`, a balanced-parenthesis
+# check (the unique total function matching every io). A pair of mutually
+# recursive *boolean* functions cannot track nesting depth without a counter, so
+# the reference threads an Int depth (`fd`, sticky-negative once unbalanced) and
+# derives `is_open`/`is_close` from it.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/mutrec/parenthesis_match.ae
+
+inductive Par
+| left : Par
+| right : Par
+
+inductive ParList
+| nil : ParList
+| cons (hd: Par) (tl: ParList) : ParList
+
+def bIff (a: Bool) (b: Bool) : Bool := if a then b else (if b then false else true)
+
+# running depth, left-to-right; once negative it stays negative (unbalanced)
+def fd (xs: ParList) (d: Int) : Int :=
+    match xs with
+    | .nil => d
+    | .cons p ps =>
+        if d < 0 then fd ps (d - 1)
+        else (match p with
+              | .left => fd ps (d + 1)
+              | .right => fd ps (d - 1))
+
+# --- reference solution ---
+def isOpen (xs: ParList) : Bool := fd xs 0 = 0
+def isClose (xs: ParList) : Bool := !(isOpen xs)
+
+# --- specification: the complementarity property + the io examples ---
+@property(40)
+def prop_open_not_close (xs: ParList) : Bool := bIff (isOpen xs) (!(isClose xs))
+
+@example(isOpen .nil = true)
+@example(isClose .nil = false)
+@example(isClose (.cons .right .nil) = true)
+@example(isOpen (.cons .left .nil) = false)
+@example(isOpen (.cons .left (.cons .right .nil)) = true)
+@example(isOpen (.cons .left (.cons .right (.cons .right .nil))) = false)
+def main (z: Int) : Unit := print (isOpen (.cons .left (.cons .right .nil)))

--- a/examples/synthesis/cata/contata/mutrec/tree_forest_leaves.ae
+++ b/examples/synthesis/cata/contata/mutrec/tree_forest_leaves.ae
@@ -1,0 +1,47 @@
+# Contata benchmark: mutrec/tree_forest_leaves.mls  (category MR)
+#
+# Original: mutually-recursive datatypes tree/forest, and mutually-recursive
+#     synth count_leaves_tree   : [tree]  -> nat calling [count_leaves_forest]
+#     synth count_leaves_forest : [forest] -> nat calling [count_leaves_tree, count_leaves_forest]
+# count_leaves_tree(Empty)=0, count_leaves_tree(Node a f)=count_leaves_forest f;
+# count_leaves_forest(Leaf)=1, count_leaves_forest(Tree t f)=clt t + clf f. Spec:
+#     test forall f. count_leaves_forest f == count_leaves_tree (Node 0 f)
+#     test forall f. count_leaves_forest f == count_leaves_forest (Tree Empty f)
+#
+# aeon: genuine mutual `inductive` types + a true `mutual ... end` group. nat ↦ Int.
+#
+# Verification note. As in tree_forest_size.ae, the mutual group spans two ADT
+# sorts, which aeon's `--test` SMT reflection cannot yet handle (z3 "Sort
+# mismatch" — an aeon bug; the defs typecheck and run). This file verifies by
+# evaluating every Contata io example and both properties in `main`:
+#
+#   uv run python -m aeon examples/synthesis/cata/contata/mutrec/tree_forest_leaves.ae   # -> True
+
+inductive Tree
+| empty : Tree
+| node (v: Int) (children: Forest) : Tree
+
+inductive Forest
+| leaf : Forest
+| tcons (t: Tree) (rest: Forest) : Forest
+
+# --- reference solution: a true mutual-recursion group ---
+mutual
+  def leavesTree (t: Tree) : Int :=
+    match t with | .empty => 0 | .node v f => leavesForest f
+  def leavesForest (f: Forest) : Int :=
+    match f with | .leaf => 1 | .tcons t rest => leavesTree t + leavesForest rest
+end
+
+def prop_node_keeps (f: Forest) : Bool := leavesForest f = leavesTree (.node 0 f)
+def prop_empty_keeps (f: Forest) : Bool := leavesForest f = leavesForest (.tcons .empty f)
+
+def f1 : Forest := .tcons (.node 0 .leaf) (.tcons (.node 1 .leaf) .leaf)
+
+def main (z: Int) : Unit :=
+    print (
+        (leavesTree .empty = 0) &&
+        (leavesForest .leaf = 1) &&
+        (leavesForest f1 = 3) &&
+        prop_node_keeps .leaf && prop_node_keeps f1 &&
+        prop_empty_keeps .leaf && prop_empty_keeps f1)

--- a/examples/synthesis/cata/contata/mutrec/tree_forest_size.ae
+++ b/examples/synthesis/cata/contata/mutrec/tree_forest_size.ae
@@ -1,0 +1,52 @@
+# Contata benchmark: mutrec/tree_forest_size.mls  (category MR)
+#
+# Original: mutually-recursive datatypes tree/forest, and mutually-recursive
+#     synth size_tree : [tree]  -> nat calling [size_forest]
+#     synth size_forest: [forest] -> nat calling [size_tree, size_forest]
+# size_tree(Empty)=0, size_tree(Node a f)=1+size_forest f;
+# size_forest(Leaf)=0, size_forest(Tree t f)=size_tree t + size_forest f. Spec:
+#     test forall f. size_forest f < size_tree (Node 0 f)
+#     test forall f. not (size_forest (Tree Empty f) < size_forest f)
+#
+# aeon: genuine mutual `inductive` types AND a true `mutual ... end` group
+# (forest = Leaf | Tree of tree*forest, i.e. a list of trees). nat ↦ Int.
+#
+# Verification note. The mutual functions span TWO datatype sorts (Tree, Forest).
+# aeon's `--test` path reflects called functions into z3, and reflecting a mutual
+# group across distinct ADT sorts currently raises a z3 "Sort mismatch" (an aeon
+# bug, not a spec issue) — the definitions themselves typecheck and run. So this
+# file verifies by evaluating every Contata io example and both properties (on
+# sampled forests) in `main`, which prints `True`:
+#
+#   uv run python -m aeon examples/synthesis/cata/contata/mutrec/tree_forest_size.ae   # -> True
+
+inductive Tree
+| empty : Tree
+| node (v: Int) (children: Forest) : Tree
+
+inductive Forest
+| leaf : Forest
+| tcons (t: Tree) (rest: Forest) : Forest
+
+# --- reference solution: a true mutual-recursion group ---
+mutual
+  def sizeTree (t: Tree) : Int :=
+    match t with | .empty => 0 | .node v f => 1 + sizeForest f
+  def sizeForest (f: Forest) : Int :=
+    match f with | .leaf => 0 | .tcons t rest => sizeTree t + sizeForest rest
+end
+
+# Contata's two relational properties, instantiated on a sample forest f:
+def prop_node_grows (f: Forest) : Bool := sizeForest f < sizeTree (.node 0 f)
+def prop_empty_tree_no_growth (f: Forest) : Bool := !(sizeForest (.tcons .empty f) < sizeForest f)
+
+def f1 : Forest := .tcons (.node 0 .leaf) (.tcons (.node 1 .leaf) .leaf)
+
+def main (z: Int) : Unit :=
+    print (
+        (sizeTree .empty = 0) &&
+        (sizeForest .leaf = 0) &&
+        (sizeTree (.node 0 .leaf) = 1) &&
+        (sizeForest f1 = 2) &&
+        prop_node_grows .leaf && prop_node_grows f1 &&
+        prop_empty_tree_no_growth .leaf && prop_empty_tree_no_growth f1)

--- a/examples/synthesis/cata/contata/reccomp/binary_tree_eq.ae
+++ b/examples/synthesis/cata/contata/reccomp/binary_tree_eq.ae
@@ -1,0 +1,40 @@
+# Contata benchmark: reccomp/binary_tree_eq.mls  (category RC -- Recursive Comparators)
+#
+# Original: synth bt_eq : [(bst * bst)] -> bool calling [bt_eq], structural
+# equality on binary search trees. Spec:
+#     test forall b.        bt_eq (b, b) == True                 -- reflexivity
+#     test forall b1 b2.    bt_eq (b1, b2) == bt_eq (b2, b1)     -- symmetry
+#     test forall b1 b2 n.  bt_eq (b1, Node(b1, n, b2)) == False -- proper subtree
+#     io ... (two equal / one unequal)
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/reccomp/binary_tree_eq.ae
+
+inductive BST
+| leaf : BST
+| node (l: BST) (v: Int) (r: BST) : BST
+
+# --- reference solution ---
+def btEq (a: BST) (b: BST) : Bool :=
+    match a with
+    | .leaf => (match b with | .leaf => true | .node lb vb rb => false)
+    | .node la va ra =>
+        (match b with
+         | .leaf => false
+         | .node lb vb rb => if va = vb then (if btEq la lb then btEq ra rb else false) else false)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_reflexive (b: BST) : Bool := btEq b b
+
+@property(30)
+def prop_symmetric (b1: BST) (b2: BST) : Bool := btEq b1 b2 = btEq b2 b1
+
+@property(30)
+def prop_proper_subtree (b1: BST) (b2: BST) (n: Int) : Bool :=
+    btEq b1 (.node b1 n b2) = false
+
+@example(btEq (.node .leaf 0 (.node .leaf 3 .leaf)) (.node .leaf 0 (.node .leaf 3 .leaf)) = true)
+@example(btEq (.node .leaf 0 (.node .leaf 1 .leaf)) (.node .leaf 0 (.node .leaf 3 .leaf)) = false)
+def main (z: Int) : Unit := print (btEq (.node .leaf 0 .leaf) (.node .leaf 0 .leaf))

--- a/examples/synthesis/cata/contata/reccomp/list_cmp.ae
+++ b/examples/synthesis/cata/contata/reccomp/list_cmp.ae
@@ -1,0 +1,48 @@
+# Contata benchmark: reccomp/list_cmp.mls  (category RC)
+#
+# Original: synth list_cmp : [(list * list)] -> compare calling [list_cmp], a
+# three-way lexicographic comparator (Eq/Lt/Gt) over lists. Spec:
+#     test forall xs. list_cmp (xs, xs) == Eq
+#     test forall x.  list_cmp ([x], Nil) == Gt
+#     test forall x.  list_cmp (Nil, [x]) == Lt
+#     io list_cmp ([0],[1]) -> Lt ; list_cmp ([1],[0]) -> Gt
+#
+# aeon transcription (A ↦ Int), with a `Compare` enum.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/reccomp/list_cmp.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+inductive Compare
+| eq : Compare
+| lt : Compare
+| gt : Compare
+
+def isEq (c: Compare) : Bool := match c with | .eq => true | .lt => false | .gt => false
+def isLt (c: Compare) : Bool := match c with | .lt => true | .eq => false | .gt => false
+def isGt (c: Compare) : Bool := match c with | .gt => true | .eq => false | .lt => false
+
+# --- reference solution: lexicographic three-way comparison ---
+def listCmp (a: IntList) (b: IntList) : Compare :=
+    match a with
+    | .nil => (match b with | .nil => .eq | .cons hb tb => .lt)
+    | .cons ha ta =>
+        (match b with
+         | .nil => .gt
+         | .cons hb tb => if ha < hb then .lt else (if hb < ha then .gt else listCmp ta tb))
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_reflexive (xs: IntList) : Bool := isEq (listCmp xs xs)
+
+@property(30)
+def prop_longer_gt (x: Int) : Bool := isGt (listCmp (.cons x .nil) .nil)
+
+@property(30)
+def prop_shorter_lt (x: Int) : Bool := isLt (listCmp .nil (.cons x .nil))
+
+@example(isLt (listCmp (.cons 0 .nil) (.cons 1 .nil)) = true)
+@example(isGt (listCmp (.cons 1 .nil) (.cons 0 .nil)) = true)
+def main (z: Int) : Unit := print (isEq (listCmp (.cons 1 (.cons 2 .nil)) (.cons 1 (.cons 2 .nil))))

--- a/examples/synthesis/cata/contata/reccomp/ternary_tree_depth.ae
+++ b/examples/synthesis/cata/contata/reccomp/ternary_tree_depth.ae
@@ -1,0 +1,51 @@
+# Contata benchmark: reccomp/ternary_tree_depth.mls  (category RC)
+#
+# Original: over a ternary tree (Leaf | Node of t*A*t*t), co-synthesise
+#     synth depth  : [tree] -> nat calling [depth]
+#     synth tt_cmp : [(tree*tree)] -> compare calling [tt_cmp]
+# Spec: depth(Leaf)=0; depth(Node(.,_,.,.)) = 1 + depth(child) for each child
+# placed singly; tt_cmp(b,b)=Eq; io comparisons consistent with comparing by depth.
+#
+# aeon transcription (A ↦ Int). `tt_cmp` compares by depth — the total function
+# satisfying every io and the reflexivity property.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/reccomp/ternary_tree_depth.ae
+
+inductive TTree
+| leaf : TTree
+| node (l: TTree) (v: Int) (m: TTree) (r: TTree) : TTree
+
+inductive Compare
+| eq : Compare
+| lt : Compare
+| gt : Compare
+
+def isEq (c: Compare) : Bool := match c with | .eq => true | .lt => false | .gt => false
+def isLt (c: Compare) : Bool := match c with | .lt => true | .eq => false | .gt => false
+def isGt (c: Compare) : Bool := match c with | .gt => true | .eq => false | .lt => false
+
+def maxInt (a: Int) (b: Int) : Int := if a >= b then a else b
+
+# --- reference solutions ---
+def depth (t: TTree) : Int :=
+    match t with
+    | .leaf => 0
+    | .node l v m r => 1 + maxInt (depth l) (maxInt (depth m) (depth r))
+
+def ttCmp (a: TTree) (b: TTree) : Compare :=
+    if depth a < depth b then .lt else (if depth b < depth a then .gt else .eq)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_depth_left (t: TTree) : Bool := depth (.node t 0 .leaf .leaf) = 1 + depth t
+@property(30)
+def prop_depth_mid (t: TTree) : Bool := depth (.node .leaf 0 t .leaf) = 1 + depth t
+@property(30)
+def prop_depth_right (t: TTree) : Bool := depth (.node .leaf 0 .leaf t) = 1 + depth t
+@property(30)
+def prop_cmp_reflexive (b: TTree) : Bool := isEq (ttCmp b b)
+
+@example(depth .leaf = 0)
+@example(isLt (ttCmp .leaf (.node .leaf 0 .leaf .leaf)) = true)
+@example(isGt (ttCmp (.node .leaf 0 (.node .leaf 0 .leaf .leaf) .leaf) (.node .leaf 0 .leaf .leaf)) = true)
+def main (z: Int) : Unit := print (depth (.node .leaf 0 (.node .leaf 0 .leaf .leaf) .leaf))

--- a/examples/synthesis/cata/contata/reccomp/ternary_tree_eq.ae
+++ b/examples/synthesis/cata/contata/reccomp/ternary_tree_eq.ae
@@ -1,0 +1,37 @@
+# Contata benchmark: reccomp/ternary_tree_eq.mls  (category RC)
+#
+# Original: synth tree_eq : [(tree*tree)] -> bool calling [tree_eq], structural
+# equality on ternary trees (Leaf | Node of t*nat*t*t). Spec:
+#     test forall t.      tree_eq (t, t) == True
+#     test forall t1 t2.  tree_eq (t1, t2) == tree_eq (t2, t1)
+#     io tree_eq (Node(Leaf,0,Leaf,Leaf), Node(Leaf,0,Leaf,Node(Leaf,1,Leaf,Leaf))) -> False
+#
+# aeon transcription (nat ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/reccomp/ternary_tree_eq.ae
+
+inductive TTree
+| leaf : TTree
+| node (l: TTree) (v: Int) (m: TTree) (r: TTree) : TTree
+
+def and (a: Bool) (b: Bool) : Bool := if a then b else false
+
+# --- reference solution ---
+def treeEq (a: TTree) (b: TTree) : Bool :=
+    match a with
+    | .leaf => (match b with | .leaf => true | .node lb vb mb rb => false)
+    | .node la va ma ra =>
+        (match b with
+         | .leaf => false
+         | .node lb vb mb rb =>
+            if va = vb then and (treeEq la lb) (and (treeEq ma mb) (treeEq ra rb)) else false)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_reflexive (t: TTree) : Bool := treeEq t t
+
+@property(30)
+def prop_symmetric (t1: TTree) (t2: TTree) : Bool := treeEq t1 t2 = treeEq t2 t1
+
+@example(treeEq (.node .leaf 0 .leaf .leaf) (.node .leaf 0 .leaf (.node .leaf 1 .leaf .leaf)) = false)
+def main (z: Int) : Unit := print (treeEq (.node .leaf 0 .leaf .leaf) (.node .leaf 0 .leaf .leaf))

--- a/examples/synthesis/cata/contata/reccomp/trie_eq.ae
+++ b/examples/synthesis/cata/contata/reccomp/trie_eq.ae
@@ -1,0 +1,41 @@
+# Contata benchmark: reccomp/trie_eq.mls  (category RC)
+#
+# Original: synth trie_eq : [(trie*trie)] -> bool calling [trie_eq], structural
+# equality on tries (Leaf | Node of trie*A*trie). Spec:
+#     test forall t. trie_eq (t, t) == True
+#     test forall t. trie_eq (Node(t,0,t), Node(t,1,t)) == False
+#     test forall t. trie_eq (t, Node(t,0,t)) == False
+#     test forall t. trie_eq (Leaf, Node(t,0,t)) == False
+#     post: trie_eq (t1,t2) == (t1 == t2)
+#
+# aeon transcription (A ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/reccomp/trie_eq.ae
+
+inductive Trie
+| leaf : Trie
+| node (l: Trie) (v: Int) (r: Trie) : Trie
+
+# --- reference solution ---
+def trieEq (a: Trie) (b: Trie) : Bool :=
+    match a with
+    | .leaf => (match b with | .leaf => true | .node lb vb rb => false)
+    | .node la va ra =>
+        (match b with
+         | .leaf => false
+         | .node lb vb rb => if va = vb then (if trieEq la lb then trieEq ra rb else false) else false)
+
+# --- specification as PBT properties ---
+@property(30)
+def prop_reflexive (t: Trie) : Bool := trieEq t t
+
+@property(30)
+def prop_value_differs (t: Trie) : Bool := trieEq (.node t 0 t) (.node t 1 t) = false
+
+@property(30)
+def prop_proper_subtrie (t: Trie) : Bool := trieEq t (.node t 0 t) = false
+
+@property(30)
+def prop_leaf_vs_node (t: Trie) : Bool := trieEq .leaf (.node t 0 t) = false
+
+def main (z: Int) : Unit := print (trieEq (.node .leaf 5 .leaf) (.node .leaf 5 .leaf))

--- a/examples/synthesis/cata/contata/stackoverflow/pairs.ae
+++ b/examples/synthesis/cata/contata/stackoverflow/pairs.ae
@@ -1,0 +1,44 @@
+# Contata benchmark: stackoverflow/pairs.mls  (category SO -- Stack Overflow / k-safety)
+#
+# Original: synth pairs : [list] -> pair_list calling [pairs], grouping a list
+# into adjacent pairs. Spec (k-safety, via a round-trip):
+#     test forall xs. is_even (length xs) --> (pair_list_to_list (pairs xs) == xs)
+# i.e. when the length is even, flattening the pairs recovers the input.
+#
+# aeon transcription (A ↦ Int): `PairList` stores each pair as two Ints.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/stackoverflow/pairs.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+inductive PairList
+| pnil : PairList
+| pcons (a: Int) (b: Int) (rest: PairList) : PairList
+
+def len (xs: IntList) : Int := match xs with | .nil => 0 | .cons h t => 1 + len t
+
+def listEq (a: IntList) (b: IntList) : Bool :=
+    match a with
+    | .nil => (match b with | .nil => true | .cons hb tb => false)
+    | .cons ha ta => (match b with | .nil => false | .cons hb tb => if ha = hb then listEq ta tb else false)
+
+# --- reference solution ---
+def pairs (xs: IntList) : PairList :=
+    match xs with
+    | .nil => .pnil
+    | .cons x rest => (match rest with | .nil => .pnil | .cons y rest2 => .pcons x y (pairs rest2))
+
+def flatten (p: PairList) : IntList :=
+    match p with
+    | .pnil => .nil
+    | .pcons a b ps => .cons a (.cons b (flatten ps))
+
+# --- specification: round-trip on even-length inputs ---
+@property(40)
+def prop_roundtrip_even (xs: IntList) : Bool :=
+    if len xs % 2 = 0 then listEq (flatten (pairs xs)) xs else true
+
+@example(listEq (flatten (pairs (.cons 1 (.cons 2 (.cons 3 (.cons 4 .nil)))))) (.cons 1 (.cons 2 (.cons 3 (.cons 4 .nil)))) = true)
+def main (z: Int) : Unit := print (len (flatten (pairs (.cons 1 (.cons 2 .nil)))))

--- a/examples/synthesis/cata/contata/stackoverflow/split_on.ae
+++ b/examples/synthesis/cata/contata/stackoverflow/split_on.ae
@@ -1,0 +1,65 @@
+# Contata benchmark: stackoverflow/split_on.mls  (category SO / k-safety)
+#
+# Original: synth split_on_zero : [list] -> nested_list calling [split_on_zero].
+# Splits a list around 0 markers; the k-safety spec is a round-trip:
+#     test forall l. l == concat_list (split_on_zero l)
+#     io split_on_zero [1,0,1] -> [[1],[0],[1]]
+#     io split_on_zero [1,1,2] -> [[1,1,2]]
+# i.e. each 0 becomes its own singleton sublist, maximal non-zero runs are
+# grouped, and flattening recovers the input.
+#
+# aeon transcription (nat ↦ Int).
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/stackoverflow/split_on.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+inductive NestedList
+| nnil : NestedList
+| ncons (hd: IntList) (tl: NestedList) : NestedList
+
+def append (a: IntList) (b: IntList) : IntList :=
+    match a with | .nil => b | .cons h t => .cons h (append t b)
+
+def concatNL (ns: NestedList) : IntList :=
+    match ns with | .nnil => .nil | .ncons l ls => append l (concatNL ls)
+
+def listEq (a: IntList) (b: IntList) : Bool :=
+    match a with
+    | .nil => (match b with | .nil => true | .cons hb tb => false)
+    | .cons ha ta => (match b with | .nil => false | .cons hb tb => if ha = hb then listEq ta tb else false)
+
+def nlEq (a: NestedList) (b: NestedList) : Bool :=
+    match a with
+    | .nnil => (match b with | .nnil => true | .ncons hb tb => false)
+    | .ncons ha ta => (match b with | .nnil => false | .ncons hb tb => if listEq ha hb then nlEq ta tb else false)
+
+# --- reference solution ---
+# Each 0 is its own singleton; a non-zero x is prepended to the first group iff
+# that group is itself a non-zero run, otherwise it opens a new group.
+def split (xs: IntList) : NestedList :=
+    match xs with
+    | .nil => .nnil
+    | .cons x rest =>
+        if x = 0 then .ncons (.cons 0 .nil) (split rest)
+        else (match split rest with
+              | .nnil => .ncons (.cons x .nil) .nnil
+              | .ncons h hs =>
+                  (match h with
+                   | .nil => .ncons (.cons x .nil) (.ncons h hs)
+                   | .cons hh ht =>
+                       if hh = 0 then .ncons (.cons x .nil) (.ncons h hs)
+                       else .ncons (.cons x h) hs))
+
+# --- specification: round-trip property + the two io examples (exact shape) ---
+@property(40)
+def prop_roundtrip (l: IntList) : Bool := listEq (concatNL (split l)) l
+
+@example(nlEq (split (.cons 1 (.cons 0 (.cons 1 .nil))))
+              (.ncons (.cons 1 .nil) (.ncons (.cons 0 .nil) (.ncons (.cons 1 .nil) .nnil))) = true)
+@example(nlEq (split (.cons 1 (.cons 1 (.cons 2 .nil))))
+              (.ncons (.cons 1 (.cons 1 (.cons 2 .nil))) .nnil) = true)
+def main (z: Int) : Unit :=
+    print (listEq (concatNL (split (.cons 1 (.cons 0 (.cons 2 .nil))))) (.cons 1 (.cons 0 (.cons 2 .nil))))

--- a/examples/synthesis/cata/contata/stackoverflow/zip_same_len.ae
+++ b/examples/synthesis/cata/contata/stackoverflow/zip_same_len.ae
@@ -1,0 +1,35 @@
+# Contata benchmark: stackoverflow/zip_same_len.mls  (category SO / k-safety)
+#
+# Original: synth zip : [(a_list * b_list)] -> pair_list calling [zip]. Spec
+# relates the lengths of three lists (a k-safety property):
+#     test forall xs ys. length_p (zip (xs, ys)) == min (length_a xs, length_b ys)
+#
+# aeon transcription (A,B ↦ Int): `PairList` stores each pair as two Ints.
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/stackoverflow/zip_same_len.ae
+
+inductive IntList
+| nil : IntList
+| cons (hd: Int) (tl: IntList) : IntList
+
+inductive PairList
+| pnil : PairList
+| pcons (a: Int) (b: Int) (rest: PairList) : PairList
+
+def len (xs: IntList) : Int := match xs with | .nil => 0 | .cons h t => 1 + len t
+def lenP (p: PairList) : Int := match p with | .pnil => 0 | .pcons a b ps => 1 + lenP ps
+def minInt (a: Int) (b: Int) : Int := if a <= b then a else b
+
+# --- reference solution ---
+def zip (xs: IntList) (ys: IntList) : PairList :=
+    match xs with
+    | .nil => .pnil
+    | .cons x xs2 => (match ys with | .nil => .pnil | .cons y ys2 => .pcons x y (zip xs2 ys2))
+
+# --- specification: the length relation ---
+@property(40)
+def prop_len_is_min (xs: IntList) (ys: IntList) : Bool :=
+    lenP (zip xs ys) = minInt (len xs) (len ys)
+
+@example(lenP (zip (.cons 1 (.cons 2 .nil)) (.cons 9 (.cons 8 (.cons 7 .nil)))) = 2)
+def main (z: Int) : Unit := print (lenP (zip (.cons 1 .nil) (.cons 9 (.cons 8 .nil))))


### PR DESCRIPTION
## What

Completes the faithful aeon transcription of the **Contata** suite (Miltner, Wang, Chaudhuri & Dillig, CAV 2024), adding the **remaining 23** benchmarks on top of the 7 that landed in #411. The full suite (all 30, from [`amiltner/ContataArtifactEvaluation`](https://github.com/amiltner/ContataArtifactEvaluation)) now lives under `examples/synthesis/cata/contata/`.

Added this PR:

- **MR (7 total, +5):** `even_odd2`, `nested_list_eq`, `parenthesis_match`, `tree_forest_size`, `tree_forest_leaves`
- **RC (7 total, +5):** `list_cmp`, `binary_tree_eq`, `ternary_tree_depth`, `ternary_tree_eq`, `trie_eq`
- **PDS (12 total, +10):** `list_insertion2/3`, `list_removal`, `list_removal2`, `list_sort`, `bst_insertion`, `mirror_tree_test2`, `mirror_ternary_test`, `mirror_ternary_test2`, `sized_list`
- **SO (4 total, +3):** `pairs`, `split_on`, `zip_same_len`

Each file = the datatype(s) + helpers + the **reference solution** + the original spec rendered as `@property` (the `test forall …`) and `@example` (the `io …`). MR cases use real `mutual … end` groups (incl. genuine mutually-recursive `inductive` tree/forest types).

## Verification

All **30/30** pass (28 via `aeon --test`, 2 via plain run). Full log in the commit; sample:

```
[test ✔] reccomp/trie_eq.ae (4 passed, 0 failed)
[test ✔] stackoverflow/split_on.ae (3 passed, 0 failed)
[plain ✔] mutrec/tree_forest_size.ae   # prints True
...
==== files passed: 30, failed: 0 ====
```

## Two honest transcription notes (documented in-file + README)

- **`tree_forest_{size,leaves}` use a plain run, not `--test`.** Their mutual group spans *two* datatype sorts (`Tree`, `Forest`); aeon's `--test` reflects called functions into z3, and reflecting a mutual group across distinct ADT sorts currently raises a z3 *“Sort mismatch”* — an aeon bug (the definitions typecheck and run fine; single-sort mutual groups like `even_odd` reflect cleanly). These verify by evaluating every io + property in `main`. Worth a separate aeon issue.
- **`list_insertion3`** transcribes the *intended* property (“insertion adds no element other than the inserted one”); the original `.mls` test read literally is contradicted by its own io, so the literal form is unsatisfiable.

## Test plan

- [x] `uv run python -m aeon --test <file>` green for all 28 `--test` files
- [x] `uv run python -m aeon <file>` prints `True` for the 2 tree/forest files
- [x] README maps all 30 benchmarks to their sources

Builds on #411 (merged). 🤖 Generated with [Claude Code](https://claude.com/claude-code)