### PR TITLE
test(synthesis): cover smt, llm, and the 1p1/hc strategies

### DIFF
--- a/tests/ge_strategies_test.py
+++ b/tests/ge_strategies_test.py
@@ -1,0 +1,49 @@
+"""Functional coverage for the (1+1)-ES (``1p1``) and hill-climbing (``hc``)
+search strategies.
+
+Both reuse ``GESynthesizer`` -- the engine that ``gp``/``enumerative``/
+``random_search`` already exercise end-to-end -- so the rest of the suite only
+smoke-constructs them (``synthesizer_seed_test``). These confirm the factory
+wires each strategy and that each actually synthesizes a well-typed term for a
+basic-typed hole.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.core.terms import Term
+from aeon.core.types import top, t_bool, t_int
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.grammar.ge_synthesis import GESynthesizer
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+from aeon.typechecking.typeinfer import check_type
+
+from tests.driver import check_and_return_core
+
+STRATEGIES = [("1p1", "one_plus_one"), ("hc", "hill_climbing")]
+TYPES = [("Int", t_int), ("Bool", t_bool)]
+
+
+def _synthesize(code: str, method: str, budget: float = 2.0):
+    term, ctx, ectx, metadata = check_and_return_core(code)
+    assert check_type(ctx, term, top)
+    targets = incomplete_functions_and_holes(ctx, term)
+    holes = synthesize_holes(ctx, ectx, term, targets, metadata, GESynthesizer(method=method), budget=budget)
+    return holes[next(iter(holes))], ctx
+
+
+@pytest.mark.parametrize("backend_id,method", STRATEGIES)
+def test_factory_registers_strategy(backend_id, method):
+    synth = make_synthesizer(backend_id)
+    assert isinstance(synth, GESynthesizer)
+    assert synth.method == method
+
+
+@pytest.mark.parametrize("backend_id,method", STRATEGIES)
+@pytest.mark.parametrize("type_name,ty", TYPES)
+def test_synthesizes_basic_typed_hole(backend_id, method, type_name, ty):
+    t, ctx = _synthesize(f"def s : {type_name} := ?hole;", method)
+    assert isinstance(t, Term)
+    assert check_type(ctx, t, ty)

--- a/tests/llm_synthesizer_test.py
+++ b/tests/llm_synthesizer_test.py
@@ -1,0 +1,67 @@
+"""Tests for the LLM (Ollama) synthesis backend (``-s llm``, ``LLMSynthesizer``).
+
+The backend prompts a local Ollama model, parses each response into an Aeon
+expression, and returns the first candidate that type-checks against the hole.
+The model call (``ollama.generate``) is the only external dependency, so it is
+mocked here -- the tests exercise the parse/validate/retry loop deterministically
+without contacting a server.
+"""
+
+from __future__ import annotations
+
+import types
+
+
+import aeon.synthesis.modules.llm as llm
+from aeon.core.terms import Literal
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.modules.llm import LLMSynthesizer
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+
+from tests.driver import check_and_return_core
+
+
+def _mock_generate(monkeypatch, responses):
+    """Patch ``ollama.generate`` to yield ``responses`` in order, counting calls."""
+    it = iter(responses)
+    calls = {"n": 0}
+
+    def fake(model=None, prompt=None, options=None):
+        calls["n"] += 1
+        return types.SimpleNamespace(response=next(it))
+
+    monkeypatch.setattr(llm, "generate", fake)
+    return calls
+
+
+def _solve(code: str, budget: float = 5.0):
+    term, ctx, ectx, metadata = check_and_return_core(code)
+    targets = incomplete_functions_and_holes(ctx, term)
+    holes = synthesize_holes(ctx, ectx, term, targets, metadata, LLMSynthesizer(), budget=budget)
+    return holes[next(iter(holes))]
+
+
+def test_factory_registers_llm():
+    assert isinstance(make_synthesizer("llm"), LLMSynthesizer)
+
+
+def test_synthesizes_mocked_candidate(monkeypatch):
+    calls = _mock_generate(monkeypatch, ["3"])
+    t = _solve("def n : {x:Int | x = 3} := ?hole;")
+    assert isinstance(t, Literal) and t.value == 3
+    assert calls["n"] == 1
+
+
+def test_synthesizes_plain_typed_hole(monkeypatch):
+    _mock_generate(monkeypatch, ["7"])
+    t = _solve("def n : Int := ?hole;")
+    assert isinstance(t, Literal) and t.value == 7
+
+
+def test_recovers_from_unparseable_response(monkeypatch):
+    # A malformed first response must not crash the loop; the next valid one wins.
+    calls = _mock_generate(monkeypatch, ["this is not aeon code !!!", "3"])
+    t = _solve("def n : {x:Int | x = 3} := ?hole;")
+    assert isinstance(t, Literal) and t.value == 3
+    assert calls["n"] == 2

--- a/tests/smt_synthesizer_test.py
+++ b/tests/smt_synthesizer_test.py
@@ -1,0 +1,54 @@
+"""Tests for the SMT-guided synthesis backend (``-s smt``, ``SMTSynthesizer``).
+
+The backend builds an expression tree top-down, encodes the refinement on an
+SMT base type (Int/Bool/Float) as z3 constraints, solves them, and substitutes
+the resulting literal. These cover that refinement-solving path. (The
+verification-layer z3 tests in ``smt_test``/``smt_sets_test`` exercise a
+different component and do not touch this synthesizer.)
+"""
+
+from __future__ import annotations
+
+from aeon.core.terms import Literal
+from aeon.synthesis.entrypoint import synthesize_holes
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.modules.smt_synthesizer import SMTSynthesizer
+from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
+
+from tests.driver import check_and_return_core
+
+
+def _solve(code: str, budget: float = 10.0):
+    term, ctx, ectx, metadata = check_and_return_core(code)
+    targets = incomplete_functions_and_holes(ctx, term)
+    holes = synthesize_holes(ctx, ectx, term, targets, metadata, SMTSynthesizer(), budget=budget)
+    return holes[next(iter(holes))]
+
+
+def test_factory_registers_smt():
+    assert isinstance(make_synthesizer("smt"), SMTSynthesizer)
+
+
+def test_solves_linear_refinement():
+    t = _solve("def n : {v:Int | v + 4 = 7} := ?hole;")
+    assert isinstance(t, Literal) and t.value == 3
+
+
+def test_solves_conjoined_refinement():
+    t = _solve("def m : {v:Int | v * 2 = 10 && v - 1 = 4} := ?hole;")
+    assert isinstance(t, Literal) and t.value == 5
+
+
+def test_solves_constant_int_refinement():
+    t = _solve("def k : {x:Int | x = 35} := ?hole;")
+    assert isinstance(t, Literal) and t.value == 35
+
+
+def test_solves_bool_refinement():
+    t = _solve("def b : {z:Bool | z = true} := ?hole;")
+    assert isinstance(t, Literal) and t.value is True
+
+
+def test_solves_float_refinement():
+    t = _solve("def p : {x:Float | x = 2.5} := ?hole;")
+    assert isinstance(t, Literal) and t.value == 2.5


### PR DESCRIPTION
## Why

A coverage audit of the synthesizer factory found three backends with no functional test:

- **`smt`** (`SMTSynthesizer`) — completely untested (`smt_test`/`smt_sets_test` cover the z3 *verification* layer, a different component).
- **`llm`** (`LLMSynthesizer`) — untested (external Ollama dependency).
- **`1p1` / `hc`** — only smoke-constructed in `synthesizer_seed_test`; never run a synthesis.

(Every other backend — gp, enumerative, random_search, genomic_ng, float_ng, ortools, synquid, decision_tree, sygus, tdsyn, tactics, lta, symetric, fta, afta, cata, contata — already has a dedicated functional test.)

## What

Three focused test files, all using the standard `synthesize_holes` + `check_and_return_core` harness:

- **`tests/smt_synthesizer_test.py`** — factory wiring + solving refinement holes on Int (`v+4=7`→3, `v*2=10 && v-1=4`→5, `x=35`), Bool (`z=true`), and Float (`x=2.5`). Scoped to the backend's actual capability (refinement-constrained base-type literals; it does not synthesize input-dependent terms).
- **`tests/llm_synthesizer_test.py`** — mocks `ollama.generate` (the only external call) so the parse/validate/**retry** loop runs deterministically with no server: a valid candidate is returned, and a malformed first response is recovered from on the next call.
- **`tests/ge_strategies_test.py`** — `1p1` and `hc` reuse `GESynthesizer` (already covered end-to-end via gp/enumerative/random_search), so this asserts the factory wires each to the right method and that each synthesizes a well-typed term for an `Int`/`Bool` hole.

## Verification

`uv run pytest tests/smt_synthesizer_test.py tests/ge_strategies_test.py tests/llm_synthesizer_test.py` → **16 passed**. Pre-commit (mypy + ruff) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)