### PR TITLE
fix(bind): resolve forward references between mutually-recursive inductives (Z3 "Sort mismatch")

### DIFF
--- a/aeon/sugar/bind.py
+++ b/aeon/sugar/bind.py
@@ -298,8 +298,18 @@ def bind_program(p: Program, subs: RenamingSubstitions) -> Program:
             nname, nsubs = check_name(pname, nsubs)
             trfs.append((nname, bind_stype(psort, nsubs)))
         type_decls.append(TypeDecl(name, targs, trfs, loc=td.loc))
+    # Pre-register every inductive type name before binding any constructor, so
+    # a constructor of one inductive can reference a sibling inductive declared
+    # *later* in the file (mutually-recursive datatypes, e.g. `Tree` whose
+    # `node` constructor carries a `Forest` field while `Forest` is declared
+    # below it) and resolve to the same id. Without this, the forward reference
+    # binds to a fresh, distinct id, and the SMT backend then mints two separate
+    # Z3 sorts for what is logically the same type (a "Sort mismatch").
+    prebound_ind_names: list[Name] = []
     for ind in p.inductive_decls:
         name, nsubs = check_name(ind.name, nsubs)
+        prebound_ind_names.append(name)
+    for ind, name in zip(p.inductive_decls, prebound_ind_names, strict=True):
         iargs = []
         for aname in ind.args:
             nname, nsubs = check_name(aname, nsubs)

--- a/examples/synthesis/cata/contata/mutrec/tree_forest_leaves.ae
+++ b/examples/synthesis/cata/contata/mutrec/tree_forest_leaves.ae
@@ -10,10 +10,14 @@
 #
 # aeon: genuine mutual `inductive` types + a true `mutual ... end` group. nat ↦ Int.
 #
-# Verification note. As in tree_forest_size.ae, the mutual group spans two ADT
-# sorts, which aeon's `--test` SMT reflection cannot yet handle (z3 "Sort
-# mismatch" — an aeon bug; the defs typecheck and run). This file verifies by
-# evaluating every Contata io example and both properties in `main`:
+# Verification. The mutual functions span TWO datatype sorts (Tree, Forest).
+# The Contata io examples are pinned as `@example` assertions and both
+# relational properties as `@property` tests (the runner generates `Forest`
+# values), so the whole spec is checked with `--test`:
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/mutrec/tree_forest_leaves.ae
+#
+# `main` keeps a self-contained smoke check for a plain run:
 #
 #   uv run python -m aeon examples/synthesis/cata/contata/mutrec/tree_forest_leaves.ae   # -> True
 
@@ -33,10 +37,18 @@ mutual
     match f with | .leaf => 1 | .tcons t rest => leavesTree t + leavesForest rest
 end
 
-def prop_node_keeps (f: Forest) : Bool := leavesForest f = leavesTree (.node 0 f)
-def prop_empty_keeps (f: Forest) : Bool := leavesForest f = leavesForest (.tcons .empty f)
-
 def f1 : Forest := .tcons (.node 0 .leaf) (.tcons (.node 1 .leaf) .leaf)
+
+# Contata's io examples.
+@example(leavesTree .empty = 0)
+@example(leavesForest .leaf = 1)
+@example(leavesForest f1 = 3)
+# Contata's two relational properties, checked over generated forests.
+@property(40)
+def prop_node_keeps (f: Forest) : Bool := leavesForest f = leavesTree (.node 0 f)
+
+@property(40)
+def prop_empty_keeps (f: Forest) : Bool := leavesForest f = leavesForest (.tcons .empty f)
 
 def main (z: Int) : Unit :=
     print (

--- a/examples/synthesis/cata/contata/mutrec/tree_forest_size.ae
+++ b/examples/synthesis/cata/contata/mutrec/tree_forest_size.ae
@@ -11,12 +11,14 @@
 # aeon: genuine mutual `inductive` types AND a true `mutual ... end` group
 # (forest = Leaf | Tree of tree*forest, i.e. a list of trees). nat ↦ Int.
 #
-# Verification note. The mutual functions span TWO datatype sorts (Tree, Forest).
-# aeon's `--test` path reflects called functions into z3, and reflecting a mutual
-# group across distinct ADT sorts currently raises a z3 "Sort mismatch" (an aeon
-# bug, not a spec issue) — the definitions themselves typecheck and run. So this
-# file verifies by evaluating every Contata io example and both properties (on
-# sampled forests) in `main`, which prints `True`:
+# Verification. The mutual functions span TWO datatype sorts (Tree, Forest).
+# The Contata io examples are pinned as `@example` assertions and the two
+# relational properties as `@property` tests (the runner generates `Forest`
+# values), so the whole spec is checked with `--test`:
+#
+#   uv run python -m aeon --test examples/synthesis/cata/contata/mutrec/tree_forest_size.ae
+#
+# `main` keeps a self-contained smoke check for a plain run:
 #
 #   uv run python -m aeon examples/synthesis/cata/contata/mutrec/tree_forest_size.ae   # -> True
 
@@ -36,11 +38,19 @@ mutual
     match f with | .leaf => 0 | .tcons t rest => sizeTree t + sizeForest rest
 end
 
-# Contata's two relational properties, instantiated on a sample forest f:
-def prop_node_grows (f: Forest) : Bool := sizeForest f < sizeTree (.node 0 f)
-def prop_empty_tree_no_growth (f: Forest) : Bool := !(sizeForest (.tcons .empty f) < sizeForest f)
-
 def f1 : Forest := .tcons (.node 0 .leaf) (.tcons (.node 1 .leaf) .leaf)
+
+# Contata's io examples.
+@example(sizeTree .empty = 0)
+@example(sizeForest .leaf = 0)
+@example(sizeTree (.node 0 .leaf) = 1)
+@example(sizeForest f1 = 2)
+# Contata's two relational properties, checked over generated forests.
+@property(40)
+def prop_node_grows (f: Forest) : Bool := sizeForest f < sizeTree (.node 0 f)
+
+@property(40)
+def prop_empty_tree_no_growth (f: Forest) : Bool := !(sizeForest (.tcons .empty f) < sizeForest f)
 
 def main (z: Int) : Unit :=
     print (

--- a/tests/mutual_recursion_test.py
+++ b/tests/mutual_recursion_test.py
@@ -136,3 +136,32 @@ def test_mutual_nonterminating_absurd_refinement_rejected():
     def main (x: Int) : Int := 0;
     """
     assert not _typechecks(src)
+
+
+def test_mutual_reflection_across_two_datatype_sorts():
+    """A ``mutual`` group whose members range over *distinct* ADT sorts reflects
+    into SMT without a Z3 ``Sort mismatch``.
+
+    Regression: mutually-recursive datatypes ``Tree``/``Forest`` (``Tree``'s
+    ``node`` constructor carries a ``Forest`` field, and ``Forest`` is declared
+    *after* ``Tree``) used to bind that forward ``Forest`` reference to a fresh,
+    distinct id from the ``Forest`` declaration. The SMT backend then minted two
+    separate Z3 sorts for the one type, so applying the ``node`` constructor to a
+    ``Forest`` argument inside a reflected refinement raised ``Sort mismatch``.
+    The relational refinement on ``check`` forces the cross-sort constructor
+    application through SMT, exercising the path that used to crash."""
+    src = """
+    inductive Tree | empty : Tree | node (v: Int) (children: Forest) : Tree
+    inductive Forest | leaf : Forest | tcons (t: Tree) (rest: Forest) : Forest
+    mutual
+      def sizeTree (fuel: {x:Int | x >= 0}) (t: Tree) : Int decreasing_by [fuel] :=
+        if fuel = 0 then 0 else (match t with | .empty => 0 | .node v f => 1 + sizeForest (fuel - 1) f);
+      def sizeForest (fuel: {x:Int | x >= 0}) (f: Forest) : Int decreasing_by [fuel] :=
+        if fuel = 0 then 0 else (match f with | .leaf => 0 | .tcons t rest => sizeTree (fuel - 1) t + sizeForest (fuel - 1) rest);
+    end
+    def check (x: Forest) : {r:Int | r = sizeTree 0 (.node 0 x)} := sizeTree 0 (.node 0 x);
+    def main (z: Int) : Int := sizeTree 10 .empty;
+    """
+    errors, result = _run(src)
+    assert errors == []
+    assert result == 0


### PR DESCRIPTION
## Problem

`--test` (and any SMT reflection) of a `mutual ... end` group whose members range over **different datatype sorts** raised `z3.z3types.Z3Exception: Sort mismatch` from `aeon/verification/smt.py` (`_translate_liq`, at the `fun(*args)` application).

```
inductive Tree   | empty : Tree   | node (v: Int) (children: Forest) : Tree
inductive Forest | leaf  : Forest | tcons (t: Tree) (rest: Forest)    : Forest
mutual
  def sizeTree   (t: Tree)   : Int := match t with | .empty => 0 | .node v f => 1 + sizeForest f
  def sizeForest (f: Forest) : Int := match f with | .leaf => 0 | .tcons t rest => sizeTree t + sizeForest rest
end
```

## Root cause

`bind_program` registers inductive type names one at a time in declaration order. `Tree` is declared **before** `Forest`, but its `node` constructor carries a `Forest` field. When that constructor was bound, `Forest` was not yet in scope, so the forward reference bound to a fresh, distinct `Name.id` instead of the id later assigned to the `Forest` declaration.

The SMT backend keys Z3 sorts on the type's `Name` (id included — intentionally, so two same-named types from different scopes don't collide on one sort). The two ids therefore minted **two separate Z3 sorts** for the one logical `Forest` type. Reflecting the mutual group into Z3 — e.g. applying the `node` constructor (declared domain `[Int, Forest¹³⁷]`) to a `Forest¹¹`-sorted argument — then failed with `Sort mismatch`.

Single-sort mutual groups (even/odd over one `Nat`) were unaffected because there is only ever one sort.

## Fix

Pre-register **all** inductive type names before binding any constructor — the same forward-reference handling the `mutual ... end` *definition* block already applies to its members. Cross-references between mutually-recursive datatypes now resolve to a single canonical id, hence one Z3 sort.

## Tests / verification

- New end-to-end regression in `tests/mutual_recursion_test.py`: a `Tree`/`Forest` mutual group reflected into SMT (relational refinement forces the cross-sort constructor through Z3). Crashes on `master`, passes here.
- Updated `tree_forest_{size,leaves}` Contata benchmarks to verify their io examples and relational properties via `@example`/`@property` under `--test` (the previous workaround was a plain `main` run, with a note blaming this very bug). Stale "Sort mismatch" notes removed.
- Full suite: **1681 passed, 14 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kNFM114D5Zeocdnx3uLvk

---
_Generated by [Claude Code](https://claude.ai/code/session_019kNFM114D5Zeocdnx3uLvk)_