### PR TITLE
chore(release): 4.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AeonLang"
-version = "4.2.0"
+version = "4.3.0"
 description = "Language with Refinement Types"
 authors = [
     { name = "Alcides Fonseca", email = "me@alcidesfonseca.com" }


### PR DESCRIPTION
## Summary
- Bump version to 4.3.0 for the next AeonLang release.

## Test plan
- [ ] CI passes on merge
- [ ] Tag `v4.3.0` and publish GitHub release after merge


Made with [Cursor](https://cursor.com)