### PR TITLE
refactor: extract shared bottom-up skeleton of tree-automata synthesis backends

### DIFF
--- a/aeon/synthesis/modules/afta/synthesizer.py
+++ b/aeon/synthesis/modules/afta/synthesizer.py
@@ -45,7 +45,6 @@ Selected with ``--synthesizer afta``.
 
 from __future__ import annotations
 
-import itertools
 import random
 import time
 from typing import Any, Callable, Optional
@@ -61,7 +60,7 @@ from aeon.core.liquid import (
     LiquidTerm,
     LiquidVar,
 )
-from aeon.core.terms import Application, Literal, Term, Var
+from aeon.core.terms import Literal, Term, Var
 from aeon.core.types import (
     AbstractionType,
     RefinedType,
@@ -71,7 +70,14 @@ from aeon.core.types import (
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
-from aeon.synthesis.modules.fta.synthesizer import _freeze, _safe, _term_size
+from aeon.synthesis.modules.bottom_up import (
+    application,
+    combos,
+    deepen,
+    freeze as _freeze,
+    safe as _safe,
+    term_size as _term_size,
+)
 from aeon.synthesis.modules.symetric.synthesizer import (
     Component,
     _peel,
@@ -154,31 +160,14 @@ class AFTASynthesizer(Synthesizer):
     def _combos(self, comp: Component, bank: dict[str, list[Term]], deadline: float, rnd: random.Random) -> list[Term]:
         """Transitions ``comp(q1, ..., qk) -> q``: applications of ``comp`` whose
         arguments are drawn from the current bank (per argument type)."""
-        pools: list[list[Term]] = []
-        for ak in comp.arg_keys:
-            pool = bank.get(ak, [])
-            if not pool:
-                return []
-            pools.append(pool)
-        total = 1
-        for p in pools:
-            total *= len(p)
-        out: list[Term] = []
-        if total <= self.combo_cap:
-            for choice in itertools.product(*pools):
-                if time.time() >= deadline:
-                    break
-                term: Term = Var(comp.name)
-                for a in choice:
-                    term = Application(term, a)
-                out.append(term)
-        else:
-            for _ in range(self.combo_cap):
-                term = Var(comp.name)
-                for p in pools:
-                    term = Application(term, rnd.choice(p))
-                out.append(term)
-        return out
+        return combos(
+            comp,
+            bank,
+            deadline,
+            rnd,
+            self.combo_cap,
+            lambda c, choice: application(Var(c.name), choice),
+        )
 
     # -- entry point ----------------------------------------------------------
 
@@ -350,12 +339,9 @@ class AFTASynthesizer(Synthesizer):
         # reaches a fixpoint (a full round adds no new terms). ``self.rounds``,
         # when set, caps the depth explicitly.
         solution = cegar_pass()
-        depth = 0
-        while solution is None and time.time() < deadline:
-            if self.rounds is not None and depth >= self.rounds:
-                break
-            before = sum(len(v) for v in bank.values())
-            snapshot = {k: list(v) for k, v in bank.items()}
+
+        def step(snapshot: dict[str, list[Term]]) -> None:
+            nonlocal solution
             for comps in builders.values():
                 for comp in comps:
                     if time.time() >= deadline:
@@ -364,9 +350,8 @@ class AFTASynthesizer(Synthesizer):
             solution = cegar_pass()
             # created = candidate terms banked; assessed = candidates validated.
             ui.progress(sum(len(v) for v in bank.values()), len(tried), time.time() - start)
-            depth += 1
-            if sum(len(v) for v in bank.values()) == before:
-                break
+
+        depth = deepen(bank, deadline, self.rounds, lambda: solution is not None, step)
 
         if solution is not None:
             ui.register(solution, [0.0], time.time() - start, True)

--- a/aeon/synthesis/modules/bottom_up.py
+++ b/aeon/synthesis/modules/bottom_up.py
@@ -1,0 +1,175 @@
+"""Shared bottom-up skeleton for the tree-automata synthesis backends.
+
+The ``fta``, ``afta`` and ``cata`` backends all build candidate programs
+bottom-up over an in-scope component bank: round 0 seeds nullary leaves, and
+each later round applies every component-transition to the bank grown so far,
+deepening the programs by one operator. They share four genuinely-identical
+pieces, collected here so the three backends stop copy-pasting them:
+
+* ``Component`` -- a ranked transition label (a head ``Term`` plus the base-type
+  keys of its arguments and result), generic enough to carry a plain ``Var``
+  head (fta/afta) or a type-applied / monomorphised head (cata, and fta's
+  polymorphic operators);
+* ``combos`` -- the product-or-sample enumeration of a transition's
+  applications over the bank (full product when small, else a bounded random
+  sample), parameterised by the term builder so each backend keeps its own node
+  construction;
+* ``deepen`` -- the round-deepening loop's bookkeeping (snapshot the bank, run
+  the per-round step, stop on success / deadline / depth cap / bank fixpoint);
+* ``safe`` / ``term_size`` / ``freeze`` -- the validate-with-guard, size measure
+  and hashable-output helpers.
+
+What is *not* unified: component collection (``_collect``) stays per-backend --
+the signatures and instantiation policies genuinely differ (fta monomorphises
+operators itself at the goal type, afta skips polymorphic bindings entirely, and
+cata monomorphises via the ``lta`` universe). Forcing those together would
+change which components each search sees.
+"""
+
+from __future__ import annotations
+
+import itertools
+import random
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol, TypeVar
+
+from aeon.core.terms import Application, Term
+from aeon.synthesis.modules.symetric.synthesizer import _decompose
+
+
+class _HasArgKeys(Protocol):
+    @property
+    def arg_keys(self) -> tuple[str, ...]: ...
+
+
+C = TypeVar("C", bound=_HasArgKeys)
+
+
+@dataclass(frozen=True)
+class Component:
+    """A ranked transition ``head(q1, ..., qk) -> q`` of the tree automaton: a
+    head term -- ``Var(f)`` for a monomorphic binding, or a ``TypeApplication``
+    nest for a polymorphic operator instantiated at concrete types -- with the
+    base-type keys of its arguments and result.
+
+    ``is_if`` marks the conditional builder ``If(cond, then, else)``, whose
+    construction the backends supply themselves (the head is then unused)."""
+
+    head: Term
+    arg_keys: tuple[str, ...]
+    ret_key: str
+    is_if: bool = False
+    # Backend-specific extras carried alongside the transition (e.g. fta tags
+    # each component with the concrete argument types it was instantiated at);
+    # never inspected here, only by the owning backend.
+    extra: Any = field(default=None, compare=False)
+
+
+def application(head: Term, args: tuple[Term, ...]) -> Term:
+    """Left-fold ``head`` over ``args`` into a curried application."""
+    term = head
+    for a in args:
+        term = Application(term, a)
+    return term
+
+
+def combos(
+    comp: C,
+    bank: dict[str, list[Term]],
+    deadline: float,
+    rnd: random.Random,
+    combo_cap: int,
+    build: Callable[[C, tuple[Term, ...]], Term],
+    *,
+    pool_for: Callable[[int, str, list[Term]], list[Term]] | None = None,
+    cap_for: Callable[[C, int], int] | None = None,
+) -> list[Term]:
+    """Transitions ``comp(q1, ..., qk) -> q``: build ``comp`` over arguments
+    drawn from the current bank (one pool per argument key). Enumerate the full
+    product when it fits within the cap, else draw ``cap`` random samples of it.
+
+    ``build`` turns a chosen argument tuple into a term -- the only backend
+    variation in the common case. ``pool_for`` may restrict / reorder a pool by
+    argument position (fta's then/else branch cap); ``cap_for`` may raise the cap
+    for a given transition (fta enumerates the bounded conditional fully)."""
+    pools: list[list[Term]] = []
+    for idx, ak in enumerate(comp.arg_keys):
+        pool = bank.get(ak, [])
+        if not pool:
+            return []
+        if pool_for is not None:
+            pool = pool_for(idx, ak, pool)
+        pools.append(pool)
+    total = 1
+    for p in pools:
+        total *= len(p)
+    cap = cap_for(comp, total) if cap_for is not None else combo_cap
+
+    out: list[Term] = []
+    if total <= cap:
+        for choice in itertools.product(*pools):
+            if time.time() >= deadline:
+                break
+            out.append(build(comp, choice))
+    else:
+        for _ in range(cap):
+            out.append(build(comp, tuple(rnd.choice(p) for p in pools)))
+    return out
+
+
+def deepen(
+    bank: dict[str, list[Term]],
+    deadline: float,
+    rounds: int | None,
+    found: Callable[[], bool],
+    step: Callable[[dict[str, list[Term]]], None],
+) -> int:
+    """Run the round-deepening loop over ``bank`` and return the depth reached.
+
+    Each round snapshots the bank, runs ``step`` (the backend's per-round growth
+    over that snapshot), and stops when a solution is found, the deadline passes,
+    the explicit ``rounds`` depth cap is hit, or the bank reaches a fixpoint (a
+    full round adds no new terms). ``step`` mutates ``bank`` in place and is the
+    only backend-specific part; ``found`` reports whether a solution now exists.
+
+    Mirrors the bottom-up bound shared by fta/afta/cata: depth is governed by the
+    time budget, not a fixed round count, so the search reaches the smallest
+    programs first and only deepens while shallower depths are dry."""
+    depth = 0
+    while not found() and time.time() < deadline:
+        if rounds is not None and depth >= rounds:
+            break
+        before = sum(len(v) for v in bank.values())
+        snapshot = {k: list(v) for k, v in bank.items()}
+        step(snapshot)
+        depth += 1
+        if sum(len(v) for v in bank.values()) == before:
+            break
+    return depth
+
+
+def term_size(term: Term) -> int:
+    """Node count of a term -- the size measure minimised during extraction."""
+    _head, args = _decompose(term)
+    return 1 + sum(term_size(a) for a in args)
+
+
+def freeze(v: object) -> Any:
+    """A hashable, order-stable view of a candidate's output, so that equal
+    outputs map to the same automaton state regardless of container type."""
+    if isinstance(v, (list, tuple)):
+        return tuple(freeze(x) for x in v)
+    if isinstance(v, (set, frozenset)):
+        return frozenset(freeze(x) for x in v)
+    if isinstance(v, dict):
+        return tuple(sorted((k, freeze(x)) for k, x in v.items()))
+    return v
+
+
+def safe(validate: Callable[[Term], bool], term: Term) -> bool:
+    """Run ``validate`` on ``term``, treating any exception as rejection."""
+    try:
+        return validate(term)
+    except Exception:
+        return False

--- a/aeon/synthesis/modules/cata/synthesizer.py
+++ b/aeon/synthesis/modules/cata/synthesizer.py
@@ -60,10 +60,8 @@ Selected with ``--synthesizer cata``.
 
 from __future__ import annotations
 
-import itertools
 import random
 import time
-from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from loguru import logger
@@ -78,7 +76,14 @@ from aeon.core.types import (
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
-from aeon.synthesis.modules.fta.synthesizer import _safe, _term_size
+from aeon.synthesis.modules.bottom_up import (
+    Component,
+    application,
+    combos,
+    deepen,
+    safe as _safe,
+    term_size as _term_size,
+)
 from aeon.synthesis.modules.lta.polymorphism import (
     collect_type_universe,
     is_polymorphic,
@@ -93,17 +98,11 @@ from aeon.utils.name import Name
 _loc = SynthesizedLocation("cata")
 
 
-@dataclass(frozen=True)
-class Comp:
-    """A component (constraint-annotated transition's label): a head term --
-    ``Var(f)`` for a monomorphic binding or a ``TypeApplication`` nest for an
-    instantiated polymorphic one -- with the base-type keys of its arguments and
-    result. Unlike the first-order ``Component`` shared by ``fta``/``afta``, the
-    head is a full ``Term`` so monomorphised (type-applied) operators qualify."""
-
-    head: Term
-    arg_keys: tuple[str, ...]
-    ret_key: str
+# A CATA component (constraint-annotated transition's label) is the shared
+# bottom-up ``Component``: a head term -- ``Var(f)`` for a monomorphic binding,
+# or a ``TypeApplication`` nest for a monomorphised (type-applied) operator --
+# with the base-type keys of its arguments and result.
+Comp = Component
 
 
 class CATASynthesizer(Synthesizer):
@@ -179,31 +178,14 @@ class CATASynthesizer(Synthesizer):
     def _app_combos(self, comp: Comp, bank: dict[str, list[Term]], deadline: float, rnd: random.Random) -> list[Term]:
         """Application transitions ``comp(q1, ..., qk) -> q``: applications of
         ``comp`` whose arguments are drawn from the current bank per type."""
-        pools: list[list[Term]] = []
-        for ak in comp.arg_keys:
-            pool = bank.get(ak, [])
-            if not pool:
-                return []
-            pools.append(pool)
-        total = 1
-        for p in pools:
-            total *= len(p)
-        out: list[Term] = []
-        if total <= self.combo_cap:
-            for choice in itertools.product(*pools):
-                if time.time() >= deadline:
-                    break
-                term: Term = comp.head
-                for a in choice:
-                    term = Application(term, a)
-                out.append(term)
-        else:
-            for _ in range(self.combo_cap):
-                term = comp.head
-                for p in pools:
-                    term = Application(term, rnd.choice(p))
-                out.append(term)
-        return out
+        return combos(
+            comp,
+            bank,
+            deadline,
+            rnd,
+            self.combo_cap,
+            lambda c, choice: application(c.head, choice),
+        )
 
     def _cond_combos(
         self, bool_pool: list[Term], goal_pool: list[Term], deadline: float, rnd: random.Random
@@ -313,12 +295,7 @@ class CATASynthesizer(Synthesizer):
         # number of rounds: keep deepening until a state is accepted, the budget
         # runs out, or the bank reaches a fixpoint (a full round adds no new
         # terms). ``self.rounds``, when set, caps the depth explicitly.
-        depth = 0
-        while best is None and time.time() < deadline:
-            if self.rounds is not None and depth >= self.rounds:
-                break
-            before = sum(len(v) for v in bank.values())
-            snapshot = {k: list(v) for k, v in bank.items()}
+        def step(snapshot: dict[str, list[Term]]) -> None:
             for comps in builders.values():
                 for comp in comps:
                     if best is not None or time.time() >= deadline:
@@ -330,9 +307,8 @@ class CATASynthesizer(Synthesizer):
                 add_bank(goal_key, conds)
             # created = candidate terms banked; assessed = candidates discharged.
             ui.progress(sum(len(v) for v in bank.values()), validated_count, time.time() - start)
-            depth += 1
-            if sum(len(v) for v in bank.values()) == before:
-                break
+
+        depth = deepen(bank, deadline, self.rounds, lambda: best is not None, step)
 
         if best is not None:
             shape = []

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -38,7 +38,6 @@ Selected with ``--synthesizer fta``.
 
 from __future__ import annotations
 
-import itertools
 import random
 import time
 from typing import Any, Callable, Optional
@@ -52,7 +51,6 @@ from dataclasses import dataclass, field
 
 from aeon.core.terms import (
     Abstraction,
-    Application,
     If,
     Let,
     Literal,
@@ -74,8 +72,15 @@ from aeon.core.types import (
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.modules.bottom_up import (
+    application,
+    combos,
+    deepen,
+    freeze as _freeze,
+    safe as _safe,
+    term_size as _term_size,
+)
 from aeon.synthesis.modules.symetric.synthesizer import (
-    _decompose,
     _peel,
     base_key,
 )
@@ -198,43 +203,27 @@ class FTASynthesizer(Synthesizer):
         """Transitions ``comp(q1, ..., qk) -> q``: applications of ``comp`` whose
         arguments are drawn from the current bank (per argument type). Enumerates
         the full product when small, else samples ``combo_cap`` of it."""
-        pools: list[list[Term]] = []
-        for idx, ak in enumerate(comp.arg_keys):
-            pool = bank.get(ak, [])
-            if not pool:
-                return []
+
+        def pool_for(idx: int, _ak: str, pool: list[Term]) -> list[Term]:
             if comp.is_if and idx >= 1:
                 # then/else: only the smallest representatives, so the product
                 # stays bounded and is enumerated exhaustively (below).
-                pool = sorted(pool, key=_term_size)[: self.if_branch_cap]
-            pools.append(pool)
-        total = 1
-        for p in pools:
-            total *= len(p)
-        # The conditional's space is already bounded by the branch cap, so
-        # enumerate it fully rather than sampling.
-        cap = max(self.combo_cap, total) if comp.is_if else self.combo_cap
+                return sorted(pool, key=_term_size)[: self.if_branch_cap]
+            return pool
 
-        def build(choice: tuple[Term, ...]) -> Term:
+        def cap_for(c: _MonoComponent, total: int) -> int:
+            # The conditional's space is already bounded by the branch cap, so
+            # enumerate it fully rather than sampling.
+            return max(self.combo_cap, total) if c.is_if else self.combo_cap
+
+        def build(c: _MonoComponent, choice: tuple[Term, ...]) -> Term:
             # If(cond, then, else) for the conditional builder; otherwise an
             # application of the (possibly type-applied) component to its args.
-            if comp.is_if:
+            if c.is_if:
                 return If(choice[0], choice[1], choice[2])
-            term = self._head(comp)
-            for a in choice:
-                term = Application(term, a)
-            return term
+            return application(self._head(c), choice)
 
-        out: list[Term] = []
-        if total <= cap:
-            for choice in itertools.product(*pools):
-                if time.time() >= deadline:
-                    break
-                out.append(build(choice))
-        else:
-            for _ in range(cap):
-                out.append(build(tuple(rnd.choice(p) for p in pools)))
-        return out
+        return combos(comp, bank, deadline, rnd, self.combo_cap, build, pool_for=pool_for, cap_for=cap_for)
 
     # -- entry point ----------------------------------------------------------
 
@@ -452,12 +441,8 @@ class FTASynthesizer(Synthesizer):
         # found (bottom-up construction reaches the smallest programs first), the
         # budget runs out, or the bank reaches a fixpoint (a full round adds no
         # new terms). ``self.rounds``, when set, caps the depth explicitly.
-        depth = 0
-        while best is None and time.time() < deadline:
-            if self.rounds is not None and depth >= self.rounds:
-                break
-            before = sum(len(v) for v in bank.values())
-            snapshot = {k: list(v) for k, v in bank.items()}
+        def step(snapshot: dict[str, list[Term]]) -> None:
+            nonlocal transitions
             for comps in builders.values():
                 for comp in comps:
                     if best is not None or time.time() >= deadline:
@@ -468,9 +453,8 @@ class FTASynthesizer(Synthesizer):
             # Report counts after each round: transitions are the candidates
             # generated; the validated goal states are those assessed.
             ui.progress(transitions, len(validated), time.time() - start)
-            depth += 1
-            if sum(len(v) for v in bank.values()) == before:
-                break
+
+        depth = deepen(bank, deadline, self.rounds, lambda: best is not None, step)
 
         states = len(rep)
         if best is not None:
@@ -489,31 +473,8 @@ class FTASynthesizer(Synthesizer):
 
 
 # -- free helpers ------------------------------------------------------------
-
-
-def _term_size(term: Term) -> int:
-    """Node count of a term -- the size measure minimised during extraction."""
-    _head, args = _decompose(term)
-    return 1 + sum(_term_size(a) for a in args)
-
-
-def _freeze(v: object) -> Any:
-    """A hashable, order-stable view of a candidate's output, so that equal
-    outputs map to the same automaton state regardless of container type."""
-    if isinstance(v, (list, tuple)):
-        return tuple(_freeze(x) for x in v)
-    if isinstance(v, (set, frozenset)):
-        return frozenset(_freeze(x) for x in v)
-    if isinstance(v, dict):
-        return tuple(sorted((k, _freeze(x)) for k, x in v.items()))
-    return v
-
-
-def _safe(validate: Callable[[Term], bool], term: Term) -> bool:
-    try:
-        return validate(term)
-    except Exception:
-        return False
+# ``_term_size``, ``_freeze`` and ``_safe`` are imported from ``bottom_up`` and
+# re-exported here for the modules (afta/pbe, contata) that import them from fta.
 
 
 def _close(o: object, e: object) -> bool:


### PR DESCRIPTION
## What

The `fta`, `afta` and `cata` synthesis backends each carried a near-identical, copy-pasted bottom-up core under parallel names (`_MonoComponent`/`Component`/`Comp`, `_combos`/`_app_combos`, the round-deepening loop, and `_safe`/`_term_size`/`_freeze`). This extracts the genuinely-shared pieces into a new `aeon/synthesis/modules/bottom_up.py` and has each backend adopt them.

## Unified (in `bottom_up.py`)

- **`combos`** — the product-or-sample enumeration of a transition's applications over the bank (full product when it fits the cap, else a bounded random sample). Parameterised by a term-builder callback, plus optional `pool_for`/`cap_for` hooks that `fta` uses for its conditional builder. Replaces the three near-identical `_combos`/`_app_combos` bodies.
- **`deepen`** — the round-deepening loop's bookkeeping: snapshot the bank, run a backend-supplied per-round `step`, and stop on success / deadline / explicit depth cap / bank fixpoint. Replaces the three identical `while ... time.time() < deadline` loops.
- **`safe` / `term_size` / `freeze`** — the validate-with-guard, size measure, and hashable-output helpers (previously defined in `fta` and imported by the others). `fta` re-exports them as `_safe`/`_term_size`/`_freeze` so `afta/pbe.py` and `contata` keep resolving their existing imports.
- **`Component`** dataclass (head + arg keys + ret key) — adopted by `cata` (`Comp` is now an alias). `fta` keeps `_MonoComponent` (carries `name`/`type_apps`/`is_if` for its own head construction) and `afta` keeps `symetric.Component`; both pass through the generic `combos`.

## Deliberately left per-backend

**Component collection (`_collect`).** The three signatures and instantiation policies genuinely differ — `fta` monomorphises operators itself at the goal type, `afta` skips polymorphic bindings entirely, `cata` monomorphises via the `lta` type universe (and takes a `universe` argument). Forcing these together would change which components each search sees, so they stay separate. `cata`'s `_cond_combos` (a deterministic smallest-first enumerator, not the product/sample logic) also stays local.

## Behavior preservation

The candidate enumeration order, sampling caps, RNG consumption (`rnd.choice` call order), `itertools.product` iteration, deadline checks, depth bookkeeping and syntactic/observational dedup keys are all unchanged — the shared helpers mirror the originals line-for-line, only hoisting the duplicated structure and parameterising the few real differences.

## Validation

- **`uv run pytest -q`: `1686 passed, 14 skipped`, 0 failed, 0 errors** (17:54). The tree-automata test files (`fta_test`, `afta_test`, `afta_pbe_test`, `cata_test`, `contata_test`) were re-run green (34 passed) after the final `cata` `Component` adoption.
- Pre-commit (mypy + ruff + ruff format) passes; no new mypy errors introduced.
- ~78 net lines removed from the three backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)