### PR TITLE
refactor(lsp): narrow scope of holes in _parse

### DIFF
--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -166,8 +166,6 @@ async def _parse(
         # non-empty, as long as the program reached core generation).
         _refresh_analysis(driver, uri)
 
-        holes = find_holes_in_source(content)
-
         for error in errors:
             error_message = str(error)
             error_position = error.position()
@@ -190,6 +188,7 @@ async def _parse(
             )
 
         if not errors:
+            holes = find_holes_in_source(content)
             return ParseResult(diagnostics, holes)
 
     except UnexpectedToken as e:


### PR DESCRIPTION
`find_holes_in_source(content)` was computed at the top of the `try` block in `_parse`, but its only reader is the `return ParseResult(diagnostics, holes)` inside the `if not errors:` branch — every other return path passes `[]`.

Moving the call into that branch tightens the variable's scope to where it is actually used, and as a side benefit skips the hole scan entirely on the parse-error path.

Behavior-preserving: `content` is unchanged between the two locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)