### PR TITLE
refactor(typechecking): narrow scope of outer_binders

### DIFF
--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -561,9 +561,9 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
             ctx_inner = ctx
             for bn, bt in fun_binders:
                 ctx_inner = ctx_inner.with_var(bn, bt)
-            outer_binders: tuple[tuple[Name, Type], ...] = fun_binders
             match ty:
                 case AbstractionType(aname, atype, rtype):
+                    outer_binders: tuple[tuple[Name, Type], ...] = fun_binders
                     cp = check(ctx_inner, arg, atype)
                     # Abstractions can't be synthesised on their own (no
                     # annotation), and Var/Literal liquefy directly. In all


### PR DESCRIPTION
In the application case of `synth`, `outer_binders` was initialized to `fun_binders` before the `match ty:` block, but every read of it (the two `outer_binders = outer_binders + ...` updates and the final `with_binders(outer_binders, t_subs)` return) lives inside `case AbstractionType(...)`. The only other arm (`case _`) raises `CoreInvalidApplicationError`.

Moving the initialization into the `AbstractionType` arm tightens its scope to where it's actually used, without changing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)