### PR TITLE
fix(core): check the parameter type in is_bare

### DIFF
--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -301,8 +301,8 @@ def is_bare(t: Type) -> bool:
             return True
         case RefinedType(_, _, ref):
             return ref == LiquidHole() or isinstance(ref, LiquidHornApplication)
-        case AbstractionType(_, _, vtype):
-            return is_bare(vtype) and is_bare(vtype)
+        case AbstractionType(_, vtype, rtype):
+            return is_bare(vtype) and is_bare(rtype)
         case TypePolymorphism(_, _, ty):
             return is_bare(ty)
         case _:


### PR DESCRIPTION
## Problem

`is_bare` in `aeon/core/types.py` had a bug in the `AbstractionType` arm:

```python
case AbstractionType(_, _, vtype):
    return is_bare(vtype) and is_bare(vtype)
```

The pattern bound only the **return** type to `vtype`; the parameter type (second field) was never inspected, and the same value was checked twice. A function type whose *parameter* type is non-bare (e.g. carries a refinement) was therefore wrongly classified as bare.

## Fix

Bind both fields and check each once:

```python
case AbstractionType(_, vtype, rtype):
    return is_bare(vtype) and is_bare(rtype)
```

## Verification

`uv run pytest -k "type or bare or typecheck or core"` → 796 passed, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)