### PR TITLE
feat(optimization): eliminate dead branches using liquid refinements (#114)

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -309,6 +309,14 @@ def _error_kind_and_hint(err: AeonError) -> tuple[str, str | None]:
             return "Error", None
 
 
+def print_dead_branch_warnings(driver: AeonDriver) -> None:
+    from aeon.optimization.refinement_branches import format_location
+
+    for w in getattr(driver, "dead_branch_warnings", []):
+        print(f">>> Warning (dead {w.branch} branch) at {format_location(w.location)}:", file=sys.stderr)
+        print(f"    {w.message}", file=sys.stderr)
+
+
 def print_decidability_warnings(driver: AeonDriver) -> None:
     """Print non-fatal warnings for refinements that leave the decidable
     fragment (issue #438). Collected during ``driver.parse``; under
@@ -415,6 +423,7 @@ def main() -> None:
         sys.exit(error_exit_code(e))
 
     print_decidability_warnings(driver)
+    print_dead_branch_warnings(driver)
 
     match errors:
         case [] if getattr(args, "trust_report", False) or getattr(args, "trust_for", None):

--- a/aeon/compilation/compile.py
+++ b/aeon/compilation/compile.py
@@ -29,6 +29,8 @@ from aeon.sugar.program import Definition
 from aeon.sugar.stypes import SType
 from aeon.typechecking.context import TypingContext, UninterpretedBinder
 from aeon.typechecking.typeinfer import check_type_errors
+from aeon.optimization.normal_form import optimize_bindings
+from aeon.optimization.refinement_branches import collect_dead_branch_warnings, optimize_refinement_bindings
 from aeon.utils.name import Name
 
 _COMPILER_VERSION = version("AeonLang")
@@ -381,6 +383,13 @@ def compile_program(
         )
         return unit, type_errors
 
+    optimize_spine = linked_core if export_prefix is None else core_ast
+    optimize_ctx = linked_ctx if export_prefix is None else typing_ctx
+    dead_branch_warnings = collect_dead_branch_warnings(optimize_spine, optimize_ctx, source_path=path)
+    optimize_spine = optimize_refinement_bindings(optimize_spine, optimize_ctx)
+    optimize_spine = optimize_bindings(optimize_spine)
+    core_ast = optimize_spine
+
     exports = _exports_from_spine(core_ast, typing_ctx, prog.definitions, export_prefix, export_sugar_types)
     exports.update(_exports_from_uninterpreted(typing_ctx, export_prefix))
 
@@ -411,6 +420,7 @@ def compile_program(
         qualified_scope=_qualified_scope(exports, module_path) if export_prefix else {},
         dependencies=dep_module_paths,
         trusted_names=frozenset(v.internal_name for v in exports.values()),
+        dead_branch_warnings=dead_branch_warnings,
         source_metadata=source_metadata,
     )
 

--- a/aeon/compilation/unit.py
+++ b/aeon/compilation/unit.py
@@ -52,6 +52,7 @@ class CompiledUnit:
 
     dependencies: list[str]  # module_path strings of direct imports
     trusted_names: frozenset[Name] = field(default_factory=frozenset)
+    dead_branch_warnings: list = field(default_factory=list)
     # Decorator metadata before the core phase runs (includes the core-phase queue).
     source_metadata: Metadata = field(default_factory=dict)
 

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -60,11 +60,13 @@ class AeonDriver:
     def __init__(self, cfg: AeonConfig):
         self.cfg = cfg
         self.decidability_warnings: list = []
+        self.dead_branch_warnings: list = []
 
     def parse(self, filename: str = None, aeon_code: str = None) -> Iterable[AeonError]:
         self.core = None
         self.typing_ctx = None
         self.decidability_warnings = []
+        self.dead_branch_warnings = []
 
         with RecordTime("ParseSugar"):
             clear_instance_registry()
@@ -108,6 +110,9 @@ class AeonDriver:
                     UndecidableRefinementError(construct=w.construct, detail=w.message, loc=w.location)
                     for w in self.decidability_warnings
                 ]
+
+        with RecordTime("DeadBranchScan"):
+            self.dead_branch_warnings = list(getattr(unit, "dead_branch_warnings", []))
 
         self.metadata = metadata
 

--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -335,6 +335,16 @@ async def _parse(
                     )
                 )
 
+        for warning in getattr(driver, "dead_branch_warnings", []):
+            diagnostics.append(
+                Diagnostic(
+                    message=f"dead {warning.branch} branch: {warning.message}",
+                    range=_loc_to_range(warning.location),
+                    source="aeon",
+                    severity=DiagnosticSeverity.Warning,
+                )
+            )
+
         if not errors:
             holes = find_holes_in_source(content)
             return ParseResult(diagnostics, holes)

--- a/aeon/optimization/normal_form.py
+++ b/aeon/optimization/normal_form.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from aeon.core.substitutions import substitute_vartype_in_term, substitution
 from aeon.core.terms import (
     Abstraction,
@@ -181,16 +183,9 @@ def optimize(t: Term) -> Term:
 def optimize_bindings(core: Term) -> Term:
     """Run ``optimize`` on every top-level binding value in a core program."""
     match core:
-        case Rec(var_name, var_type, var_value, body, decreasing_by, loc):
-            return Rec(
-                var_name,
-                var_type,
-                optimize(var_value),
-                optimize_bindings(body),
-                decreasing_by=decreasing_by,
-                loc=loc,
-            )
-        case Let(var_name, var_value, body):
-            return Let(var_name, optimize(var_value), optimize_bindings(body))
+        case Rec() as rec:
+            return replace(rec, var_value=optimize(rec.var_value), body=optimize_bindings(rec.body))
+        case Let() as let:
+            return replace(let, var_value=optimize(let.var_value), body=optimize_bindings(let.body))
         case _:
             return core

--- a/aeon/optimization/refinement_branches.py
+++ b/aeon/optimization/refinement_branches.py
@@ -1,0 +1,303 @@
+"""Refinement-aware dead branch elimination (issue #114).
+
+When liquid refinements in scope entail an ``if`` condition (or its negation),
+the unreachable branch is removed and a warning may be recorded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from aeon.core.liquid import LiquidApp, LiquidTerm
+from aeon.core.substitutions import liquefy
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    Hole,
+    If,
+    Let,
+    Literal,
+    Rec,
+    RefinementAbstraction,
+    RefinementApplication,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+    Var,
+)
+from aeon.core.types import AbstractionType, Type
+from aeon.typechecking.context import TypingContext
+from aeon.typechecking.entailment import entailment
+from aeon.utils.location import FileLocation, Location, SynthesizedLocation
+from aeon.utils.name import Name
+from aeon.verification.vcs import LiquidConstraint
+
+
+@dataclass(frozen=True)
+class DeadBranchWarning:
+    """Emitted when a refinement-known-dead ``if`` branch is eliminated."""
+
+    location: Location
+    branch: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"dead {self.branch} branch: {self.message}"
+
+
+def _negate(liq: LiquidTerm) -> LiquidTerm:
+    return LiquidApp(Name("!", 0), [liq])
+
+
+def _context_entails(ctx: TypingContext, liq: LiquidTerm) -> bool:
+    return entailment(ctx, LiquidConstraint(liq))
+
+
+def _location_in_file(loc: Location, source_path: str | None) -> bool:
+    if not isinstance(loc, FileLocation):
+        return False
+    if source_path is None:
+        return True
+    if loc.file == source_path:
+        return True
+    if not loc.file:
+        return False
+    try:
+        return Path(loc.file).resolve() == Path(source_path).resolve()
+    except (OSError, ValueError, TypeError):
+        return False
+
+
+def _fold_if(
+    ctx: TypingContext,
+    cond: Term,
+    then: Term,
+    otherwise: Term,
+    *,
+    on_dead_branch: list[DeadBranchWarning] | None,
+    source_path: str | None,
+) -> Term | None:
+    liq_cond = liquefy(cond)
+    if liq_cond is None:
+        return None
+    if _context_entails(ctx, liq_cond):
+        if on_dead_branch is not None and _location_in_file(otherwise.loc, source_path):
+            on_dead_branch.append(
+                DeadBranchWarning(
+                    location=otherwise.loc,
+                    branch="else",
+                    message=(
+                        "this branch is unreachable because refinements in scope entail the condition is always true"
+                    ),
+                )
+            )
+        return then
+    if _context_entails(ctx, _negate(liq_cond)):
+        if on_dead_branch is not None and _location_in_file(then.loc, source_path):
+            on_dead_branch.append(
+                DeadBranchWarning(
+                    location=then.loc,
+                    branch="then",
+                    message=(
+                        "this branch is unreachable because refinements in scope entail the condition is always false"
+                    ),
+                )
+            )
+        return otherwise
+    return None
+
+
+def _optimize_refinement(
+    term: Term,
+    ctx: TypingContext,
+    *,
+    expected_type: Type | None = None,
+    on_dead_branch: list[DeadBranchWarning] | None = None,
+    source_path: str | None = None,
+) -> Term:
+    match term:
+        case If(cond, then, otherwise):
+            folded = _fold_if(
+                ctx,
+                cond,
+                then,
+                otherwise,
+                on_dead_branch=on_dead_branch,
+                source_path=source_path,
+            )
+            if folded is not None:
+                return _optimize_refinement(
+                    folded,
+                    ctx,
+                    expected_type=expected_type,
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                )
+            return If(
+                _optimize_refinement(cond, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+                _optimize_refinement(then, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+                _optimize_refinement(otherwise, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+            )
+        case Abstraction(name, body):
+            body_ctx = ctx
+            if isinstance(expected_type, AbstractionType):
+                body_ctx = ctx.with_var(name, expected_type.var_type)
+            return Abstraction(
+                name,
+                _optimize_refinement(
+                    body,
+                    body_ctx,
+                    expected_type=None,
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                ),
+            )
+        case Rec() as rec:
+            return _optimize_refinement_bindings(
+                rec,
+                ctx,
+                on_dead_branch=on_dead_branch,
+                source_path=source_path,
+            )
+        case Let() as let:
+            return replace(
+                let,
+                var_value=_optimize_refinement(
+                    let.var_value,
+                    ctx,
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                ),
+                body=_optimize_refinement(
+                    let.body,
+                    ctx,
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                ),
+            )
+        case Application(fun, arg):
+            return Application(
+                _optimize_refinement(fun, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+                _optimize_refinement(arg, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+            )
+        case Annotation(expr, ty):
+            return Annotation(
+                _optimize_refinement(expr, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+                ty,
+            )
+        case TypeAbstraction(name, kind, body):
+            return TypeAbstraction(
+                name,
+                kind,
+                _optimize_refinement(
+                    body, ctx.with_typevar(name, kind), on_dead_branch=on_dead_branch, source_path=source_path
+                ),
+            )
+        case TypeApplication(body, ty):
+            return TypeApplication(
+                _optimize_refinement(body, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+                ty,
+            )
+        case RefinementAbstraction(name, sort, body):
+            return RefinementAbstraction(
+                name,
+                sort,
+                _optimize_refinement(body, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+            )
+        case RefinementApplication(body, refinement):
+            return RefinementApplication(
+                _optimize_refinement(body, ctx, on_dead_branch=on_dead_branch, source_path=source_path),
+                refinement,
+            )
+        case Literal() | Var() | Hole():
+            return term
+        case _:
+            return term
+
+
+def _optimize_refinement_bindings(
+    core: Term,
+    ctx: TypingContext,
+    *,
+    on_dead_branch: list[DeadBranchWarning] | None = None,
+    source_path: str | None = None,
+) -> Term:
+    match core:
+        case Rec() as rec:
+            return replace(
+                rec,
+                var_value=_optimize_refinement(
+                    rec.var_value,
+                    ctx,
+                    expected_type=rec.var_type,
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                ),
+                body=_optimize_refinement_bindings(
+                    rec.body,
+                    ctx.with_var(rec.var_name, rec.var_type),
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                ),
+            )
+        case Let() as let:
+            return replace(
+                let,
+                var_value=_optimize_refinement(
+                    let.var_value,
+                    ctx,
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                ),
+                body=_optimize_refinement_bindings(
+                    let.body,
+                    ctx,
+                    on_dead_branch=on_dead_branch,
+                    source_path=source_path,
+                ),
+            )
+        case _:
+            return _optimize_refinement(
+                core,
+                ctx,
+                on_dead_branch=on_dead_branch,
+                source_path=source_path,
+            )
+
+
+def optimize_refinement_bindings(core: Term, ctx: TypingContext) -> Term:
+    """Remove ``if`` branches that refinements prove unreachable."""
+    return _optimize_refinement_bindings(core, ctx)
+
+
+def collect_dead_branch_warnings(
+    core: Term,
+    ctx: TypingContext,
+    *,
+    source_path: str | None = None,
+) -> list[DeadBranchWarning]:
+    """Return warnings for every dead branch that refinement optimization would remove."""
+    warnings: list[DeadBranchWarning] = []
+    _optimize_refinement_bindings(core, ctx, on_dead_branch=warnings, source_path=source_path)
+    seen: set[tuple[object, object, str]] = set()
+    result: list[DeadBranchWarning] = []
+    for warning in warnings:
+        loc = warning.location
+        key = (loc.get_start(), loc.get_end(), warning.branch)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(warning)
+    return result
+
+
+def format_location(loc: Location) -> str:
+    if isinstance(loc, FileLocation):
+        line, col = loc.start
+        prefix = f"{loc.file}:" if loc.file else ""
+        return f"{prefix}{line}:{col}"
+    if isinstance(loc, SynthesizedLocation):
+        return str(loc)
+    return str(loc)

--- a/tests/refinement_branch_opt_test.py
+++ b/tests/refinement_branch_opt_test.py
@@ -1,0 +1,91 @@
+"""Tests for refinement-aware dead branch elimination (issue #114)."""
+
+from __future__ import annotations
+
+import tempfile
+
+from aeon.compilation.compile import clear_unit_cache, compile_and_link_program
+from aeon.core.parser import parse_term
+from aeon.core.terms import Abstraction, If, Rec
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SynthesisUI
+
+setup_logger()
+
+
+def _compile(source: str):
+    clear_unit_cache()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ae", delete=False, encoding="utf-8") as tmp:
+        tmp.write(source)
+        path = tmp.name
+    return compile_and_link_program(source, filename=path, is_main=True, is_main_hole=True)
+
+
+def _fun_body(core):
+    match core:
+        case Rec(_, _, Abstraction(_, body), _):
+            return body
+        case _:
+            raise AssertionError(f"unexpected core shape: {core}")
+
+
+def test_dead_else_branch_eliminated():
+    source = """
+def fun (x: {a:Int | a > 2}) : Int := (if x > 0 then 100 else 200)
+"""
+    unit, core, ctx, _meta, _trusted, errors = _compile(source)
+    assert errors == []
+    assert core is not None and ctx is not None
+    body = _fun_body(core)
+    assert body == parse_term("100")
+    assert len(unit.dead_branch_warnings) == 1
+    assert unit.dead_branch_warnings[0].branch == "else"
+
+
+def test_dead_then_branch_eliminated():
+    source = """
+def fun (x: {a:Int | a < 0}) : Int := (if x > 0 then 100 else 200)
+"""
+    unit, core, ctx, _meta, _trusted, errors = _compile(source)
+    assert errors == []
+    body = _fun_body(core)
+    assert body == parse_term("200")
+    assert len(unit.dead_branch_warnings) == 1
+    assert unit.dead_branch_warnings[0].branch == "then"
+
+
+def test_both_branches_live():
+    source = """
+def fun (x: {a:Int | a > (0 - 10)}) : Int := (if x > 0 then 100 else 200)
+"""
+    _unit, core, ctx, _meta, _trusted, errors = _compile(source)
+    assert errors == []
+    body = _fun_body(core)
+    assert isinstance(body, If)
+
+
+def test_driver_surfaces_dead_branch_warning():
+    source = """
+def fun (x: {a:Int | a > 2}) : Int := (if x > 0 then 100 else 200)
+"""
+    clear_unit_cache()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ae", delete=False, encoding="utf-8") as tmp:
+        tmp.write(source)
+        path = tmp.name
+    driver = AeonDriver(AeonConfig("dummy", SynthesisUI(), 1))
+    errors = list(driver.parse(filename=path))
+    assert errors == []
+    assert len(driver.dead_branch_warnings) == 1
+
+
+def test_constant_folding_after_refinement_elimination():
+    source = """
+def fun (x: {a:Int | a > 2}) : Int := (if x > 0 then (50 + 50) else 200)
+"""
+    _unit, core, _ctx, _meta, _trusted, errors = _compile(source)
+    assert errors == []
+    body = _fun_body(core)
+    assert not isinstance(body, If)
+    # Typed ``+`` applications are not literal-folded; the dead branch is gone.
+    assert str(body) == "(((+)[Int ] 50) 50)" or body == parse_term("100")


### PR DESCRIPTION
## Summary
- Add a post-typecheck optimization pass that uses SMT entailment to remove `if` branches made unreachable by liquid refinements in scope (closes #114).
- Emit dead-branch warnings in the CLI and LSP when a branch is eliminated.
- Fix `optimize_bindings` to preserve all `Rec` metadata (including mutual-recursion companions) when folding binding bodies.

## Test plan
- [x] `pytest tests/refinement_branch_opt_test.py`
- [x] `pytest tests/contata_test.py::test_cata_recovers_evaluable_definitions` (mutual recursion spine preserved)
- [x] `pytest tests/optimization_test.py`
- [x] pre-commit (mypy, ruff) passes locally


Made with [Cursor](https://cursor.com)