### PR TITLE
chore(release): 4.1.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AeonLang"
-version = "4.1.6"
+version = "4.1.7"
 description = "Language with Refinement Types"
 authors = [
     { name = "Alcides Fonseca", email = "me@alcidesfonseca.com" }


### PR DESCRIPTION
Version bump to **4.1.7** for the next release.

Builds on the packaging fix from #448 (ships the stdlib `.ae` modules inside the wheel/egg so imports resolve on non-editable installs).

Tagging `v4.1.7` after merge triggers `python-publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)