### PR TITLE
feat(sugar): single-constructor destructuring let

### DIFF
--- a/aeon/sugar/aeon_sugar.lark
+++ b/aeon/sugar/aeon_sugar.lark
@@ -162,6 +162,12 @@ expression_i : "by" by_body                                  -> by_e
           | "let" ID ":" type _PIPE expression ":=" expression  ("in"|";") expression     -> rec_refined_e
           | "let" MULT ID ":" type _PIPE expression ":=" expression  ("in"|";") expression     -> mult_rec_refined_e
           | ID ":" type _PIPE expression ":=" expression  ("in"|";") expression     -> rec_refined_e
+          // Single-constructor destructuring let. `let (.mk a b) := e in body`
+          // binds the fields of a one-constructor type by pattern matching.
+          // Desugars to a single-branch `match`.
+          | "let" "(" ID pat_binders ")" ":=" expression  ("in"|";") expression          -> let_pat_e
+          | "let" "(" QUALIFIED_ID pat_binders ")" ":=" expression  ("in"|";") expression -> let_pat_qualified_e
+          | "let" "(" DOT_ID pat_binders ")" ":=" expression  ("in"|";") expression       -> let_pat_anon_e
           | "if" expression "then" expression "else" expression    -> if_e
           | "match" expression "with" match_branches              -> match_e
           | expression_dollar                                      -> same

--- a/aeon/sugar/parser.py
+++ b/aeon/sugar/parser.py
@@ -269,6 +269,37 @@ class TreeToSugar(Transformer):
             multiplicity=from_token(str(args[0])),
         )
 
+    def _let_pat(self, meta, constructor, binders, value, body, qualifier=None):
+        # `let (<pattern>) := value in body` destructures a single-constructor
+        # value by lowering to a one-branch match:
+        #   match value with | <pattern> => body
+        loc = self._loc(meta)
+        branch = SMatchBranch(
+            constructor=constructor,
+            binders=[Name(b) for b in binders],
+            body=body,
+            qualifier=qualifier,
+            loc=loc,
+        )
+        return SMatch(value, [branch], loc=loc)
+
+    @v_args(meta=True)
+    def let_pat_e(self, meta, args):
+        # let (Constructor binders) := value in body
+        return self._let_pat(meta, Name(args[0]), args[1], args[2], args[3])
+
+    @v_args(meta=True)
+    def let_pat_qualified_e(self, meta, args):
+        # let (Type.Constructor binders) := value in body
+        qualifier, cname = str(args[0]).split(".", 1)
+        return self._let_pat(meta, Name(cname), args[1], args[2], args[3], qualifier=qualifier)
+
+    @v_args(meta=True)
+    def let_pat_anon_e(self, meta, args):
+        # let (.Constructor binders) := value in body
+        bare = str(args[0])[1:]  # strip leading dot
+        return self._let_pat(meta, Name(bare), args[1], args[2], args[3])
+
     @v_args(meta=True)
     def if_e(self, meta, args):
         return SIf(args[0], args[1], args[2], loc=self._loc(meta))

--- a/examples/synthesis/dungeon.ae
+++ b/examples/synthesis/dungeon.ae
@@ -118,8 +118,7 @@ def conflicts (fs: (List Feature)) : Int :=
 
 # Extract features from a dungeon
 def dungeon_features (d: Dungeon) : (List Feature) :=
-    match d with
-    | mk_dungeon fs ms => fs;
+    let (mk_dungeon fs ms) := d in fs;
 
 # --- Synthesis target ---
 # Maximize explorable area, minimize spatial conflicts between features.

--- a/examples/synthesis/nqueens.ae
+++ b/examples/synthesis/nqueens.ae
@@ -21,10 +21,8 @@ def conflicts (t:Coordinate) (b:Board) : Int :=
     match b with
     | Board_empty => 0
     | Board_cons h tl =>
-        match t with
-        | C_mk tx ty =>
-            match h with
-            | C_mk hx hy =>
+        let (C_mk tx ty) := t in
+            let (C_mk hx hy) := h in
                 let row : {r:Int | 0 <= r && r <= 1} := if tx = hx then 1 else 0 in
                 let col : {r:Int | 0 <= r && r <= 1} := if ty = hy then 1 else 0 in
                 let dx : Int := abs (tx - hx) in

--- a/examples/synthesis/smt/archery_puzzle.ae
+++ b/examples/synthesis/smt/archery_puzzle.ae
@@ -30,8 +30,7 @@ inductive Archery
 def abs (x:Int) : {r:Int | r >= 0} := if x >= 0 then x else 0 - x;
 
 def score (s:Archery) : Int :=
-    match s with
-    | mk a b c d e f =>
+    let (mk a b c d e f) := s in
         a * 16 + b * 17 + c * 23 + d * 24 + e * 39 + f * 40;
 
 @minimize_int(abs (100 - score archery_hole))

--- a/examples/synthesis/smt/coin_change.ae
+++ b/examples/synthesis/smt/coin_change.ae
@@ -22,8 +22,7 @@ inductive Change
 + tens  (c:Change) : Int
 
 def total (c:Change) : Int :=
-    match c with
-    | mk c1 c5 c10 => c1 + c5 + c10;
+    let (mk c1 c5 c10) := c in c1 + c5 + c10;
 
 @minimize_int(total change_hole)
 def change_hole : {c:Change |

--- a/examples/synthesis/stock_profit.ae
+++ b/examples/synthesis/stock_profit.ae
@@ -29,10 +29,9 @@ def price_at (i:Int) : Int :=
     else if i = 10 then 5
     else 8;
 
-# Match-based profit calculation: extract buy and sell indices via pattern matching.
+# Single-constructor destructuring let: bind buy and sell indices directly.
 def profit (t:Trade) : Int :=
-    match t with
-    | mk b s => price_at s - price_at b;
+    let (mk b s) := t in price_at s - price_at b;
 
 # Synthesize a valid trade that maximizes profit.
 @maximize_int(profit trade_hole)

--- a/examples/synthesis/supermario.ae
+++ b/examples/synthesis/supermario.ae
@@ -133,8 +133,7 @@ def conflicts (cs: (List Chunk)) : Int :=
 
 # Extract chunks from a level
 def level_chunks (level: Level) : (List Chunk) :=
-    match level with
-    | mk_level cs es => cs;
+    let (mk_level cs es) := level in cs;
 
 # --- Cluster feature (SyMetric): pure-Aeon scene rasteriser ---
 # Draw the level into a 2D occupancy matrix and project it onto a 1D vector by
@@ -160,11 +159,9 @@ def overlaps (bx: Int) (lo: Int) (w: Int) : Int :=
 
 # X position of a box / enemy.
 def box_x (b: Box) : Int :=
-    match b with
-    | mk_box bt x y => x;
+    let (mk_box bt x y) := b in x;
 def enemy_x (e: Enemy) : Int :=
-    match e with
-    | mk_enemy m x => x;
+    let (mk_enemy m x) := e in x;
 
 # Boxes / enemies overlapping bin bx.
 def boxes_at (bs: (List Box)) (bx: Int) : Int :=
@@ -197,8 +194,7 @@ def chunks_col (cs: (List Chunk)) (bx: Int) : Int :=
 
 # Extract the enemies of a level.
 def level_enemies (level: Level) : (List Enemy) :=
-    match level with
-    | mk_level cs es => es;
+    let (mk_level cs es) := level in es;
 
 # Total filled cells in bin bx (the 2D matrix projected onto that bin).
 def column_value (level: Level) (x: Int) : Int :=

--- a/examples/testing/pair_tests.ae
+++ b/examples/testing/pair_tests.ae
@@ -1,14 +1,14 @@
 # Tests for the Pair library (polymorphic product type). Pair has no projection
-# functions — its single `mk` constructor is eliminated with `match` — so we
-# define small projections to observe the components.
+# functions — its single `mk` constructor is destructured with a one-constructor
+# `let` pattern — so we define small projections to observe the components.
 #
 # Run with:  aeon --test examples/testing/pair_tests.ae
 
 open Testing
 open Pair
 
-def pfst (p : (Pair Int Int)) : Int := match p with | mk a b => a;
-def psnd (p : (Pair Int Int)) : Int := match p with | mk a b => b;
+def pfst (p : (Pair Int Int)) : Int := let (mk a b) := p in a;
+def psnd (p : (Pair Int Int)) : Int := let (mk a b) := p in b;
 
 # ── Unit tests ───────────────────────────────────────────────────────────────
 

--- a/tests/match_inductive_test.py
+++ b/tests/match_inductive_test.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from aeon.sugar.bind import bind, bind_program
 from aeon.sugar.desugar import desugar, expand_inductive_decls, infer_inductive_rforall_decls
-from aeon.sugar.parser import parse_main_program, parse_program
-from aeon.sugar.program import Program, SAnonConstructor
+from aeon.sugar.parser import parse_main_program, parse_program, parse_expression
+from aeon.sugar.program import Program, SAnonConstructor, SMatch, SMatchBranch
 from aeon.elaboration import elaborate
 from aeon.sugar.ast_helpers import st_top
+from tests.driver import check_compile
 
 
 def test_match_lowering_intlist():
@@ -286,6 +287,79 @@ def test_bare_constructors_require_open():
     # After open, bare 'cons' and 'empty' should resolve to IntList_cons / IntList_empty
     assert "IntList_cons" in dumped or "cons" in dumped
     assert "IntList_rec" in dumped
+
+
+def test_let_pattern_parses_to_single_branch_match():
+    """`let (.mk a b) := e in body` desugars to a one-branch match."""
+    t = parse_expression("let (.mk a b) := p in a")
+    assert isinstance(t, SMatch)
+    assert len(t.branches) == 1
+    branch = t.branches[0]
+    assert isinstance(branch, SMatchBranch)
+    assert branch.constructor.name == "mk"
+    assert [b.name for b in branch.binders] == ["a", "b"]
+    assert branch.qualifier is None
+
+
+def test_let_pattern_qualified_records_qualifier():
+    """`let (Pair.mk a b) := e in body` keeps the qualifier for inductive selection."""
+    t = parse_expression("let (Pair.mk a b) := p in a")
+    assert isinstance(t, SMatch)
+    assert t.branches[0].qualifier == "Pair"
+    assert t.branches[0].constructor.name == "mk"
+
+
+def test_let_pattern_bare_constructor():
+    """`let (mk a b) := e in body` (bare constructor name) parses to a match."""
+    t = parse_expression("let (mk a b) := p in a")
+    assert isinstance(t, SMatch)
+    assert t.branches[0].constructor.name == "mk"
+    assert [b.name for b in t.branches[0].binders] == ["a", "b"]
+
+
+def test_let_pattern_evaluates_single_constructor():
+    """End-to-end: destructuring a single-constructor value binds its fields."""
+    src = """
+        inductive Pair
+        | mk (a:Int) (b:Int) : Pair
+        + fst (p:Pair) : Int
+        + snd (p:Pair) : Int
+        def main (args:Int) : Int :=
+            let (.mk a b) := Pair.mk 1 2 in
+            a + b
+    """
+    assert check_compile(src, st_top, 3)
+
+
+def test_let_pattern_three_arguments():
+    """The destructuring let supports constructors with more than two fields."""
+    src = """
+        inductive Triple
+        | mk (a:Int) (b:Int) (c:Int) : Triple
+        + ta (t:Triple) : Int
+        + tb (t:Triple) : Int
+        + tc (t:Triple) : Int
+        def main (args:Int) : Int :=
+            let (.mk a b c) := Triple.mk 10 20 30 in
+            a + b + c
+    """
+    assert check_compile(src, st_top, 60)
+
+
+def test_let_pattern_qualified_and_bare_forms_evaluate():
+    """Qualified (`Pair.mk`) and bare (`mk`, via open) constructor patterns work end-to-end."""
+    src = """
+        open Pair
+        inductive Pair
+        | mk (a:Int) (b:Int) : Pair
+        + fst (p:Pair) : Int
+        + snd (p:Pair) : Int
+        def main (args:Int) : Int :=
+            let (Pair.mk a b) := Pair.mk 1 2 in
+            let (mk c d) := Pair.mk 100 200 in
+            a + b + c + d
+    """
+    assert check_compile(src, st_top, 303)
 
 
 def test_bare_constructors_fail_without_open():


### PR DESCRIPTION
## What

Adds a syntax extension to pattern-match on `let` bindings when the type has a single constructor:

```aeon
let (.mk a b) := Pair.mk 1 2 in
a + b
```

Three forms are supported, mirroring `match` branches:

- `let (.mk a b) := e in body` — anonymous constructor
- `let (Pair.mk a b) := e in body` — qualified
- `let (mk a b) := e in body` — bare (resolves like a bare match branch; no `open` required)

Multiple fields work (tested with 2-, 3-, and 6-field constructors).

## How

The construct desugars **at the parser level** into a single-branch `match`:

```aeon
match e with | <pattern> => body
```

This reuses all the existing match→recursor machinery, so there are **no changes to the typechecker, desugarer, or evaluator**. The "only one constructor" requirement falls out naturally — a one-branch match is exhaustive only when the type has exactly one constructor.

Implementation:
- `aeon/sugar/aeon_sugar.lark` — three new parens-delimited `expression_i` rules (`let_pat_e`, `let_pat_qualified_e`, `let_pat_anon_e`). Parens keep the LALR grammar conflict-free (`let (` is a distinct prefix from `let ID` / `let MULT`).
- `aeon/sugar/parser.py` — transformer methods building a one-branch `SMatch`, sharing a `_let_pat` helper.

Note: uses Aeon's binding operator `:=` (consistent with `let`/`def` everywhere), not `=`.

## Examples updated

Converted every single-constructor single-branch `match` in the examples to the new syntax (11 sites across 7 files): `stock_profit`, `dungeon`, `supermario` (×4), `nqueens` (×2 nested, on `Coordinate`), `archery_puzzle` (6 fields), `coin_change`, `pair_tests` (×2). The bare-constructor form was used to mirror each file's existing match-branch style; two stale comments referring to "match" were updated.

## Tests

- 6 new tests in `tests/match_inductive_test.py`: 3 parse-shape (anon/qualified/bare) and 3 end-to-end evaluation (single, three-arg, qualified+bare).
- Full suite: **1693 passed, 14 skipped**.
- All converted example files typecheck under CI's `--no-main --budget 10` (the few returning exit 2 = synthesis hole unsolved within budget 10, identical before/after — not a typecheck error). `pair_tests.ae` under `--test`: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)