### PR TITLE
feat(cli): distinct non-zero exit code per compiler error category

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -6,12 +6,15 @@ import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
+from lark.exceptions import UnexpectedInput
+
 from aeon.facade.api import (
     AeonError,
     CoreTypeCheckingError,
     ModuleNotFoundAeonError as AeonImportError,
     InstanceResolutionError,
     LinearityError,
+    MethodResolutionError,
     NonOrderableComparisonError,
     UnificationFailedError,
     UnificationKindError,
@@ -19,6 +22,8 @@ from aeon.facade.api import (
     UnificationUnknownTypeError,
 )
 from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.facade.exit_codes import ExitCode, error_exit_code
+from aeon.sugar.lowering import LiquefactionException
 from aeon.synthesis.api import SynthesisNotSuccessful
 from aeon.logger.logger import export_log
 from aeon.logger.logger import setup_logger
@@ -214,6 +219,8 @@ def _error_kind_and_hint(err: AeonError) -> tuple[str, str | None]:
             return "Missing instance", "Define a typeclass instance for this type, or add it as a constraint."
         case NonOrderableComparisonError():
             return "Non-orderable comparison", "Use Int, Float or String, or define an Ord instance for this type."
+        case MethodResolutionError():
+            return "Method resolution error", "No method with this name is defined for the receiver's type."
         case LinearityError():
             return "Linearity error", "A binding's usage does not match its declared multiplicity."
         case CoreTypeCheckingError():
@@ -285,7 +292,26 @@ def main() -> None:
         print(f"Documentation generated: {output_path}")
         sys.exit(0)
 
-    errors = driver.parse(args.filename)
+    try:
+        errors = driver.parse(args.filename)
+    except UnexpectedInput as e:
+        # Lark's parse errors carry their own position rendering.
+        print(">>> Syntax error:")
+        print(f"    {e}")
+        sys.exit(ExitCode.SYNTAX_ERROR)
+    except LiquefactionException as e:
+        print(">>> Invalid refinement predicate:")
+        print(f"    {e}")
+        print("    hint: refinement predicates are restricted to liquid terms (no method calls or binders).")
+        sys.exit(ExitCode.INVALID_REFINEMENT)
+    except NameError as e:
+        # Name-resolution failures (e.g. ``Module.unknown``) surface as NameError.
+        print(">>> Unknown name:")
+        print(f"    {e}")
+        sys.exit(ExitCode.UNKNOWN_NAME)
+    except AeonError as e:
+        handle_error(e)
+        sys.exit(error_exit_code(e))
 
     match errors:
         case [] if getattr(args, "trust_report", False) or getattr(args, "trust_for", None):
@@ -307,7 +333,7 @@ def main() -> None:
                     print("No @property functions found.")
                     sys.exit(0)
                 failures = driver.run_tests(seed=args.seed)
-                sys.exit(1 if failures else 0)
+                sys.exit(ExitCode.TESTS_FAILED_OR_CRASH if failures else ExitCode.SUCCESS)
             match (args.format, driver.has_synth()):
                 case (True, _):
                     driver.pretty_print(args.filename, args.fix)
@@ -317,7 +343,7 @@ def main() -> None:
                     except SynthesisNotSuccessful as e:
                         message = str(e) or f"Cannot find a suitable expression within {args.budget} seconds."
                         print(message, file=sys.stderr)
-                        sys.exit(2)
+                        sys.exit(ExitCode.SYNTHESIS_NOT_SUCCESSFUL)
                     print("Synthesized:")
                     print("#str")
                     print(str(term))
@@ -325,9 +351,10 @@ def main() -> None:
                     print(pretty_print_sterm(term))
                 case (False, False):
                     driver.run()
-        case [*_]:
+        case [first, *_]:
             for err in errors:
                 handle_error(err)
+            sys.exit(error_exit_code(first))
 
 
 if __name__ == "__main__":

--- a/aeon/facade/exit_codes.py
+++ b/aeon/facade/exit_codes.py
@@ -1,0 +1,86 @@
+"""Process exit codes for the ``aeon`` command-line interface.
+
+Every error category the compiler reports maps to a distinct, stable exit
+code, so scripts and CI can react to *what* failed without scraping stdout.
+
+The contract:
+
+* ``0``  — success.
+* ``1``  — failing ``--test`` properties/examples, or an internal crash
+  (Python's default for an unhandled exception).
+* ``2``  — synthesis finished without finding a solution (pre-existing
+  contract, relied on by ``run_examples.sh``).
+* ``3+`` — compile-time errors, one code per category (see ``ExitCode``).
+
+When a run reports several errors, the process exits with the code of the
+*first* error reported.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+from aeon.facade.api import (
+    AeonError,
+    CoreTypeCheckingError,
+    InstanceResolutionError,
+    LinearityError,
+    MethodResolutionError,
+    ModuleNotFoundAeonError as AeonImportError,
+    NonOrderableComparisonError,
+    UnificationFailedError,
+    UnificationKindError,
+    UnificationSubtypingError,
+    UnificationUnknownTypeError,
+)
+
+
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    TESTS_FAILED_OR_CRASH = 1
+    SYNTHESIS_NOT_SUCCESSFUL = 2
+    SYNTAX_ERROR = 3
+    IMPORT_ERROR = 4
+    TYPE_MISMATCH = 5
+    UNIFICATION_ERROR = 6
+    KIND_MISMATCH = 7
+    UNKNOWN_NAME = 8
+    METHOD_RESOLUTION_ERROR = 9
+    MISSING_INSTANCE = 10
+    NON_ORDERABLE_COMPARISON = 11
+    LINEARITY_ERROR = 12
+    CORE_TYPE_ERROR = 13
+    INVALID_REFINEMENT = 14
+    OTHER_ERROR = 15
+
+
+def error_exit_code(err: AeonError) -> ExitCode:
+    """Map an error to its exit code.
+
+    Subclass order matters: ``LinearityError`` specialises
+    ``CoreTypeCheckingError``, so it is matched first (mirroring
+    ``_error_kind_and_hint`` in ``aeon.__main__``).
+    """
+    match err:
+        case AeonImportError():
+            return ExitCode.IMPORT_ERROR
+        case UnificationSubtypingError():
+            return ExitCode.TYPE_MISMATCH
+        case UnificationFailedError():
+            return ExitCode.UNIFICATION_ERROR
+        case UnificationKindError():
+            return ExitCode.KIND_MISMATCH
+        case UnificationUnknownTypeError():
+            return ExitCode.UNKNOWN_NAME
+        case MethodResolutionError():
+            return ExitCode.METHOD_RESOLUTION_ERROR
+        case InstanceResolutionError():
+            return ExitCode.MISSING_INSTANCE
+        case NonOrderableComparisonError():
+            return ExitCode.NON_ORDERABLE_COMPARISON
+        case LinearityError():
+            return ExitCode.LINEARITY_ERROR
+        case CoreTypeCheckingError():
+            return ExitCode.CORE_TYPE_ERROR
+        case _:
+            return ExitCode.OTHER_ERROR

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,32 @@ Aeon can be executed directly from PyPI using [uvx](https://github.com/astral-sh
 
 `uvx --from aeonlang aeon file.ae`
 
+### Exit codes
+
+The interpreter exits with a distinct code per error category, so scripts and
+CI can react to *what* failed (defined in `aeon.facade.exit_codes`):
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Failing `--test` properties/examples, or an internal crash |
+| 2 | Synthesis finished without finding a solution |
+| 3 | Syntax error |
+| 4 | Import error |
+| 5 | Type mismatch |
+| 6 | Unification error |
+| 7 | Kind mismatch |
+| 8 | Unknown name or variable |
+| 9 | Method resolution error |
+| 10 | Missing typeclass instance |
+| 11 | Comparison on a non-orderable type |
+| 12 | Linearity error |
+| 13 | Core type-checking error |
+| 14 | Invalid refinement predicate |
+| 15 | Other compiler error |
+
+When several errors are reported, the exit code reflects the first one.
+
 ## Hello World
 
 If your aeon file contains a function named `main`, it will be the entrypoint to the program.

--- a/examples/PSB2/solved/square_digits.ae
+++ b/examples/PSB2/solved/square_digits.ae
@@ -5,7 +5,14 @@ def String_concat : (i:String) -> (j:String) -> String := fun i => fun j => nati
 def String_intToString : (i:Int) -> String := fun i => native "str(i)"
 
 
-def square_digits ( n : Int) : String := if n = 0 then
+# Recursion on the digits of ``n``. The quotient ``n // 10`` is opaque to the
+# solver (an uninterpreted native), so the termination metric is an explicit
+# ``fuel`` counter instead: it provably decreases on every call, and 19 units
+# cover every 64-bit integer's digit count.
+def square_digits_go (fuel : {v:Int | v >= 0}) (n : Int) : String decreasing_by [fuel] :=
+    if fuel = 0 then
+        ""
+    else if n = 0 then
         "0"
     else
         digit := n % 10;
@@ -14,6 +21,8 @@ def square_digits ( n : Int) : String := if n = 0 then
         if floor = 0 then
             String_intToString(square)
         else
-            (square_digits(Math_floor_division n 10)).concat (String_intToString(square));
+            (square_digits_go (fuel - 1) floor).concat (String_intToString(square));
+
+def square_digits ( n : Int) : String := square_digits_go 19 n;
 
 def main (n : Int) : Unit := print (square_digits 44 )

--- a/examples/synthesis/pagie1.ae
+++ b/examples/synthesis/pagie1.ae
@@ -16,9 +16,11 @@
 # Run with, e.g.:
 #   uv run python -m aeon --budget 60 -s gp examples/synthesis/pagie1.ae
 
-# Reference specification.  1 / (1 + x^-4) == 1 / (1 + 1/x^4).
+# Reference specification.  1 / (1 + x^-4) is written in its algebraically
+# equivalent total form x^4 / (x^4 + 1), whose denominator is provably
+# non-zero for every x (x^4 >= 0), so the division obligations discharge.
 def pagie1_spec (x:Float) (y:Float) : Float :=
-    1.0 / (1.0 + 1.0 / (x * x * x * x)) + 1.0 / (1.0 + 1.0 / (y * y * y * y));
+    (x * x * x * x) / (x * x * x * x + 1.0) + (y * y * y * y) / (y * y * y * y + 1.0);
 
 # Mean absolute error of a candidate `func` against Pagie-1 over the 100-point
 # grid (the two list comprehensions drop x == 0 / y == 0).

--- a/tests/exit_codes_test.py
+++ b/tests/exit_codes_test.py
@@ -1,0 +1,120 @@
+"""The CLI must exit non-zero whenever it reports an error, with a distinct
+exit code per error category (see ``aeon.facade.exit_codes``).
+
+Regression context: ``main()`` used to print the errors returned by
+``driver.parse`` and fall through to an implicit ``exit 0``, so CI treated
+broken programs as passing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from aeon.facade.api import (
+    CoreSubtypingError,
+    ModuleNotFoundAeonError as AeonImportError,
+    InstanceResolutionError,
+    LinearUnusedError,
+    MethodResolutionError,
+    NonOrderableComparisonError,
+    UnificationFailedError,
+    UnificationKindError,
+    UnificationSubtypingError,
+    UnificationUnknownTypeError,
+)
+from aeon.facade.exit_codes import ExitCode, error_exit_code
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# --- Unit: error class -> exit code mapping ---------------------------------
+
+
+def _make(cls):
+    """Errors are dataclasses; field contents are irrelevant to the mapping."""
+    return cls.__new__(cls)
+
+
+@pytest.mark.parametrize(
+    "cls,expected",
+    [
+        (AeonImportError, ExitCode.IMPORT_ERROR),
+        (UnificationSubtypingError, ExitCode.TYPE_MISMATCH),
+        (UnificationFailedError, ExitCode.UNIFICATION_ERROR),
+        (UnificationKindError, ExitCode.KIND_MISMATCH),
+        (UnificationUnknownTypeError, ExitCode.UNKNOWN_NAME),
+        (MethodResolutionError, ExitCode.METHOD_RESOLUTION_ERROR),
+        (InstanceResolutionError, ExitCode.MISSING_INSTANCE),
+        (NonOrderableComparisonError, ExitCode.NON_ORDERABLE_COMPARISON),
+        # LinearityError specialises CoreTypeCheckingError and must win.
+        (LinearUnusedError, ExitCode.LINEARITY_ERROR),
+        (CoreSubtypingError, ExitCode.CORE_TYPE_ERROR),
+    ],
+)
+def test_error_exit_code_mapping(cls, expected):
+    assert error_exit_code(_make(cls)) == expected
+
+
+# --- End to end: the CLI process exit status ---------------------------------
+
+
+def run_aeon(tmp_path: Path, source: str) -> subprocess.CompletedProcess:
+    f = tmp_path / "prog.ae"
+    f.write_text(source)
+    return subprocess.run(
+        [sys.executable, "-m", "aeon", "--no-main", "--budget", "1", str(f)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+
+
+def test_cli_success_exits_zero(tmp_path):
+    r = run_aeon(tmp_path, "def main (x:Int) : Unit := print 42;\n")
+    assert r.returncode == ExitCode.SUCCESS, r.stderr
+
+
+def test_cli_syntax_error(tmp_path):
+    r = run_aeon(tmp_path, "def main (x:Int) : Unit := print (1 +;\n")
+    assert r.returncode == ExitCode.SYNTAX_ERROR
+    assert "Syntax error" in r.stdout
+
+
+def test_cli_import_error(tmp_path):
+    r = run_aeon(tmp_path, "import NoSuchModule;\ndef main (x:Int) : Unit := print 1;\n")
+    assert r.returncode == ExitCode.IMPORT_ERROR
+
+
+def test_cli_type_mismatch(tmp_path):
+    r = run_aeon(tmp_path, 'def main (x:Int) : Unit := y : Int := "hello";\n    print y;\n')
+    assert r.returncode == ExitCode.TYPE_MISMATCH
+    # The error report must still be printed.
+    assert "Type mismatch" in r.stdout
+
+
+def test_cli_unknown_variable(tmp_path):
+    r = run_aeon(tmp_path, "def main (x:Int) : Unit := print missing_var;\n")
+    assert r.returncode == ExitCode.UNKNOWN_NAME
+
+
+def test_cli_unknown_qualified_name(tmp_path):
+    r = run_aeon(tmp_path, 'import String;\ndef main (x:Int) : Unit := print (String.nope "a");\n')
+    assert r.returncode == ExitCode.UNKNOWN_NAME
+
+
+def test_cli_method_resolution_error(tmp_path):
+    r = run_aeon(tmp_path, "def main (x:Int) : Unit := print (1.nonexistent);\n")
+    assert r.returncode == ExitCode.METHOD_RESOLUTION_ERROR
+
+
+def test_cli_invalid_refinement(tmp_path):
+    src = (
+        'import String;\ndef f (s : {x:String | x.len > 0}) : String := s;\ndef main (x:Int) : Unit := print (f "a");\n'
+    )
+    r = run_aeon(tmp_path, src)
+    assert r.returncode == ExitCode.INVALID_REFINEMENT


### PR DESCRIPTION
## Summary

The CLI previously printed the errors returned by `driver.parse` and then fell through to an implicit `exit 0`, so scripts and CI treated broken programs as passing. Parse-time failures escaped as raw Python tracebacks.

This adds `aeon.facade.exit_codes.ExitCode` and makes `main()` exit with a distinct, stable code per error category.

### Exit-code contract
| Code | Meaning |
|------|---------|
| 0 | Success |
| 1 | Failing `--test` properties/examples, or an internal crash |
| 2 | Synthesis finished without finding a solution (pre-existing) |
| 3 | Syntax error |
| 4 | Import error |
| 5 | Type mismatch |
| 6 | Unification error |
| 7 | Kind mismatch |
| 8 | Unknown name/variable |
| 9 | Method resolution error |
| 10 | Missing typeclass instance |
| 11 | Non-orderable comparison |
| 12 | Linearity error |
| 13 | Core type-checking error |
| 14 | Invalid refinement predicate |
| 15 | Other compiler error |

When several errors are reported, the exit code reflects the first one.

Lark parse errors, `LiquefactionException` and name-resolution `NameError`s are now caught and reported in the same `>>>` format instead of crashing with a traceback.

### Examples fixed
Two examples passed CI only because their type errors were swallowed; both are now genuinely well-typed:
- `examples/synthesis/pagie1.ae` — divided by `x^4` (unprovably non-zero, and genuinely zero at x=0). Reference spec rewritten in the algebraically equivalent total form `x^4 / (x^4 + 1)`.
- `examples/PSB2/solved/square_digits.ae` — recursed on an uninterpreted native floor division, leaving the auto-inferred termination metric unprovable. The digit loop now carries an explicit `fuel` metric with `decreasing_by`.

## Test plan
- New `tests/exit_codes_test.py` (18 tests): unit coverage of the error→code mapping + end-to-end CLI exit-status checks per category. All passing.
- Full `run_examples.sh` suite passes (167 examples, exit 0).
- Pre-commit (mypy, ruff, ruff format, pyroma) clean.

## Motivation
Enables tooling — notably the VS Code extension's new "Format Document" provider — to detect a failed run by exit code rather than scraping stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)