### PR TITLE
refactor: pythonic idioms and micro dead-code cleanup

### DIFF
--- a/aeon/backend/evaluator.py
+++ b/aeon/backend/evaluator.py
@@ -65,7 +65,7 @@ class EvaluationContext:
 
 
 def is_native_var(fun: Any):
-    return fun == real_eval
+    return fun is real_eval
 
 
 def is_native_import(fun: Term):

--- a/aeon/core/liquid.py
+++ b/aeon/core/liquid.py
@@ -135,7 +135,7 @@ class LiquidApp(LiquidTerm):
     loc: Location = field(default_factory=lambda: SynthesizedLocation("default"))
 
     def __repr__(self):
-        if all([not c.isalnum() for c in self.fun.name]) and len(self.args) == 2:
+        if all(not c.isalnum() for c in self.fun.name) and len(self.args) == 2:
             (a1, a2) = (repr(x) for x in self.args)
             return f"({a1} {self.fun} {a2})"
 

--- a/aeon/core/liquid_ops.py
+++ b/aeon/core/liquid_ops.py
@@ -36,7 +36,7 @@ liquid_prelude: dict[Name, list[TypeConstructor | TypeVar]] = {
     Name("Set_sub", 0): [t_set, t_set, t_bool],
 }
 
-ops = [x for x in liquid_prelude]
+ops = list(liquid_prelude)
 
 
 def mk_liquid_and(e1: LiquidTerm, e2: LiquidTerm):

--- a/aeon/typechecking/liquid.py
+++ b/aeon/typechecking/liquid.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from dataclasses import dataclass
-import typing
 
 from aeon.core.liquid import LiquidApp, LiquidLiteralFloat
 from aeon.core.liquid import LiquidLiteralBool
@@ -121,15 +120,8 @@ def lower_abstraction_type(ty: Type) -> list[TypeConstructor | TypeVar]:
                 assert False, f"Unknown type {ty} when lowering to liquid"
 
 
-T = typing.TypeVar("T")
-
-
-def flatten(xs: list[list[T]]) -> list[T]:
-    return [x for y in xs for x in y]
-
-
 def lower_context(ctx: TypingContext) -> LiquidTypeCheckingContext:
-    known_types: list[Name] = native_types + []
+    known_types: list[Name] = list(native_types)
     variables: dict[Name, TypeConstructor | TypeVar] = {}
     functions = {}
 

--- a/aeon/utils/time_utils.py
+++ b/aeon/utils/time_utils.py
@@ -18,8 +18,7 @@ def measure(func):
         finally:
             end_ = int(round(process_time() * 1000)) - start
             if end_ > 1:
-                end_s = end_ if end_ > 0 else 0
-                logger.info(f"Total execution time {func.__name__}: {end_s} ms")
+                logger.info(f"Total execution time {func.__name__}: {end_} ms")
 
     return _time_it
 


### PR DESCRIPTION
## What

A handful of small, independent idiom/dead-code cleanups:

| file | change |
|------|--------|
| `aeon/typechecking/liquid.py` | remove unused `flatten` helper (no importers; the `smt.py`/pprint `flatten`s are unrelated) and the `T`/`import typing` it required; `native_types + []` → `list(native_types)` |
| `aeon/core/liquid_ops.py` | `[x for x in liquid_prelude]` (no-op comprehension over dict keys) → `list(liquid_prelude)` |
| `aeon/core/liquid.py` | `all([not c.isalnum() ...])` → generator form (drop throwaway list) |
| `aeon/utils/time_utils.py` | `end_s = end_ if end_ > 0 else 0` is always `end_` inside `if end_ > 1` — log `end_` directly |
| `aeon/backend/evaluator.py` | `fun == real_eval` → `fun is real_eval` (identity test against the builtin `eval`) |

No behaviour change.

## Verification

- `uv run pytest tests/end_to_end_test.py tests/backend_test.py` → 19 passed.
- import smoke + pre-commit (ruff/mypy) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)