### PR TITLE
Surface the goal in refinement errors and omit trivial refinements

### DIFF
--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -190,7 +190,14 @@ class LiquidTypeCheckingFailedRelation(CoreTypeCheckingError):
     loc: Location | None = None
 
     def __str__(self) -> str:
-        base = f"Failed to prove ({pretty_print_constraint(self.vc)}) in {self.position()}"
+        from aeon.verification.helpers import constraint_goal
+
+        goal = constraint_goal(self.vc)
+        if goal is not None:
+            base = f"Failed to prove `{goal}` in {self.position()}"
+            base += f"\n    Could not establish it from the available facts:{pretty_print_constraint(self.vc)}"
+        else:
+            base = f"Failed to prove ({pretty_print_constraint(self.vc)}) in {self.position()}"
         cex = self.counterexample()
         if cex is not None:
             base += f"\n    counterexample: {cex}"

--- a/aeon/verification/helpers.py
+++ b/aeon/verification/helpers.py
@@ -970,10 +970,14 @@ def pretty_print_generator(c: Constraint) -> Generator[tuple[str, int], None, No
             yield (f"reflected {rname}({params}) : {rtype}", 0)
             yield from pretty_print_generator(rseq)
         case Implication(name=iname, base=base, pred=pred, seq=sseq):
+            trivial_pred = pred == LiquidLiteralBool(True)
             if is_used(iname, sseq):
-                yield (f"∀{iname}:{base} | {pred}", 0)
+                if trivial_pred:
+                    yield (f"∀{iname}:{base}", 0)
+                else:
+                    yield (f"∀{iname}:{base} | {pred}", 0)
             else:
-                if pred != LiquidLiteralBool(True):
+                if not trivial_pred:
                     yield (f"{iname}:_ | {pred}", 0)
             if not isinstance(sseq, Implication):
                 yield ("====>", 0)
@@ -1059,6 +1063,27 @@ def pretty_print_constraint(c: Constraint) -> str:
     middle = "\n+--------------------+\n".join(top)
     footer = "\n+---------//---------+\n"
     return header + middle + footer
+
+
+def constraint_goal(c: Constraint) -> LiquidTerm | None:
+    """Return the goal (innermost conclusion) of a constraint.
+
+    A verification condition has the shape ``∀…, premises => goal``; this digs
+    through the binders/premises to the final ``LiquidConstraint`` and returns
+    its expression, which is the property that actually has to hold. Used to
+    surface the concrete goal at the top of an error message.
+    """
+    match c:
+        case LiquidConstraint(expr=expr):
+            return expr
+        case Implication(seq=seq):
+            return constraint_goal(seq)
+        case UninterpretedFunctionDeclaration(seq=seq):
+            return constraint_goal(seq)
+        case ReflectedFunctionDeclaration(seq=seq):
+            return constraint_goal(seq)
+        case _:
+            return None
 
 
 def show_constraint(c: Constraint):

--- a/tests/simplification_constraints_test.py
+++ b/tests/simplification_constraints_test.py
@@ -467,3 +467,35 @@ def test_fixpoint_extensibility():
 
     simplify_constraint_fixpoint(c, extra_passes=[counting_pass])
     assert call_count[0] > 0, "Extra pass was never called"
+
+
+# ---------------------------------------------------------------------------
+# Tests for error-message goal extraction and trivial-refinement printing
+# ---------------------------------------------------------------------------
+
+
+def test_constraint_goal_extracts_conclusion():
+    """constraint_goal digs through binders/premises to the final goal."""
+    from aeon.verification.helpers import constraint_goal
+
+    a_name = Name("a", 10)
+    pred = bind_lq(parse_liquid("a > 0"), [("a", a_name)])
+    concl = bind_lq(parse_liquid("a > 5"), [("a", a_name)])
+    c = Implication(a_name, t_int, pred, LiquidConstraint(concl))
+
+    assert constraint_goal(c) == concl
+
+
+def test_pretty_print_omits_trivial_true_refinement():
+    """A binder with a trivial `true` refinement prints without `| true`."""
+    from aeon.verification.helpers import pretty_print_constraint
+
+    a_name = Name("a", 10)
+    # forall a:Int (with trivial `true` premise) => a > 5
+    concl = bind_lq(parse_liquid("a > 5"), [("a", a_name)])
+    c = Implication(a_name, t_int, LiquidLiteralBool(True), LiquidConstraint(concl))
+
+    out = pretty_print_constraint(c)
+    assert "| true" not in out, out
+    # The binder itself is still shown.
+    assert "∀a" in out, out


### PR DESCRIPTION
## Summary
- Refinement type errors now **lead with the concrete goal** that could not be proven — ``Failed to prove `<goal>` `` — via a new `constraint_goal` helper, instead of only dumping the entire verification condition. The full VC is still shown below as "the available facts".
- The constraint pretty-printer **omits `| true`** for binders whose refinement is trivially `true` (e.g. `∀x:Int` instead of `∀x:Int | true`), reducing noise.

### Example
```
Failed to prove `(x > x)` in ...:1:36
    Could not establish it from the available facts:
+-----Constraint-----+
∀x:Int
====>
(x > x)
+---------//---------+
```

## Notes
This is scoped to only the message/printing improvements. It is intentionally additive to (and does not duplicate) the AND-splitting / inert-precondition removal work tracked separately in #464 — `constraint_goal` and the trivial-refinement omission are independent and compose with that change.

## Test plan
- [x] `pytest tests/simplification_constraints_test.py tests/counterexample_test.py` (added `test_constraint_goal_extracts_conclusion`, `test_pretty_print_omits_trivial_true_refinement`)
- [x] `pre-commit run` (mypy + ruff + format) on changed files
- [x] Manual: a failing `.ae` program shows the goal-first message with `| true` omitted

Made with [Cursor](https://cursor.com)