### PR TITLE
feat(verification): surface SMT counterexamples on refinement failures (#439)

### DIFF
--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -169,7 +169,27 @@ class LiquidTypeCheckingFailedRelation(CoreTypeCheckingError):
     loc: Location | None = None
 
     def __str__(self) -> str:
-        return f"Failed to prove ({pretty_print_constraint(self.vc)}) in {self.position()}"
+        base = f"Failed to prove ({pretty_print_constraint(self.vc)}) in {self.position()}"
+        cex = self.counterexample()
+        if cex is not None:
+            base += f"\n    counterexample: {cex}"
+        return base
+
+    def counterexample(self) -> str | None:
+        """A concrete assignment that falsifies this verification condition,
+        rendered as ``name = value, ...`` (issue #439). Computed lazily and
+        memoised; ``None`` when no concrete witness is available."""
+        cached = getattr(self, "_counterexample", "unset")
+        if cached != "unset":
+            return cached
+        try:
+            from aeon.verification.smt import render_counterexample
+
+            value = render_counterexample(self.vc)
+        except Exception:
+            value = None
+        self._counterexample = value
+        return value
 
     def position(self) -> Location:
         return self.loc if self.loc is not None else self.term.loc

--- a/aeon/verification/smt.py
+++ b/aeon/verification/smt.py
@@ -793,6 +793,55 @@ def smt_valid(constraint: Constraint) -> bool:
     return True
 
 
+# Superscript digits encode binder ids in variable names (e.g. ``x¹¹``); strip
+# them so a counterexample reads source-like.
+_STRIP_SUPERSCRIPTS = str.maketrans("", "", "⁰¹²³⁴⁵⁶⁷⁸⁹")
+
+
+def model_for_invalid(constraint: Constraint) -> list[tuple[str, str]] | None:
+    """When ``constraint`` is *invalid*, return a witnessing counterexample as
+    a list of ``(variable, value)`` pairs from Z3's model for the first
+    falsifiable conjunct. Returns ``None`` if the constraint is actually valid
+    or no concrete model is available (issue #439).
+
+    Used only to enrich an already-emitted failure message, so re-solving here
+    is off the hot path."""
+    translate_memo: dict[int, tuple[LiquidTerm, Any]] = {}
+    for c in flatten(constraint):
+        s.push()
+        try:
+            try:
+                smt_c = translate(c, translate_memo)
+            except ZeroDivisionError:
+                continue
+            if smt_c is False:
+                continue
+            s.add(smt_c)
+            if s.check() == sat:
+                model = s.model()
+                # Arity-0 declarations are the free constants standing for the
+                # VC's universally-quantified binders — i.e. the inputs that
+                # falsify it. Function interpretations are not shown.
+                return [(d.name(), str(model[d])) for d in model.decls() if d.arity() == 0]
+        finally:
+            s.pop()
+    return None
+
+
+def render_counterexample(constraint: Constraint, limit: int = 8) -> str | None:
+    """Render the counterexample for an invalid ``constraint`` as a compact
+    ``name = value, ...`` string (binder ids stripped), or ``None`` when no
+    concrete witness is available."""
+    pairs = model_for_invalid(constraint)
+    if not pairs:
+        return None
+    shown = sorted((name.translate(_STRIP_SUPERSCRIPTS), value) for name, value in pairs)
+    body = ", ".join(f"{name} = {value}" for name, value in shown[:limit])
+    if len(shown) > limit:
+        body += ", …"
+    return body or None
+
+
 def type_of_variable(variables: list[tuple[str, Any]], name: str) -> Any:
     for na, ref in reversed(variables):
         if na == name:

--- a/tests/counterexample_test.py
+++ b/tests/counterexample_test.py
@@ -81,3 +81,80 @@ def test_render_counterexample_consistent_with_validity():
     # The stored VC is genuinely invalid, and the renderer produces a witness.
     assert not smt_valid(err.vc)
     assert render_counterexample(err.vc) is not None
+
+
+def test_counterexample_with_uninterpreted_function():
+    """Counterexamples display values for base-type inputs even when
+    uninterpreted functions are involved.
+
+    The uninterpreted function itself won't have a concrete interpretation
+    in the model, but base-type variables will have concrete values."""
+    src = """
+def my_measure: (x:Int) -> Int := uninterpreted;
+
+def claim_positive (n:{v:Int | v >= 0}) : {r:Int | r >= 0} :=
+    n - 10;
+"""
+    err = _liquid_failure(src)
+    cex = err.counterexample()
+    # This should produce a counterexample because n - 10 is not always >= 0
+    # when n >= 0 (e.g., n=5 gives -5)
+    assert cex is not None
+    assert "n =" in cex
+    # The counterexample should show a small non-negative value for n
+    pairs = model_for_invalid(err.vc)
+    assert pairs is not None
+    values = dict(pairs)
+    n_key = next(k for k in values if k.startswith("n"))
+    n_val = int(values[n_key])
+    # n should be >= 0 (the precondition) but n - 10 < 0, so 0 <= n < 10
+    assert 0 <= n_val < 10
+
+
+def test_counterexample_with_polymorphic_uninterpreted():
+    """Counterexamples with polymorphic uninterpreted functions on base types."""
+    src = """
+def my_len : forall a:B, (x: a) -> Int := uninterpreted
+
+def bad_double (n: {v:Int | v >= 0}) : {r: Int | r >= n + 10} :=
+    n + n ;
+"""
+    err = _liquid_failure(src)
+    cex = err.counterexample()
+    assert cex is not None
+    assert "counterexample:" in str(err)
+    # Should show the value of n that makes the postcondition false
+    assert "n =" in cex
+    # n should be small (0-9) since n + n < n + 10 when n < 10
+    pairs = model_for_invalid(err.vc)
+    assert pairs is not None
+    values = dict(pairs)
+    n_key = next((k for k in values if "n" in k.lower()), None)
+    if n_key:
+        n_val = int(values[n_key])
+        assert 0 <= n_val < 10
+
+
+def test_counterexample_with_custom_sort_constructor():
+    """Custom sort values may appear as opaque witnesses in counterexamples.
+
+    When Z3 needs to produce a counterexample involving custom sorts, it
+    creates opaque witness values. The counterexample shows both base-type
+    values (Int, Float, etc.) and these opaque sort values."""
+    src = """
+type Tree;
+def tree_make : Tree := native "None";
+
+def bad_check (n:{v:Int | v >= 0}) : {r:Int | r >= n + 5} :=
+    n;
+"""
+    err = _liquid_failure(src)
+    cex = err.counterexample()
+    # This should produce a counterexample because n >= n + 5 is false
+    assert cex is not None
+    assert "n =" in cex
+    pairs = model_for_invalid(err.vc)
+    assert pairs is not None
+    # n should be a concrete Int value
+    values = dict(pairs)
+    assert any("n" in k.lower() for k in values)

--- a/tests/counterexample_test.py
+++ b/tests/counterexample_test.py
@@ -1,0 +1,83 @@
+"""Counterexamples on refinement failures (issue #439).
+
+When a verification condition is invalid, Z3 has a model witnessing the
+failure. These tests check that the model is surfaced as a concrete,
+source-level ``name = value`` counterexample on the error (used by both the
+CLI and the LSP, which render errors via ``str``), and that valid programs
+produce neither an error nor a spurious witness.
+"""
+
+from __future__ import annotations
+
+from aeon.facade.api import LiquidTypeCheckingFailedRelation
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.uis.api import SilentSynthesisUI
+from aeon.verification.smt import model_for_invalid, render_counterexample
+
+
+def _errors(source: str):
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=True,
+    )
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _liquid_failure(source: str) -> LiquidTypeCheckingFailedRelation:
+    errors = _errors(source)
+    failures = [e for e in errors if isinstance(e, LiquidTypeCheckingFailedRelation)]
+    assert failures, f"expected a liquid type-checking failure, got {errors}"
+    return failures[0]
+
+
+def test_counterexample_on_refinement_failure():
+    # `x + x >= x` only for non-negative x, so this fails with a negative witness.
+    err = _liquid_failure("def double (x:Int) : {v:Int | v >= x} := x + x ;")
+    cex = err.counterexample()
+    assert cex is not None
+    assert "x =" in cex
+    assert "counterexample:" in str(err)
+
+
+def test_counterexample_witness_is_falsifying():
+    # The reported `x` must actually break `x + x >= x`, i.e. be negative.
+    err = _liquid_failure("def double (x:Int) : {v:Int | v >= x} := x + x ;")
+    pairs = model_for_invalid(err.vc)
+    assert pairs is not None
+    values = dict(pairs)
+    # variable names carry binder-id superscripts; find the one named `x...`.
+    x_key = next(k for k in values if k.startswith("x"))
+    assert int(values[x_key]) < 0
+
+
+def test_counterexample_on_precondition_failure():
+    src = """
+    open Math
+    def f (n:Int) : Float := Math.sqrt n
+    def main (a:Int) : Unit := print (f a) ;
+    """
+    err = _liquid_failure(src)
+    cex = err.counterexample()
+    assert cex is not None
+    assert "n =" in cex
+
+
+def test_counterexample_is_memoised():
+    err = _liquid_failure("def double (x:Int) : {v:Int | v >= x} := x + x ;")
+    first = err.counterexample()
+    assert err.counterexample() == first  # second call hits the cache
+
+
+def test_valid_program_has_no_failure():
+    assert not _errors("def double (x:Int) : {v:Int | v = x + x} := x + x ;")
+
+
+def test_render_counterexample_consistent_with_validity():
+    from aeon.verification.smt import smt_valid
+
+    err = _liquid_failure("def double (x:Int) : {v:Int | v >= x} := x + x ;")
+    # The stored VC is genuinely invalid, and the renderer produces a witness.
+    assert not smt_valid(err.vc)
+    assert render_counterexample(err.vc) is not None


### PR DESCRIPTION
Closes #439.

## Problem

When Z3 refutes a verification condition it produces a **model** — a concrete assignment witnessing the failure — but it was discarded. Users saw only the unsatisfied constraint:

```
>>> Type error at double.ae:1:42:
    Failed to prove (
    ∀x:Int | true
    ∀zv:Int | (zv == (x + x))
    ====> (zv >= x) )
```

## Fix

`model_for_invalid` / `render_counterexample` (smt.py) re-solve the failing VC, extract the arity-0 model constants (the free binders that falsify it — the inputs), strip binder-id superscripts, and render a compact witness. `LiquidTypeCheckingFailedRelation.__str__` appends it:

```
>>> Type error at double.ae:1:42:
    Failed to prove ( ... )
    counterexample: x = -1, zv = -2
```

Because **both the CLI and the LSP render errors via `str(err)`**, this single change gives concrete feedback in both. Real examples:

| Program | Counterexample |
|---|---|
| `def double (x:Int) : {v:Int \| v >= x} := x + x` | `x = -1, zv = -2` |
| `def f (n:Int) : Float := Math.sqrt n`  (needs `n >= 0`) | `n = -1` |
| `def half (x:Float) : {v:Float \| v >= 1.0} := x` | `x = 0` |

The witness is computed **lazily and memoised** on the error instance, so it stays off the type-checking hot path — nothing changes for programs that verify.

## Tests

`tests/counterexample_test.py` (6 tests): a witness appears on refinement and precondition failures, the reported `x` is genuinely falsifying (negative for `x + x >= x`), the result is memoised, valid programs produce no error/witness, and the renderer is consistent with `smt_valid`. Existing liquid/smt/axiom suites pass unchanged (no exact-string assertions on the message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)