### PR TITLE
refactor(backend): inline single-use name_str in eval

### DIFF
--- a/aeon/backend/evaluator.py
+++ b/aeon/backend/evaluator.py
@@ -167,10 +167,9 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
         case Rec(var_name, _, var_value, body, _, _):
             found_llvm = False
             if ctx.pipeline and ctx.metadata:
-                name_str = var_name.name
                 for k, v in ctx.metadata.items():
                     k_name = k.name if isinstance(k, Name) else str(k)
-                    if k_name == name_str and v.get("llvm"):
+                    if k_name == var_name.name and v.get("llvm"):
                         found_llvm = True
                         break
 


### PR DESCRIPTION
In the `Rec` case of `eval`, `name_str = var_name.name` was assigned at the top of the `if ctx.pipeline and ctx.metadata:` block but its only read was inside the `for k, v in ctx.metadata.items()` loop.

Since `var_name` is loop-invariant, the comparison now uses `var_name.name` directly, removing the intermediate and tightening its live range to the single expression that needs it.

Behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)