### PR TITLE
fix(libraries): thread linear Rng through Distributions samplers (#441)

### DIFF
--- a/aeon/bindings/random_sample.py
+++ b/aeon/bindings/random_sample.py
@@ -1,0 +1,25 @@
+"""Batch sampling helpers for ``libraries/Distributions.ae`` (issue #441).
+
+All functions draw from a Python ``random.Random`` instance (the runtime
+representation of aeon's linear ``Rng``) so sample batches never touch the
+global ``numpy.random`` / ``random.random()`` state.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def poisson_batch(lam: float, n: int, g: Any) -> list[float]:
+    """Draw *n* Poisson(*lam*) samples using Knuth's algorithm on *g*."""
+    out: list[float] = []
+    for _ in range(n):
+        threshold = math.exp(-lam)
+        k = 0
+        p = 1.0
+        while p > threshold:
+            k += 1
+            p *= g.random()
+        out.append(float(k - 1))
+    return out

--- a/aeon/libraries/Distributions.ae
+++ b/aeon/libraries/Distributions.ae
@@ -1,27 +1,39 @@
-# Distributions.ae
+# Distributions.ae — linear batch samplers (issue #441 follow-up).
 #
-# Probability distribution producers paired with quantile-bound postulates.
+# Each producer draws a batch from a linear ``Rng`` (``libraries/Random.ae``),
+# returning an opaque ``SampleDraw`` paired with the successor generator. Project
+# the array through the distribution-specific ``*_value`` function (where the
+# quantile-bound refinements live), then bind ``sample_next`` to continue the
+# chain. Batch draws never use ``numpy.random`` or other global RNG state.
+#
 # Refinement-language predicates (fracBelow, fracAbove, sampleMean, ...) and
 # their monotonicity axioms (widenBelow, widenAbove, ...) live in Statistics.
-#
-# Each producer is `native` (numpy under the hood). Its return refinement
-# is a *postulate* asserting the true distributional quantiles. For finite
-# samples these are expected-value claims; we treat them as trusted facts
-# since the FFI is on the user's honor.
-#
-# Constants are CDF-inverse evaluations (z-scores, ln(1-p), etc.) hardcoded.
 
 open Array
 open Math
+open Random
 open Statistics
+
+# Opaque batch draw: a sample array paired with the successor generator.
+type SampleDraw
+
+def sample_next (d: SampleDraw) : Rng := native "d[1]"
 
 # ─── Normal distribution N(mu, sigma) ──────────────────────────────────
 # z-scores: 1.282 (90%), 1.645 (95%), 2.33 (99%).
 
-def normalSample
+def normal_sample
+    (1 g: Rng)
     (mu: Float)
     (sigma: {s: Float | s > 0.0})
     (n: {m: Int | m > 0})
+    : SampleDraw
+    := native "(list(g.gauss(mu, sigma) for _ in range(n)), g)"
+
+def normal_value
+    (mu: Float)
+    (sigma: {s: Float | s > 0.0})
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracBelow xs (mu + 2.33 * sigma)  >= 0.99
@@ -31,12 +43,18 @@ def normalSample
         && fracAbove xs (mu - 1.282 * sigma) >= 0.90
         && fracAbove xs (mu - 1.645 * sigma) >= 0.95
         && fracAbove xs (mu - 2.33 * sigma)  >= 0.99 }
-    := native "list(__import__('numpy').random.normal(mu, sigma, n))"
+    := native "d[0]"
 
 # ─── Standard normal Z ~ N(0, 1) ───────────────────────────────────────
 
-def standardNormalSample
+def standard_normal_sample
+    (1 g: Rng)
     (n: {m: Int | m > 0})
+    : SampleDraw
+    := native "(list(g.gauss(0.0, 1.0) for _ in range(n)), g)"
+
+def standard_normal_value
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracBelow xs 2.33  >= 0.99
@@ -46,15 +64,23 @@ def standardNormalSample
         && fracAbove xs 0.0    >= 0.50
         && fracAbove xs (0.0 - 1.282) >= 0.90
         && fracAbove xs (0.0 - 2.33)  >= 0.99 }
-    := native "list(__import__('numpy').random.standard_normal(n))"
+    := native "d[0]"
 
 # ─── Uniform distribution U(a, b) ──────────────────────────────────────
 # Quantile p is exactly a + p*(b - a). Support is [a, b].
 
-def uniformSample
+def uniform_sample
+    (1 g: Rng)
     (a: Float)
     (b: {bb: Float | bb > a})
     (n: {m: Int | m > 0})
+    : SampleDraw
+    := native "(list(g.uniform(a, b) for _ in range(n)), g)"
+
+def uniform_value
+    (a: Float)
+    (b: {bb: Float | bb > a})
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracAbove xs a >= 1.0
@@ -63,15 +89,22 @@ def uniformSample
         && fracBelow xs (a + 0.95 * (b - a)) >= 0.95
         && fracBelow xs (a + 0.50 * (b - a)) >= 0.50
         && fracBelow xs (a + 0.10 * (b - a)) >= 0.10 }
-    := native "list(__import__('numpy').random.uniform(a, b, n))"
+    := native "d[0]"
 
 # ─── Exponential distribution Exp(rate = lambda) ───────────────────────
 # Quantile p:  -ln(1 - p) / lambda.   Support [0, ∞).
 # Constants: 0.6931 (50%), 2.3026 (90%), 2.9957 (95%), 4.6052 (99%).
 
-def exponentialSample
+def exponential_sample
+    (1 g: Rng)
     (lam: {l: Float | l > 0.0})
     (n: {m: Int | m > 0})
+    : SampleDraw
+    := native "(list(g.expovariate(lam) for _ in range(n)), g)"
+
+def exponential_value
+    (lam: {l: Float | l > 0.0})
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracAbove xs 0.0 >= 1.0
@@ -79,81 +112,123 @@ def exponentialSample
         && fracBelow xs (2.9957 / lam) >= 0.95
         && fracBelow xs (2.3026 / lam) >= 0.90
         && fracBelow xs (0.6931 / lam) >= 0.50 }
-    := native "list(__import__('numpy').random.exponential(1.0 / lam, n))"
+    := native "d[0]"
 
 # ─── Beta distribution Beta(alpha, beta) ───────────────────────────────
 # Support is (0, 1). Mean = alpha / (alpha + beta).
 
-def betaSample
+def beta_sample
+    (1 g: Rng)
     (alpha: {a: Float | a > 0.0})
     (beta:  {b: Float | b > 0.0})
     (n:     {m: Int   | m > 0})
+    : SampleDraw
+    := native "(list(g.betavariate(alpha, beta) for _ in range(n)), g)"
+
+def beta_value
+    (alpha: {a: Float | a > 0.0})
+    (beta:  {b: Float | b > 0.0})
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracAbove xs 0.0 >= 1.0
         && fracBelow xs 1.0 >= 1.0
         && ((sampleMean xs) = (alpha / (alpha + beta))) }
-    := native "list(__import__('numpy').random.beta(alpha, beta, n))"
+    := native "d[0]"
 
 # ─── Gamma distribution Gamma(shape k, scale theta) ────────────────────
 # Support [0, ∞). Mean = k * theta. Var = k * theta * theta.
 
-def gammaSample
+def gamma_sample
+    (1 g: Rng)
     (k:     {kk: Float | kk > 0.0})
     (theta: {th: Float | th > 0.0})
     (n:     {m:  Int   | m > 0})
+    : SampleDraw
+    := native "(list(g.gammavariate(k, theta) for _ in range(n)), g)"
+
+def gamma_value
+    (k:     {kk: Float | kk > 0.0})
+    (theta: {th: Float | th > 0.0})
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracAbove xs 0.0 >= 1.0
         && ((sampleMean xs) = (k * theta))
         && ((sampleVar  xs) = (k * (theta * theta))) }
-    := native "list(__import__('numpy').random.gamma(k, theta, n))"
+    := native "d[0]"
 
 # ─── Chi-squared distribution Chi²(k) ──────────────────────────────────
 # Support [0, ∞). Mean = k.  Var = 2k.
 
-def chiSquaredSample
+def chi_squared_sample
+    (1 g: Rng)
     (k: {kk: Int | kk > 0})
     (n: {m: Int  | m > 0})
+    : SampleDraw
+    := native "(list(sum(g.gauss(0.0, 1.0)**2 for _ in range(k)) for _ in range(n)), g)"
+
+def chi_squared_value
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracAbove xs 0.0 >= 1.0 }
-    := native "list(__import__('numpy').random.chisquare(k, n))"
+    := native "d[0]"
 
 # ─── Bernoulli distribution Ber(p) ─────────────────────────────────────
 # Values are 0.0 or 1.0. Mean = p.
 
-def bernoulliSample
+def bernoulli_sample
+    (1 g: Rng)
     (p: {pp: Float | pp >= 0.0 && pp <= 1.0})
     (n: {m: Int | m > 0})
+    : SampleDraw
+    := native "(list(1.0 if g.random() < p else 0.0 for _ in range(n)), g)"
+
+def bernoulli_value
+    (p: {pp: Float | pp >= 0.0 && pp <= 1.0})
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracBelow xs 0.5 >= (1.0 - p)
         && fracAbove xs 0.5 >= p
         && fracBelow xs 1.5 >= 1.0
         && fracAbove xs (0.0 - 0.5) >= 1.0 }
-    := native "list(map(float, __import__('numpy').random.binomial(1, p, n)))"
+    := native "d[0]"
 
 # ─── Binomial distribution Bin(trials, p) ──────────────────────────────
 # Support {0, 1, ..., trials}. Mean = trials * p.
 
-def binomialSample
+def binomial_sample
+    (1 g: Rng)
     (trials: {t: Int | t > 0})
     (p:      {pp: Float | pp >= 0.0 && pp <= 1.0})
     (n:      {m: Int | m > 0})
+    : SampleDraw
+    := native "(list(float(sum(1 if g.random() < p else 0 for _ in range(trials))) for _ in range(n)), g)"
+
+def binomial_value
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracAbove xs (0.0 - 0.5) >= 1.0 }
-    := native "list(map(float, __import__('numpy').random.binomial(trials, p, n)))"
+    := native "d[0]"
 
 # ─── Poisson distribution Pois(lambda) ─────────────────────────────────
 # Support {0, 1, 2, ...}. Mean = Var = lambda.
 
-def poissonSample
+def poisson_sample
+    (1 g: Rng)
     (lam: {l: Float | l > 0.0})
     (n:   {m: Int | m > 0})
+    : SampleDraw
+    := native "(__import__('aeon.bindings.random_sample', fromlist=['poisson_batch']).poisson_batch(lam, n, g), g)"
+
+def poisson_value
+    (lam: {l: Float | l > 0.0})
+    (d: SampleDraw)
     : { xs: (Array Float)
       | Array.size xs > 0
         && fracAbove xs (0.0 - 0.5) >= 1.0
         && ((sampleMean xs) = lam) }
-    := native "list(map(float, __import__('numpy').random.poisson(lam, n)))"
+    := native "d[0]"

--- a/examples/probabilistic/distributions_demo.ae
+++ b/examples/probabilistic/distributions_demo.ae
@@ -1,5 +1,6 @@
 open Array
 open Math
+open Random
 open Statistics
 open Distributions
 
@@ -15,16 +16,23 @@ def expectMostlyPositive
     : Unit
     := print "ok: 95% of values above 0"
 
-# Demo: pull samples from several distributions and feed them to the
-# consumers, widening as needed.
-def main (_: Int) : Unit :=
-    let g  := normalSample 2.0 1.0 100 in
+# Demo: thread one linear generator through several batch samplers.
+def main (seed: Int) : Unit :=
+    let 1 g0 := new_rng seed in
+    let nd := normal_sample g0 2.0 1.0 100 in
+    let g := normal_value 2.0 1.0 nd in
+    let 1 g1 := sample_next nd in
     let g7 := widenBelow g (2.0 + 2.33 * 1.0) 7.0 in
     let r1 := expectMostlyBelow7 g7 in
-    let u  := uniformSample 0.0 5.0 100 in
+    let ud := uniform_sample g1 0.0 5.0 100 in
+    let u := uniform_value 0.0 5.0 ud in
+    let 1 g2 := sample_next ud in
     let u7 := widenBelow u 5.0 7.0 in
     let r2 := expectMostlyBelow7 u7 in
-    let e  := exponentialSample 1.0 100 in
+    let ed := exponential_sample g2 1.0 100 in
+    let e := exponential_value 1.0 ed in
+    let 1 g3 := sample_next ed in
     let r3 := expectMostlyPositive e in
-    let b  := betaSample 2.0 5.0 100 in
+    let bd := beta_sample g3 2.0 5.0 100 in
+    let b := beta_value 2.0 5.0 bd in
     expectMostlyPositive b

--- a/tests/linear_distributions_test.py
+++ b/tests/linear_distributions_test.py
@@ -1,0 +1,91 @@
+"""Linear batch samplers in ``libraries/Distributions.ae`` (issue #441 follow-up)."""
+
+from __future__ import annotations
+
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _errors(source: str):
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=True,
+    )
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _typechecks(source: str) -> bool:
+    return not _errors(source)
+
+
+_CHAIN = """
+open Random
+open Distributions
+def chain (seed: Int) : {xs: (Array Float) | Array.size xs > 0} :=
+    let 1 g0 := new_rng seed in
+    let nd := normal_sample g0 2.0 1.0 10 in
+    let xs := normal_value 2.0 1.0 nd in
+    let 1 g1 := sample_next nd in
+    let ud := uniform_sample g1 0.0 1.0 10 in
+    uniform_value 0.0 1.0 ud
+def main (x:Int) : Unit := print 0 ;
+"""
+
+
+def test_distribution_chain_typechecks():
+    assert _typechecks(_CHAIN)
+
+
+def test_unextracted_successor_needs_no_close():
+    # Like scalar draws, stopping after projecting the sample is fine.
+    src = """
+    open Random
+    open Distributions
+    def one_batch (seed: Int) : {xs: (Array Float) | Array.size xs > 0} :=
+        let 1 g0 := new_rng seed in
+        let nd := normal_sample g0 2.0 1.0 10 in
+        normal_value 2.0 1.0 nd
+    def main (x:Int) : Unit := print 0 ;
+    """
+    assert _typechecks(src)
+
+
+def test_extracted_successor_must_be_used():
+    src = """
+    open Random
+    open Distributions
+    def bad (seed: Int) : {xs: (Array Float) | Array.size xs > 0} :=
+        let 1 g0 := new_rng seed in
+        let nd := normal_sample g0 2.0 1.0 10 in
+        let xs := normal_value 2.0 1.0 nd in
+        let 1 g1 := sample_next nd in
+        xs
+    def main (x:Int) : Unit := print 0 ;
+    """
+    assert not _typechecks(src)
+
+
+def test_poisson_batch_helper():
+    import random
+
+    from aeon.bindings.random_sample import poisson_batch
+
+    g = random.Random(0)
+    xs = poisson_batch(3.0, 50, g)
+    assert len(xs) == 50
+    assert all(x >= 0.0 for x in xs)
+
+
+def test_distributions_demo_runs():
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=False,
+    )
+    driver = AeonDriver(cfg)
+    src = open("examples/probabilistic/distributions_demo.ae").read()
+    assert not driver.parse(aeon_code=src)
+    driver.run()  # should not raise


### PR DESCRIPTION
## Summary

- Rewrites `libraries/Distributions.ae` to draw batch samples from a linear `Rng` (matching `Random.ae`) instead of `numpy.random` global state.
- Each distribution exposes a consistent snake_case API: `{name}_sample`, `{name}_value`, plus shared `sample_next`.
- Adds `aeon/bindings/random_sample.py` for Poisson batch draws (Knuth's algorithm on a `random.Random` instance).
- Updates `examples/probabilistic/distributions_demo.ae` to thread one generator through several samplers.
- Adds `tests/linear_distributions_test.py` covering typechecking, linearity, and a demo smoke run.

Closes #441

## Test plan

- [x] `uv run pytest tests/linear_distributions_test.py tests/linear_random_test.py -q`
- [x] `uv run python -m aeon examples/probabilistic/distributions_demo.ae`
- [x] pre-commit hooks pass on commit


Made with [Cursor](https://cursor.com)