### PR TITLE
chore(verification): remove dead, broken is_whitespace

### DIFF
--- a/aeon/verification/helpers.py
+++ b/aeon/verification/helpers.py
@@ -93,10 +93,6 @@ def simplify_is_true(c: Constraint):
             return False
 
 
-def is_whitespace(s: str) -> bool:
-    return all(x in ["\t\n "] for x in s)
-
-
 def flatten_conjunctions(c: Conjunction) -> list[Constraint]:
     queue = [c.c1, c.c2]
     conjunctions = []


### PR DESCRIPTION
## Problem

`is_whitespace` in `aeon/verification/helpers.py`:

```python
def is_whitespace(s: str) -> bool:
    return all(x in ["\t\n "] for x in s)
```

Each character is tested for membership in a **one-element list** containing the 3-character string `"\t\n "` — so the predicate is `False` for every non-empty string (and the membership target is a string, not a set of chars). The function has no callers anywhere in `aeon/` or `tests/`.

## Fix

Remove the dead function. (Had it been needed, `s.isspace()` is the correct primitive.)

## Verification

`grep -rn is_whitespace aeon/ tests/` → only the definition; import smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)