### PR TITLE
feat: opt-in --contracts runtime refinement checks (#443)

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -396,9 +396,9 @@ def main() -> None:
                 case (False, False):
                     try:
                         driver.run()
-                    except ContractViolationError as err:
-                        handle_error(err)
-                        sys.exit(error_exit_code(err))
+                    except ContractViolationError as contract_err:
+                        handle_error(contract_err)
+                        sys.exit(error_exit_code(contract_err))
         case [first, *_]:
             for err in errors:
                 handle_error(err)

--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -10,6 +10,7 @@ from lark.exceptions import UnexpectedInput
 
 from aeon.facade.api import (
     AeonError,
+    ContractViolationError,
     CoreTypeCheckingError,
     ModuleNotFoundAeonError as AeonImportError,
     InstanceResolutionError,
@@ -99,6 +100,12 @@ def _parse_common_arguments(parser: ArgumentParser):
             "Treat refinements that leave the decidable fragment (nonlinear arithmetic such as `x * y`, "
             "division/modulo by a non-constant divisor, ...) as errors instead of warnings."
         ),
+    )
+
+    parser.add_argument(
+        "--contracts",
+        action="store_true",
+        help="Check argument and result refinements at run time (gradual verification; off by default).",
     )
 
     parser.add_argument(
@@ -238,6 +245,8 @@ def _error_kind_and_hint(err: AeonError) -> tuple[str, str | None]:
             return "Method resolution error", "No method with this name is defined for the receiver's type."
         case LinearityError():
             return "Linearity error", "A binding's usage does not match its declared multiplicity."
+        case ContractViolationError():
+            return "Contract violation", "A runtime refinement check failed; see blame (caller vs callee)."
         case CoreTypeCheckingError():
             return "Type error", None
         case _:
@@ -301,6 +310,7 @@ def main() -> None:
         no_main=(args.no_main or bool(getattr(args, "export", None))) and not run_tests,
         synthesis_format=SynthesisFormat.from_string(args.synthesis_format),
         strict_decidable=getattr(args, "strict_decidable", False),
+        contracts=getattr(args, "contracts", False),
     )
     driver = AeonDriver(cfg)
 
@@ -384,7 +394,11 @@ def main() -> None:
                     print("#pprint")
                     print(pretty_print_sterm(term))
                 case (False, False):
-                    driver.run()
+                    try:
+                        driver.run()
+                    except ContractViolationError as err:
+                        handle_error(err)
+                        sys.exit(error_exit_code(err))
         case [first, *_]:
             for err in errors:
                 handle_error(err)

--- a/aeon/backend/contracts.py
+++ b/aeon/backend/contracts.py
@@ -1,0 +1,151 @@
+"""Runtime refinement contracts with Findler–Felleisen blame (issue #443)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from aeon.backend.liquid_eval import UninterpretedInLiquid, UnevaluableLiquid, eval_liquid_bool
+from aeon.core.liquid import LiquidLiteralBool, LiquidTerm
+from aeon.core.terms import Rec, Term
+from aeon.core.types import AbstractionType, RefinedType, Type
+from aeon.core.types import TypePolymorphism, RefinementPolymorphism
+from aeon.facade.api import ContractViolationError
+from aeon.typechecking.context import TypingContext, UninterpretedBinder
+from aeon.typechecking.termination import _opened_refinement_liquid
+from aeon.utils.location import Location, SynthesizedLocation
+from aeon.utils.name import Name
+
+
+@dataclass
+class ContractState:
+    """Runtime contract configuration threaded through evaluation."""
+
+    uninterpreted: dict[str, Type]
+    runtime: dict[str, Any]
+    fn_types: dict[Name, Type]
+
+    @classmethod
+    def from_contexts(
+        cls, typing_ctx: TypingContext, fn_types: dict[Name, Type], runtime: dict[str, Any]
+    ) -> ContractState:
+        uninterpreted: dict[str, Type] = {}
+        for entry in typing_ctx.entries:
+            if isinstance(entry, UninterpretedBinder):
+                uninterpreted[entry.name.name] = entry.type
+        return cls(uninterpreted=uninterpreted, runtime=runtime, fn_types=fn_types)
+
+
+def collect_top_level_fn_types(core: Term) -> dict[Name, Type]:
+    out: dict[Name, Type] = {}
+    cur: Term = core
+    while isinstance(cur, Rec):
+        out[cur.var_name] = cur.var_type
+        cur = cur.body
+    return out
+
+
+def build_runtime_liquid_env(values: dict[Name, Any]) -> dict[str, Any]:
+    """Map surface function names to callables for liquid predicate evaluation."""
+    runtime: dict[str, Any] = {}
+    for name, value in values.items():
+        if callable(value):
+            runtime[name.name] = value
+    return runtime
+
+
+def register_runtime_callable(state: ContractState, name: Name, value: Any) -> None:
+    if callable(value):
+        state.runtime[name.name] = value
+
+
+def _strip_type_wrappers(ty: Type) -> Type:
+    while isinstance(ty, (TypePolymorphism, RefinementPolymorphism)):
+        ty = ty.body
+    return ty
+
+
+def _check_liquid(
+    predicate: LiquidTerm,
+    env: dict[Name, Any],
+    state: ContractState,
+    *,
+    blame: str,
+    callee: Name | None,
+    loc: Location | None,
+) -> None:
+    if predicate == LiquidLiteralBool(True):
+        return
+    try:
+        ok = eval_liquid_bool(predicate, env, uninterpreted=state.uninterpreted, runtime=state.runtime)
+    except UninterpretedInLiquid:
+        return
+    except UnevaluableLiquid:
+        return
+    if not ok:
+        where = callee.name if callee is not None else "<unknown>"
+        raise ContractViolationError(
+            blame=blame,
+            binding=where,
+            predicate=predicate,
+            loc=loc or SynthesizedLocation("contracts"),
+        )
+
+
+def check_param_refinement(
+    param_type: Type, param_name: Name, value: Any, state: ContractState, *, callee: Name, loc: Location | None
+) -> None:
+    param_type = _strip_type_wrappers(param_type)
+    if not isinstance(param_type, RefinedType):
+        return
+    opened = _opened_refinement_liquid(param_type, param_name, [param_name], [param_name])
+    if opened is None:
+        return
+    env = {param_name: value}
+    _check_liquid(opened, env, state, blame="caller", callee=callee, loc=loc)
+
+
+def check_return_refinement(
+    return_type: Type, value: Any, state: ContractState, *, callee: Name, loc: Location | None
+) -> None:
+    return_type = _strip_type_wrappers(return_type)
+    if not isinstance(return_type, RefinedType):
+        return
+    env = {return_type.name: value}
+    _check_liquid(return_type.refinement, env, state, blame="callee", callee=callee, loc=loc)
+
+
+@dataclass
+class ContractClosure:
+    """Callable wrapper that checks curried refinements at run time."""
+
+    fn: Callable[[Any], Any]
+    arrow_type: Type
+    callee: Name
+    state: ContractState
+    loc: Location | None = None
+
+    def __call__(self, arg: Any) -> Any:
+        ty = _strip_type_wrappers(self.arrow_type)
+        if isinstance(ty, AbstractionType):
+            check_param_refinement(ty.var_type, ty.var_name, arg, self.state, callee=self.callee, loc=self.loc)
+            result = self.fn(arg)
+            rest = _strip_type_wrappers(ty.type)
+            if isinstance(rest, AbstractionType):
+                return ContractClosure(result, rest, self.callee, self.state, loc=self.loc)
+            check_return_refinement(rest, result, self.state, callee=self.callee, loc=self.loc)
+            return result
+        result = self.fn(arg)
+        check_return_refinement(ty, result, self.state, callee=self.callee, loc=self.loc)
+        return result
+
+
+def wrap_callable(
+    fn: Callable[[Any], Any],
+    fn_type: Type,
+    callee: Name,
+    state: ContractState,
+    *,
+    loc: Location | None = None,
+) -> ContractClosure:
+    return ContractClosure(fn, fn_type, callee, state, loc=loc)

--- a/aeon/backend/evaluator.py
+++ b/aeon/backend/evaluator.py
@@ -14,6 +14,8 @@ from aeon.core.terms import Rec
 from aeon.core.terms import Term
 from aeon.core.terms import Var
 from aeon.utils.name import Name
+from aeon.backend.contracts import ContractClosure, ContractState, wrap_callable
+from aeon.core.types import Type
 from aeon.decorators.api import Metadata
 from aeon.llvm.core import LLVMPipeline
 
@@ -34,6 +36,7 @@ class EvaluationContext:
     # is shared (by reference) with ``trace`` across ``with_var``.
     trace: list | None
     trace_stack: list | None
+    contract_state: ContractState | None
 
     def __init__(
         self,
@@ -42,6 +45,7 @@ class EvaluationContext:
         pipeline: LLVMPipeline | None = None,
         trace: list | None = None,
         trace_stack: list | None = None,
+        contract_state: ContractState | None = None,
     ):
         if prev:
             self.variables = {k: v for (k, v) in prev.items()}
@@ -51,13 +55,23 @@ class EvaluationContext:
         self.pipeline = pipeline
         self.trace = trace
         self.trace_stack = trace_stack
+        self.contract_state = contract_state
 
     def with_var(self, name: Name, value: Any):
         assert isinstance(name, Name)
         v = self.variables.copy()
         v.update({name: value})
+        if self.contract_state is not None:
+            from aeon.backend.contracts import register_runtime_callable
+
+            register_runtime_callable(self.contract_state, name, value)
         return EvaluationContext(
-            v, metadata=self.metadata, pipeline=self.pipeline, trace=self.trace, trace_stack=self.trace_stack
+            v,
+            metadata=self.metadata,
+            pipeline=self.pipeline,
+            trace=self.trace,
+            trace_stack=self.trace_stack,
+            contract_state=self.contract_state,
         )
 
     def get(self, name: Name):
@@ -78,6 +92,19 @@ def is_native_import(fun: Term):
             return False
 
 
+def _wrap_if_contract(
+    fn: Any,
+    fn_type: Type | None,
+    callee: Name,
+    ctx: EvaluationContext,
+    *,
+    loc,
+) -> Any:
+    if ctx.contract_state is None or fn_type is None:
+        return fn
+    return wrap_callable(fn, fn_type, callee, ctx.contract_state, loc=loc)
+
+
 # pattern match term
 def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
     match t:
@@ -96,6 +123,8 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                 python_ctx = {str(name): v for name, v in globals().items()}
                 python_ctx.update({str(name.name): v for name, v in ctx.variables.items()})
                 e = real_eval(argv, python_ctx)
+            elif isinstance(f, ContractClosure):
+                e = f(argv)
             else:
                 e = f(argv)
             if is_native_import(fun):
@@ -109,7 +138,8 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
             # would raise immediately, surfacing a missed check.
             return eval(body, ctx.with_var(var_name, None))
         case Let(var_name, var_value, body):
-            return eval(body, ctx.with_var(var_name, eval(var_value, ctx)))
+            value = eval(var_value, ctx)
+            return eval(body, ctx.with_var(var_name, value))
         case Rec(var_name, _, _, body, _, _, mult) if mult is M0:
             # Phase 4 — same erasure for ``Rec``. ``var_value`` may be a
             # recursive lambda that's only meaningful at type level.
@@ -132,6 +162,7 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                 pipeline=ctx.pipeline,
                 trace=ctx.trace,
                 trace_stack=ctx.trace_stack,
+                contract_state=ctx.contract_state,
             )
             for m in members:
                 inner_value = m.var_value
@@ -139,7 +170,7 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                     inner_value = inner_value.body
                 if isinstance(inner_value, Abstraction):
 
-                    def make_closure(fun: Abstraction, fname: Name):
+                    def make_closure(fun: Abstraction, fname: Name, ftype: Type):
                         def v(x):
                             tr = group_ctx.trace
                             if tr is None:
@@ -155,16 +186,16 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                             tr[idx][2] = result
                             return result
 
-                        return v
+                        return _wrap_if_contract(v, ftype, fname, group_ctx, loc=fun.loc)
 
-                    group_ctx.variables[m.var_name] = make_closure(inner_value, m.var_name)
+                    group_ctx.variables[m.var_name] = make_closure(inner_value, m.var_name, m.var_type)
                 else:
                     # Non-lambda mutual binding: evaluate in the shared context
                     # (closures resolve siblings lazily) and patch the cell.
                     group_ctx.variables[m.var_name] = None
                     group_ctx.variables[m.var_name] = eval(m.var_value, group_ctx)
             return eval(final_body, group_ctx)
-        case Rec(var_name, _, var_value, body, _, _):
+        case Rec(var_name, var_type, var_value, body, _, _):
             found_llvm = False
             if ctx.pipeline and ctx.metadata:
                 for k, v in ctx.metadata.items():
@@ -207,6 +238,7 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                     tr[idx][2] = result
                     return result
 
+                v = _wrap_if_contract(v, var_type, var_name, ctx, loc=t.loc)
             else:
                 # General recursion for non-lambda values (e.g. instance
                 # dictionaries whose default methods reference sibling
@@ -226,8 +258,19 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                 return eval(then, ctx)
             else:
                 return eval(otherwise, ctx)
-        case Annotation(expr, _):
-            return eval(expr, ctx)
+        case Annotation(expr, ty):
+            value = eval(expr, ctx)
+            if ctx.contract_state is not None:
+                from aeon.backend.contracts import check_return_refinement
+
+                check_return_refinement(
+                    ty,
+                    value,
+                    ctx.contract_state,
+                    callee=Name("<annotation>", 0),
+                    loc=expr.loc,
+                )
+            return value
         case Hole(name):
             args = ", ".join([str(n.name) for n in ctx.variables])
             print(f"Context ({args})")
@@ -254,6 +297,13 @@ def eval_with_trace(t: Term, ctx: EvaluationContext = EvaluationContext()) -> tu
     ``-1`` for a top-level call). Used by co-synthesis to observe a candidate's
     behaviour, reconstruct its call tree, and blame failing inputs."""
     sink: list = []
-    traced = EvaluationContext(ctx.variables, metadata=ctx.metadata, pipeline=ctx.pipeline, trace=sink, trace_stack=[])
+    traced = EvaluationContext(
+        ctx.variables,
+        metadata=ctx.metadata,
+        pipeline=ctx.pipeline,
+        trace=sink,
+        trace_stack=[],
+        contract_state=ctx.contract_state,
+    )
     value = eval(t, traced)
     return value, sink

--- a/aeon/backend/liquid_eval.py
+++ b/aeon/backend/liquid_eval.py
@@ -1,0 +1,102 @@
+"""Runtime evaluation of liquid refinement predicates (issue #443).
+
+Deliberately partial: refinements mentioning symbols listed in the
+``uninterpreted`` dictionary cannot be checked at run time and are skipped.
+Runtime-callable symbols are resolved through a separate ``runtime`` dictionary
+so each name maps to at most one implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aeon.core.liquid import (
+    LiquidApp,
+    LiquidLiteralBool,
+    LiquidLiteralFloat,
+    LiquidLiteralInt,
+    LiquidLiteralString,
+    LiquidTerm,
+    LiquidVar,
+)
+from aeon.core.types import Type
+from aeon.utils.name import Name
+
+
+class UnevaluableLiquid(Exception):
+    """Predicate fragment outside the runtime interpreter."""
+
+
+class UninterpretedInLiquid(Exception):
+    """Predicate mentions an uninterpreted symbol — no runtime meaning."""
+
+
+_BINOPS: dict[str, Any] = {
+    "==": lambda a, b: a == b,
+    "!=": lambda a, b: a != b,
+    "<": lambda a, b: a < b,
+    "<=": lambda a, b: a <= b,
+    ">": lambda a, b: a > b,
+    ">=": lambda a, b: a >= b,
+    "+": lambda a, b: a + b,
+    "-": lambda a, b: a - b,
+    "*": lambda a, b: a * b,
+    "&&": lambda a, b: bool(a) and bool(b),
+    "||": lambda a, b: bool(a) or bool(b),
+    "-->": lambda a, b: (not bool(a)) or bool(b),
+}
+
+
+def eval_liquid(
+    term: LiquidTerm,
+    env: dict[Name, Any],
+    *,
+    uninterpreted: dict[str, Type],
+    runtime: dict[str, Any],
+) -> Any:
+    if isinstance(term, LiquidVar):
+        if term.name not in env:
+            raise UnevaluableLiquid(f"unbound liquid variable {term.name}")
+        return env[term.name]
+    if isinstance(term, LiquidLiteralBool):
+        return term.value
+    if isinstance(term, LiquidLiteralInt | LiquidLiteralFloat | LiquidLiteralString):
+        return term.value
+    if isinstance(term, LiquidApp):
+        head = term.fun.name
+        if head in uninterpreted:
+            raise UninterpretedInLiquid(head)
+        if head == "!" and len(term.args) == 1:
+            return not bool(eval_liquid(term.args[0], env, uninterpreted=uninterpreted, runtime=runtime))
+        if head in ("/", "%") and len(term.args) == 2:
+            a = eval_liquid(term.args[0], env, uninterpreted=uninterpreted, runtime=runtime)
+            b = eval_liquid(term.args[1], env, uninterpreted=uninterpreted, runtime=runtime)
+            if not isinstance(a, int) or not isinstance(b, int) or b == 0:
+                raise UnevaluableLiquid("non-integral or zero division")
+            q = int(a / b)
+            return q if head == "/" else a - b * q
+        fn = _BINOPS.get(head)
+        if fn is not None and len(term.args) == 2:
+            return fn(
+                eval_liquid(term.args[0], env, uninterpreted=uninterpreted, runtime=runtime),
+                eval_liquid(term.args[1], env, uninterpreted=uninterpreted, runtime=runtime),
+            )
+        callee = runtime.get(head)
+        if callee is None:
+            raise UnevaluableLiquid(f"unknown liquid head {head!r}")
+        args = [eval_liquid(a, env, uninterpreted=uninterpreted, runtime=runtime) for a in term.args]
+        return callee(*args)
+    raise UnevaluableLiquid(f"unsupported liquid form {type(term).__name__}")
+
+
+def eval_liquid_bool(
+    term: LiquidTerm,
+    env: dict[Name, Any],
+    *,
+    uninterpreted: dict[str, Type],
+    runtime: dict[str, Any],
+) -> bool:
+    try:
+        return bool(eval_liquid(term, env, uninterpreted=uninterpreted, runtime=runtime))
+    except (TypeError, ValueError, ZeroDivisionError, OverflowError) as exc:
+        raise UnevaluableLiquid(str(exc)) from exc

--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
+from aeon.core.liquid import LiquidTerm
 from aeon.core.multiplicity import Multiplicity
 from aeon.core.terms import Term
 from aeon.core.types import Kind, Type
@@ -409,6 +410,26 @@ class LinearBranchMismatchError(LinearityError):
 
     def position(self) -> Location:
         return self.term.loc
+
+
+@dataclass
+class ContractViolationError(AeonError):
+    """Raised when ``--contracts`` detects a refinement violation at run time."""
+
+    blame: str
+    binding: str
+    predicate: LiquidTerm
+    loc: Location
+
+    def __str__(self) -> str:
+        side = "caller" if self.blame == "caller" else "callee"
+        return (
+            f"Contract violation (blame: {side}): binding '{self.binding}' "
+            f"does not satisfy refinement `{self.predicate}`."
+        )
+
+    def position(self) -> Location:
+        return self.loc
 
 
 def _format_location(loc: Location) -> str:

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable
 
 from aeon.backend.evaluator import EvaluationContext
 from aeon.backend.evaluator import eval
+from aeon.backend.contracts import ContractState, build_runtime_liquid_env, collect_top_level_fn_types
 from aeon.backend.python_export import export_function
 from aeon.compilation.compile import (
     clear_unit_cache,
@@ -49,6 +50,7 @@ class AeonConfig:
     # Treat refinements that leave the decidable fragment (nonlinear
     # arithmetic, ...) as errors instead of warnings (issue #438).
     strict_decidable: bool = False
+    contracts: bool = False
 
 
 class AeonDriver:
@@ -114,7 +116,17 @@ class AeonDriver:
 
         with RecordTime("Preparing execution env"):
             pipeline = MultiBackendPipeline(metadata=metadata)
-            self.evaluation_ctx = EvaluationContext(evaluation_vars, metadata=metadata, pipeline=pipeline)
+            contract_state: ContractState | None = None
+            if self.cfg.contracts:
+                fn_types = collect_top_level_fn_types(core)
+                runtime = build_runtime_liquid_env(evaluation_vars)
+                contract_state = ContractState.from_contexts(typing_ctx, fn_types, runtime)
+            self.evaluation_ctx = EvaluationContext(
+                evaluation_vars,
+                metadata=metadata,
+                pipeline=pipeline,
+                contract_state=contract_state,
+            )
 
         with RecordTime("LLVM compilation"):
             pipeline.compile(self.core)

--- a/tests/contracts_test.py
+++ b/tests/contracts_test.py
@@ -1,0 +1,93 @@
+"""Runtime refinement contracts (--contracts, issue #443)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.backend.liquid_eval import UninterpretedInLiquid, eval_liquid_bool
+from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidVar
+from aeon.core.types import t_int
+from aeon.facade.api import ContractViolationError
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.uis.api import SilentSynthesisUI
+from aeon.utils.name import Name
+
+
+def _driver(source: str, *, contracts: bool = False) -> AeonDriver:
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=False,
+        contracts=contracts,
+    )
+    driver = AeonDriver(cfg)
+    errors = driver.parse(aeon_code=source)
+    assert not errors, errors
+    return driver
+
+
+def test_native_violation_raises_with_contracts():
+    src = """
+    def bad_abs (i:Int) : {v:Int | v >= 0} := native "i - 10"
+    def main (a:Int) : Int := bad_abs 5 ;
+    """
+    driver = _driver(src, contracts=True)
+    with pytest.raises(ContractViolationError) as exc:
+        driver.run()
+    assert exc.value.blame == "callee"
+    assert "bad_abs" in exc.value.binding
+
+
+def test_native_violation_silent_without_contracts():
+    src = """
+    def bad_abs (i:Int) : {v:Int | v >= 0} := native "i - 10"
+    def main (a:Int) : Int := bad_abs 5 ;
+    """
+    driver = _driver(src, contracts=False)
+    assert driver.run() == -5
+
+
+def test_pure_aeon_refinement_checked():
+    src = """
+    def inc (i:Int) : {v:Int | v > i} := i + 1
+    def main (a:Int) : Int := inc 3 ;
+    """
+    driver = _driver(src, contracts=True)
+    assert driver.run() == 4
+
+
+def test_caller_blame_on_bad_argument():
+    from aeon.backend.contracts import ContractState, check_param_refinement
+    from aeon.core.types import RefinedType, t_int
+    from aeon.core.liquid import LiquidApp, LiquidLiteralInt, LiquidVar
+
+    state = ContractState(uninterpreted={}, runtime={}, fn_types={})
+    param = RefinedType(Name("x", 0), t_int, LiquidApp(Name(">=", 0), [LiquidVar(Name("x", 0)), LiquidLiteralInt(0)]))
+    with pytest.raises(ContractViolationError) as exc:
+        check_param_refinement(
+            param,
+            Name("i", 0),
+            -1,
+            state,
+            callee=Name("use", 0),
+            loc=None,
+        )
+    assert exc.value.blame == "caller"
+
+
+def test_uninterpreted_predicate_is_skipped():
+    src = """
+    def p : (x:Int) -> Bool := uninterpreted
+    def main (_:Int) : Int := 0 ;
+    """
+    driver = _driver(src, contracts=True)
+    assert driver.run() == 0
+
+
+def test_liquid_eval_uses_uninterpreted_dict():
+    head = Name("fracBelow", 0)
+    uninterpreted = {"fracBelow": t_int}
+    pred = LiquidApp(head, [LiquidVar(Name("x", 0)), LiquidLiteralInt(1)])
+    with pytest.raises(UninterpretedInLiquid):
+        eval_liquid_bool(pred, {Name("x", 0): [1.0]}, uninterpreted=uninterpreted, runtime={})


### PR DESCRIPTION
## Summary

- Adds `--contracts` (opt-in, off by default) to check argument and result refinements during evaluation — gradual verification for trusted `native` bindings and pure Aeon code.
- Wraps top-level `Rec` functions in `ContractClosure` at eval time; violations raise `ContractViolationError` with Findler–Felleisen blame (`caller` vs `callee`).
- Introduces `aeon/backend/liquid_eval.py` (runtime liquid interpreter) and `aeon/backend/contracts.py` (orchestration).
- **Uninterpreted symbols** are collected into a `dict[str, Type]` from `TypingContext`; if a predicate mentions one, the check is skipped (no runtime meaning). **Runtime-callable symbols** live in a separate `dict[str, Any]` so each name maps to at most one implementation.

Closes #443

## Test plan

- [x] `uv run pytest tests/contracts_test.py -q`
- [x] `uv run pytest tests/trust_report_test.py tests/end_to_end_test.py -q`
- [x] pre-commit (mypy, ruff, format) passes


Made with [Cursor](https://cursor.com)