### PR TITLE
fix(sugar): drop shared mutable defaults on DesugaredProgram

### DIFF
--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -270,8 +270,8 @@ class DesugaredProgram(NamedTuple):
     program: STerm
     elabcontext: ElaborationTypingContext
     metadata: Metadata
-    constructor_to_type: dict[str, Name] = {}
-    constructor_defs: dict[str, Name] = {}
+    constructor_to_type: dict[str, Name]
+    constructor_defs: dict[str, Name]
 
 
 def lower_by_blocks_in_sterm(t: STerm) -> tuple[STerm, dict[Name, tuple[str, ...]]]:


### PR DESCRIPTION
## Problem

```python
class DesugaredProgram(NamedTuple):
    ...
    constructor_to_type: dict[str, Name] = {}
    constructor_defs: dict[str, Name] = {}
```

`NamedTuple` evaluates field defaults once, so these `{}` literals become a single class-level dict shared by every instance constructed without them — the classic mutable-default aliasing hazard (`field(default_factory=dict)` is the dataclass remedy, but `NamedTuple` doesn't support it).

## Fix

Every construction site (`desugar()`, `AeonDriver`, and all tests) already passes both fields explicitly, so the defaults are dead. Remove them, making the fields required.

## Verification

`uv run pytest tests/decreasing_by_test.py tests/end_to_end_test.py tests/match_inductive_test.py` → 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)