### PR TITLE
chore(cloud): add Cursor cloud agent environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "aeon",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Idempotent dependency setup for Aeon Cursor Cloud agents.
+#
+# Referenced as the `install` command in .cursor/environment.json, so it runs on
+# every cloud-agent VM boot (after the latest changes are pulled). It must be
+# safe to run repeatedly and on a partially-cached filesystem.
+#
+# What it does:
+#   1. Ensures `uv` (the project's package manager) is on PATH.
+#   2. Creates the project virtualenv at /workspace/.venv. We use `uv venv`
+#      rather than `python3 -m venv` because the base image's system Python
+#      ships without `ensurepip`, so the stdlib venv module fails.
+#   3. Installs Aeon in editable mode plus the test/lint toolchain.
+#   4. Pre-caches the pre-commit hook environments (the first run is slow;
+#      subsequent runs are fast).
+#
+# After this runs, an interactive shell only needs:
+#   source /workspace/.venv/bin/activate
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+cd "$ROOT"
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# 1. Ensure uv is available. Try the standalone installer first (no assumptions
+#    about pip or an active virtualenv); fall back to pip in its various flavours
+#    so this works whether or not a venv happens to be active.
+if ! command -v uv >/dev/null 2>&1; then
+    echo "[install] uv not found; bootstrapping ..."
+    if command -v curl >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh || true
+    fi
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+fi
+if ! command -v uv >/dev/null 2>&1; then
+    python3 -m pip install --user uv \
+        || python3 -m pip install --user --break-system-packages uv \
+        || python3 -m pip install --break-system-packages uv
+fi
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+
+# 2. Create the venv if it does not already exist.
+if [ ! -x .venv/bin/python ]; then
+    echo "[install] creating virtualenv at .venv ..."
+    uv venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+# 3. Install Aeon (editable) plus the test and lint toolchain. `[tests]` brings
+#    in pytest + pytest-beartype; pre-commit/mypy/ruff are the lint stack the
+#    repo's pre-commit hooks use.
+echo "[install] installing Aeon and dependencies ..."
+uv pip install -e ".[tests]"
+uv pip install pre-commit mypy ruff
+
+# 4. Pre-cache pre-commit hook environments. We use `pre-commit run` rather than
+#    `pre-commit install` so we do not clobber the cloud harness's managed git
+#    hooksPath; running the hooks once is enough to populate their cached envs.
+echo "[install] warming pre-commit hook environments ..."
+pre-commit run --all-files || true
+
+echo "[install] done."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a committed Cursor Cloud agent environment configuration so agents provision the Aeon toolchain automatically on boot, instead of each agent re-discovering and re-installing dependencies by hand.

## What's included

- **`.cursor/environment.json`** — points the cloud `install` step at the setup script.
- **`.cursor/install.sh`** — an idempotent setup script that:
  1. bootstraps `uv` (standalone installer, with `pip --user` / `--break-system-packages` fallbacks),
  2. creates the project virtualenv at `/workspace/.venv` with `uv venv` — the base image's system Python ships **without `ensurepip`**, so `python3 -m venv` fails; `uv venv` sidesteps that,
  3. installs Aeon editable with the test extras plus the lint stack (`uv pip install -e ".[tests]"`, then `pre-commit`, `mypy`, `ruff`), and
  4. warms the pre-commit hook environments via `pre-commit run --all-files` (uses `run`, not `install`, so it doesn't clobber the cloud harness's managed git `hooksPath`).

After boot, an interactive shell only needs `source /workspace/.venv/bin/activate`, matching the instructions already documented in `AGENTS.md`.

## Why

On a fresh VM the system Python had no `pytest`/`lark`/`z3` and `python3 -m venv` failed (no `ensurepip`), so the toolchain had to be reconstructed manually. This config makes that setup automatic and reproducible for every cloud agent.

## Validation

Ran `bash .cursor/install.sh` from scratch (no pre-existing `.venv`) in a sanitized shell:
- `uv` bootstrapped, `.venv` created, Aeon + toolchain installed.
- `pre-commit run --all-files` passed (check-yaml, check-toml, mypy, ruff, ruff-format, pyroma, ...).
- `python -c "import aeon, z3, lark"` and `pytest tests/end_to_end_test.py` (12 passed) succeed in the resulting venv.

The script is idempotent: a second run reuses the existing `.venv` and only performs incremental work.

## Notes

- `.venv` is already gitignored, so nothing environment-specific is committed beyond the config + script.
- This is independent of the #438 bug-fix work (PR #457) and is on its own branch off `master`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1185a11-9ed1-4917-be5f-83240d0f67b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1185a11-9ed1-4917-be5f-83240d0f67b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

