### PR TITLE
fix: instantiate native return refinements per call site (#378)

### DIFF
--- a/aeon/typechecking/entailment.py
+++ b/aeon/typechecking/entailment.py
@@ -17,7 +17,7 @@ from aeon.typechecking.context import UninterpretedBinder
 from aeon.typechecking.context import VariableBinder
 from aeon.typechecking.qualifiers import extract_qualifier_atoms
 from aeon.verification.horn import solve
-from aeon.verification.sub import is_first_order_function, lower_constraint_type
+from aeon.verification.sub import is_first_order_function, lower_constraint_type_keep_refinements
 from aeon.verification.vcs import Constraint
 from aeon.verification.vcs import Implication
 from aeon.verification.vcs import ReflectedFunctionDeclaration
@@ -75,7 +75,10 @@ def entailment_context(ctx: TypingContext, c: Constraint) -> Constraint:
                 # call site. ``lower_constraint_type`` already strips
                 # ``TypePolymorphism`` / ``RefinementPolymorphism`` while
                 # keeping ``TypeVar`` in nested positions.
-                lowered = lower_constraint_type(type)
+                # Keep refinements (only polymorphism is stripped) so the
+                # declared return contract of a native/uninterpreted helper can
+                # be instantiated per call site at the SMT layer (issue #378).
+                lowered = lower_constraint_type_keep_refinements(type)
                 if isinstance(lowered, AbstractionType):
                     c = UninterpretedFunctionDeclaration(name, lowered, c)
             case ReflectedBinder(name, type, params, body):

--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -138,6 +138,36 @@ def _erase_return_refinement(ty: Type) -> Type:
     return ty
 
 
+_TRUSTED_NATIVE_HEADS = frozenset({"native", "native_import", "uninterpreted"})
+
+
+def _is_trusted_native_value(t: Term) -> bool:
+    """Whether a binding's value is a ``native``/``uninterpreted`` builtin.
+
+    Such a definition is *trusted*: its declared type is an axiom (no body is
+    checked), so the return refinement may be assumed at every call site
+    (issue #378). Peels the abstraction/annotation wrappers a def body carries,
+    then the application/type-application spine down to the head variable.
+    """
+    while True:
+        match t:
+            case Abstraction(_, body, _) | TypeAbstraction(_, _, body, _) | RefinementAbstraction(_, _, body, _):
+                t = body
+            case Annotation(expr, _, _):
+                t = expr
+            case _:
+                break
+    while True:
+        match t:
+            case Application(fun, _, _):
+                t = fun
+            case TypeApplication(body, _, _) | RefinementApplication(body, _, _):
+                t = body
+            case _:
+                break
+    return isinstance(t, Var) and t.name.name in _TRUSTED_NATIVE_HEADS
+
+
 def _reflected_impl_for(
     name: Name,
     ty: Type,
@@ -690,10 +720,17 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                 var_value,
                 has_termination_metric=has_metric,
             )
-            c1 = implication_constraint(var_name, var_type, c1, var_value.loc, reflected_impl=reflected_impl)
-            c2 = implication_constraint(var_name, var_type, c2, body.loc, reflected_impl=reflected_impl)
+            keep_refs = _is_trusted_native_value(var_value)
+            c1 = implication_constraint(
+                var_name, var_type, c1, var_value.loc, reflected_impl=reflected_impl, keep_refinements=keep_refs
+            )
+            c2 = implication_constraint(
+                var_name, var_type, c2, body.loc, reflected_impl=reflected_impl, keep_refinements=keep_refs
+            )
             term_c = termination_metric_constraints(t, term_ctx)
-            term_c = implication_constraint(var_name, var_type, term_c, var_value.loc, reflected_impl=reflected_impl)
+            term_c = implication_constraint(
+                var_name, var_type, term_c, var_value.loc, reflected_impl=reflected_impl, keep_refinements=keep_refs
+            )
             # Declare mutually-recursive siblings so calls to them inside this
             # member's value (e.g. selfified applications ``v == odd (n - 1)``)
             # translate. When the whole group is well-founded and a sibling's
@@ -706,7 +743,10 @@ def synth(ctx: TypingContext, t: Term) -> tuple[Constraint, Type]:
                     if (group_has_metric and comp.value is not None)
                     else None
                 )
-                c1 = implication_constraint(comp.name, comp.type, c1, var_value.loc, reflected_impl=comp_reflected)
+                comp_keep = comp.value is not None and _is_trusted_native_value(comp.value)
+                c1 = implication_constraint(
+                    comp.name, comp.type, c1, var_value.loc, reflected_impl=comp_reflected, keep_refinements=comp_keep
+                )
             # Form B introduction: if the body's type still mentions `var_name`,
             # wrap it in an existential so the scope leak is preserved as a
             # binder when the type flows outward.
@@ -1082,10 +1122,17 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
                 var_value,
                 has_termination_metric=has_metric,
             )
-            c1 = implication_constraint(var_name, t1, c1, var_value.loc, reflected_impl=reflected_impl)
-            c2 = implication_constraint(var_name, t1, c2, body.loc, reflected_impl=reflected_impl)
+            keep_refs = _is_trusted_native_value(var_value)
+            c1 = implication_constraint(
+                var_name, t1, c1, var_value.loc, reflected_impl=reflected_impl, keep_refinements=keep_refs
+            )
+            c2 = implication_constraint(
+                var_name, t1, c2, body.loc, reflected_impl=reflected_impl, keep_refinements=keep_refs
+            )
             term_c = termination_metric_constraints(t, term_ctx)
-            term_c = implication_constraint(var_name, t1, term_c, var_value.loc, reflected_impl=reflected_impl)
+            term_c = implication_constraint(
+                var_name, t1, term_c, var_value.loc, reflected_impl=reflected_impl, keep_refinements=keep_refs
+            )
             # Declare mutually-recursive siblings so calls to them inside this
             # member's value translate (selfified applications such as
             # ``v == odd (n - 1)``). Reflect a sibling's definition when the group
@@ -1097,7 +1144,10 @@ def check(ctx: TypingContext, t: Term, ty: Type) -> Constraint:
                     if (group_has_metric and comp.value is not None)
                     else None
                 )
-                c1 = implication_constraint(cname, ctype, c1, var_value.loc, reflected_impl=comp_reflected)
+                comp_keep = comp.value is not None and _is_trusted_native_value(comp.value)
+                c1 = implication_constraint(
+                    cname, ctype, c1, var_value.loc, reflected_impl=comp_reflected, keep_refinements=comp_keep
+                )
             return Conjunction(Conjunction(c1, c2), term_c)
         case If(cond, then, otherwise), _:
             y = Name("_cond", fresh_counter.fresh())

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -510,6 +510,126 @@ def _ctx_with_curried_formals(ctx: SMTContext, fun_ty: AbstractionType) -> SMTCo
     return out
 
 
+def _collect_liquid_apps(t: LiquidTerm, acc: list[LiquidApp]) -> None:
+    """Gather every ``LiquidApp`` node (including nested ones) in ``t``."""
+    if isinstance(t, LiquidApp):
+        acc.append(t)
+        for a in t.args:
+            _collect_liquid_apps(a, acc)
+
+
+def _refined_return_contract(app: LiquidApp, fun_ty: AbstractionType) -> LiquidTerm | None:
+    r"""Instantiate the declared return refinement of ``app.fun`` at this call site.
+
+    A declared function is encoded as a *bare uninterpreted* SMT symbol, so the
+    postcondition stated by its return refinement never reaches the solver — a
+    recursive call decreasing through a native helper (e.g. floor division,
+    issue #378) cannot be proven no matter how precisely the helper is
+    specified. Given ``f : (x1:T1) -> ... -> (xn:Tn) -> {r:B | post}`` and a call
+    ``f(a1, ..., an)``, this returns the call's contract
+
+    ``(pre1 /\ ... /\ pren) --> post[xi := ai, r := f(a1..an)]``
+
+    where ``prek`` is ``Tk``'s refinement opened at ``ak``. The guard keeps the
+    instantiation sound even where the precondition is not met: a native is
+    trusted only over its declared domain, and a verified definition's body was
+    only checked to satisfy ``post`` under its preconditions. Returns ``None``
+    when the return type is unrefined (no fact to add), the arity mismatches, or
+    the refinement is trivially ``true``.
+    """
+    formals: list[Name] = []
+    var_types: list[Type] = []
+    cur: Type = fun_ty
+    while isinstance(cur, AbstractionType):
+        formals.append(cur.var_name)
+        var_types.append(cur.var_type)
+        cur = cur.type
+    if not isinstance(cur, RefinedType) or len(formals) != len(app.args):
+        return None
+
+    def open_formals(liq: LiquidTerm) -> LiquidTerm:
+        for fname, arg in zip(formals, app.args):
+            liq = substitution_in_liquid(liq, arg, fname)
+        return liq
+
+    # Postcondition: bind the result variable to the application itself, then
+    # replace each formal with its actual argument.
+    post = open_formals(substitution_in_liquid(cur.refinement, app, cur.name))
+    # ``true`` adds nothing; ``false`` is the bottom contract of the polymorphic
+    # ``native``/``uninterpreted`` builtins (``{x:a | false}``) — assuming it
+    # would make every obligation vacuously provable, so never inject it.
+    if post == LiquidLiteralBool(True) or post == LiquidLiteralBool(False):
+        return None
+
+    # Preconditions: each refined parameter type, opened at its argument (earlier
+    # formals may appear in later types, so substitute them all).
+    pres: list[LiquidTerm] = []
+    for vt, arg in zip(var_types, app.args):
+        if isinstance(vt, RefinedType):
+            pre = open_formals(substitution_in_liquid(vt.refinement, arg, vt.name))
+            if pre != LiquidLiteralBool(True):
+                pres.append(pre)
+    if not pres:
+        return post
+    guard = pres[0]
+    for p in pres[1:]:
+        guard = mk_liquid_and(guard, p)
+    return LiquidApp(Name("-->", 0), [guard, post])
+
+
+def _contract_well_scoped(t: LiquidTerm, ctx: SMTContext) -> bool:
+    """Whether every symbol in ``t`` is declared at this SMT leaf.
+
+    A kept refinement may mention symbols not in scope at a given call site —
+    e.g. a refinement-polymorphism predicate bound where the function was
+    declared. Injecting such a contract would make ``translate`` fail on an
+    undeclared symbol. Operators (non-alphanumeric heads) are handled directly
+    by ``translate_liq``; any other applied head must be a declared function (or
+    a built-in), and every free variable must be a bound scalar.
+    """
+    if isinstance(t, LiquidVar):
+        return str(t.name) in ctx.variables
+    if isinstance(t, LiquidApp):
+        is_operator = all(not c.isalnum() and c != "_" for c in t.fun.name)
+        if not (is_operator or str(t.fun) in ctx.functions or t.fun.name in base_functions):
+            return False
+        return all(_contract_well_scoped(a, ctx) for a in t.args)
+    return True
+
+
+def _refined_return_contracts(expr: LiquidTerm, ctx: SMTContext) -> list[LiquidTerm]:
+    """Per-call-site return-refinement contracts for every declared function
+    applied in ``expr`` or in the accumulated premises (issue #378)."""
+    apps: list[LiquidApp] = []
+    _collect_liquid_apps(expr, apps)
+    for p in ctx.premises:
+        _collect_liquid_apps(p, apps)
+    contracts: list[LiquidTerm] = []
+    seen: set[str] = set()
+    for app in apps:
+        fname = str(app.fun)
+        # Reflected functions already contribute their body equation
+        # (``f(args) == body``). Assuming their declared postcondition on top of
+        # it is circular: while checking ``f``'s own body against that postcondition
+        # the two combine into a contradiction (issue #378 regression). The
+        # postcondition is only an axiom for *uninterpreted* (native/trusted)
+        # symbols, whose body the solver never sees.
+        if fname in ctx.reflected_functions:
+            continue
+        fun_ty = ctx.functions.get(fname)
+        if not isinstance(fun_ty, AbstractionType):
+            continue
+        contract = _refined_return_contract(app, fun_ty)
+        if contract is None or not _contract_well_scoped(contract, ctx):
+            continue
+        key = repr(contract)
+        if key in seen:
+            continue
+        seen.add(key)
+        contracts.append(contract)
+    return contracts
+
+
 @dataclass(init=False)
 class CanonicConstraint:
     """Represents SMT-valid constraints."""
@@ -565,7 +685,11 @@ def flatten(c: Constraint, ctx: SMTContext | None = None) -> Generator[CanonicCo
             nfunctions = ctx.functions
             nref = ctx.reflected_functions
             sprem: list[LiquidTerm] = []
-            for p in ctx.premises:
+            # Each declared function applied here contributes its return-refinement
+            # contract as an extra hypothesis, so postconditions of native/
+            # uninterpreted helpers reach the obligation that mentions them (#378).
+            premises_in = ctx.premises + _refined_return_contracts(expr, ctx)
+            for p in premises_in:
                 sp, nfunctions, nref = _specialize_liquid_term(p, nfunctions, ctx.variables, nref, specializations)
                 sprem.append(sp)
             sexpr, nfunctions, nref = _specialize_liquid_term(expr, nfunctions, ctx.variables, nref, specializations)

--- a/aeon/verification/sub.py
+++ b/aeon/verification/sub.py
@@ -94,6 +94,43 @@ def lower_constraint_type(ttype: Type) -> Type:
             assert False, f"Unsupport type in constraint {ttype} ({type(ttype)})"
 
 
+def lower_constraint_type_keep_refinements(ttype: Type) -> Type:
+    """Like :func:`lower_constraint_type`, but preserves argument/return
+    refinements while still stripping polymorphism and lowering bases.
+
+    The SMT layer encodes a declared function as a bare uninterpreted symbol,
+    so to instantiate its return-refinement contract per call site (issue #378)
+    the refinement must survive into ``SMTContext.functions``. ``RefinedType``
+    wrappers in function signatures are already tolerated there: regular
+    first-order ``VariableBinder`` functions keep theirs (see
+    ``entailment_context``), and the specialisation/sort machinery lowers each
+    base anew where it needs one.
+    """
+    match ttype:
+        case TypeVar(name):
+            return TypeConstructor(name)
+        case Top():
+            return t_unit
+        case AbstractionType(name, b, r):
+            return AbstractionType(
+                name,
+                lower_constraint_type_keep_refinements(b),
+                lower_constraint_type_keep_refinements(r),
+            )
+        case TypePolymorphism(_, _, body):
+            return lower_constraint_type_keep_refinements(body)
+        case RefinementPolymorphism(_, _, body):
+            return lower_constraint_type_keep_refinements(body)
+        case RefinedType(name, t, ref):
+            inner = lower_constraint_type_keep_refinements(t)
+            assert isinstance(inner, (TypeConstructor, TypeVar))
+            return RefinedType(name, inner, ref)
+        case TypeConstructor(name, args):
+            return TypeConstructor(name, [lower_constraint_type_keep_refinements(a) for a in args])
+        case _:
+            assert False, f"Unsupport type in constraint {ttype} ({type(ttype)})"
+
+
 def _has_concrete_base_result(ty: Type) -> bool:
     """True when peeling all ``forall`` binders and value arrows lands on a
     concrete base type (a ``TypeConstructor``, possibly refined). Polymorphic
@@ -116,7 +153,15 @@ def implication_constraint(
     c: Constraint,
     loc: Location | None = None,
     reflected_impl: tuple[tuple[Name, ...], LiquidTerm] | None = None,
+    keep_refinements: bool = False,
 ) -> Constraint:
+    # ``keep_refinements`` preserves a function's argument/return refinements in
+    # its uninterpreted declaration so its contract can be instantiated per call
+    # site at the SMT layer (issue #378). It is set only for *trusted*
+    # native/uninterpreted bindings, whose contract is an axiom; a regular
+    # function's body is verified separately, so assuming its own postcondition
+    # while checking (or synthesising) that body would be circular.
+    lower = lower_constraint_type_keep_refinements if keep_refinements else lower_constraint_type
     match ty:
         case Top() | TypeVar(_) | TypeConstructor(_, _):
             basety = lower_constraint_type(ty)
@@ -129,7 +174,7 @@ def implication_constraint(
             return Implication(name, ltype, ref_subs, c, loc=loc)
         case AbstractionType(_, _, _):
             if is_first_order_function(ty):
-                absty = lower_constraint_type(ty)
+                absty = lower(ty)
                 assert isinstance(absty, AbstractionType)
                 if reflected_impl is not None:
                     (params, body) = reflected_impl
@@ -138,7 +183,7 @@ def implication_constraint(
             else:
                 return c
         case TypePolymorphism(_, _, _) | RefinementPolymorphism(_, _, _):
-            lowered = lower_constraint_type(ty)
+            lowered = lower(ty)
             if not isinstance(lowered, AbstractionType):
                 # Higher-order or otherwise non-first-order polymorphic
                 # types stay opaque — no constraint contribution.

--- a/tests/native_refinement_recursion_test.py
+++ b/tests/native_refinement_recursion_test.py
@@ -1,0 +1,144 @@
+"""Recursion through a refined `native` helper (issue #378).
+
+A declared function is encoded as a bare uninterpreted SMT symbol, so the
+postcondition stated by its return refinement never reached the obligation that
+mentions it. A recursive function whose decreasing argument flows through a
+native helper (e.g. floor division) could therefore not be verified, however
+precisely the helper was specified. The fix instantiates the return-refinement
+contract of a *trusted* (`native`/`uninterpreted`) function at each of its
+applications.
+
+The trust is what keeps it sound: the contract is an axiom only for a binding
+whose body is never checked. A regular function's postcondition is *proven*, so
+assuming it while checking that very function would be circular — pinned by the
+negative cases below.
+"""
+
+from __future__ import annotations
+
+from aeon.core.bind import bind_ids
+from aeon.core.types import top
+from aeon.elaboration import elaborate
+from aeon.sugar.ast_helpers import st_top
+from aeon.sugar.bind import bind, bind_program
+from aeon.sugar.desugar import DesugaredProgram, desugar
+from aeon.sugar.lowering import lower_to_core, lower_to_core_context
+from aeon.sugar.parser import parse_main_program
+from aeon.typechecking.typeinfer import check_type_errors
+
+
+def _typechecks(src: str) -> bool:
+    """Run the full front-to-typecheck pipeline; True iff no type errors."""
+    prog = parse_main_program(src, filename="<test>")
+    prog = bind_program(prog, [])
+    desugared = desugar(prog, is_main_hole=True)
+    ctx, progt = bind(desugared.elabcontext, desugared.program)
+    desugared = DesugaredProgram(
+        progt, ctx, desugared.metadata, desugared.constructor_to_type, desugared.constructor_defs
+    )
+    sterm = elaborate(desugared.elabcontext, desugared.program, st_top)
+    typing_ctx = lower_to_core_context(desugared.elabcontext)
+    core_ast = lower_to_core(sterm)
+    typing_ctx, core_ast = bind_ids(typing_ctx, core_ast)
+    errors = list(check_type_errors(typing_ctx, core_ast, top))
+    return errors == []
+
+
+# ---------------------------------------------------------------------------
+# Positive: a precisely specified native helper makes the recursion verifiable.
+# ---------------------------------------------------------------------------
+
+
+def test_refined_native_enables_termination_direct_arg():
+    # The decreasing argument flows directly through the native helper:
+    # `count (fdiv n 10)`. `fdiv`'s return refinement supplies exactly the facts
+    # the auto-inferred metric (`n`) needs: `fdiv n 10 < n` (since n != 0) and
+    # `fdiv n 10 >= 0`.
+    src = """
+        def fdiv (i:{v:Int | v >= 0}) (j:{v:Int | v >= 2}) : {r:Int | r >= 0 && (i = 0 || r < i)} := native "i // j";
+        def count (n : {v:Int | v >= 0}) : Int :=
+            if n = 0 then 0 else 1 + count (fdiv n 10);
+        def main (x:Int) : Int := count 100
+    """
+    assert _typechecks(src)
+
+
+def test_refined_native_enables_termination_let_bound():
+    # The same fact must reach the obligation when the result is let-bound and
+    # the recursion is on the binder.
+    src = """
+        def fdiv (i:{v:Int | v >= 0}) (j:{v:Int | v >= 2}) : {r:Int | r >= 0 && (i = 0 || r < i)} := native "i // j";
+        def count (n : {v:Int | v >= 0}) : Int :=
+            if n = 0 then 0 else (floor := fdiv n 10; 1 + count floor);
+        def main (x:Int) : Int := count 100
+    """
+    assert _typechecks(src)
+
+
+def test_refined_native_postcondition_reaches_argument_subtyping():
+    # The postcondition must also discharge an argument-refinement subtyping
+    # check, not only a termination obligation.
+    src = """
+        def fdiv (i:{v:Int | v >= 0}) (j:{v:Int | v >= 2}) : {r:Int | r >= 0 && (i = 0 || r < i)} := native "i // j";
+        def needs_nat (m : {v:Int | v >= 0}) : Int := m;
+        def test (n : {v:Int | v >= 0}) : Int := needs_nat (fdiv n 10);
+        def main (x:Int) : Int := test 5
+    """
+    assert _typechecks(src)
+
+
+def test_uninterpreted_axiom_instantiation_reaches_subtyping():
+    # The ghost-axiom idiom (issue #378, manifestation 2): an `axiom`-declared
+    # fact instantiated at the call site flows into the argument check.
+    src = """
+        def fdiv : (i:Int) -> (j:Int) -> Int := uninterpreted;
+        axiom fdiv_bounds : (i: Int) -> (j: Int) ->
+            {u: Unit | (i >= 0 && j >= 2) --> (fdiv i j >= 0 && (i = 0 || fdiv i j < i))} ;
+        def needs_nat (m : {v:Int | v >= 0}) : Int := m;
+        def test (n : {v:Int | v >= 0}) : Int :=
+            b := fdiv_bounds n 10;
+            needs_nat (fdiv n 10);
+        def main (x:Int) : Int := test 5
+    """
+    assert _typechecks(src)
+
+
+# ---------------------------------------------------------------------------
+# Negative: soundness must be preserved. A native too weakly specified to imply
+# the decrease, and the circularity that trust-gating exists to prevent.
+# ---------------------------------------------------------------------------
+
+
+def test_unspecified_native_does_not_terminate():
+    # No useful return refinement: nothing implies `fdiv n 10 < n`, so the
+    # termination obligation must remain unprovable.
+    src = """
+        def fdiv (i:Int) (j:Int) : Int := native "i // j";
+        def count (n : {v:Int | v >= 0}) : Int :=
+            if n = 0 then 0 else 1 + count (fdiv n 10);
+        def main (x:Int) : Int := count 100
+    """
+    assert not _typechecks(src)
+
+
+def test_native_refinement_too_weak_for_decrease():
+    # `r >= 0` alone does not imply `r < i`: the decrease still fails.
+    src = """
+        def fdiv (i:{v:Int | v >= 0}) (j:{v:Int | v >= 2}) : {r:Int | r >= 0} := native "i // j";
+        def count (n : {v:Int | v >= 0}) : Int :=
+            if n = 0 then 0 else 1 + count (fdiv n 10);
+        def main (x:Int) : Int := count 100
+    """
+    assert not _typechecks(src)
+
+
+def test_regular_function_postcondition_not_assumed_circularly():
+    # `x` does not satisfy `{v:Int | v > x}`. A regular function is NOT trusted:
+    # its own postcondition must not be assumed while checking its body (which
+    # would make `x > x` vacuously provable). Contrast with a native, whose
+    # contract is axiomatic.
+    src = """
+        def succ (x:Int) : {v:Int | v > x} := x;
+        def main (a:Int) : Int := succ 3
+    """
+    assert not _typechecks(src)


### PR DESCRIPTION
Closes the last gap of #378, after #379 landed options 2 and 3.

## The problem

A declared function is encoded as a **bare uninterpreted SMT symbol**, so the postcondition stated by its return refinement never reached the obligation that mentions it. A recursive function whose decreasing argument flows through a native helper could not be verified, however precisely the helper was specified:

```aeon
def fdiv (i:{v:Int | v >= 0}) (j:{v:Int | v >= 2}) : {r:Int | r >= 0 && (i = 0 || r < i)} := native "i // j";
def count (n : {v:Int | v >= 0}) : Int :=
    if n = 0 then 0 else 1 + count (fdiv n 10);   -- termination obligation was unprovable
```

The auto-inferred metric `n` produced `((n >= 0) && !(n == 0)) --> ((fdiv(n,10) < n) && (fdiv(n,10) >= 0))`, with `fdiv` an uninterpreted symbol carrying no facts.

## The fix (option 1)

At each application of a **trusted** (`native`/`uninterpreted`) function `f : (x1:T1) -> ... -> {r:B | post}`, inject the call's contract as an SMT hypothesis:

```
(pre1 && ... && pren) --> post[xi := ai, r := f(a1..an)]
```

(`_refined_return_contracts` in `verification/smt.py`). The precondition guard keeps it sound even where the helper's domain is not met.

## Why it's sound

Trust is the crux of the change — the contract is an axiom **only** for a binding whose body is never checked:

- **Only native/uninterpreted bindings keep their refinements** down to the SMT layer (`keep_refinements` on `implication_constraint`, driven by `_is_trusted_native_value`; `UninterpretedBinder` in `entailment_context`). A regular function's body is verified separately, so assuming its own postcondition while checking — or synthesising — that body would be circular.
- **Reflected functions are excluded:** their body equation `f(args) == body` combined with an assumed postcondition is contradictory.
- **Out-of-scope contracts are skipped:** a kept refinement mentioning a predicate not declared at the leaf can never reach Z3.

## Tests

`tests/native_refinement_recursion_test.py`:
- ✅ refined-native recursion (direct argument and let-bound), axiom instantiation into argument subtyping
- ❌ negatives pinning soundness: an unspecified / too-weak native still fails its termination obligation; a regular function's postcondition (`def succ (x:Int) : {v:Int | v > x} := x`) is never assumed circularly

Full suite: **1693 passed, 14 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)