### PR TITLE
fix(afta): PBE synthesis crashed on unbounded rounds (rounds=None)

### DIFF
--- a/aeon/synthesis/modules/afta/pbe.py
+++ b/aeon/synthesis/modules/afta/pbe.py
@@ -247,10 +247,17 @@ def synthesize_pbe(
                 return None
         return None
 
+    # Depth is bounded by the time budget (and a fixpoint, when a full round adds
+    # no new terms), not a fixed number of rounds; ``synth.rounds``, when set,
+    # caps it explicitly. ``rounds`` defaults to ``None`` (unbounded), so a plain
+    # ``range(synth.rounds)`` would crash -- deepen with a budget-guarded loop
+    # mirroring the non-PBE path.
     solution = cegar_pass()
-    for _round in range(synth.rounds):
-        if solution is not None or time.time() >= deadline:
+    depth = 0
+    while solution is None and time.time() < deadline:
+        if synth.rounds is not None and depth >= synth.rounds:
             break
+        before = sum(len(v) for v in bank.values())
         snapshot = {k: list(v) for k, v in bank.items()}
         for comps in builders.values():
             for comp in comps:
@@ -258,6 +265,9 @@ def synthesize_pbe(
                     break
                 add_bank(comp.ret_key, synth._combos(comp, snapshot, deadline, rnd))
         solution = cegar_pass()
+        depth += 1
+        if sum(len(v) for v in bank.values()) == before:
+            break
 
     if solution is not None:
         ui.register(solution, [0.0], time.time() - start, True)
@@ -268,8 +278,8 @@ def synthesize_pbe(
         )
         return solution
     raise SynthesisNotSuccessful(
-        f"afta(pbe): no program consistent with all {n} example(s) of depth < {synth.rounds} "
-        f"found within the budget (enumerated {len(goal_terms)} goal terms, {refinements} refinements). "
+        f"afta(pbe): no program consistent with all {n} example(s) found within the budget "
+        f"(reached depth {depth}, enumerated {len(goal_terms)} goal terms, {refinements} refinements). "
         "Try a larger budget, more rounds, or a richer DSL in scope."
     )
 


### PR DESCRIPTION
## Problem

The AFTA PBE synthesis path iterated `for _round in range(synth.rounds)`, but `rounds` defaults to `None` (unbounded depth, bounded by the time budget). So **every** `-s afta` PBE run crashed immediately:

```
TypeError: 'NoneType' object cannot be interpreted as an integer
```

at `aeon/synthesis/modules/afta/pbe.py:251`.

## Fix

Replace the `range(synth.rounds)` loop with the same budget-guarded `while` pattern the non-PBE AFTA path already uses: deepen until a solution is found, the deadline hits, the program bank reaches a fixpoint (a full round adds no new terms), or an explicit `rounds` cap is reached when one is set. The failure message now reports the depth actually reached instead of `< None`.

## Verification

- Direct repro (`-s afta` PBE program): 0 crashes (was crashing).
- `tests/afta_pbe_test.py`: **5 passed** (previously crashing).
- mypy / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)