### PR TITLE
fix(typechecking): add missing f-prefix to liquid type error message

### DIFF
--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -208,7 +208,7 @@ def type_infer_liquid(
                 case TypeVar(_) as ty:
                     return ty
                 case _:
-                    raise LiquidTypeCheckException("Could not find type for {liq} ({ctx.variables[name]})")
+                    raise LiquidTypeCheckException(f"Could not find type for {liq} ({ctx.variables[name]})")
         case LiquidApp(Name("ite", _), [cond, then, otherwise]):
             kc = type_infer_liquid(ctx, cond)
             if not (isinstance(kc, TypeConstructor) and kc.name.name == "Bool"):


### PR DESCRIPTION
## Problem

In `aeon/typechecking/liquid.py`, the fallback branch of `type_infer_liquid` raised:

```python
raise LiquidTypeCheckException("Could not find type for {liq} ({ctx.variables[name]})")
```

Missing the `f` prefix, so the message printed the literal `{liq} ({ctx.variables[name]})` rather than the offending term and its context type.

## Fix

Add the `f` prefix.

## Verification

import smoke passes; pre-commit (ruff/mypy) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)