### PR TITLE
fix(facade): AeonError extends Exception; rename shadowing ImportError

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from aeon.facade.api import (
     AeonError,
     CoreTypeCheckingError,
-    ImportError as AeonImportError,
+    ModuleNotFoundAeonError as AeonImportError,
     InstanceResolutionError,
     LinearityError,
     NonOrderableComparisonError,

--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
@@ -14,14 +13,14 @@ from aeon.verification.vcs import Constraint
 from aeon.verification.helpers import pretty_print_constraint
 
 
-class AeonError(ABC, BaseException):
+class AeonError(Exception):
     def __str__(self) -> str: ...
 
     def position(self) -> Location: ...
 
 
 @dataclass
-class ImportError(AeonError):
+class ModuleNotFoundAeonError(AeonError):
     importel: ImportAe
     possible_containers: Iterable[Path]
 

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -64,7 +64,7 @@ from aeon.utils.name import Name, fresh_counter
 from aeon.sugar.ast_helpers import st_int, st_string, st_unit, st_bool
 from aeon.sugar.instance_registry import InstanceInfo, register_instance
 
-from aeon.facade.api import ImportError
+from aeon.facade.api import ModuleNotFoundAeonError
 from aeon.sugar.equality import type_equality
 
 
@@ -2113,7 +2113,7 @@ def _resolve_import(imp: ImportAe) -> Program:
         if file.exists():
             resolved = str(file.resolve())
             if resolved in _currently_importing:
-                raise ImportError(importel=imp, possible_containers=possible_containers)
+                raise ModuleNotFoundAeonError(importel=imp, possible_containers=possible_containers)
             if resolved in _import_cache:
                 return _import_cache[resolved]
             _currently_importing.add(resolved)
@@ -2125,4 +2125,4 @@ def _resolve_import(imp: ImportAe) -> Program:
                 return result
             finally:
                 _currently_importing.discard(resolved)
-    raise ImportError(importel=imp, possible_containers=possible_containers)
+    raise ModuleNotFoundAeonError(importel=imp, possible_containers=possible_containers)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -9,7 +9,7 @@ import pytest
 from aeon.sugar.desugar import _get_package_libraries_dir, _resolve_import, clear_import_cache
 from aeon.sugar.program import ImportAe
 from aeon.sugar.parser import mk_parser
-from aeon.facade.api import ImportError as AeonImportError
+from aeon.facade.api import ModuleNotFoundAeonError as AeonImportError
 
 
 class TestPackageLibrariesDir:


### PR DESCRIPTION
## Problems

In `aeon/facade/api.py`:

1. **`AeonError(ABC, BaseException)`** — extending `BaseException` means the idiomatic `except Exception` guard does **not** catch Aeon's own errors, and they sit alongside `KeyboardInterrupt`/`SystemExit` in the exception hierarchy.
2. **`class ImportError(AeonError)`** shadowed the builtin `ImportError`, silently changing the meaning of any `except ImportError` in the module's namespace.
3. The `ABC` base declared no `@abstractmethod`s, so it was inert.

## Fix

- `AeonError(Exception)` (drop the inert `ABC` and its import).
- Rename `ImportError` → `ModuleNotFoundAeonError`. Call sites updated: `aeon/sugar/desugar.py` (import + two raise sites), and the `... as AeonImportError` aliases in `aeon/__main__.py` and `tests/test_imports.py` (local alias preserved, so downstream usage is unchanged).

## Verification

- `uv run pytest tests/test_imports.py` → 14 passed.
- `uv run pytest tests/multiple_errors_test.py tests/method_call_test.py tests/ordered_comparison_test.py` (AeonError-catching paths) → 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)