### PR TITLE
refactor(verification): collapse single-use temporaries in solve

### DIFF
--- a/aeon/verification/horn.py
+++ b/aeon/verification/horn.py
@@ -585,8 +585,6 @@ def solve(
     def merge(acc: Constraint, pi: Constraint) -> Constraint:
         return Conjunction(acc, pi)
 
-    merged_csps: Constraint
     seed: Constraint = LiquidConstraint(LiquidLiteralBool(True))
     merged_csps = reduce(merge, csp, seed)
-    c_final: Constraint = apply(subst, merged_csps)
-    return smt_valid(c_final)
+    return smt_valid(apply(subst, merged_csps))


### PR DESCRIPTION
In `solve`, `merged_csps` was forward-declared (`merged_csps: Constraint`) and then assigned on the next line, and `c_final` was a single-use temporary read only by the `return`. Both are inlined.

`seed` keeps its explicit `Constraint` annotation — `reduce` needs it to widen the accumulator type (dropping it makes mypy infer the seed as `LiquidConstraint`).

Net: three statements become two, with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)