### PR TITLE
chore(release): 4.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AeonLang"
-version = "4.1.7"
+version = "4.2.0"
 description = "Language with Refinement Types"
 authors = [
     { name = "Alcides Fonseca", email = "me@alcidesfonseca.com" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release 4.2.0

Bumps version from 4.1.7 to 4.2.0.

### What's Changed Since 4.1.7

- **Refactor compiler to use compilation units with `.aec` caching** (#453) — significant architectural improvement that introduces compilation unit boundaries and caches compiled modules as `.aec` files for faster subsequent builds.
- **Consolidate WHNF into `aeon.optimization`** (#454) — moves weak head normal form reduction into a dedicated optimization package for cleaner architecture.
- **feat(cli): distinct non-zero exit code per compiler error category** (#451) — the CLI now returns different exit codes for parse errors, type errors, synthesis failures, etc., enabling better scripting and CI integration.
- **examples: add nurse scheduling with shift requests** (#452) — new constraint-based scheduling example demonstrating soft and hard constraints.
- **docs(examples): model lethal-trifecta prevention with Liquid Types** (#450) — new documentation example showcasing refinement types for safety-critical scheduling.

**Full diff:** https://github.com/alcides/aeon/compare/v4.1.7...cursor/release-4.2.0-6168
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-883d48bc-29e9-417a-9e8e-b049dd096168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-883d48bc-29e9-417a-9e8e-b049dd096168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

