### PR TITLE
chore: remove stale comments and commented-out code

### DIFF
--- a/aeon/core/substitutions.py
+++ b/aeon/core/substitutions.py
@@ -664,7 +664,6 @@ def liquefy_ann(t: Annotation) -> LiquidTerm | None:
     return liquefy(t.expr)
 
 
-# patterm matching term
 def liquefy(rep: Term) -> LiquidTerm | None:
     """Converts a term to a liquid term."""
 

--- a/aeon/elaboration/__init__.py
+++ b/aeon/elaboration/__init__.py
@@ -927,8 +927,6 @@ def elaborate_remove_unification(ctx: ElaborationTypingContext, t: STerm) -> STe
                         case SAbstractionType(_, _, _):
                             # AbstractionTypes are not refined
                             return STypeApplication(body, nt, loc=loc)
-                        # case TypePolymorphism(name, kind, body_):
-
                         case _:
                             assert False, f"{nt} ({type(nt)}) not an SType."
 

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -502,7 +502,6 @@ def _as_predicate_type(sort: Type) -> AbstractionType:
     return AbstractionType(Name("_", fresh_counter.fresh()), sort, t_bool)
 
 
-# patterm matching term
 def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
     match t:
         case Literal(_, TypeConstructor(Name("Unit", _))):
@@ -528,10 +527,8 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             if isinstance(ty, TypeConstructor) or isinstance(ty, RefinedType) or isinstance(ty, TypeVar):
                 ty = ensure_refined(ty)
                 assert isinstance(ty, RefinedType)
-                # assert ty.name != t.name
                 if ty.name == t.name:
                     ty = renamed_refined_type(ty)
-                # Self
                 ty = RefinedType(
                     ty.name,
                     ty.type,


### PR DESCRIPTION
## What

Small comment-hygiene pass removing noise that restates code or is dead:

- `aeon/core/substitutions.py` & `aeon/typechecking/typeinfer.py` — the `# patterm matching term` typo comments above `liquefy` / `synth`.
- `aeon/typechecking/typeinfer.py` — a commented-out `# assert ty.name != t.name` and a lone, cryptic `# Self` marker inside the `Var` selfification path.
- `aeon/elaboration/__init__.py` — a commented-out `# case TypePolymorphism(name, kind, body_):` stub.

No behaviour change.

## Verification

`uv run pytest tests/end_to_end_test.py` → 12 passed; import smoke + pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)