### PR TITLE
docs(examples): refinement-types talk sequence for the LLM world

### DIFF
--- a/examples/llm_talk/1_types_are_not_enough.ae
+++ b/examples/llm_talk/1_types_are_not_enough.ae
@@ -1,0 +1,19 @@
+# ============================================================
+# 1. THE PROBLEM:  ordinary types are too coarse
+# ============================================================
+#
+# An LLM writes this `max`. It type-checks in any mainstream language and in
+# Aeon too: two Ints in, one Int out. The signature is *true* and *useless* —
+# `Int -> Int -> Int` says nothing about which Int comes out.
+#
+# The body is BUGGY: the else branch returns `a`, never `b`. So `max 2 9` is 9?
+# No — it returns 2. A wrong answer, fully well-typed, ships silently.
+#
+# This is the gap LLM-generated code lives in: plausible, well-typed, wrong.
+# A classical type checker has no vocabulary to express "the result is the
+# larger of the two", so it cannot notice the bug.
+
+def max (a:Int) (b:Int) : Int :=
+    if a > b then a else a;     # bug: the else branch should return `b`
+
+def main (_:Int) : Unit := print (max 2 9)   # prints 2, not 9 — and types are happy

--- a/examples/llm_talk/2_refinements.ae
+++ b/examples/llm_talk/2_refinements.ae
@@ -1,0 +1,27 @@
+# ============================================================
+# 2. THE IDEA:  refinement types = types that carry a logical claim
+# ============================================================
+#
+# A refinement type is `{ x : Base | predicate }` — "a Base, but only those
+# values for which the predicate holds". The predicate is ordinary logic the
+# compiler hands to an SMT solver (Z3) to discharge.
+#
+# Watch a real precondition appear. This `average` divides by `count`. In Aeon
+# the `/` operator is ITSELF refined: its divisor must be provably non-zero.
+# So the naive `count : Int` version below does NOT compile —
+#
+#     def average (total:Int) (count:Int) : Int := total / count;
+#         >>> Failed to prove  (count != 0)
+#
+# The fix is to state the precondition in the type. Now `count` is not just an
+# Int; it is an Int that CANNOT be zero, and the division is justified.
+
+def average (total:Int) (count:{x:Int | x != 0}) : Int := total / count;
+
+# This call is fine: 2 satisfies (x != 0), proved before the program runs.
+def main (_:Int) : Unit := print (average 10 2)
+
+# Change the call to `average 10 0` and re-run. No test executes; the compiler
+# refuses up front with a proof obligation it cannot discharge:
+#     Failed to prove  (0 == 0) ===> (0 != 0)
+# The division-by-zero is impossible by construction, not caught at runtime.

--- a/examples/llm_talk/3_specs_as_types.ae
+++ b/examples/llm_talk/3_specs_as_types.ae
@@ -1,0 +1,25 @@
+# ============================================================
+# 3. THE POWER:  the return type becomes a machine-checked spec
+# ============================================================
+#
+# Refinements aren't only preconditions on inputs. A refinement on the RESULT
+# is a postcondition — a specification the implementation must satisfy. The
+# checker proves the body lives up to its advertised type, for ALL inputs.
+#
+# `abs` claims to return a non-negative number AND one with the same magnitude.
+# Z3 checks both branches against that claim. If the body were `x` (forgetting
+# the negation), the proof would fail — the spec catches the bug.
+
+def abs (x:Int) : {y:Int | y >= 0 && (y = x || y = 0 - x)} :=
+    if x >= 0 then x else 0 - x;
+
+# A non-trivial proof: with non-negative weights, a ReLU layer is MONOTONE.
+# The dependent type on `xp` carries the hypothesis (xp >= x); the result type
+# carries the conclusion (output difference >= 0). No NN test suite — a proof.
+def relu (x:Float) : {y:Float | y >= 0.0 && y >= x && (y = x || y = 0.0)} :=
+    if x >= 0.0 then x else 0.0;
+
+def monotone (x:Float) (xp:{v:Float | v >= x}) : {d:Float | d >= 0.0} :=
+    relu (2.0 * xp + 1.0) - relu (2.0 * x + 1.0);
+
+def main (_:Int) : Unit := print (monotone 1.0 3.0)

--- a/examples/llm_talk/4_limitations.ae
+++ b/examples/llm_talk/4_limitations.ae
@@ -1,0 +1,29 @@
+# ============================================================
+# 4. THE LIMITS:  a refinement only checks what you actually wrote
+# ============================================================
+#
+# Refinements are not magic. Two honest boundaries to put on a slide:
+#
+# (A) THE SPEC IS ONLY AS STRONG AS YOU MAKE IT.
+#     This `max` is BUGGY — the else branch returns `a`, never `b`. Yet it
+#     type-checks, because the postcondition `r >= a` is too weak: returning
+#     `a` always satisfies it. A weak refinement rubber-stamps wrong code,
+#     exactly the failure mode of an LLM that writes its own loose spec.
+def max_weak (a:Int) (b:Int) : {r:Int | r >= a} :=
+    if a > b then a else a;   # bug: should be `b`
+
+# Strengthen the type — "the result is >= both AND is one of them" — and the
+# SAME buggy body is now rejected. The proof obligation (a >= b) when a <= b
+# is unprovable. The lesson: writing the right specification is the hard part;
+# the solver only enforces it.
+#   def max (a:Int) (b:Int) : {r:Int | r >= a && r >= b && (r = a || r = b)} :=
+#       if a > b then a else a;     # <-- uncomment: TYPE ERROR
+
+# (B) THE LOGIC IS DECIDABLE, SO IT IS A FRAGMENT.
+#     Predicates live in a decidable theory (linear/some nonlinear integer &
+#     real arithmetic, booleans, equality) that Z3 can decide. You cannot drop
+#     an arbitrary recursive or higher-order function into a refinement and
+#     expect a decision. Push too far and the solver times out or gives up —
+#     even when the claim is true. Expressiveness is traded for automation.
+
+def main (_:Int) : Unit := print (max_weak 2 9)   # prints 2 — the bug, well-typed

--- a/examples/llm_talk/5_robotics_rospec.ae
+++ b/examples/llm_talk/5_robotics_rospec.ae
@@ -1,0 +1,47 @@
+# ============================================================
+# 5. IN THE WILD (robotics):  refinements as a robot-safety contract
+# ============================================================
+#
+# Adapted from ROSpec [Canelas, Schmerl, Fonseca & Timperley, OOPSLA 2025], a
+# DSL that puts liquid types on ROS component configurations. The paper's
+# motivating bug (Fig. 1): a driver PUBLISHES colour (RGB) images while the
+# detector SUBSCRIBES expecting GRAYSCALE — a silent misconfiguration that
+# strips the robot's ability to avoid obstacles. Below, the type system makes
+# these robot-safety properties checkable, the way ROSpec does for ROS.
+
+# (a) PARAMETER BOUND.  ROSpec Listing 1:  max_acceleration: double where {_ >= 0}.
+#     A negative acceleration limit would let the joint start moving BACKWARD
+#     while performing an operation. The refinement forbids it at config time.
+def scale_accel (a:{x:Float | x >= 0.0}) (gain:{g:Float | g >= 0.0}) : {r:Float | r >= 0.0} :=
+    a * gain;
+
+# (b) ACTUATOR SAFETY.  A commanded velocity must stay within the robot's
+#     rated envelope. The RESULT type proves every output lands in [-vmax, vmax]
+#     — the motor can never be handed an out-of-range command.
+def clamp_velocity (vmax:{m:Float | m > 0.0}) (v:Float) : {r:Float | 0.0 - vmax <= r && r <= vmax} :=
+    if v > vmax then vmax
+    else if v < 0.0 - vmax then 0.0 - vmax
+    else v;
+
+# (c) PRECONDITION (collision avoidance).  Forward motion is only well-typed
+#     when the measured clearance exceeds the safety margin. The Fig. 1 detector
+#     exists precisely to supply this `clearance`; here the type DEMANDS it.
+def safety_margin : {m:Float | m = 0.5} := 0.5;
+def move_forward (clearance:{d:Float | d > safety_margin}) (v:{x:Float | x > 0.0}) : Unit :=
+    print "advancing";
+
+# (d) INTEGRATION (the Fig. 1 bug itself).  A publisher/subscriber link is only
+#     well-typed when image encodings agree. grayscale = 1 channel, rgb = 3.
+#     `connect 3 1` (publish RGB, expect grayscale) is a TYPE ERROR — the exact
+#     misconfiguration ROSpec was built to catch, caught before deployment.
+def connect_image (pub_channels:Int) (sub_channels:{c:Int | c = pub_channels}) : Unit :=
+    print "topics linked";
+
+def main (_:Int) : Unit :=
+    let _ := move_forward 1.2 0.3 in         # 1.2m clearance > 0.5m margin, forward 0.3: OK
+    let _ := connect_image 1 1 in            # grayscale ↔ grayscale: OK
+    let _ := print (scale_accel 2.0 3.0) in  # non-negative accel: 6.0
+    print (clamp_velocity 1.0 5.0)           # 5.0 clamped to the 1.0 limit -> 1.0
+
+# Try `connect_image 3 1` (RGB publisher, grayscale subscriber) or drop the
+# clearance to `move_forward 0.3 v` — both are rejected at compile time.

--- a/examples/llm_talk/6_ml_pipeline.ae
+++ b/examples/llm_talk/6_ml_pipeline.ae
@@ -1,0 +1,45 @@
+# ============================================================
+# 6. IN THE WILD (ML pipelines):  refinements as data contracts
+# ============================================================
+#
+# ML pipelines fail silently: an unnormalized feature, a probability that isn't
+# one, a train/test split that leaks. None of these are type errors in NumPy —
+# they are wrong numbers that flow downstream and quietly wreck a model.
+# Refinements turn each pipeline invariant into a checked contract between stages.
+
+# (a) FEATURE SCALING.  Min-max normalization must land in [0, 1]. The input
+#     refinement says the raw value is within [lo, hi]; the result refinement is
+#     the post-condition every downstream layer relies on. Proven, not asserted.
+def normalize (lo:Float) (hi:{h:Float | h > lo}) (x:{v:Float | lo <= v && v <= hi}) : {y:Float | 0.0 <= y && y <= 1.0} :=
+    (x - lo) / (hi - lo);
+
+# (b) PROBABILITIES STAY PROBABILITIES.  A model head emits values that must be
+#     in [0, 1]. Combining two independent probabilities multiplies them — and
+#     the checker PROVES the product is still a valid probability (nonlinear:
+#     0<=p<=1 and 0<=q<=1 imply 0<=p*q<=1). Invariants survive composition.
+def joint_prob (p:{x:Float | 0.0 <= x && x <= 1.0}) (q:{y:Float | 0.0 <= y && y <= 1.0}) : {r:Float | 0.0 <= r && r <= 1.0} :=
+    p * q;
+
+# (c) HYPERPARAMETER PRECONDITION.  A learning rate outside (0, 1) silently
+#     diverges or freezes training. The contract lives in the type of the
+#     argument, so `step 1.5 ...` or `step 0.0 ...` never type-checks.
+def step (lr:{r:Float | r > 0.0 && r < 1.0}) (grad:Float) (w:Float) : Float :=
+    w - lr * grad;
+
+# (d) NO DATA LEAKAGE.  A train/test split must be disjoint and exhaustive:
+#     train + test = n, both non-empty. The result type pins `test = n - train`,
+#     so an overlapping or oversized split (e.g. train = n) is a TYPE ERROR —
+#     the classic leakage bug caught structurally instead of by a corrupted score.
+def test_size (n:{x:Int | x > 0}) (train:{t:Int | t > 0 && t < n}) : {test:Int | test > 0 && test = n - train} :=
+    n - train;
+
+def main (_:Int) : Unit :=
+    let _ := print (normalize 0.0 255.0 128.0) in    # pixel 128/255 -> ~0.50
+    let _ := print (joint_prob 0.5 0.5) in           # 0.25, still a probability
+    let _ := print (step 0.1 2.0 1.0) in             # one valid SGD step -> 0.8
+    print (test_size 100 80)                         # 80 train -> 20 test, no leak
+
+# Break any contract and the pipeline refuses to compile:
+#   normalize 0.0 255.0 300.0   (feature out of declared range)
+#   step 1.5 2.0 1.0            (learning rate >= 1)
+#   test_size 100 100          (train = n: empty test set / leakage)

--- a/examples/llm_talk/7_synthesis.ae
+++ b/examples/llm_talk/7_synthesis.ae
@@ -1,0 +1,26 @@
+# ============================================================
+# 7. THE FLIP:  if the type is a spec, the compiler can write the code
+# ============================================================
+#
+# A refinement type says WHAT, not HOW. Once the "what" is precise enough, the
+# "how" can be searched for automatically. We replace the body with a hole `?`
+# and let synthesis fill it so that the refinement is satisfied.
+#
+# `?hole` here must be an Int that is > 100, < 110, and divisible by 7.
+# There is exactly one such value, and the SMT-backed search finds it: 105.
+#   uv run python -m aeon -s synquid examples/llm_talk/7_synthesis.ae
+
+def secret : {v:Int | v > 100 && v < 110 && v % 7 = 0} := ?hole;
+
+# Synthesis also writes FUNCTION bodies from a refined signature. The type
+# `{j:Int | j = i + i}` fully pins the behaviour, and the search returns `i + i`
+# — no examples, no tests, just the specification.
+def dbl (i:Int) : {j:Int | j = i + i} := ?body;
+
+def main (_:Int) : Unit := print (dbl secret)
+
+# This is program synthesis driven by types. The same machinery that REJECTED
+# wrong code in examples 2-6 now GENERATES correct code: verification run
+# backwards. Note the asymmetry with an LLM — synthesis here cannot be wrong.
+# Anything it returns provably meets the spec, because it had to pass the
+# checker to be returned at all.

--- a/examples/llm_talk/8_llm_plus_refinements.ae
+++ b/examples/llm_talk/8_llm_plus_refinements.ae
@@ -1,0 +1,44 @@
+# ============================================================
+# 8. THE SYNTHESIS:  LLM proposes, refinement type disposes
+# ============================================================
+#
+# This is the thesis of the talk. An LLM is a fast, fluent, UNSOUND generator:
+# it produces plausible code, sometimes wrong. A refinement type is a slow,
+# precise, SOUND judge: it accepts only code proven to meet the spec.
+#
+# Put them together. The `@prompt` decorator feeds a natural-language intent to
+# an LLM; the refinement type is the contract the LLM's answer MUST satisfy.
+#
+#   uv run python -m aeon -s llm examples/llm_talk/8_llm_plus_refinements.ae
+#
+# The LLM is asked: "an HTTP error code for 'not found', plus 200". It might
+# answer 404, 604, "not_found", or nonsense. The refinement `v >= 100 && v <= 599`
+# rejects everything outside the valid HTTP range BEFORE it ever runs.
+
+@prompt("HTTP Error code for not found, plus 200")
+def http_code : {v:Int | v >= 100 && v <= 599} := ?hole;
+
+def main (_:Int) : Unit := print http_code
+
+# ------------------------------------------------------------------------
+# Why this is the right architecture for the LLM world:
+#
+#   aeon/synthesis/modules/llm/__init__.py  line 93:
+#
+#       if validate(core_tterm):       # <-- the type system is the gate
+#           ...return it...
+#       else:
+#           ...reject, raise temperature, ask the LLM again...
+#
+# The LLM never gets the last word. Every candidate it emits is parsed and run
+# through the SAME refinement-type checker from examples 2-4. Hallucinations
+# are filtered structurally, not hoped away. Generation gets the LLM's speed
+# and breadth; correctness gets the type system's guarantees.
+#
+#   refinements        = the machine-checkable contract / prompt
+#   verification       = reject the LLM's wrong answers (soundness)
+#   synthesis          = let the proposer (search OR LLM) fill the hole
+#
+# Types stop being documentation. In the LLM world they become the interface
+# between what we can say we want and what a stochastic model gives us.
+# ------------------------------------------------------------------------

--- a/examples/llm_talk/README.md
+++ b/examples/llm_talk/README.md
@@ -1,0 +1,70 @@
+# Programming Languages in the LLM World — a worked sequence
+
+An eight-step arc on refinement types: what they are, where they stop, how they
+look in real domains, and why they are the right substrate for trustworthy
+LLM-generated code. Each `.ae` file runs on its own; the comments inside carry
+the talking points.
+
+Run any example:
+
+```bash
+uv run python -m aeon examples/llm_talk/<file>.ae
+```
+
+| # | File | Beat | What to show live |
+|---|------|------|-------------------|
+| 1 | `1_types_are_not_enough.ae` | **Problem.** Ordinary types are too coarse. | Runs, prints `2` — a *wrong* `max`, fully well-typed. The bug an LLM ships. |
+| 2 | `2_refinements.ae` | **Idea.** `{x:Base \| pred}` puts logic in the type. | Runs (`5.0`). Aeon refines `/` for free; edit the call to `average 10 0` → compile-time rejection, no test run. |
+| 3 | `3_specs_as_types.ae` | **Power.** A return refinement is a machine-checked spec. | `abs` and a *proof* that a ReLU layer is monotone — verification, not a test suite. |
+| 4 | `4_limitations.ae` | **Limits.** A refinement only checks what you wrote. | A weak spec rubber-stamps the buggy `max` from step 1; uncomment the strong spec → rejected. Plus: the logic is a decidable fragment. |
+| 5 | `5_robotics_rospec.ae` | **In the wild: robotics.** Refinements as a robot-safety contract. | Non-negative joint accel, velocity clamp, collision-avoidance precondition, and the ROSpec Fig. 1 grayscale-vs-RGB bug — `connect_image 3 1` is a type error. |
+| 6 | `6_ml_pipeline.ae` | **In the wild: ML.** Refinements as data contracts. | Min-max normalization proven in [0,1], probabilities that stay probabilities, a bounded learning rate, and a no-leakage train/test split (`test_size 100 100` rejected). |
+| 7 | `7_synthesis.ae` | **Flip.** If the type is the spec, search writes the body. | `?hole` filled to `105`, `?body` filled to `i + i`, from the types alone. |
+| 8 | `8_llm_plus_refinements.ae` | **Thesis.** LLM proposes, refinement type disposes. | `@prompt` + a refinement: the LLM is the generator, the type checker is the gate. |
+
+Steps 5 and 6 are the "this is not a toy" interlude: the same `{x | pred}`
+machinery, now expressing real robot-safety and ML-pipeline invariants, right
+before the talk flips from *checking* to *generating*.
+
+## The robotics step (5)
+
+Adapted from **ROSpec** — *A Domain-Specific Language for ROS-Based Robot
+Software*, Canelas, Schmerl, Fonseca & Timperley, OOPSLA 2025
+([10.1145/3763169](https://doi.org/10.1145/3763169)) — which puts liquid types
+on ROS component configurations. The paper's motivating misconfiguration (Fig.
+1) is a publisher sending RGB images to a subscriber that expects grayscale;
+step 5 reconstructs that bug as a type error, alongside the paper's
+`max_acceleration where {_ >= 0}` parameter bound.
+
+## The synthesis steps (7 & 8)
+
+```bash
+# Type-driven synthesis — deterministic, SMT-backed. Fills the holes with 105 and i+i.
+uv run python -m aeon -s synquid examples/llm_talk/7_synthesis.ae
+
+# LLM-driven synthesis — needs a local ollama model (qwen2.5:32b). The refinement
+# is the contract every LLM candidate must pass before it is accepted.
+uv run python -m aeon -s llm examples/llm_talk/8_llm_plus_refinements.ae
+```
+
+## The one-slide takeaway
+
+```
+refinements   = a machine-checkable contract  (the "what")
+verification  = reject wrong code, including the LLM's   (soundness)
+synthesis     = let a proposer — search OR an LLM — fill the hole
+```
+
+The architecture is in `aeon/synthesis/modules/llm/__init__.py:93`:
+
+```python
+if validate(core_tterm):     # every LLM candidate runs through the SAME
+    ...return it...          # refinement-type checker from steps 2–6
+else:
+    ...reject, ask again...  # hallucinations filtered structurally
+```
+
+The LLM never gets the last word. Generation gets the model's speed and
+breadth; correctness gets the type system's guarantees. In the LLM world,
+types stop being documentation and become the interface between what we can
+say we want and what a stochastic model gives us.


### PR DESCRIPTION
A self-contained, eight-step example sequence in `examples/llm_talk/` for a presentation on **programming languages in the LLM world** — introducing refinement types, their limitations, and their power for verification and synthesis. Every example runs from a clean checkout, and each "watch it break" demo in the comments reproduces.

## The arc

| # | File | Beat |
|---|------|------|
| 1 | `1_types_are_not_enough.ae` | Ordinary types are too coarse — a well-typed but wrong `max` |
| 2 | `2_refinements.ae` | `{x:Base \| pred}` puts logic in the type (Aeon refines `/` for free) |
| 3 | `3_specs_as_types.ae` | Return refinements as machine-checked specs (`abs`, ReLU monotonicity proof) |
| 4 | `4_limitations.ae` | The honest limits: weak specs rubber-stamp bugs; the logic is a decidable fragment |
| 5 | `5_robotics_rospec.ae` | **Robotics** — refinements as a robot-safety contract, adapted from ROSpec |
| 6 | `6_ml_pipeline.ae` | **ML pipelines** — refinements as data contracts |
| 7 | `7_synthesis.ae` | Flip: types as the search target (`?hole → 105`, `?body → i + i`) |
| 8 | `8_llm_plus_refinements.ae` | Thesis: LLM proposes, refinement type disposes (`@prompt` + the `validate()` gate) |

Steps 5–6 are the "this is not a toy" interlude before the talk flips from *checking* to *generating*.

- **Robotics (5)** is adapted from **ROSpec** — *A Domain-Specific Language for ROS-Based Robot Software*, Canelas, Schmerl, Fonseca & Timperley, OOPSLA 2025 ([10.1145/3763169](https://doi.org/10.1145/3763169)). It reconstructs the paper's Fig. 1 misconfiguration (an RGB publisher feeding a grayscale subscriber) as a type error, alongside the paper's `max_acceleration where {_ >= 0}` parameter bound, a velocity clamp, and a collision-avoidance precondition.
- **ML (6)** covers min-max normalization proven in `[0,1]`, probabilities that stay probabilities under composition, a bounded learning rate, and a no-leakage train/test split.

## Running

```bash
uv run python -m aeon examples/llm_talk/1_types_are_not_enough.ae      # ... through 6
uv run python -m aeon -s synquid examples/llm_talk/7_synthesis.ae      # fills 105 and i+i
uv run python -m aeon -s llm     examples/llm_talk/8_llm_plus_refinements.ae   # needs local ollama
```

See `examples/llm_talk/README.md` for the per-slide table and the live-demo cues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)