### PR TITLE
Improve VC error printing for refinement failures

### DIFF
--- a/aeon/typechecking/typeinfer.py
+++ b/aeon/typechecking/typeinfer.py
@@ -83,10 +83,10 @@ from aeon.utils.location import Location
 from aeon.utils.name import Name, fresh_counter
 from aeon.verification.helpers import (
     constraint_location,
-    remove_unrelated_context,
-    simplify_constraint_fixpoint,
     conjunctive_normal_form,
     is_implication_true,
+    prepare_vc_for_display,
+    split_and_in_conclusion,
     split_or_in_conclusion,
 )
 
@@ -1272,13 +1272,18 @@ def constraint_to_parts(
     for cons in conjunctive_normal_form(c):
         if not is_implication_true(cons):
             if not solve(cons, typing_ctx=typing_ctx, qualifier_atoms=atoms):
-                vcs = split_or_in_conclusion(cons)
-                for vc in vcs:
-                    if not solve(vc, typing_ctx=typing_ctx, qualifier_atoms=atoms):
-                        cons_simp = simplify_constraint_fixpoint(vc)
-                        cons_clean, _ = remove_unrelated_context(cons_simp, ignore_vars=set())
-                        loc = constraint_location(cons_clean)
-                        yield cons_clean, loc
+                or_vcs = split_or_in_conclusion(cons)
+                for or_vc in or_vcs:
+                    if not solve(or_vc, typing_ctx=typing_ctx, qualifier_atoms=atoms):
+                        and_vcs = split_and_in_conclusion(or_vc)
+                        failing = [
+                            part for part in and_vcs if not solve(part, typing_ctx=typing_ctx, qualifier_atoms=atoms)
+                        ]
+                        if not failing:
+                            failing = [or_vc]
+                        for part in failing:
+                            prepared = prepare_vc_for_display(part)
+                            yield prepared, constraint_location(prepared)
                         break
 
 

--- a/aeon/verification/helpers.py
+++ b/aeon/verification/helpers.py
@@ -769,6 +769,193 @@ def split_or_in_conclusion(c: Constraint) -> list[Constraint]:
             return [c]
 
 
+def split_and_conjuncts(expr: LiquidTerm) -> list[LiquidTerm]:
+    """Flattens AND in the conclusion into a list of conjuncts."""
+    conjuncts = flatten_conjuncts(expr)
+    return conjuncts if conjuncts else [expr]
+
+
+def split_and_in_conclusion(c: Constraint) -> list[Constraint]:
+    """Splits AND in the conclusion (innermost LiquidConstraint) into separate VCs."""
+    match c:
+        case LiquidConstraint(expr=expr, loc=loc):
+            conjuncts = split_and_conjuncts(expr)
+            if len(conjuncts) <= 1:
+                return [c]
+            return [LiquidConstraint(conj, loc=loc) for conj in conjuncts]
+        case Implication(name=iname, base=base, pred=pred, seq=seq, loc=iloc):
+            return [Implication(iname, base, pred, s, loc=iloc) for s in split_and_in_conclusion(seq)]
+        case UninterpretedFunctionDeclaration(name=uname, type=utype, seq=useq):
+            return [UninterpretedFunctionDeclaration(uname, utype, s) for s in split_and_in_conclusion(useq)]
+        case ReflectedFunctionDeclaration(name=rname, type=rtype, params=rparams, body=rbody, seq=rseq):
+            return [
+                ReflectedFunctionDeclaration(rname, rtype, rparams, rbody, s) for s in split_and_in_conclusion(rseq)
+            ]
+        case _:
+            return [c]
+
+
+def is_false_liquid(expr: LiquidTerm) -> bool:
+    """Returns whether a liquid term simplifies to ``false``."""
+    return simplify_expr(expr) == LiquidLiteralBool(False)
+
+
+def conclusion_variables(c: Constraint) -> set[Name]:
+    """Returns free variables appearing in the innermost conclusion."""
+    match c:
+        case LiquidConstraint(expr=expr):
+            return used_variables(expr)
+        case Implication(seq=seq):
+            return conclusion_variables(seq)
+        case UninterpretedFunctionDeclaration(seq=seq):
+            return conclusion_variables(seq)
+        case ReflectedFunctionDeclaration(seq=seq):
+            return conclusion_variables(seq)
+        case Conjunction(c1=c1, c2=c2):
+            return conclusion_variables(c1).union(conclusion_variables(c2))
+        case _:
+            return set()
+
+
+def _extract_var_literal_bound(
+    expr: LiquidTerm,
+) -> tuple[Name, str, int] | None:
+    """If *expr* is ``var op literal`` or ``literal op var``, return ``(var, op, n)``."""
+    match expr:
+        case LiquidApp(fun=f, args=[LiquidVar(name), LiquidLiteralInt(n)]) if f.name in {">", ">=", "<", "<="}:
+            return (name, f.name, n)
+        case LiquidApp(fun=f, args=[LiquidLiteralInt(n), LiquidVar(name)]) if f.name in {">", ">=", "<", "<="}:
+            op = f.name
+            if op == ">":
+                op = "<"
+            elif op == ">=":
+                op = "<="
+            elif op == "<":
+                op = ">"
+            elif op == "<=":
+                op = ">="
+            return (name, op, n)
+        case _:
+            return None
+
+
+def _bounds_contradict(left: tuple[Name, str, int], right: tuple[Name, str, int]) -> bool:
+    """Detect incompatible literal bounds on the same variable."""
+    (v1, op1, n1), (v2, op2, n2) = left, right
+    if v1.name != v2.name or v1.id != v2.id:
+        return False
+
+    def lower_bound(op: str, n: int) -> tuple[bool, int] | None:
+        if op in {">", ">="}:
+            return (op == ">", n)
+        if op in {"<", "<="}:
+            return (op == "<", n)
+        return None
+
+    lb = lower_bound(op1, n1)
+    rb = lower_bound(op2, n2)
+    if lb is None or rb is None:
+        return False
+
+    (strict_l, lo), (strict_u, hi) = lb, rb
+    if strict_l and strict_u:
+        return lo >= hi
+    if strict_l and not strict_u:
+        return lo >= hi
+    if not strict_l and strict_u:
+        return lo > hi
+    return lo > hi
+
+
+def _extract_var_equality_value(expr: LiquidTerm) -> tuple[Name, LiquidTerm] | None:
+    match expr:
+        case LiquidApp(fun=f, args=[LiquidVar(name), rhs]) if f == Name("==", 0):
+            return (name, rhs)
+        case LiquidApp(fun=f, args=[lhs, LiquidVar(name)]) if f == Name("==", 0):
+            return (name, lhs)
+        case _:
+            return None
+
+
+def _equalities_contradict(a: LiquidTerm, b: LiquidTerm) -> bool:
+    eq_a = _extract_var_equality_value(a)
+    eq_b = _extract_var_equality_value(b)
+    if eq_a is None or eq_b is None:
+        return False
+    (v1, rhs1), (v2, rhs2) = eq_a, eq_b
+    if v1.name != v2.name or v1.id != v2.id:
+        return False
+    return not liquid_terms_alpha_equal(rhs1, rhs2)
+
+
+def predicates_contradict(p1: LiquidTerm, p2: LiquidTerm) -> bool:
+    """Conservative syntactic check for contradictory preconditions."""
+    for c1 in flatten_conjuncts(p1) or [p1]:
+        for c2 in flatten_conjuncts(p2) or [p2]:
+            if _equalities_contradict(c1, c2):
+                return True
+            b1 = _extract_var_literal_bound(c1)
+            b2 = _extract_var_literal_bound(c2)
+            if b1 is not None and b2 is not None and _bounds_contradict(b1, b2):
+                return True
+    return False
+
+
+def _should_keep_precondition(
+    iname: Name,
+    pred: LiquidTerm,
+    goal_vars: set[Name],
+    other_preds: list[LiquidTerm],
+) -> bool:
+    """Keep preconditions that are false, contradictory, or mention goal variables."""
+    if is_false_liquid(pred):
+        return True
+    if any(predicates_contradict(pred, other) for other in other_preds):
+        return True
+    pred_vars = used_variables(pred)
+    pred_vars.add(iname)
+    return not goal_vars.isdisjoint(pred_vars)
+
+
+def remove_inert_preconditions(c: Constraint) -> Constraint:
+    """Drop implication preconditions that do not affect the displayed goal."""
+    match c:
+        case UninterpretedFunctionDeclaration(name=uname, type=utype, seq=useq):
+            return UninterpretedFunctionDeclaration(uname, utype, remove_inert_preconditions(useq))
+        case ReflectedFunctionDeclaration(name=rname, type=rtype, params=rparams, body=rbody, seq=rseq):
+            return ReflectedFunctionDeclaration(rname, rtype, rparams, rbody, remove_inert_preconditions(rseq))
+        case _:
+            return _remove_inert_implication_chain(c)
+
+
+def _remove_inert_implication_chain(c: Constraint) -> Constraint:
+    parts: list[tuple[Name, TypeConstructor | TypeVar | Top, LiquidTerm, Location | None]] = []
+    goal = c
+    while isinstance(goal, Implication):
+        parts.append((goal.name, goal.base, goal.pred, goal.loc))
+        goal = goal.seq
+
+    goal_vars = conclusion_variables(goal)
+    kept: list[tuple[Name, TypeConstructor | TypeVar | Top, LiquidTerm, Location | None]] = []
+    for i, (iname, base, pred, loc) in enumerate(parts):
+        others = [p for j, (_, _, p, _) in enumerate(parts) if j != i]
+        if _should_keep_precondition(iname, pred, goal_vars, others):
+            kept.append((iname, base, pred, loc))
+
+    result = goal
+    for iname, base, pred, loc in reversed(kept):
+        result = Implication(iname, base, pred, result, loc=loc)
+    return result
+
+
+def prepare_vc_for_display(c: Constraint) -> Constraint:
+    """Simplify a VC for error messages: rewrite, drop inert preconditions, prune context."""
+    cons_simp = simplify_constraint_fixpoint(c)
+    cons_clean = remove_inert_preconditions(cons_simp)
+    cons_clean, _ = remove_unrelated_context(cons_clean, ignore_vars=set())
+    return cons_clean
+
+
 def pretty_print_generator(c: Constraint) -> Generator[tuple[str, int], None, None]:
     """Recursive generates a list of items to print, with the respective
     indentation level."""
@@ -845,9 +1032,7 @@ def reduce_to_useful_constraint(c: Constraint) -> Constraint:
     top = []
     for cons in conjunctive_normal_form(c):
         if not is_implication_true(cons):
-            cons_simp = simplify_constraint_fixpoint(cons)
-            cons_clean, _ = remove_unrelated_context(cons_simp, ignore_vars=set())
-            top.append(cons_clean)
+            top.append(prepare_vc_for_display(cons))
     llb = LiquidLiteralBool(True)
     return reduce(Conjunction, top, LiquidConstraint(llb))  # type: ignore
 
@@ -866,8 +1051,7 @@ def pretty_print_constraint(c: Constraint) -> str:
     for cons in conjunctive_normal_form(c):
         if not is_implication_true(cons):
             r = []
-            cons_simp = simplify_constraint_fixpoint(cons)
-            cons_clean, _ = remove_unrelated_context(cons_simp, ignore_vars=set())
+            cons_clean = prepare_vc_for_display(cons)
             for item, indent in pretty_print_generator(cons_clean):
                 r.append(indent * "\t" + item)
             top.append("\n".join(r))

--- a/tests/simplification_constraints_test.py
+++ b/tests/simplification_constraints_test.py
@@ -6,9 +6,12 @@ from aeon.utils.name import Name
 from aeon.core.liquid import LiquidLiteralBool, LiquidLiteralInt, LiquidVar
 from aeon.core.types import t_int, TypeConstructor
 from aeon.verification.helpers import parse_liquid
+from aeon.verification.helpers import prepare_vc_for_display
+from aeon.verification.helpers import remove_inert_preconditions
 from aeon.verification.helpers import simplify_constraint
 from aeon.verification.helpers import simplify_constraint_fixpoint
 from aeon.verification.helpers import simplify_expr
+from aeon.verification.helpers import split_and_in_conclusion
 from aeon.verification.helpers import split_or_disjuncts
 from aeon.verification.helpers import split_or_in_conclusion
 from aeon.verification.vcs import Conjunction
@@ -122,6 +125,67 @@ def test_split_or_in_conclusion():
     assert len(result) == 2
     assert result[0].seq.expr == parse_liquid("x > 0")
     assert result[1].seq.expr == parse_liquid("x < 0")
+
+
+def test_split_and_in_conclusion():
+    """AND in nested conclusion is split into separate VCs."""
+    x_name = Name("x", 0)
+    pred = parse_liquid("x > 0")
+    concl = parse_liquid("x > 1 && x < 10")
+
+    c = Implication(x_name, t_int, pred, LiquidConstraint(concl))
+    result = split_and_in_conclusion(c)
+
+    assert len(result) == 2
+    assert result[0].seq.expr == parse_liquid("x > 1")
+    assert result[1].seq.expr == parse_liquid("x < 10")
+
+
+def test_remove_inert_precondition_unused_binder():
+    """Drop preconditions whose variables do not appear in the goal."""
+    i_name = Name("i", 1)
+    x_name = Name("x", 0)
+    irrelevant = bind_lq(parse_liquid("len i >= 0"), [("i", i_name)])
+    goal = bind_lq(parse_liquid("x > 0"), [("x", x_name)])
+
+    c = Implication(i_name, t_int, irrelevant, LiquidConstraint(goal))
+    r = remove_inert_preconditions(c)
+    assert r == LiquidConstraint(goal)
+
+
+def test_keep_false_precondition():
+    """False preconditions are kept because they explain an impossible context."""
+    n_name = Name("n", 1)
+    pred = bind_lq(parse_liquid("false"), [("n", n_name)])
+    goal = bind_lq(parse_liquid("n > 0"), [("n", n_name)])
+
+    c = Implication(n_name, t_int, pred, LiquidConstraint(goal))
+    r = remove_inert_preconditions(c)
+    assert r == c
+
+
+def test_keep_contradictory_preconditions():
+    """Contradictory preconditions are kept because they are diagnostically relevant."""
+    x_name = Name("x", 0)
+    low = bind_lq(parse_liquid("x > 10"), [("x", x_name)])
+    high = bind_lq(parse_liquid("x < 0"), [("x", x_name)])
+    goal = bind_lq(parse_liquid("x == 5"), [("x", x_name)])
+
+    inner = Implication(x_name, t_int, high, LiquidConstraint(goal))
+    c = Implication(x_name, t_int, low, inner)
+    r = remove_inert_preconditions(c)
+    assert r == c
+
+
+def test_prepare_vc_for_display_drops_irrelevant():
+    i_name = Name("i", 1)
+    x_name = Name("x", 0)
+    irrelevant = bind_lq(parse_liquid("len i >= 0"), [("i", i_name)])
+    goal = bind_lq(parse_liquid("x > 0"), [("x", x_name)])
+
+    c = Implication(i_name, t_int, irrelevant, LiquidConstraint(goal))
+    r = prepare_vc_for_display(c)
+    assert r == LiquidConstraint(goal)
 
 
 def test_simplify_redundant_conclusion():

--- a/tests/vc_error_printing_test.py
+++ b/tests/vc_error_printing_test.py
@@ -1,0 +1,95 @@
+"""Integration tests for VC decomposition used in error messages."""
+
+from __future__ import annotations
+
+from aeon.core.bind import bind_lq
+from aeon.core.types import t_int
+from aeon.facade.api import LiquidTypeCheckingFailedRelation
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.uis.api import SilentSynthesisUI
+from aeon.typechecking.typeinfer import constraint_to_parts
+from aeon.utils.name import Name
+from aeon.verification.helpers import liquid_terms_alpha_equal
+from aeon.verification.helpers import parse_liquid, pretty_print_constraint
+from aeon.verification.vcs import Implication, LiquidConstraint
+
+
+def _errors(source: str):
+    cfg = AeonConfig(
+        synthesizer="random_search",
+        synthesis_ui=SilentSynthesisUI(),
+        synthesis_budget=0,
+        no_main=True,
+    )
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _liquid_failures(source: str) -> list[LiquidTypeCheckingFailedRelation]:
+    return [e for e in _errors(source) if isinstance(e, LiquidTypeCheckingFailedRelation)]
+
+
+def test_constraint_to_parts_yields_only_failing_and_conjunct():
+    """When only one supertype conjunct fails, only that sub-VC is reported."""
+    x_name = Name("x", 0)
+    pred = bind_lq(parse_liquid("x > 0"), [("x", x_name)])
+    concl = bind_lq(parse_liquid("x > 1 && x > 0"), [("x", x_name)])
+
+    c = Implication(x_name, t_int, pred, LiquidConstraint(concl))
+    parts = list(constraint_to_parts(c))
+
+    assert len(parts) == 1
+    vc, _ = parts[0]
+    assert isinstance(vc, Implication)
+    expected = bind_lq(parse_liquid("x > 1"), [("x", x_name)])
+    assert liquid_terms_alpha_equal(vc.seq.expr, expected)
+
+
+def test_constraint_to_parts_yields_both_failing_and_conjuncts():
+    """When every supertype conjunct fails, each failing sub-VC is reported."""
+    x_name = Name("x", 0)
+    pred = bind_lq(parse_liquid("true"), [("x", x_name)])
+    concl = bind_lq(parse_liquid("x > 10 && x < 5"), [("x", x_name)])
+
+    c = Implication(x_name, t_int, pred, LiquidConstraint(concl))
+    parts = list(constraint_to_parts(c))
+
+    assert len(parts) == 2
+    goals = [vc.seq.expr for vc, _ in parts if isinstance(vc, Implication)]
+    expected = [
+        bind_lq(parse_liquid("x > 10"), [("x", x_name)]),
+        bind_lq(parse_liquid("x < 5"), [("x", x_name)]),
+    ]
+    for goal in goals:
+        assert any(liquid_terms_alpha_equal(goal, exp) for exp in expected)
+    for exp in expected:
+        assert any(liquid_terms_alpha_equal(goal, exp) for goal in goals)
+
+
+def test_error_message_omits_irrelevant_preconditions():
+    src = """
+def my_len: (s:String) -> Int := uninterpreted;
+
+def claim (x:Int) : {r:Int | r >= x} :=
+    x - 10;
+"""
+    failures = _liquid_failures(src)
+    assert failures
+    rendered = pretty_print_constraint(failures[0].vc)
+    assert "len" not in rendered
+
+
+def test_error_message_keeps_relevant_precondition():
+    src = """
+open Math
+def f (n:Int) : Float := Math.sqrt n
+def main (a:Int) : Unit := print (f a) ;
+"""
+    failures = _liquid_failures(src)
+    assert failures
+    rendered = str(failures[0])
+    assert "counterexample:" in rendered
+    assert "n =" in rendered
+
+
+def test_valid_program_has_no_vc_errors():
+    assert not _liquid_failures("def ok (x:Int) : {v:Int | v = x + x} := x + x ;")


### PR DESCRIPTION
## Summary
- Split failing supertype conjunctions (`… => Q && R`) into separate sub-obligations and report only the conjuncts that fail
- Drop inert VC preconditions that do not affect the goal (while keeping false and contradictory ones)
- Unify the display pipeline via `prepare_vc_for_display` for errors and pretty-printing

## Test plan
- [x] `pytest tests/simplification_constraints_test.py tests/vc_error_printing_test.py tests/counterexample_test.py`
- [x] `pytest tests/end_to_end_test.py tests/partial_vc_test.py`


Made with [Cursor](https://cursor.com)