### PR TITLE
feat(verification): warn when refinements leave the decidable fragment (#438)

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -16,6 +16,7 @@ from aeon.facade.api import (
     LinearityError,
     MethodResolutionError,
     NonOrderableComparisonError,
+    UndecidableRefinementError,
     UnificationFailedError,
     UnificationKindError,
     UnificationSubtypingError,
@@ -90,6 +91,15 @@ def _parse_common_arguments(parser: ArgumentParser):
     )
 
     parser.add_argument("-n", "--no-main", action="store_true", help="Disables introducing hole in main")
+
+    parser.add_argument(
+        "--strict-decidable",
+        action="store_true",
+        help=(
+            "Treat refinements that leave the decidable fragment (nonlinear arithmetic such as `x * y`, "
+            "division/modulo by a non-constant divisor, ...) as errors instead of warnings."
+        ),
+    )
 
     parser.add_argument(
         "--test",
@@ -219,6 +229,11 @@ def _error_kind_and_hint(err: AeonError) -> tuple[str, str | None]:
             return "Missing instance", "Define a typeclass instance for this type, or add it as a constraint."
         case NonOrderableComparisonError():
             return "Non-orderable comparison", "Use Int, Float or String, or define an Ord instance for this type."
+        case UndecidableRefinementError():
+            return (
+                "Undecidable refinement",
+                "Keep refinements in the decidable fragment (linear arithmetic), or drop --strict-decidable.",
+            )
         case MethodResolutionError():
             return "Method resolution error", "No method with this name is defined for the receiver's type."
         case LinearityError():
@@ -227,6 +242,22 @@ def _error_kind_and_hint(err: AeonError) -> tuple[str, str | None]:
             return "Type error", None
         case _:
             return "Error", None
+
+
+def print_decidability_warnings(driver: AeonDriver) -> None:
+    """Print non-fatal warnings for refinements that leave the decidable
+    fragment (issue #438). Collected during ``driver.parse``; under
+    ``--strict-decidable`` these surface as errors instead and this list is
+    empty."""
+    from aeon.verification.decidability import format_location
+
+    if driver.cfg.strict_decidable:
+        # Under strict mode these are reported as errors instead, so printing
+        # them here as warnings too would just duplicate the diagnostic.
+        return
+    for w in getattr(driver, "decidability_warnings", []):
+        print(f">>> Warning ({w.construct}) at {format_location(w.location)}:", file=sys.stderr)
+        print(f"    {w.message}", file=sys.stderr)
 
 
 def handle_error(err: AeonError):
@@ -269,6 +300,7 @@ def main() -> None:
         # under ``--test`` the slot must exist even if ``--no-main`` was passed.
         no_main=(args.no_main or bool(getattr(args, "export", None))) and not run_tests,
         synthesis_format=SynthesisFormat.from_string(args.synthesis_format),
+        strict_decidable=getattr(args, "strict_decidable", False),
     )
     driver = AeonDriver(cfg)
 
@@ -312,6 +344,8 @@ def main() -> None:
     except AeonError as e:
         handle_error(e)
         sys.exit(error_exit_code(e))
+
+    print_decidability_warnings(driver)
 
     match errors:
         case [] if getattr(args, "trust_report", False) or getattr(args, "trust_for", None):

--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -145,6 +145,26 @@ class NonOrderableComparisonError(AeonError):
         return self.loc
 
 
+@dataclass
+class UndecidableRefinementError(AeonError):
+    """A refinement predicate uses syntax outside the decidable fragment Liquid
+    Types target (e.g. ``x * y`` or ``x % y`` with a non-constant divisor).
+
+    Only raised under strict mode (``--strict-decidable``); otherwise the same
+    situation is reported as a non-fatal warning. ``construct`` names the
+    offending syntax and ``detail`` explains why it is problematic."""
+
+    construct: str
+    detail: str
+    loc: Location
+
+    def __str__(self) -> str:
+        return f"Refinement uses {self.construct}, which is outside the decidable fragment: {self.detail}"
+
+    def position(self) -> Location:
+        return self.loc
+
+
 class CoreTypeCheckingError(AeonError):
     pass
 

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -15,7 +15,7 @@ from aeon.compilation.compile import (
 from aeon.compilation.link import collect_constructor_names
 from aeon.core.substitutions import substitution
 from aeon.core.terms import Term
-from aeon.facade.api import AeonError
+from aeon.facade.api import AeonError, UndecidableRefinementError
 from aeon.prelude.prelude import evaluation_vars
 from aeon.sugar.bind import bind_program
 from aeon.sugar.instance_registry import clear_instance_registry
@@ -46,6 +46,9 @@ class AeonConfig:
     timings: bool = False
     no_main: bool = False
     synthesis_format: SynthesisFormat = SynthesisFormat.DEFAULT
+    # Treat refinements that leave the decidable fragment (nonlinear
+    # arithmetic, ...) as errors instead of warnings (issue #438).
+    strict_decidable: bool = False
 
 
 class AeonDriver:
@@ -54,10 +57,12 @@ class AeonDriver:
 
     def __init__(self, cfg: AeonConfig):
         self.cfg = cfg
+        self.decidability_warnings: list = []
 
     def parse(self, filename: str = None, aeon_code: str = None) -> Iterable[AeonError]:
         self.core = None
         self.typing_ctx = None
+        self.decidability_warnings = []
 
         with RecordTime("ParseSugar"):
             clear_instance_registry()
@@ -91,6 +96,16 @@ class AeonDriver:
         if errors:
             return errors
         assert core is not None and typing_ctx is not None and metadata is not None
+
+        with RecordTime("DecidabilityScan"):
+            from aeon.verification.decidability import collect_decidability_warnings
+
+            self.decidability_warnings = collect_decidability_warnings(core, source_path=unit.source_path)
+            if self.cfg.strict_decidable and self.decidability_warnings:
+                return [
+                    UndecidableRefinementError(construct=w.construct, detail=w.message, loc=w.location)
+                    for w in self.decidability_warnings
+                ]
 
         self.metadata = metadata
 

--- a/aeon/facade/exit_codes.py
+++ b/aeon/facade/exit_codes.py
@@ -28,6 +28,7 @@ from aeon.facade.api import (
     MethodResolutionError,
     ModuleNotFoundAeonError as AeonImportError,
     NonOrderableComparisonError,
+    UndecidableRefinementError,
     UnificationFailedError,
     UnificationKindError,
     UnificationSubtypingError,
@@ -51,7 +52,8 @@ class ExitCode(IntEnum):
     LINEARITY_ERROR = 12
     CORE_TYPE_ERROR = 13
     INVALID_REFINEMENT = 14
-    OTHER_ERROR = 15
+    UNDECIDABLE_REFINEMENT = 15
+    OTHER_ERROR = 16
 
 
 def error_exit_code(err: AeonError) -> ExitCode:
@@ -78,6 +80,8 @@ def error_exit_code(err: AeonError) -> ExitCode:
             return ExitCode.MISSING_INSTANCE
         case NonOrderableComparisonError():
             return ExitCode.NON_ORDERABLE_COMPARISON
+        case UndecidableRefinementError():
+            return ExitCode.UNDECIDABLE_REFINEMENT
         case LinearityError():
             return ExitCode.LINEARITY_ERROR
         case CoreTypeCheckingError():

--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -27,7 +27,7 @@ from lsprotocol.types import Diagnostic, DiagnosticSeverity
 from lsprotocol.types import Position, Range
 
 from aeon.facade.driver import AeonDriver
-from aeon.lsp.server import AeonLanguageServer
+from aeon.lsp.server import AeonLanguageServer, _loc_to_range
 
 requests_session = requests.Session()
 
@@ -186,6 +186,22 @@ async def _parse(
                     severity=DiagnosticSeverity.Error,
                 )
             )
+
+        # Non-fatal decidability warnings (issue #438): refinements that leave
+        # the decidable fragment z3 can reliably decide. Surface them as
+        # Warning-severity diagnostics so they appear in the editor. Under strict
+        # mode they are already returned as errors above, so skip them here to
+        # avoid a duplicate squiggle on the same span.
+        if not getattr(driver.cfg, "strict_decidable", False):
+            for warning in getattr(driver, "decidability_warnings", []):
+                diagnostics.append(
+                    Diagnostic(
+                        message=f"{warning.construct}: {warning.message}",
+                        range=_loc_to_range(warning.location),
+                        source="aeon",
+                        severity=DiagnosticSeverity.Warning,
+                    )
+                )
 
         if not errors:
             holes = find_holes_in_source(content)

--- a/aeon/verification/decidability.py
+++ b/aeon/verification/decidability.py
@@ -1,0 +1,335 @@
+"""Decidable-fragment classification for refinement predicates (issue #438).
+
+Refinement checking is discharged by Z3. Liquid Types target a *decidable*
+fragment — quantifier-free linear integer/real arithmetic (QF_LIA / QF_LRA),
+the theory of equality with uninterpreted functions (EUF), plus the predicate
+abstraction Horn solving adds on top. As long as every refinement stays inside
+that fragment, Z3 is a *decision procedure*: it answers ``sat``/``unsat`` and
+the type checker's yes/no verdict is reliable.
+
+When a refinement steps outside the fragment — most commonly *nonlinear*
+arithmetic such as ``x * y`` (a product of two unknowns), ``x / y`` or
+``x % y`` with a non-constant divisor — Z3 becomes *incomplete*: it may return
+``unknown`` or time out, and a once-passing program can start failing for no
+visible reason. That is the worst failure mode for a verification-first
+language, so this module classifies each predicate and lets the front end warn
+(or, in strict mode, reject) before the solver is ever consulted.
+
+What is *in* the fragment (no warning):
+
+* Boolean/relational structure: ``&&``, ``||``, ``!``, ``-->``, ``==``,
+  ``!=``, ``<``, ``<=``, ``>``, ``>=``, ``ite``.
+* Linear arithmetic: ``+``, ``-``, and multiplication/division/modulo where at
+  least one side is a *constant* (e.g. ``2 * x``, ``x / 4``, ``x % 2``).
+* Uninterpreted-function applications (measures, datatype projections, reflected
+  functions) and predicate-abstraction holes — these live in EUF / Horn.
+* Set operations (``Set_mem``, ``Set_cup``, ...), which Z3 decides natively.
+
+What is *out* of the fragment (warned about here):
+
+* ``x * y`` — multiplication of two non-constant terms (nonlinear).
+* ``x / y`` / ``x % y`` — division or modulo by a non-constant divisor.
+* ``x ** y`` — exponentiation (no native Z3 theory). The surface syntax has no
+  ``**`` operator, but the classifier flags it defensively.
+* Quantifiers (``forall`` / ``exists``) inside a predicate. The surface
+  refinement language cannot express these today; they are listed for
+  completeness and flagged defensively if ever constructed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from aeon.core.liquid import (
+    LiquidApp,
+    LiquidHole,
+    LiquidLiteralBool,
+    LiquidLiteralFloat,
+    LiquidLiteralInt,
+    LiquidLiteralString,
+    LiquidLiteralUnit,
+    LiquidTerm,
+    LiquidVar,
+)
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    Hole,
+    If,
+    ImplicitRefinementHole,
+    Let,
+    Literal,
+    Rec,
+    RefinementAbstraction,
+    RefinementApplication,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+    Var,
+)
+from aeon.core.types import (
+    AbstractionType,
+    ExistentialType,
+    LiquidHornApplication,
+    RefinedType,
+    RefinementPolymorphism,
+    Top,
+    Type,
+    TypeConstructor,
+    TypePolymorphism,
+    TypeVar,
+)
+from aeon.utils.location import FileLocation, Location, SynthesizedLocation
+
+# Operator names (the ``Name.name`` string of a ``LiquidApp.fun``).
+_MULTIPLICATION = {"*", "*."}
+_DIVISION_MODULO = {"/", "/.", "%", "%."}
+_EXPONENTIATION = {"**", "^"}
+_QUANTIFIERS = {"forall", "exists"}
+
+
+@dataclass(frozen=True)
+class DecidabilityWarning:
+    """A refinement construct that leaves the decidable fragment Liquid Types
+    target. ``construct`` names the offending syntax; ``message`` is a full,
+    user-facing explanation; ``location`` points at the source span."""
+
+    location: Location
+    construct: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.construct}: {self.message}"
+
+
+def _mentions_variable(t: LiquidTerm) -> bool:
+    """Whether ``t`` references any program variable (i.e. is *not* a constant).
+
+    A term with no variable references folds to a literal and keeps a product /
+    divisor inside linear arithmetic; one that mentions a variable does not.
+    Predicate-abstraction holes and Horn applications count as variable-bearing.
+    """
+    match t:
+        case LiquidVar(_):
+            return True
+        case (
+            LiquidLiteralBool(_)
+            | LiquidLiteralInt(_)
+            | LiquidLiteralFloat(_)
+            | LiquidLiteralString(_)
+            | LiquidLiteralUnit()
+        ):
+            return False
+        case LiquidApp(_, args, _):
+            return any(_mentions_variable(a) for a in args)
+        case LiquidHornApplication(_, _, _) | LiquidHole():
+            return True
+        case _:
+            return False
+
+
+def classify_refinement(refinement: LiquidTerm) -> list[DecidabilityWarning]:
+    """Classify a single refinement predicate, returning a warning for every
+    out-of-fragment construct it contains (depth-first, source order)."""
+    warnings: list[DecidabilityWarning] = []
+    _classify(refinement, warnings)
+    return warnings
+
+
+def _classify(t: LiquidTerm, warnings: list[DecidabilityWarning]) -> None:
+    match t:
+        case LiquidApp(fun, args, loc):
+            name = fun.name
+            if name in _MULTIPLICATION and len(args) == 2:
+                if _mentions_variable(args[0]) and _mentions_variable(args[1]):
+                    warnings.append(
+                        DecidabilityWarning(
+                            location=loc,
+                            construct="nonlinear multiplication",
+                            message=(
+                                "multiplication of two non-constant terms (variable × variable) is nonlinear "
+                                "arithmetic, which is outside the decidable fragment Liquid Types rely on; "
+                                "Z3 may return 'unknown' or time out. Keep at least one factor constant, or "
+                                "encode the relation with an uninterpreted function."
+                            ),
+                        )
+                    )
+            elif name in _DIVISION_MODULO and len(args) == 2:
+                if _mentions_variable(args[1]):
+                    op = "modulo" if name in ("%", "%.") else "division"
+                    warnings.append(
+                        DecidabilityWarning(
+                            location=loc,
+                            construct=f"non-constant {op}",
+                            message=(
+                                f"{op} by a non-constant divisor is nonlinear arithmetic, which is outside "
+                                "the decidable fragment Liquid Types rely on; Z3 may return 'unknown' or time "
+                                "out. Divide by a constant, or encode the relation with an uninterpreted function."
+                            ),
+                        )
+                    )
+            elif name in _EXPONENTIATION and len(args) == 2:
+                warnings.append(
+                    DecidabilityWarning(
+                        location=loc,
+                        construct="exponentiation",
+                        message=(
+                            "exponentiation has no native Z3 theory and is outside the decidable fragment "
+                            "Liquid Types rely on; Z3 may return 'unknown' or time out."
+                        ),
+                    )
+                )
+            elif name in _QUANTIFIERS:
+                warnings.append(
+                    DecidabilityWarning(
+                        location=loc,
+                        construct="quantifier",
+                        message=(
+                            f"the quantifier '{name}' takes the predicate outside the quantifier-free "
+                            "fragment Liquid Types rely on; Z3 may return 'unknown' or time out."
+                        ),
+                    )
+                )
+            for a in args:
+                _classify(a, warnings)
+        case _:
+            # Literals, variables, Horn applications and holes carry no
+            # out-of-fragment arithmetic of their own.
+            pass
+
+
+def _refinements_in_type(ty: Type, acc: list[LiquidTerm]) -> None:
+    """Collect every refinement predicate reachable inside ``ty``."""
+    match ty:
+        case RefinedType(_, base, refinement):
+            acc.append(refinement)
+            _refinements_in_type(base, acc)
+        case AbstractionType(_, var_type, rtype):
+            _refinements_in_type(var_type, acc)
+            _refinements_in_type(rtype, acc)
+        case TypePolymorphism(_, _, body):
+            _refinements_in_type(body, acc)
+        case RefinementPolymorphism(_, sort, body):
+            _refinements_in_type(sort, acc)
+            _refinements_in_type(body, acc)
+        case TypeConstructor(_, args):
+            for arg in args:
+                _refinements_in_type(arg, acc)
+        case ExistentialType(binders, body):
+            for _, bt in binders:
+                _refinements_in_type(bt, acc)
+            _refinements_in_type(body, acc)
+        case Top() | TypeVar(_):
+            pass
+        case _:
+            pass
+
+
+def _types_in_term(term: Term, acc: list[Type]) -> None:
+    """Collect every ``Type`` embedded inside a core ``term``."""
+    match term:
+        case Literal(_, ty, _):
+            acc.append(ty)
+        case Annotation(expr, ty, _):
+            acc.append(ty)
+            _types_in_term(expr, acc)
+        case Application(fun, arg, _):
+            _types_in_term(fun, acc)
+            _types_in_term(arg, acc)
+        case Abstraction(_, body, _):
+            _types_in_term(body, acc)
+        case Let(_, var_value, body, _, _):
+            _types_in_term(var_value, acc)
+            _types_in_term(body, acc)
+        case Rec(var_type=var_type, var_value=var_value, body=body):
+            acc.append(var_type)
+            _types_in_term(var_value, acc)
+            _types_in_term(body, acc)
+        case If(cond, then, otherwise, _):
+            _types_in_term(cond, acc)
+            _types_in_term(then, acc)
+            _types_in_term(otherwise, acc)
+        case TypeAbstraction(_, _, body, _):
+            _types_in_term(body, acc)
+        case RefinementAbstraction(_, sort, body, _):
+            acc.append(sort)
+            _types_in_term(body, acc)
+        case TypeApplication(body, ty, _):
+            acc.append(ty)
+            _types_in_term(body, acc)
+        case RefinementApplication(body, refinement, _):
+            _types_in_term(body, acc)
+            _types_in_term(refinement, acc)
+        case Var(_, _) | Hole(_, _) | ImplicitRefinementHole(_, _):
+            pass
+        case _:
+            pass
+
+
+def _location_in_file(loc: Location, source_path: str | None) -> bool:
+    """Whether ``loc`` belongs to the user's source file.
+
+    With ``source_path`` given, only refinements written in that file are kept,
+    so warnings never point at library/prelude code spliced into the program.
+    Synthesized locations (no real span) are always dropped.
+    """
+    if not isinstance(loc, FileLocation):
+        return False
+    if source_path is None:
+        return True
+    if loc.file == source_path:
+        return True
+    # The parser may record an unresolved path while the compiled unit stores
+    # the resolved one (or vice versa); compare normalized paths so a relative
+    # filename does not silently drop every warning.
+    try:
+        return Path(loc.file).resolve() == Path(source_path).resolve()
+    except (OSError, ValueError):
+        return False
+
+
+def collect_decidability_warnings(
+    term: Term,
+    *,
+    source_path: str | None = None,
+) -> list[DecidabilityWarning]:
+    """Scan a typed core ``term`` and return one warning per out-of-fragment
+    refinement construct.
+
+    Warnings are de-duplicated by ``(location span, construct)`` so a predicate
+    that the pipeline copies (elaboration, ANF) is reported once, and restricted
+    to ``source_path`` when given so only the user's own refinements warn.
+    """
+    types: list[Type] = []
+    _types_in_term(term, types)
+
+    refinements: list[LiquidTerm] = []
+    for ty in types:
+        _refinements_in_type(ty, refinements)
+
+    seen: set[tuple[object, object, str]] = set()
+    result: list[DecidabilityWarning] = []
+    for refinement in refinements:
+        for warning in classify_refinement(refinement):
+            loc = warning.location
+            if not _location_in_file(loc, source_path):
+                continue
+            key = (loc.get_start(), loc.get_end(), warning.construct)
+            if key in seen:
+                continue
+            seen.add(key)
+            result.append(warning)
+    return result
+
+
+def format_location(loc: Location) -> str:
+    """Render a ``Location`` as ``file:line:col`` (or ``str`` when synthesized)."""
+    if isinstance(loc, FileLocation):
+        line, col = loc.start
+        prefix = f"{loc.file}:" if loc.file else ""
+        return f"{prefix}{line}:{col}"
+    if isinstance(loc, SynthesizedLocation):
+        return str(loc)
+    return str(loc)

--- a/aeon/verification/decidability.py
+++ b/aeon/verification/decidability.py
@@ -281,12 +281,14 @@ def _location_in_file(loc: Location, source_path: str | None) -> bool:
         return True
     if loc.file == source_path:
         return True
+    if not loc.file:
+        return False
     # The parser may record an unresolved path while the compiled unit stores
     # the resolved one (or vice versa); compare normalized paths so a relative
     # filename does not silently drop every warning.
     try:
         return Path(loc.file).resolve() == Path(source_path).resolve()
-    except (OSError, ValueError):
+    except (OSError, ValueError, TypeError):
         return False
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -297,7 +297,9 @@ can return `unknown` or time out, and a program that verified yesterday may
 start failing for no visible reason. To make this failure mode visible, Aeon
 classifies every refinement predicate and emits a located **warning** naming the
 offending construct (and the option `--strict-decidable` turns those warnings
-into errors).
+into errors). On the command line the warning is printed to stderr; in the
+editor it surfaces through the language server as a `Warning`-severity
+diagnostic on the offending span.
 
 ### In the fragment (no warning)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,8 @@ CI can react to *what* failed (defined in `aeon.facade.exit_codes`):
 | 12 | Linearity error |
 | 13 | Core type-checking error |
 | 14 | Invalid refinement predicate |
-| 15 | Other compiler error |
+| 15 | Undecidable refinement (under `--strict-decidable`) |
+| 16 | Other compiler error |
 
 When several errors are reported, the exit code reflects the first one.
 
@@ -276,6 +277,63 @@ Aeon infers the most precise type it can for each binding:
 ```
 let balance := 1000;                          # inferred: {balance:Int | balance = 1000}
 let remaining := withdraw balance 200;        # inferred: {remaining:Int | remaining >= 0}
+```
+
+## The decidable fragment
+
+Aeon discharges every refinement proof obligation with the SMT solver z3. Liquid
+Types are designed so the predicates stay inside a **decidable** logical
+fragment, where z3 is a true *decision procedure*: it always answers
+`sat`/`unsat`, so the type checker's verdict is reliable. That fragment is:
+
+- **quantifier-free linear arithmetic** over `Int` and `Float` (QF_LIA / QF_LRA),
+- **equality with uninterpreted functions** (EUF) — measures, datatype
+  projections, and reflected function bodies become uninterpreted symbols, and
+- the **predicate abstraction** that Liquid-type (Horn-clause) inference layers
+  on top.
+
+When a refinement steps *outside* this fragment, z3 becomes **incomplete**: it
+can return `unknown` or time out, and a program that verified yesterday may
+start failing for no visible reason. To make this failure mode visible, Aeon
+classifies every refinement predicate and emits a located **warning** naming the
+offending construct (and the option `--strict-decidable` turns those warnings
+into errors).
+
+### In the fragment (no warning)
+
+| Construct | Examples |
+|---|---|
+| Boolean / relational structure | `&&`, `\|\|`, `!`, `-->`, `=`, `!=`, `<`, `<=`, `>`, `>=`, `if`/`ite` |
+| Linear arithmetic | `x + y`, `x - y`, `2 * x`, `x * 3`, `x / 4`, `x % 2` (multiplication, division, or modulo where at least one side is a **constant**) |
+| Uninterpreted functions | measures, datatype projections, reflected/`native` functions applied in a predicate (live in EUF) |
+| Predicate abstraction | inference holes for `Int<p>` / `forall <p>` parametric refinements |
+| Set operations | `Set_mem`, `Set_cup`, `Set_cap`, `Set_sub`, ... |
+
+### Out of the fragment (warned about)
+
+| Construct | Why | Example |
+|---|---|---|
+| Nonlinear multiplication | product of two unknowns is undecidable | `{v:Int \| v = x * y}` |
+| Non-constant division | division by a non-constant divisor is nonlinear | `{v:Int \| v = x / y}` |
+| Non-constant modulo | modulo by a non-constant divisor is nonlinear | `{v:Int \| v = x % y}` |
+| Exponentiation | no native z3 theory | `x ** y` |
+| Quantifiers | leave the quantifier-free fragment | `forall`, `exists` inside a predicate |
+
+The surface refinement language has no exponentiation operator or in-predicate
+quantifiers today, so in practice the warnings you will see are the nonlinear
+arithmetic ones; the rest are documented and detected defensively.
+
+To stay in the fragment, keep at least one factor of a product (or a divisor)
+constant, or model the relation with an **uninterpreted function** declared via
+`native` — z3 then reasons about it by equality (EUF) instead of trying to
+interpret the nonlinear operation.
+
+```
+# Warns: x * y is a product of two variables.
+def mul (x:Int) (y:Int) : {v:Int | v = x * y} := x * y;
+
+# No warning: one factor is constant (linear).
+def double (x:Int) : {v:Int | v = x * 2} := x * 2;
 ```
 
 ## Modules and Imports
@@ -500,6 +558,7 @@ The generated files are gitignored; they are produced from source by the
 | -l, --log | Sets the log level (TRACE, DEBUG, INFO, WARNINGS, ERROR, CRITICAL, etc.)  |
 | -f, --logfile | Exports the log to a file                                              |
 | -n, --no-main | Disables introducing hole in main                                     |
+| --strict-decidable | Treats out-of-fragment refinements (nonlinear arithmetic, ...) as errors — see [The decidable fragment](#the-decidable-fragment) |
 | --test | Runs every `@property` and `@example` as a test and reports pass/fail        |
 | --seed | Random seed for `--test` input generation (reproducible for a fixed seed)    |
 | --doc  | Generates HTML documentation from the source file                            |

--- a/tests/decidability_test.py
+++ b/tests/decidability_test.py
@@ -1,0 +1,223 @@
+"""Tests for aeon.verification.decidability — warning when refinements leave
+the decidable fragment Liquid Types target (issue #438)."""
+
+from __future__ import annotations
+
+from aeon.core.liquid import (
+    LiquidApp,
+    LiquidLiteralInt,
+    LiquidVar,
+)
+from aeon.core.types import RefinedType, t_int
+from aeon.facade.api import UndecidableRefinementError
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SynthesisUI
+from aeon.utils.location import FileLocation
+from aeon.utils.name import Name
+from aeon.verification.decidability import (
+    DecidabilityWarning,
+    classify_refinement,
+    collect_decidability_warnings,
+)
+
+setup_logger()
+
+x = Name("x")
+y = Name("y")
+v = Name("v")
+
+LOC = FileLocation("test.ae", start=(1, 1), end=(1, 10))
+
+
+def _app(op: str, *args):
+    return LiquidApp(Name(op, 0), list(args), loc=LOC)
+
+
+# ---------------------------------------------------------------------------
+# classify_refinement — multiplication
+# ---------------------------------------------------------------------------
+
+
+def test_variable_times_variable_warns():
+    warnings = classify_refinement(_app("*", LiquidVar(x), LiquidVar(y)))
+    assert len(warnings) == 1
+    assert warnings[0].construct == "nonlinear multiplication"
+    assert warnings[0].location == LOC
+
+
+def test_constant_times_variable_no_warning():
+    assert classify_refinement(_app("*", LiquidLiteralInt(2), LiquidVar(x))) == []
+
+
+def test_variable_times_constant_no_warning():
+    assert classify_refinement(_app("*", LiquidVar(x), LiquidLiteralInt(2))) == []
+
+
+def test_constant_times_constant_no_warning():
+    assert classify_refinement(_app("*", LiquidLiteralInt(2), LiquidLiteralInt(3))) == []
+
+
+# ---------------------------------------------------------------------------
+# classify_refinement — division / modulo
+# ---------------------------------------------------------------------------
+
+
+def test_division_by_variable_warns():
+    warnings = classify_refinement(_app("/", LiquidVar(x), LiquidVar(y)))
+    assert len(warnings) == 1
+    assert warnings[0].construct == "non-constant division"
+
+
+def test_division_by_constant_no_warning():
+    assert classify_refinement(_app("/", LiquidVar(x), LiquidLiteralInt(4))) == []
+
+
+def test_modulo_by_variable_warns():
+    warnings = classify_refinement(_app("%", LiquidVar(x), LiquidVar(y)))
+    assert len(warnings) == 1
+    assert warnings[0].construct == "non-constant modulo"
+
+
+def test_modulo_by_constant_no_warning():
+    assert classify_refinement(_app("%", LiquidVar(x), LiquidLiteralInt(2))) == []
+
+
+# ---------------------------------------------------------------------------
+# classify_refinement — exponentiation / quantifiers (defensive)
+# ---------------------------------------------------------------------------
+
+
+def test_exponentiation_warns():
+    warnings = classify_refinement(_app("**", LiquidVar(x), LiquidVar(y)))
+    assert len(warnings) == 1
+    assert warnings[0].construct == "exponentiation"
+
+
+def test_exponentiation_by_constant_still_warns():
+    warnings = classify_refinement(_app("**", LiquidVar(x), LiquidLiteralInt(2)))
+    assert len(warnings) == 1
+    assert warnings[0].construct == "exponentiation"
+
+
+def test_quantifier_warns():
+    warnings = classify_refinement(_app("forall", LiquidVar(x)))
+    assert len(warnings) == 1
+    assert warnings[0].construct == "quantifier"
+
+
+# ---------------------------------------------------------------------------
+# classify_refinement — purely linear predicates produce no warning
+# ---------------------------------------------------------------------------
+
+
+def test_linear_addition_no_warning():
+    # x + y > 0
+    pred = _app(">", _app("+", LiquidVar(x), LiquidVar(y)), LiquidLiteralInt(0))
+    assert classify_refinement(pred) == []
+
+
+def test_linear_scaled_no_warning():
+    # 2 * x + 3 * y = 0
+    pred = _app(
+        "=",
+        _app("+", _app("*", LiquidLiteralInt(2), LiquidVar(x)), _app("*", LiquidLiteralInt(3), LiquidVar(y))),
+        LiquidLiteralInt(0),
+    )
+    assert classify_refinement(pred) == []
+
+
+def test_comparison_only_no_warning():
+    pred = _app("<", LiquidVar(x), LiquidVar(y))
+    assert classify_refinement(pred) == []
+
+
+# ---------------------------------------------------------------------------
+# classify_refinement — nested products are found
+# ---------------------------------------------------------------------------
+
+
+def test_nested_product_in_comparison_warns():
+    # (x * y) > 0
+    pred = _app(">", _app("*", LiquidVar(x), LiquidVar(y)), LiquidLiteralInt(0))
+    warnings = classify_refinement(pred)
+    assert len(warnings) == 1
+    assert warnings[0].construct == "nonlinear multiplication"
+
+
+# ---------------------------------------------------------------------------
+# collect_decidability_warnings — type/term walking, dedup, file filter
+# ---------------------------------------------------------------------------
+
+
+def test_collect_dedups_by_span_and_construct():
+    from aeon.core.terms import Rec, Literal
+
+    refinement = _app("*", LiquidVar(x), LiquidVar(y))
+    refined = RefinedType(v, t_int, refinement)
+    # Same refined type appears in two places (signature + annotation-like reuse).
+    inner = Rec(Name("g"), refined, Literal(0, t_int), Literal(0, t_int))
+    outer = Rec(Name("f"), refined, inner, Literal(0, t_int))
+    warnings = collect_decidability_warnings(outer, source_path="test.ae")
+    assert len(warnings) == 1
+
+
+def test_collect_filters_to_source_file():
+    from aeon.core.terms import Rec, Literal
+
+    other_loc = FileLocation("other.ae", start=(2, 2), end=(2, 5))
+    refinement = LiquidApp(Name("*", 0), [LiquidVar(x), LiquidVar(y)], loc=other_loc)
+    refined = RefinedType(v, t_int, refinement)
+    term = Rec(Name("f"), refined, Literal(0, t_int), Literal(0, t_int))
+    assert collect_decidability_warnings(term, source_path="test.ae") == []
+    assert len(collect_decidability_warnings(term, source_path="other.ae")) == 1
+
+
+def test_warning_str_is_readable():
+    w = DecidabilityWarning(LOC, "nonlinear multiplication", "because reasons")
+    assert "nonlinear multiplication" in str(w)
+    assert "because reasons" in str(w)
+
+
+# ---------------------------------------------------------------------------
+# Driver integration
+# ---------------------------------------------------------------------------
+
+
+def _driver(source: str, *, strict: bool = False):
+    cfg = AeonConfig(
+        synthesizer="none",
+        synthesis_ui=SynthesisUI(),
+        synthesis_budget=0,
+        strict_decidable=strict,
+    )
+    driver = AeonDriver(cfg)
+    errors = list(driver.parse(aeon_code=source))
+    return driver, errors
+
+
+def test_driver_warns_on_nonlinear_refinement():
+    source = "def mul (x:Int) (y:Int) : {v:Int | v = x * y} := x * y;\ndef main (_:Int) : Unit := print 0;"
+    driver, errors = _driver(source)
+    assert not errors, errors
+    assert len(driver.decidability_warnings) == 1
+    assert driver.decidability_warnings[0].construct == "nonlinear multiplication"
+
+
+def test_driver_no_warning_on_linear_refinement():
+    source = "def f (x:Int) : {v:Int | v = x * 2} := x * 2;\ndef main (_:Int) : Unit := print 0;"
+    driver, errors = _driver(source)
+    assert not errors, errors
+    assert driver.decidability_warnings == []
+
+
+def test_driver_strict_turns_warning_into_error():
+    source = "def mul (x:Int) (y:Int) : {v:Int | v = x * y} := x * y;\ndef main (_:Int) : Unit := print 0;"
+    _driver_obj, errors = _driver(source, strict=True)
+    assert any(isinstance(e, UndecidableRefinementError) for e in errors), errors
+
+
+def test_driver_strict_accepts_linear_refinement():
+    source = "def f (x:Int) : {v:Int | v = x * 2} := x * 2;\ndef main (_:Int) : Unit := print 0;"
+    _driver_obj, errors = _driver(source, strict=True)
+    assert not errors, errors

--- a/tests/lsp_features_test.py
+++ b/tests/lsp_features_test.py
@@ -344,5 +344,43 @@ def test_adapter_parse_populates_type_index_and_drives_completion():
     assert "double" in labels(comps)
 
 
+# --------------------------------------------------------------------------- #
+# Decidability warnings surface as LSP Warning diagnostics (issue #438)
+# --------------------------------------------------------------------------- #
+
+_NONLINEAR_SRC = "def mul (x:Int) (y:Int) : {v:Int | v = x * y} := x * y;\ndef main (_:Int) : Unit := print 0;"
+_LINEAR_SRC = "def f (x:Int) : {v:Int | v = x * 2} := x * 2;\ndef main (_:Int) : Unit := print 0;"
+
+
+def test_adapter_emits_warning_diagnostic_for_nonlinear_refinement():
+    import asyncio
+
+    from lsprotocol.types import DiagnosticSeverity
+
+    from aeon.lsp import aeon_adapter
+
+    ls = _MockLS(_NONLINEAR_SRC)
+    result = asyncio.run(aeon_adapter.parse(ls, "file:///nl_warn.ae"))
+
+    warnings = [d for d in result.diagnostics if d.severity == DiagnosticSeverity.Warning]
+    assert len(warnings) == 1
+    assert "nonlinear multiplication" in warnings[0].message
+    # 1-indexed core (1, 40) -> 0-indexed LSP (0, 39).
+    assert warnings[0].range.start.line == 0
+
+
+def test_adapter_no_warning_for_linear_refinement():
+    import asyncio
+
+    from lsprotocol.types import DiagnosticSeverity
+
+    from aeon.lsp import aeon_adapter
+
+    ls = _MockLS(_LINEAR_SRC)
+    result = asyncio.run(aeon_adapter.parse(ls, "file:///lin_ok.ae"))
+
+    assert [d for d in result.diagnostics if d.severity == DiagnosticSeverity.Warning] == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #438.

Refinement proof obligations are discharged by z3, which is a *decision procedure* only inside the decidable fragment Liquid Types target — quantifier-free linear arithmetic + EUF + predicate abstraction. When a refinement uses **nonlinear arithmetic** (`x * y`, or `x / y` / `x % y` with a non-constant divisor), z3 can return `unknown` or time out, and today the failure surfaces with no hint that the *predicate itself* was outside the supported fragment ("sometimes it just doesn't work").

This PR makes that failure mode visible: every refinement predicate is classified, and out-of-fragment constructs produce a **located warning** naming the offending construct — both on the CLI and as an editor diagnostic via the language server. An opt-in strict mode promotes the warnings to errors.

## What changed

- **New module `aeon/verification/decidability.py`**
  - `classify_refinement(liq)` walks a `LiquidTerm` and returns one `DecidabilityWarning` per out-of-fragment construct:
    - nonlinear multiplication (`x * y`, both sides non-constant — including products of measures like `size a * size b`),
    - non-constant division / modulo (`x / y`, `x % y`),
    - exponentiation (`**`) and quantifiers — detected defensively; the surface refinement language can't express them today.
  - `collect_decidability_warnings(term, source_path=...)` walks a typed core `Term`, gathers every refinement, de-duplicates by `(span, construct)`, and restricts results to the user's own source file so library/prelude refinements never warn.
- **Driver (`aeon/facade/driver.py`)**: after a successful compile, collects warnings onto `driver.decidability_warnings`. New `AeonConfig.strict_decidable`; when set, out-of-fragment refinements are returned as errors instead.
- **CLI (`aeon/__main__.py`)**: new `--strict-decidable` flag. Warnings are printed to stderr by default; under strict mode they surface as `UndecidableRefinementError`.
- **LSP (`aeon/lsp/aeon_adapter.py`)**: emits the warnings as `Warning`-severity diagnostics (correct 1→0 indexed span) so they show up as squiggles in the editor. Skipped under strict mode, where they are already reported as errors.
- **Errors / exit codes**: new `UndecidableRefinementError` (`aeon/facade/api.py`) mapped to a new exit code `15` (`OTHER_ERROR` shifts to `16`).
- **Docs (`docs/index.md`)**: a new "The decidable fragment" section with the documented list of in-fragment vs out-of-fragment constructs, plus the new flag, exit code, and a note that the LSP surfaces warnings.
- **Tests**: `tests/decidability_test.py` (22 tests for the classifier, term/type walking, de-dup, file filtering, and driver/strict-mode integration) and new LSP-adapter tests in `tests/lsp_features_test.py` (Warning diagnostic for nonlinear refinements; none for linear).

## Acceptance criteria

- ✅ A refinement containing `x * y` (two variables) or `x ** y` produces a located warning.
- ✅ Purely linear refinements (`x + y`, `2 * x`, `x / 4`, `x % 2`) produce no warning.
- ✅ A documented list of in-fragment vs out-of-fragment constructs (`docs/index.md`).
- ✅ Optional strict mode (`--strict-decidable`) turns warnings into errors.
- ✅ Warnings are surfaced in the editor via the language server (Warning diagnostics).

## Example

```
$ aeon nonlinear.ae
>>> Warning (nonlinear multiplication) at nonlinear.ae:1:40:
    multiplication of two non-constant terms (variable × variable) is nonlinear
    arithmetic, which is outside the decidable fragment Liquid Types rely on; ...
```

```
def mul (x:Int) (y:Int) : {v:Int | v = x * y} := x * y;   # warns
def double (x:Int)      : {v:Int | v = x * 2} := x * 2;   # no warning
```

## Testing

- `pytest tests/decidability_test.py tests/lsp_features_test.py tests/lsp_test.py` (all pass) plus related driver/typechecking suites.
- `ruff check`, `ruff format --check`, and the pre-commit `mypy` hook pass on the changed files.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1185a11-9ed1-4917-be5f-83240d0f67b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1185a11-9ed1-4917-be5f-83240d0f67b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

