### PR TITLE
chore(core): dedupe duplicate isinstance disjuncts

### DIFF
--- a/aeon/core/bind.py
+++ b/aeon/core/bind.py
@@ -145,7 +145,7 @@ def bind_type(ty: Type, subs: RenamingSubstitions) -> Type:
             nty = bind_type(ty, subs)
             nname, nsubs = check_name(name, subs)
             nref = bind_lq(ref, nsubs)
-            assert isinstance(nty, TypeConstructor) or isinstance(nty, TypeVar) or isinstance(nty, TypeConstructor)
+            assert isinstance(nty, (TypeConstructor, TypeVar))
             return RefinedType(nname, nty, nref, loc=loc)
         case TypePolymorphism(name, kind, body, loc):
             name, subs = check_name(name, subs)

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -278,15 +278,7 @@ liq_true = LiquidLiteralBool(True)
 
 
 def extract_parts(t: Type) -> tuple[Name, TypeConstructor | TypeVar, LiquidTerm]:
-    assert (
-        isinstance(t, TypeConstructor)
-        or isinstance(t, RefinedType)
-        or isinstance(
-            t,
-            TypeVar,
-        )
-        or isinstance(t, TypeConstructor)
-    )
+    assert isinstance(t, (TypeConstructor, RefinedType, TypeVar))
     match t:
         case RefinedType(name, ity, ref):
             return (name, ity, ref)

--- a/aeon/sugar/lowering.py
+++ b/aeon/sugar/lowering.py
@@ -245,11 +245,7 @@ def type_to_core(ty: SType, available_vars: list[tuple[Name, TypeConstructor | T
             else:
                 name = oname
             basety = type_to_core(ity, available_vars)
-            assert (
-                isinstance(basety, TypeConstructor)
-                or isinstance(basety, TypeVar)
-                or isinstance(basety, TypeConstructor)
-            )
+            assert isinstance(basety, (TypeConstructor, TypeVar))
             return RefinedType(name, basety, liquefy(ref, available_vars + [(name, basety)]), loc=loc)
         case STypeConstructor(name, args, loc):
             return TypeConstructor(name, [type_to_core(ity, available_vars) for ity in args], loc=loc)


### PR DESCRIPTION
## Problem

Three assertions list `isinstance(x, TypeConstructor)` **twice** (a copy-paste artifact):

- `aeon/sugar/lowering.py` — the `SRefinedType` arm of `type_to_core`
- `aeon/core/types.py` — `extract_parts`
- `aeon/core/bind.py` — the `RefinedType` arm of `bind_type`

## Fix

Collapse each to the tuple form `isinstance(x, (...))`.

No behaviour change: `RefinedType.type` is typed `TypeConstructor | TypeVar`, so a refined base type is not valid in these positions and the duplicate `TypeConstructor` added nothing. (mypy confirms — widening the set to include `RefinedType` is rejected as an incompatible argument to `RefinedType`.)

## Verification

- `uv run pytest tests/end_to_end_test.py tests/elaboration_test.py` → 18 passed.
- pre-commit `mypy` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)