### PR TITLE
Consolidate WHNF into aeon.optimization

### DIFF
--- a/aeon/backend/python_export.py
+++ b/aeon/backend/python_export.py
@@ -7,7 +7,7 @@ kept since ``native`` strings reference the imported modules by name). For
 each binding the pipeline is:
 
 1. Locate the top-level binding for ``fun_name`` in the core AST.
-2. Reduce its body to weak-head normal form (``whnf``) — this strips the
+2. Reduce its body to weak-head normal form (``aeon.optimization.whnf``) — this strips the
    type-level wrappers introduced by elaboration (type/refinement
    abstractions and applications, annotations) and beta-reduces any redex
    at the head, exposing the underlying ``Abstraction``.
@@ -24,7 +24,6 @@ the source-level parameter names) resolve against the surrounding lambdas.
 
 from __future__ import annotations
 
-from aeon.core.substitutions import substitution
 from aeon.core.terms import (
     Abstraction,
     Annotation,
@@ -41,6 +40,7 @@ from aeon.core.terms import (
     TypeApplication,
     Var,
 )
+from aeon.optimization.whnf import strip_type_wrappers, whnf
 from aeon.core.types import t_bool, t_string, t_unit
 from aeon.utils.name import Name
 
@@ -79,56 +79,6 @@ def find_binding(core: Term, fun_name: str) -> tuple[Name, Term] | None:
     return None
 
 
-def whnf(t: Term) -> Term:
-    """Reduce ``t`` to weak-head normal form.
-
-    Strips the administrative wrappers elaboration leaves around values
-    (annotations, type/refinement abstractions and applications) and
-    beta-reduces any redex sitting at the head. Reduction stops as soon as
-    the head is a value (an ``Abstraction``, ``Literal``, ...) or a stuck
-    application — it never descends into a lambda body.
-    """
-    while True:
-        match t:
-            case Annotation(expr, _):
-                t = expr
-            case TypeAbstraction(_, _, body):
-                t = body
-            case RefinementAbstraction(_, _, body):
-                t = body
-            case TypeApplication(body, _):
-                t = body
-            case RefinementApplication(body, _):
-                t = body
-            case Application(fun, arg):
-                f = whnf(fun)
-                if isinstance(f, Abstraction):
-                    t = substitution(f.body, arg, f.var_name)
-                else:
-                    return Application(f, arg, t.loc)
-            case _:
-                return t
-
-
-def _strip_type_wrappers(t: Term) -> Term:
-    """Peel only the type-level wrappers, exposing the operational head of
-    an application spine (e.g. the ``Var`` behind a ``native [a]`` instance)."""
-    while True:
-        match t:
-            case Annotation(expr, _):
-                t = expr
-            case TypeApplication(body, _):
-                t = body
-            case RefinementApplication(body, _):
-                t = body
-            case TypeAbstraction(_, _, body):
-                t = body
-            case RefinementAbstraction(_, _, body):
-                t = body
-            case _:
-                return t
-
-
 def _unfold_application(t: Application) -> tuple[Term, list[Term]]:
     """Flatten a curried application spine into ``(head, args)`` with the
     type wrappers stripped from the head."""
@@ -138,7 +88,7 @@ def _unfold_application(t: Application) -> tuple[Term, list[Term]]:
         args.append(cur.arg)
         cur = cur.fun
     args.reverse()
-    return _strip_type_wrappers(cur), args
+    return strip_type_wrappers(cur), args
 
 
 def _literal_to_python(value: object, type) -> str:
@@ -187,7 +137,7 @@ def _gen_application(t: Application) -> str:
 
     if isinstance(head, Var):
         op = head.name.name
-        first = _strip_type_wrappers(args[0]) if args else None
+        first = strip_type_wrappers(args[0]) if args else None
         # Inline ``native "..."`` strings verbatim, as the interpreter evals them.
         if op == "native" and isinstance(first, Literal):
             return f"({first.value})"
@@ -261,7 +211,7 @@ def _native_import_module(value: Term) -> str | None:
     if isinstance(head, Application):
         head, args = _unfold_application(head)
         if isinstance(head, Var) and head.name.name == "native_import" and args:
-            first = _strip_type_wrappers(args[0])
+            first = strip_type_wrappers(args[0])
             if isinstance(first, Literal):
                 return str(first.value)
     return None

--- a/aeon/optimization/__init__.py
+++ b/aeon/optimization/__init__.py
@@ -1,4 +1,4 @@
-from aeon.optimization.match import optimize_eliminator
+from aeon.optimization.match import optimize_destructor_let, optimize_eliminator
 from aeon.optimization.normal_form import normal_form, optimize, optimize_bindings
 from aeon.optimization.whnf import strip_type_wrappers, whnf
 
@@ -6,6 +6,7 @@ __all__ = [
     "normal_form",
     "optimize",
     "optimize_bindings",
+    "optimize_destructor_let",
     "optimize_eliminator",
     "strip_type_wrappers",
     "whnf",

--- a/aeon/optimization/__init__.py
+++ b/aeon/optimization/__init__.py
@@ -1,4 +1,12 @@
+from aeon.optimization.match import optimize_eliminator
 from aeon.optimization.normal_form import normal_form, optimize, optimize_bindings
 from aeon.optimization.whnf import strip_type_wrappers, whnf
 
-__all__ = ["normal_form", "optimize", "optimize_bindings", "strip_type_wrappers", "whnf"]
+__all__ = [
+    "normal_form",
+    "optimize",
+    "optimize_bindings",
+    "optimize_eliminator",
+    "strip_type_wrappers",
+    "whnf",
+]

--- a/aeon/optimization/__init__.py
+++ b/aeon/optimization/__init__.py
@@ -1,0 +1,4 @@
+from aeon.optimization.normal_form import normal_form, optimize, optimize_bindings
+from aeon.optimization.whnf import strip_type_wrappers, whnf
+
+__all__ = ["normal_form", "optimize", "optimize_bindings", "strip_type_wrappers", "whnf"]

--- a/aeon/optimization/match.py
+++ b/aeon/optimization/match.py
@@ -4,7 +4,7 @@ import ast
 
 from aeon.core.terms import Abstraction, Application, Literal, Term, TypeApplication, Var
 from aeon.core.types import Type
-from aeon.optimization.native import literal_from_python, native_code
+from aeon.optimization.native import literal_from_python, native_code, native_term
 from aeon.optimization.whnf import strip_type_wrappers
 from aeon.utils.name import Name
 from aeon.verification.constructor_registry import get_constructor_order
@@ -123,6 +123,59 @@ def apply_handler(handler: Term, args: list[Term]) -> Term:
     return result
 
 
+def handler_arity(handler: Term) -> int:
+    n = 0
+    cur = handler
+    while isinstance(cur, Abstraction):
+        n += 1
+        cur = cur.body
+    return n
+
+
+def scrutinee_fields(scrutinee: Term, arity: int) -> list[Term] | None:
+    """Field projections for a scrutinee, when its constructor shape is known or a bare variable."""
+    if (shape := recognize_constructor(scrutinee)) is not None:
+        _, _, args = shape
+        if len(args) == arity:
+            return args
+        return None
+    head = strip_type_wrappers(scrutinee)
+    if isinstance(head, Var):
+        name = head.name.name
+        return [native_term(f"{name}[{i + 1}]") for i in range(arity)]
+    return None
+
+
+def is_uni_constructor(type_name: str) -> bool:
+    order = get_constructor_order(type_name)
+    return order is not None and len(order) == 1
+
+
+def optimize_destructor_let(type_name: str, scrutinee: Term, handler: Term) -> Term | None:
+    """Optimize ``let (C x …) := scrut in body`` for single-constructor types.
+
+    When the scrutinee is a known constructor application (or native tuple),
+    apply the handler to its fields. When the scrutinee is still a variable,
+    project fields via native tuple indexing — every value of a
+    uni-constructor type carries the same runtime representation.
+    """
+    order = get_constructor_order(type_name)
+    if order is None or len(order) != 1:
+        return None
+    arity = handler_arity(handler)
+    fields = scrutinee_fields(scrutinee, arity)
+    if fields is None:
+        return None
+    if (shape := recognize_constructor(scrutinee)) is not None:
+        scr_type, _, _ = shape
+        if scr_type != type_name:
+            return None
+        key = _constructor_key(scr_type, shape[1])
+        if key != order[0]:
+            return None
+    return apply_handler(handler, fields)
+
+
 def optimize_eliminator(t: Term) -> Term | None:
     """Select a ``match`` branch when the scrutinee constructor is known."""
     parsed = parse_recursor_app(t)
@@ -130,14 +183,20 @@ def optimize_eliminator(t: Term) -> Term | None:
         return None
     type_name, _, value_args = parsed
     scrutinee, *handlers = value_args
+    order = get_constructor_order(type_name)
+    if order is None:
+        return None
+
+    if len(order) == 1 and len(handlers) == 1:
+        if (reduced := optimize_destructor_let(type_name, scrutinee, handlers[0])) is not None:
+            return reduced
+
     shape = recognize_constructor(scrutinee)
     if shape is None:
         return None
     scr_type, constructor_name, ctor_args = shape
     if scr_type != type_name:
         return None
-    order = get_constructor_order(type_name)
-    assert order is not None
     key = _constructor_key(type_name, constructor_name)
     try:
         handler_index = order.index(key)

--- a/aeon/optimization/match.py
+++ b/aeon/optimization/match.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 
-from aeon.core.terms import Abstraction, Application, Literal, Term, TypeApplication, Var
+from aeon.core.terms import Abstraction, Application, Term, TypeApplication, Var
 from aeon.core.types import Type
 from aeon.optimization.native import literal_from_python, native_code, native_term
 from aeon.optimization.whnf import strip_type_wrappers

--- a/aeon/optimization/match.py
+++ b/aeon/optimization/match.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import ast
+
+from aeon.core.terms import Abstraction, Application, Literal, Term, TypeApplication, Var
+from aeon.core.types import Type
+from aeon.optimization.native import literal_from_python, native_code
+from aeon.optimization.whnf import strip_type_wrappers
+from aeon.utils.name import Name
+from aeon.verification.constructor_registry import get_constructor_order
+
+
+def unfold_application_spine(t: Term) -> tuple[Term, list[Term]]:
+    args: list[Term] = []
+    cur = t
+    while isinstance(cur, Application):
+        args.append(cur.arg)
+        cur = cur.fun
+    args.reverse()
+    return strip_type_wrappers(cur), args
+
+
+def _constructor_key(type_name: str, constructor_name: str) -> str:
+    return f"{type_name}_{constructor_name}"
+
+
+def _split_constructor_name(name: str) -> tuple[str, str] | None:
+    if "_" not in name:
+        return None
+    type_name, constructor_name = name.split("_", 1)
+    return type_name, constructor_name
+
+
+def _known_constructor_key(key: str) -> bool:
+    if "_" not in key:
+        return False
+    type_name, _ = key.split("_", 1)
+    order = get_constructor_order(type_name)
+    return order is not None and key in order
+
+
+def _recognize_native_tuple(t: Term) -> tuple[str, str, list[Term]] | None:
+    code = native_code(t)
+    if code is None:
+        return None
+    try:
+        expr = ast.parse(code, mode="eval").body
+    except SyntaxError:
+        return None
+    if not isinstance(expr, ast.Tuple) or not expr.elts:
+        return None
+    tag = expr.elts[0]
+    if not isinstance(tag, ast.Constant) or not isinstance(tag.value, str):
+        return None
+    key = tag.value
+    if not _known_constructor_key(key):
+        return None
+    type_name, constructor_name = key.split("_", 1)
+    args: list[Term] = []
+    for elt in expr.elts[1:]:
+        match elt:
+            case ast.Constant(value=value):
+                args.append(literal_from_python(value))
+            case ast.Name(id=name):
+                args.append(Var(Name(name)))
+            case _:
+                return None
+    return type_name, constructor_name, args
+
+
+def recognize_constructor(t: Term) -> tuple[str, str, list[Term]] | None:
+    """When ``t`` has a known inductive constructor shape, return its parts."""
+    if (native_shape := _recognize_native_tuple(strip_type_wrappers(t))) is not None:
+        return native_shape
+
+    head, args = unfold_application_spine(t)
+    if not isinstance(head, Var):
+        return None
+    split = _split_constructor_name(head.name.name)
+    if split is None:
+        return None
+    type_name, constructor_name = split
+    key = _constructor_key(type_name, constructor_name)
+    if not _known_constructor_key(key):
+        return None
+    return type_name, constructor_name, args
+
+
+def parse_recursor_app(t: Term) -> tuple[str, list[Type], list[Term]] | None:
+    """Parse a fully-applied ``T_rec`` eliminator application."""
+    value_args: list[Term] = []
+    cur = strip_type_wrappers(t)
+    while isinstance(cur, Application):
+        value_args.append(cur.arg)
+        cur = cur.fun
+    value_args.reverse()
+    if len(value_args) < 2:
+        return None
+
+    type_args: list[Type] = []
+    head = cur
+    while isinstance(head, TypeApplication):
+        type_args.append(head.type)
+        head = head.body
+    head = strip_type_wrappers(head)
+    if not isinstance(head, Var) or not head.name.name.endswith("_rec"):
+        return None
+
+    type_name = head.name.name[: -len("_rec")]
+    order = get_constructor_order(type_name)
+    if order is None:
+        return None
+    handlers = value_args[1:]
+    if len(handlers) != len(order):
+        return None
+    return type_name, type_args, value_args
+
+
+def apply_handler(handler: Term, args: list[Term]) -> Term:
+    result = handler
+    for arg in args:
+        result = Application(result, arg)
+    return result
+
+
+def optimize_eliminator(t: Term) -> Term | None:
+    """Select a ``match`` branch when the scrutinee constructor is known."""
+    parsed = parse_recursor_app(t)
+    if parsed is None:
+        return None
+    type_name, _, value_args = parsed
+    scrutinee, *handlers = value_args
+    shape = recognize_constructor(scrutinee)
+    if shape is None:
+        return None
+    scr_type, constructor_name, ctor_args = shape
+    if scr_type != type_name:
+        return None
+    order = get_constructor_order(type_name)
+    assert order is not None
+    key = _constructor_key(type_name, constructor_name)
+    try:
+        handler_index = order.index(key)
+    except ValueError:
+        return None
+    return apply_handler(handlers[handler_index], ctor_args)
+
+
+def optimize_eliminator_abstraction(t: Term) -> Term | None:
+    """Peel a leading ``fun ret =>`` wrapper around a fully-applied eliminator."""
+    if not isinstance(t, Abstraction):
+        return None
+    body = t.body
+    while isinstance(body, Abstraction):
+        body = body.body
+    if (reduced := optimize_eliminator(body)) is None:
+        return None
+    return reduced

--- a/aeon/optimization/native.py
+++ b/aeon/optimization/native.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import ast
+import copy
+
+from aeon.core.terms import Application, Literal, Term, Var
+from aeon.core.types import t_bool, t_float, t_int, t_string
+from aeon.utils.name import Name
+
+
+class _SubstituteArg(ast.NodeTransformer):
+    def __init__(self, param: str, arg: ast.expr):
+        self.param = param
+        self.arg = arg
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if node.id == self.param and isinstance(node.ctx, ast.Load):
+            return ast.copy_location(copy.deepcopy(self.arg), node)
+        return node
+
+
+def _native_var(name: Name) -> bool:
+    return name.name == "native"
+
+
+def native_code(fun: Term) -> str | None:
+    match fun:
+        case Application(Var(name), Literal(code, _)) if _native_var(name):
+            return str(code)
+        case _:
+            return None
+
+
+def native_term(code: str) -> Term:
+    return Application(Var(Name("native")), Literal(code, t_string))
+
+
+def literal_from_python(value: object) -> Literal:
+    if isinstance(value, bool):
+        return Literal(value, t_bool)
+    if isinstance(value, int):
+        return Literal(value, t_int)
+    if isinstance(value, float):
+        return Literal(value, t_float)
+    if isinstance(value, str):
+        return Literal(value, t_string)
+    raise TypeError(f"unsupported native literal value: {value!r}")
+
+
+def term_to_ast(t: Term) -> ast.expr | None:
+    match t:
+        case Literal(value, _):
+            return ast.Constant(value=value)
+        case Var(name):
+            return ast.Name(id=name.name, ctx=ast.Load())
+        case _:
+            return None
+
+
+def _has_load_name(node: ast.AST) -> bool:
+    return any(isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load) for n in ast.walk(node))
+
+
+def _eval_constant_expr(node: ast.expr) -> object | None:
+    if _has_load_name(node):
+        return None
+    try:
+        return eval(compile(ast.Expression(node), "<native-opt>", "eval"), {"__builtins__": {}}, {})
+    except Exception:
+        return None
+
+
+def ast_to_term(node: ast.expr) -> Term:
+    if isinstance(node, ast.Constant):
+        return literal_from_python(node.value)
+    if isinstance(node, ast.Name):
+        return Var(Name(node.id))
+    if isinstance(node, ast.Lambda):
+        return native_term(ast.unparse(node))
+    folded = _eval_constant_expr(node)
+    if folded is not None:
+        return literal_from_python(folded)
+    return native_term(ast.unparse(node))
+
+
+def _parse_native_expr(code: str) -> ast.expr | None:
+    try:
+        return ast.parse(code, mode="eval").body
+    except SyntaxError:
+        return None
+
+
+def _mentions_name(node: ast.AST, name: str) -> bool:
+    return any(isinstance(n, ast.Name) and n.id == name for n in ast.walk(node))
+
+
+def _beta_reduce_lambda(expr: ast.Lambda, arg: ast.expr) -> ast.expr:
+    if len(expr.args.args) != 1 or expr.args.posonlyargs or expr.args.kwonlyargs or expr.args.kwarg:
+        raise ValueError("only single-argument native lambdas are supported")
+    param = expr.args.args[0].arg
+    if not _mentions_name(expr.body, param):
+        return expr.body
+    body = _SubstituteArg(param, arg).visit(expr.body)
+    assert isinstance(body, ast.expr)
+    ast.fix_missing_locations(body)
+    return body
+
+
+def fold_native_expr(code: str) -> Term | None:
+    expr = _parse_native_expr(code)
+    if expr is None or isinstance(expr, (ast.Lambda, ast.Constant)):
+        return None
+    folded = _eval_constant_expr(expr)
+    if folded is None:
+        return None
+    return literal_from_python(folded)
+
+
+def beta_reduce_native(fun: Term, arg: Term) -> Term | None:
+    code = native_code(fun)
+    if code is None:
+        return None
+    expr = _parse_native_expr(code)
+    if expr is None or not isinstance(expr, ast.Lambda):
+        return None
+    arg_expr = term_to_ast(arg)
+    if arg_expr is None:
+        return None
+    try:
+        reduced = _beta_reduce_lambda(expr, arg_expr)
+    except ValueError:
+        return None
+    return ast_to_term(reduced)

--- a/aeon/optimization/native.py
+++ b/aeon/optimization/native.py
@@ -50,7 +50,17 @@ def literal_from_python(value: object) -> Literal:
 def term_to_ast(t: Term) -> ast.expr | None:
     match t:
         case Literal(value, _):
-            return ast.Constant(value=value)
+            if isinstance(value, bool):
+                return ast.Constant(value=value)
+            if isinstance(value, int):
+                return ast.Constant(value=value)
+            if isinstance(value, float):
+                return ast.Constant(value=value)
+            if isinstance(value, str):
+                return ast.Constant(value=value)
+            if value is None:
+                return ast.Constant(value=None)
+            return None
         case Var(name):
             return ast.Name(id=name.name, ctx=ast.Load())
         case _:

--- a/aeon/optimization/normal_form.py
+++ b/aeon/optimization/normal_form.py
@@ -8,6 +8,8 @@ from aeon.core.terms import (
     Let,
     Literal,
     Rec,
+    RefinementAbstraction,
+    RefinementApplication,
     Term,
     TypeAbstraction,
     TypeApplication,
@@ -122,8 +124,8 @@ def nf(t: Term) -> Term:
             return t
         case Var(_):
             return t
-        case Annotation(_, _):
-            return t
+        case Annotation(expr, _):
+            return nf(expr)
         case Hole(_):
             return t
 
@@ -143,6 +145,10 @@ def nf(t: Term) -> Term:
             return TypeAbstraction(ty, kind, nf(body))
         case TypeApplication(body, ty):
             return TypeApplication(nf(body), ty)
+        case RefinementAbstraction(name, ty, body):
+            return RefinementAbstraction(name, ty, nf(body))
+        case RefinementApplication(body, _):
+            return nf(body)
         case _:
             assert False, f"No case for {t} ({type(t)})"
 
@@ -157,3 +163,21 @@ def normal_form(t: Term) -> Term:
 
 def optimize(t: Term) -> Term:
     return normal_form(t)
+
+
+def optimize_bindings(core: Term) -> Term:
+    """Run ``optimize`` on every top-level binding value in a core program."""
+    match core:
+        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
+            return Rec(
+                var_name,
+                var_type,
+                optimize(var_value),
+                optimize_bindings(body),
+                decreasing_by=decreasing_by,
+                loc=loc,
+            )
+        case Let(var_name, var_value, body):
+            return Let(var_name, optimize(var_value), optimize_bindings(body))
+        case _:
+            return core

--- a/aeon/optimization/normal_form.py
+++ b/aeon/optimization/normal_form.py
@@ -16,6 +16,7 @@ from aeon.core.terms import (
     Var,
 )
 from aeon.core.types import t_bool, t_int
+from aeon.optimization.native import beta_reduce_native, fold_native_expr
 from aeon.utils.name import Name
 
 
@@ -131,7 +132,14 @@ def nf(t: Term) -> Term:
 
         case Abstraction(var_name, body):
             return Abstraction(var_name, nf(body))
+        case Application(Var(Name("native", _)), Literal(code, _)):
+            if (folded := fold_native_expr(str(code))) is not None:
+                return folded
+            return t
+
         case Application(fun, arg):
+            if (reduced := beta_reduce_native(fun, arg)) is not None:
+                return reduced
             return Application(nf(fun), nf(arg))
         case Let(var_name, var_value, body):
             return substitution(body, nf(var_value), var_name)

--- a/aeon/optimization/normal_form.py
+++ b/aeon/optimization/normal_form.py
@@ -16,11 +16,16 @@ from aeon.core.terms import (
     Var,
 )
 from aeon.core.types import t_bool, t_int
+from aeon.optimization.match import optimize_eliminator, optimize_eliminator_abstraction
 from aeon.optimization.native import beta_reduce_native, fold_native_expr
 from aeon.utils.name import Name
 
 
 def nf(t: Term) -> Term:
+    if (reduced := optimize_eliminator(t)) is not None:
+        return reduced
+    if (reduced := optimize_eliminator_abstraction(t)) is not None:
+        return reduced
     match t:
         case Application(Abstraction(var_name, body), arg):
             return substitution(body, arg, var_name)

--- a/aeon/optimization/whnf.py
+++ b/aeon/optimization/whnf.py
@@ -1,0 +1,60 @@
+from aeon.core.substitutions import substitution
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    RefinementAbstraction,
+    RefinementApplication,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+)
+
+
+def strip_type_wrappers(t: Term) -> Term:
+    """Peel type-level wrappers, exposing the operational head of a term."""
+    while True:
+        match t:
+            case Annotation(expr, _):
+                t = expr
+            case TypeApplication(body, _):
+                t = body
+            case RefinementApplication(body, _):
+                t = body
+            case TypeAbstraction(_, _, body):
+                t = body
+            case RefinementAbstraction(_, _, body):
+                t = body
+            case _:
+                return t
+
+
+def whnf(t: Term) -> Term:
+    """Reduce ``t`` to weak-head normal form.
+
+    Strips the administrative wrappers elaboration leaves around values
+    (annotations, type/refinement abstractions and applications) and
+    beta-reduces any redex sitting at the head. Reduction stops as soon as
+    the head is a value (an ``Abstraction``, ``Literal``, ...) or a stuck
+    application — it never descends into a lambda body.
+    """
+    while True:
+        match t:
+            case Annotation(expr, _):
+                t = expr
+            case TypeAbstraction(_, _, body):
+                t = body
+            case RefinementAbstraction(_, _, body):
+                t = body
+            case TypeApplication(body, _):
+                t = body
+            case RefinementApplication(body, _):
+                t = body
+            case Application(fun, arg):
+                f = whnf(fun)
+                if isinstance(f, Abstraction):
+                    t = substitution(f.body, arg, f.var_name)
+                else:
+                    return Application(f, arg, t.loc)
+            case _:
+                return t

--- a/aeon/verification/constructor_registry.py
+++ b/aeon/verification/constructor_registry.py
@@ -7,17 +7,21 @@ constants of the same inductive type.
 
 from __future__ import annotations
 
-# Maps inductive type name -> set of prefixed constructor constant names
-# e.g. {"Pizza": {"Pizza_pepperoni", "Pizza_margherita", ...}}
-_constructor_groups: dict[str, set[str]] = {}
+# Maps inductive type name -> ordered prefixed constructor constant names
+# e.g. {"IntList": ["IntList_empty", "IntList_cons"]}
+_constructor_groups: dict[str, list[str]] = {}
 
 
 def register_constructors(type_name: str, constructor_names: list[str]) -> None:
-    _constructor_groups[type_name] = set(constructor_names)
+    _constructor_groups[type_name] = list(constructor_names)
 
 
 def get_constructor_groups() -> dict[str, set[str]]:
-    return _constructor_groups
+    return {name: set(ctors) for name, ctors in _constructor_groups.items()}
+
+
+def get_constructor_order(type_name: str) -> list[str] | None:
+    return _constructor_groups.get(type_name)
 
 
 def clear_constructor_registry() -> None:

--- a/tests/optimization_test.py
+++ b/tests/optimization_test.py
@@ -9,9 +9,10 @@ from aeon.verification.constructor_registry import clear_constructor_registry, r
 
 
 @pytest.fixture(autouse=True)
-def _intlist_constructors():
+def _constructor_registry():
     clear_constructor_registry()
     register_constructors("IntList", ["IntList_empty", "IntList_cons"])
+    register_constructors("Pair", ["Pair_mk"])
     yield
     clear_constructor_registry()
 
@@ -145,4 +146,18 @@ def test_opt_match_via_let_scrutinee():
         "let xs = ((IntList_cons 3) IntList_empty) in "
         "((((IntList_rec)[Int] xs) 0) (fun h => (fun t => h)))",
         "3",
+    )
+
+
+def test_opt_destructor_let_known_value():
+    eq(
+        "((((Pair_rec)[Int] ((Pair_mk 1) 2)) (fun a => (fun b => (((+)[Int] a) b)))))",
+        "(((+)[Int] 1) 2)",
+    )
+
+
+def test_opt_destructor_let_variable_scrutinee():
+    eq(
+        "((((Pair_rec)[Int] p) (fun a => (fun b => (((+)[Int] a) b)))))",
+        "(((+)[Int] (native \"p[1]\")) (native \"p[2]\"))",
     )

--- a/tests/optimization_test.py
+++ b/tests/optimization_test.py
@@ -143,8 +143,7 @@ def test_opt_match_native_tuple_scrutinee():
 
 def test_opt_match_via_let_scrutinee():
     eq(
-        "let xs = ((IntList_cons 3) IntList_empty) in "
-        "((((IntList_rec)[Int] xs) 0) (fun h => (fun t => h)))",
+        "let xs = ((IntList_cons 3) IntList_empty) in ((((IntList_rec)[Int] xs) 0) (fun h => (fun t => h)))",
         "3",
     )
 
@@ -159,5 +158,5 @@ def test_opt_destructor_let_known_value():
 def test_opt_destructor_let_variable_scrutinee():
     eq(
         "((((Pair_rec)[Int] p) (fun a => (fun b => (((+)[Int] a) b)))))",
-        "(((+)[Int] (native \"p[1]\")) (native \"p[2]\"))",
+        '(((+)[Int] (native "p[1]")) (native "p[2]"))',
     )

--- a/tests/optimization_test.py
+++ b/tests/optimization_test.py
@@ -92,3 +92,17 @@ def test_whnf_peels_annotations():
 def test_whnf_does_not_descend_into_abstraction_body():
     t = parse_term("fun x => (fun y => y) 0")
     assert whnf(t) == t
+
+
+def test_opt_native_lambda():
+    eq('(native "lambda x: x") 1', "1")
+    eq('(native "lambda x: x + 1") 2', "3")
+    eq('(native "lambda x: lambda y: x + y") 1 2', "3")
+
+
+def test_opt_native_lambda_with_var():
+    eq('(native "lambda x: x") y', "y")
+
+
+def test_opt_native_constant_expr():
+    eq('native "1+1"', "2")

--- a/tests/optimization_test.py
+++ b/tests/optimization_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from aeon.optimization.normal_form import optimize
+from aeon.optimization.whnf import whnf
 from aeon.core.parser import parse_term
 
 
@@ -81,3 +82,13 @@ def test_opt_op():
     eq("1-1", "0")
     eq("true && false", "false")
     eq("true || false", "true")
+
+
+def test_whnf_peels_annotations():
+    t = parse_term("(fun x => 1) 2")
+    assert whnf(t) == parse_term("1")
+
+
+def test_whnf_does_not_descend_into_abstraction_body():
+    t = parse_term("fun x => (fun y => y) 0")
+    assert whnf(t) == t

--- a/tests/optimization_test.py
+++ b/tests/optimization_test.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import pytest
+
 from aeon.optimization.normal_form import optimize
 from aeon.optimization.whnf import whnf
 from aeon.core.parser import parse_term
+from aeon.verification.constructor_registry import clear_constructor_registry, register_constructors
+
+
+@pytest.fixture(autouse=True)
+def _intlist_constructors():
+    clear_constructor_registry()
+    register_constructors("IntList", ["IntList_empty", "IntList_cons"])
+    yield
+    clear_constructor_registry()
 
 
 def eq(source, expected):
@@ -106,3 +117,32 @@ def test_opt_native_lambda_with_var():
 
 def test_opt_native_constant_expr():
     eq('native "1+1"', "2")
+
+
+def test_opt_match_empty():
+    eq(
+        "((((IntList_rec)[Int] IntList_empty) 0) (fun h => (fun t => 1)))",
+        "0",
+    )
+
+
+def test_opt_match_cons():
+    eq(
+        "((((IntList_rec)[Int] ((IntList_cons 2) IntList_empty)) 0) (fun h => (fun t => h)))",
+        "2",
+    )
+
+
+def test_opt_match_native_tuple_scrutinee():
+    eq(
+        "((((IntList_rec)[Int] (native \"('IntList_cons', 2, IntList_empty)\")) 0) (fun h => (fun t => h)))",
+        "2",
+    )
+
+
+def test_opt_match_via_let_scrutinee():
+    eq(
+        "let xs = ((IntList_cons 3) IntList_empty) in "
+        "((((IntList_rec)[Int] xs) 0) (fun h => (fun t => h)))",
+        "3",
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates WHNF into a shared `aeon.optimization` package, extends `optimize` for native Python FFI beta-reduction, and adds compile-time optimization for lowered `match` and destructor `let` expressions.

## Changes

- **`aeon/optimization/whnf.py`** — shared WHNF and wrapper stripping
- **`aeon/optimization/native.py`** — AST-based native lambda beta-reduction and constant folding
- **`aeon/optimization/match.py`** — eliminator branch selection and uni-constructor destructor let
- **`aeon/verification/constructor_registry.py`** — preserve constructor declaration order
- **`python_export.py`** — import WHNF from optimization package

## Native optimization

- `(native "lambda x: x") 1` → `1`
- Curried native lambdas and name-free expressions like `native "1+1"` → `2`

## Match optimization (multi-constructor)

When the scrutinee constructor is known statically, select the matching handler.

## Destructor let (uni-constructor)

For single-constructor types, apply the handler to known fields or project from a variable scrutinee via `native "p[i]"`.

## CI

- `pre-commit run --all-files` passes (mypy, ruff, format)
- `pytest`: 1766 passed, 14 skipped
- `bash run_examples.sh`: all examples and PBT suites pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01c0a360-9d4b-4d00-ba8f-7f16d38abb2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01c0a360-9d4b-4d00-ba8f-7f16d38abb2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

