### PR TITLE
Add property-based testing benchmarks from Brown teaching papers

### DIFF
--- a/examples/pbt_benchmarks/docdiff.ae
+++ b/examples/pbt_benchmarks/docdiff.ae
@@ -1,0 +1,131 @@
+# DocDiff — a Conceptual Mutation Testing benchmark.
+#
+# From:
+#   * Prasad, Greenman, Nelson, Krishnamurthi. "Conceptual Mutation Testing for
+#     Student Programming Misconceptions." Programming 2024.
+#
+# DocDiff is a document-similarity problem (the classic TF/cosine-style
+# "overlap"). Students write *examples* (input/expected-output pairs) before
+# coding; Examplar checks each example against a correct implementation (the
+# "wheat") and a set of buggy ones (the "chaffs"). A good example suite passes
+# the wheat and *kills* every chaff (disagrees with it on some input).
+#
+# This file encodes the benchmark:
+#   * the wheat: overlap = <v1,v2> / max(||v1||^2, ||v2||^2), case-insensitive,
+#     frequency-based, over the union of words;
+#   * the chaffs deployed in the paper (§8) plus the coarse ones from §10.1;
+#   * an example suite, and the checks that it passes the wheat and kills every
+#     chaff — exactly the Examplar contract.
+#
+# Documents are word lists (Array String). The numeric core uses Aeon's Python
+# FFI (mirroring the student implementations under test); the example/chaff
+# harness is pure Aeon.
+#
+# Run with:  aeon --test examples/pbt_benchmarks/docdiff.ae
+
+open Array
+open Math
+open Testing
+
+# ── The wheat (correct overlap) ─────────────────────────────────────────────
+# Frequency vectors over the union of (lower-cased) words, dot product
+# normalized by the squared magnitude of the larger vector.
+def overlap (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "(lambda a,b: (lambda U,m1,m2: (sum(a.count(w)*b.count(w) for w in U)/max(m1,m2)) if max(m1,m2)>0 else 0.0)(set(a)|set(b), sum(a.count(w)**2 for w in set(a)), sum(b.count(w)**2 for w in set(b))))([x.lower() for x in d1],[y.lower() for y in d2])"
+
+# ── The chaffs (buggy implementations) ──────────────────────────────────────
+
+# Chaff 1: case-sensitive comparison of words (no lower-casing).
+def caseSensitive (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "(lambda a,b: (lambda U,m1,m2: (sum(a.count(w)*b.count(w) for w in U)/max(m1,m2)) if max(m1,m2)>0 else 0.0)(set(a)|set(b), sum(a.count(w)**2 for w in set(a)), sum(b.count(w)**2 for w in set(b))))(list(d1),list(d2))"
+
+# Chaff 2: always returns 0 (no overlap).
+def alwaysZero (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "0.0"
+
+# Chaff 3: normalizes by the *smaller* document's squared magnitude.
+def normalizeSmaller (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "(lambda a,b: (lambda U,m1,m2: (sum(a.count(w)*b.count(w) for w in U)/min(m1,m2)) if min(m1,m2)>0 else 0.0)(set(a)|set(b), sum(a.count(w)**2 for w in set(a)), sum(b.count(w)**2 for w in set(b))))([x.lower() for x in d1],[y.lower() for y in d2])"
+
+# Chaff 4: normalizes by the magnitude, not the *squared* magnitude.
+def normalizeMagnitude (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "(lambda a,b: (lambda U,m1,m2: (sum(a.count(w)*b.count(w) for w in U)/max(m1**0.5,m2**0.5)) if max(m1,m2)>0 else 0.0)(set(a)|set(b), sum(a.count(w)**2 for w in set(a)), sum(b.count(w)**2 for w in set(b))))([x.lower() for x in d1],[y.lower() for y in d2])"
+
+# Chaff 5: returns 1 when one document's word set subsumes the other's.
+def subsumes (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "1.0 if (set(x.lower() for x in d1) <= set(y.lower() for y in d2)) or (set(y.lower() for y in d2) <= set(x.lower() for x in d1)) else 0.0"
+
+# Chaff 6 (coarse): always returns 1.
+def alwaysOne (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "1.0"
+
+# Chaff 7 (coarse): rounds the overlap to 0 or 1.
+def rounds (d1: (Array String)) (d2: (Array String)) : Float :=
+    native "float(round((lambda a,b: (lambda U,m1,m2: (sum(a.count(w)*b.count(w) for w in U)/max(m1,m2)) if max(m1,m2)>0 else 0.0)(set(a)|set(b), sum(a.count(w)**2 for w in set(a)), sum(b.count(w)**2 for w in set(b))))([x.lower() for x in d1],[y.lower() for y in d2])))"
+
+# Two overlap scores are observably different.
+def differs (w: Float) (c: Float) : Bool := absf (w - c) > 0.0001;
+
+# ── The example suite (student input/expected-output pairs) ─────────────────
+
+# A: identical single-word docs           -> 1.0
+def dA1 : (Array String) := native "['a']"
+def dA2 : (Array String) := native "['a']"
+# B: disjoint docs                         -> 0.0
+def dB1 : (Array String) := native "['a']"
+def dB2 : (Array String) := native "['b']"
+# C: same words, different frequencies     -> 0.8
+def dC1 : (Array String) := native "['a','a','b']"
+def dC2 : (Array String) := native "['a','b','b']"
+# D: differ only by letter case            -> 1.0 (case is insignificant)
+def dD1 : (Array String) := native "['A']"
+def dD2 : (Array String) := native "['a']"
+# E: one doc's words are a subset          -> 0.5 (not 1.0!)
+def dE1 : (Array String) := native "['a']"
+def dE2 : (Array String) := native "['a','b']"
+
+# Every example passes the wheat (its expected output is the wheat's output).
+@property(1)
+def test_examples_pass_wheat : Bool :=
+    allOf5 (assertClose (overlap dA1 dA2) 1.0 0.0001)
+           (assertClose (overlap dB1 dB2) 0.0 0.0001)
+           (assertClose (overlap dC1 dC2) 0.8 0.0001)
+           (assertClose (overlap dD1 dD2) 1.0 0.0001)
+           (assertClose (overlap dE1 dE2) 0.5 0.0001);
+
+# ── The chaffs are all killed by the example suite ──────────────────────────
+
+# Case-sensitivity is exposed by example D (case-only difference).
+@property(1)
+def test_kills_case_sensitive : Bool :=
+    assertTrue (differs (overlap dD1 dD2) (caseSensitive dD1 dD2));
+
+# Always-0 is exposed by any positive-overlap example (A).
+@property(1)
+def test_kills_always_zero : Bool :=
+    assertTrue (differs (overlap dA1 dA2) (alwaysZero dA1 dA2));
+
+# Wrong normalization (smaller vector) is exposed by the subset example E.
+@property(1)
+def test_kills_normalize_smaller : Bool :=
+    assertTrue (differs (overlap dE1 dE2) (normalizeSmaller dE1 dE2));
+
+# Wrong normalization (magnitude, not squared) is exposed by E.
+@property(1)
+def test_kills_normalize_magnitude : Bool :=
+    assertTrue (differs (overlap dE1 dE2) (normalizeMagnitude dE1 dE2));
+
+# The subsumption chaff is exposed by E (subset yet overlap is 0.5, not 1.0).
+@property(1)
+def test_kills_subsumes : Bool :=
+    assertTrue (differs (overlap dE1 dE2) (subsumes dE1 dE2));
+
+# Always-1 is exposed by the disjoint example B.
+@property(1)
+def test_kills_always_one : Bool :=
+    assertTrue (differs (overlap dB1 dB2) (alwaysOne dB1 dB2));
+
+# Rounding is exposed by the fractional-overlap example E.
+@property(1)
+def test_kills_rounds : Bool :=
+    assertTrue (differs (overlap dE1 dE2) (rounds dE1 dE2));

--- a/examples/pbt_benchmarks/filesystem.ae
+++ b/examples/pbt_benchmarks/filesystem.ae
@@ -1,0 +1,249 @@
+# Filesystem — a Conceptual Mutation Testing benchmark.
+#
+# From:
+#   * Prasad, Greenman, Nelson, Krishnamurthi. "Conceptual Mutation Testing for
+#     Student Programming Misconceptions." Programming 2024.
+#   * The problem itself is the classic "filesystem" from *How to Design
+#     Programs* (Brown cs019). It uses (mutually) recursive datatypes and asks
+#     for four functions: how-many, du-dir, can-find?, and fynd.
+#
+# Spec (cs019 2020):
+#   how-many : Dir -> Int      number of files in the tree
+#   du-dir   : Dir -> Int      total size: file sizes are content-string lengths;
+#                              a directory's size adds the sizes of its files and
+#                              subdirectories PLUS the lengths of its fs and ds lists
+#   can-find : Dir,String->Bool  whether a file with the given name occurs anywhere
+#   fynd     : Dir,String-> [Path]  every path (list of directory names, root
+#                              first) to a file with the given name
+#
+# Students write examples that must pass the correct implementation (the
+# "wheat") and kill each buggy one (the "chaffs"). We implement the wheat, the
+# five chaffs the paper deployed (§8), and the additional candidate chaffs from
+# §10.1. Everything is pure Aeon — the recursive datatype is the point.
+#
+# Run with:  aeon --test examples/pbt_benchmarks/filesystem.ae
+
+open List
+open String
+open Testing
+
+# ── Data representation ─────────────────────────────────────────────────────
+
+# A file has a name and content.
+inductive File
+| file (name: String) (content: String) : File
+
+# A directory has a name, a list of subdirectories, and a list of files.
+inductive Dir
+| dir (name: String) (ds: (List Dir)) (fs: (List File)) : Dir
+
+def fileName (f: File) : String :=
+    match f with | file n c => n;
+
+def fileContent (f: File) : String :=
+    match f with | file n c => c;
+
+# The size of a file is the length of its content string.
+def fileSize (f: File) : Int := len (fileContent f);
+
+def dirName (d: Dir) : String :=
+    match d with | dir n ds fs => n;
+
+def dirSubs (d: Dir) : (List Dir) :=
+    match d with | dir n ds fs => ds;
+
+def dirFiles (d: Dir) : (List File) :=
+    match d with | dir n ds fs => fs;
+
+# ── how-many: number of files in the tree ───────────────────────────────────
+# Self-recursive through List.map (no mutual recursion needed).
+
+def howMany (d: Dir) : Int :=
+    (length (dirFiles d)) + (sum (map howMany (dirSubs d)));
+
+# ── du-dir: total size ──────────────────────────────────────────────────────
+
+def duDir (d: Dir) : Int :=
+    (length (dirFiles d))
+    + (length (dirSubs d))
+    + (sum (map fileSize (dirFiles d)))
+    + (sum (map duDir (dirSubs d)));
+
+# ── can-find: is there a file with this name anywhere? ──────────────────────
+
+def anyB (l: (List Bool)) : Bool :=
+    match l with
+    | nil => false
+    | cons hd tl => hd || (anyB tl);
+
+def anyFileNamed (fs: (List File)) (target: String) : Bool :=
+    match fs with
+    | nil => false
+    | cons hd tl => (equal (fileName hd) target) || (anyFileNamed tl target);
+
+def canFind (d: Dir) (target: String) : Bool :=
+    (anyFileNamed (dirFiles d) target)
+    || (anyB (map (fun sd => canFind sd target) (dirSubs d)));
+
+# ── fynd: every path (root first) to a file with this name ──────────────────
+# A Path is a list of directory names; the result is a list of paths.
+
+def prependName (n: String) (paths: (List (List String))) : (List (List String)) :=
+    map (fun p => cons n p) paths;
+
+def flattenPaths (lls: (List (List (List String)))) : (List (List String)) :=
+    match lls with
+    | nil => nil
+    | cons hd tl => append hd (flattenPaths tl);
+
+def fynd (d: Dir) (target: String) : (List (List String)) :=
+    here : (List (List String)) := (if anyFileNamed (dirFiles d) target
+             then cons (cons (dirName d) nil) nil
+             else nil);
+    below : (List (List String)) := flattenPaths (map (fun sd => prependName (dirName d) (fynd sd target)) (dirSubs d));
+    append here below;
+
+# ── Chaffs deployed in the paper (§8) ───────────────────────────────────────
+
+# Chaff 1: can-find always returns true.
+def canFindAlwaysTrue (d: Dir) (target: String) : Bool := true;
+
+# Chaff 2: can-find skips the root directory (only searches subdirectories).
+def canFindSkipRoot (d: Dir) (target: String) : Bool :=
+    anyB (map (fun sd => canFind sd target) (dirSubs d));
+
+# Chaff 3: du-dir ignores the lengths of the file and directory lists.
+def duDirIgnoreLengths (d: Dir) : Int :=
+    (sum (map fileSize (dirFiles d)))
+    + (sum (map duDirIgnoreLengths (dirSubs d)));
+
+# Chaff 4: how-many counts files (good) and directories (bad).
+def howManyCountsDirs (d: Dir) : Int :=
+    (length (dirFiles d))
+    + (length (dirSubs d))
+    + (sum (map howManyCountsDirs (dirSubs d)));
+
+# Chaff 5: fynd returns the current directory on failure (instead of empty).
+def fyndCurrentOnFailure (d: Dir) (target: String) : (List (List String)) :=
+    if canFind d target then fynd d target
+    else cons (cons (dirName d) nil) nil;
+
+# ── Additional candidate chaffs (§10.1) ─────────────────────────────────────
+
+# can-find always returns false.
+def canFindAlwaysFalse (d: Dir) (target: String) : Bool := false;
+
+# how-many counts only directories.
+def howManyOnlyDirs (d: Dir) : Int :=
+    (length (dirSubs d)) + (sum (map howManyOnlyDirs (dirSubs d)));
+
+# du-dir counts filename length (adds the length of each file's name).
+def duDirNameLength (d: Dir) : Int :=
+    (length (dirFiles d))
+    + (length (dirSubs d))
+    + (sum (map (fun f => (fileSize f) + (len (fileName f))) (dirFiles d)))
+    + (sum (map duDirNameLength (dirSubs d)));
+
+# fynd returns each path twice.
+def fyndDuplicates (d: Dir) (target: String) : (List (List String)) :=
+    r := fynd d target;
+    append r r;
+
+# ── Fixture: the assignment's example tree ──────────────────────────────────
+#   Root      files: read!(4)                     subdirs: Text, Libs
+#   Text      files: part1(1) part2(2) part3(3)   subdirs: -
+#   Libs      files: read!(2)                      subdirs: Code
+#   Code      files: hang(4) draw(2)               subdirs: -
+
+def code : Dir :=
+    Dir.dir "Code" nil
+        (cons (File.file "hang" "dddd") (cons (File.file "draw" "ee") nil));
+
+def libs : Dir :=
+    Dir.dir "Libs"
+        (cons code nil)
+        (cons (File.file "read!" "cc") nil);
+
+def text : Dir :=
+    Dir.dir "Text" nil
+        (cons (File.file "part1" "b")
+              (cons (File.file "part2" "bb")
+                    (cons (File.file "part3" "bbb") nil)));
+
+def root : Dir :=
+    Dir.dir "Root"
+        (cons text (cons libs nil))
+        (cons (File.file "read!" "aaaa") nil);
+
+# Expected fynd results (root first, subdirectories in ds order).
+def expPart3 : (List (List String)) :=
+    cons (cons "Root" (cons "Text" nil)) nil;
+
+def expReadBang : (List (List String)) :=
+    cons (cons "Root" nil)
+         (cons (cons "Root" (cons "Libs" nil)) nil);
+
+# ── Examples pass the wheat ─────────────────────────────────────────────────
+
+# how-many: Root's tree has 7 files.
+@property(1)
+def test_how_many : Bool := assertEqual (howMany root) 7;
+
+# du-dir: computed size of the tree is 28.
+@property(1)
+def test_du_dir : Bool := assertEqual (duDir root) 28;
+
+# can-find: present vs. absent names.
+@property(1)
+def test_can_find : Bool :=
+    both (assertTrue (canFind root "part3"))
+         (assertFalse (canFind root "missing"));
+
+# fynd matches the assignment's worked examples.
+@property(1)
+def test_fynd_part3 : Bool := assertEqual (fynd root "part3") expPart3;
+
+@property(1)
+def test_fynd_readbang : Bool := assertEqual (fynd root "read!") expReadBang;
+
+# ── Chaffs are killed by the examples ───────────────────────────────────────
+
+# A file only in the root distinguishes the skip-root chaff.
+def soloRoot : Dir :=
+    Dir.dir "R" nil (cons (File.file "x" "y") nil);
+
+@property(1)
+def test_kills_canfind_always_true : Bool :=
+    assertNotEqual (canFind root "missing") (canFindAlwaysTrue root "missing");
+
+@property(1)
+def test_kills_canfind_skip_root : Bool :=
+    assertNotEqual (canFind soloRoot "x") (canFindSkipRoot soloRoot "x");
+
+@property(1)
+def test_kills_dudir_ignore_lengths : Bool :=
+    assertNotEqual (duDir root) (duDirIgnoreLengths root);
+
+@property(1)
+def test_kills_howmany_counts_dirs : Bool :=
+    assertNotEqual (howMany root) (howManyCountsDirs root);
+
+@property(1)
+def test_kills_fynd_current_on_failure : Bool :=
+    assertNotEqual (length (fynd root "missing")) (length (fyndCurrentOnFailure root "missing"));
+
+@property(1)
+def test_kills_canfind_always_false : Bool :=
+    assertNotEqual (canFind root "part3") (canFindAlwaysFalse root "part3");
+
+@property(1)
+def test_kills_howmany_only_dirs : Bool :=
+    assertNotEqual (howMany root) (howManyOnlyDirs root);
+
+@property(1)
+def test_kills_dudir_name_length : Bool :=
+    assertNotEqual (duDir root) (duDirNameLength root);
+
+@property(1)
+def test_kills_fynd_duplicates : Bool :=
+    assertNotEqual (length (fynd root "read!")) (length (fyndDuplicates root "read!"));

--- a/examples/pbt_benchmarks/matcher.ae
+++ b/examples/pbt_benchmarks/matcher.ae
@@ -1,0 +1,212 @@
+# Matcher — a Property-Based Testing benchmark (stable matching).
+#
+# From:
+#   * Wrenn, Nelson, Krishnamurthi. "Using Relational Problems to Teach
+#     Property-Based Testing." Programming 2021 (pj21).
+#   * Nelson, Rivera, Soucie, Del Vecchio, Wrenn, Krishnamurthi. "Automated,
+#     Targeted Testing of Property-Based Testing Predicates." Programming 2022.
+#
+# Task: write the predicate that decides whether a purported solution to the
+# stable-matching problem (cast as matching candidates with companies) is
+# correct. The input is a pair of preference profiles — for both candidates and
+# companies — given as ranked lists of ids (indices are identities). The output
+# is a matching (a set of candidate/company pairs).
+#
+# Correctness decomposes (2022, §9) into:
+#   Stable       no unmatched pair would both prefer each other to their match
+#   Uniqueness   no candidate/company is matched more than once
+#   Complete     every candidate and every company is matched
+#
+# Run with:  aeon --test examples/pbt_benchmarks/matcher.ae
+
+open List
+open Testing
+
+# ── Domain ────────────────────────────────────────────────────────────────
+
+# A single pairing: candidate `cand` is matched to company `comp`.
+inductive MPair
+| mpair (cand: Int) (comp: Int) : MPair
+
+def candOf (p: MPair) : Int :=
+    match p with
+    | mpair c f => c;
+
+def compOf (p: MPair) : Int :=
+    match p with
+    | mpair c f => f;
+
+# ── Int-list helpers ────────────────────────────────────────────────────────
+
+def elemInt (x: Int) (l: (List Int)) : Bool :=
+    match l with
+    | nil => false
+    | cons hd tl => (hd = x) || (elemInt x tl);
+
+def allInt (f: (x:Int) -> Bool) (l: (List Int)) : Bool :=
+    match l with
+    | nil => true
+    | cons hd tl => (f hd) && (allInt f tl);
+
+def uniqueInt (l: (List Int)) : Bool :=
+    match l with
+    | nil => true
+    | cons hd tl => (! (elemInt hd tl)) && (uniqueInt tl);
+
+# [0, 1, ..., n-1].
+def rangeAux (k: Int) (n: Int) : (List Int) :=
+    if k >= n then nil else cons k (rangeAux (k + 1) n);
+
+def range (n: Int) : (List Int) := rangeAux 0 n;
+
+# k-th element of a list of ints (0-indexed); -1 if out of range.
+def nth (l: (List Int)) (k: Int) : Int :=
+    match l with
+    | nil => 0 - 1
+    | cons hd tl => if k <= 0 then hd else nth tl (k - 1);
+
+# k-th preference list.
+def nthList (l: (List (List Int))) (k: Int) : (List Int) :=
+    match l with
+    | nil => nil
+    | cons hd tl => if k <= 0 then hd else nthList tl (k - 1);
+
+# ── Preferences and partners ─────────────────────────────────────────────────
+
+# Rank of `x` in a preference list (0 = most preferred); a large number when `x`
+# is absent, so a real option always beats "no partner" (id -1).
+def rankAux (prefs: (List Int)) (x: Int) (idx: Int) : Int :=
+    match prefs with
+    | nil => 1000000
+    | cons hd tl => if hd = x then idx else rankAux tl x (idx + 1);
+
+def rank (prefs: (List Int)) (x: Int) : Int := rankAux prefs x 0;
+
+# `a` is strictly preferred to `b` in `prefs`.
+def prefersOver (prefs: (List Int)) (a: Int) (b: Int) : Bool :=
+    (rank prefs a) < (rank prefs b);
+
+# Company matched to candidate `c` (or -1 if unmatched).
+def partnerOf (m: (List MPair)) (c: Int) : Int :=
+    match m with
+    | nil => 0 - 1
+    | cons p tl => if candOf p = c then compOf p else partnerOf tl c;
+
+# Candidate matched to company `f` (or -1 if unmatched).
+def partnerOfComp (m: (List MPair)) (f: Int) : Int :=
+    match m with
+    | nil => 0 - 1
+    | cons p tl => if compOf p = f then candOf p else partnerOfComp tl f;
+
+def candList (m: (List MPair)) : (List Int) :=
+    match m with
+    | nil => nil
+    | cons p tl => cons (candOf p) (candList tl);
+
+def compList (m: (List MPair)) : (List Int) :=
+    match m with
+    | nil => nil
+    | cons p tl => cons (compOf p) (compList tl);
+
+# ── Subproperties ────────────────────────────────────────────────────────────
+
+# (c, f) is a *blocking pair*: they are not matched to each other, yet each
+# prefers the other to their current partner.
+def isBlocking
+    (candPrefs: (List (List Int)))
+    (compPrefs: (List (List Int)))
+    (m: (List MPair))
+    (c: Int) (f: Int) : Bool :=
+    pc := partnerOf m c;
+    pf := partnerOfComp m f;
+    (pc != f)
+    && (prefersOver (nthList candPrefs c) f pc)
+    && (prefersOver (nthList compPrefs f) c pf);
+
+# Stable: no blocking pair exists over all candidate/company pairs.
+def stable
+    (candPrefs: (List (List Int)))
+    (compPrefs: (List (List Int)))
+    (m: (List MPair)) : Bool :=
+    n := length candPrefs;
+    k := length compPrefs;
+    allInt (fun c => allInt (fun f => ! (isBlocking candPrefs compPrefs m c f)) (range k))
+           (range n);
+
+# Uniqueness: no candidate and no company is matched twice.
+def uniqueMatch (m: (List MPair)) : Bool :=
+    (uniqueInt (candList m)) && (uniqueInt (compList m));
+
+# Complete: every candidate and every company is matched.
+def complete
+    (candPrefs: (List (List Int)))
+    (compPrefs: (List (List Int)))
+    (m: (List MPair)) : Bool :=
+    n := length candPrefs;
+    k := length compPrefs;
+    (allInt (fun c => partnerOf m c != (0 - 1)) (range n))
+    && (allInt (fun f => partnerOfComp m f != (0 - 1)) (range k));
+
+# The full correctness predicate students should write.
+def isValid
+    (candPrefs: (List (List Int)))
+    (compPrefs: (List (List Int)))
+    (m: (List MPair)) : Bool :=
+    (complete candPrefs compPrefs m)
+    && (uniqueMatch m)
+    && (stable candPrefs compPrefs m);
+
+# ── Fixtures: a 2x2 instance ────────────────────────────────────────────────
+# Candidates 0,1 ; Companies 0,1.
+#   cand 0 prefers company 0 then 1;  cand 1 prefers company 1 then 0.
+#   comp 0 prefers candidate 0 then 1; comp 1 prefers candidate 1 then 0.
+# Everyone can get their first choice, so 0-0 / 1-1 is the unique stable match.
+
+def candPrefs2 : (List (List Int)) :=
+    cons (cons 0 (cons 1 nil)) (cons (cons 1 (cons 0 nil)) nil);
+
+def compPrefs2 : (List (List Int)) :=
+    cons (cons 0 (cons 1 nil)) (cons (cons 1 (cons 0 nil)) nil);
+
+# The stable matching 0-0, 1-1.
+def goodMatch : (List MPair) :=
+    cons (MPair.mpair 0 0) (cons (MPair.mpair 1 1) nil);
+
+# The unstable matching 0-1, 1-0 (both would rather swap).
+def unstableMatch : (List MPair) :=
+    cons (MPair.mpair 0 1) (cons (MPair.mpair 1 0) nil);
+
+# ── Positive test ────────────────────────────────────────────────────────────
+
+@property(1)
+def test_accepts_stable : Bool :=
+    assertTrue (isValid candPrefs2 compPrefs2 goodMatch);
+
+# ── Negative tests: each subproperty catches the corresponding bug ──────────
+
+# Stable fails: 0-1 / 1-0 is complete and unique, but (0,0) is a blocking pair.
+@property(1)
+def test_catches_unstable : Bool :=
+    allOf4 (assertTrue (complete candPrefs2 compPrefs2 unstableMatch))
+           (assertTrue (uniqueMatch unstableMatch))
+           (assertFalse (stable candPrefs2 compPrefs2 unstableMatch))
+           (assertFalse (isValid candPrefs2 compPrefs2 unstableMatch));
+
+# The specific blocking pair is (candidate 0, company 0).
+@property(1)
+def test_blocking_pair_identified : Bool :=
+    assertTrue (isBlocking candPrefs2 compPrefs2 unstableMatch 0 0);
+
+# Complete fails: candidate 1 and company 1 are left unmatched.
+@property(1)
+def test_catches_incomplete : Bool :=
+    m := cons (MPair.mpair 0 0) nil;
+    both (assertFalse (complete candPrefs2 compPrefs2 m))
+         (assertFalse (isValid candPrefs2 compPrefs2 m));
+
+# Uniqueness fails: company 0 is matched to both candidates.
+@property(1)
+def test_catches_duplicate : Bool :=
+    m := cons (MPair.mpair 0 0) (cons (MPair.mpair 1 0) nil);
+    both (assertFalse (uniqueMatch m))
+         (assertFalse (isValid candPrefs2 compPrefs2 m));

--- a/examples/pbt_benchmarks/nile.ae
+++ b/examples/pbt_benchmarks/nile.ae
@@ -1,0 +1,137 @@
+# Nile — a Conceptual Mutation Testing benchmark.
+#
+# From:
+#   * Prasad, Greenman, Nelson, Krishnamurthi. "Conceptual Mutation Testing for
+#     Student Programming Misconceptions." Programming 2024.
+#
+# Nile is an imaginary online bookstore. The problem asks for two collaborative
+# filters over a set of user *collections* (each a list of book titles):
+#   * recommend a single book, and
+#   * recommend a pair of books,
+# both ranked by *frequency* of occurrence across collections.
+#
+# As with DocDiff, students write examples that must pass a correct
+# implementation (the "wheat") and kill each buggy one (the "chaffs"). We
+# implement the wheat and the six chaffs the paper deployed (§8):
+#   1. counts number of books instead of their frequency
+#   2. counts number of pairs instead of their frequency
+#   3. recommends only books that appear in multiple collections
+#   4. performs case-insensitive comparisons of books
+#   5. recommends at most one book
+#   6. recommends at most one pair
+#
+# A recommendation is returned as a sorted Array String; a pair {a,b} is encoded
+# as the string "a|b". The database is an opaque list-of-collections (DB); the
+# ranking cores use Aeon's Python FFI, and the example/chaff harness is pure
+# Aeon.
+#
+# Run with:  aeon --test examples/pbt_benchmarks/nile.ae
+
+open Array
+open Testing
+
+# A bookstore database: a list of collections, each a list of book titles.
+type DB
+
+# ── The wheats (correct recommenders) ───────────────────────────────────────
+
+# Recommend the book(s) with the highest total frequency across collections.
+def recommendBooks (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda books, flat: sorted([b for b in books if flat.count(b)==max(flat.count(x) for x in books)]) if books else [])(sorted(set(x for c in cols for x in c)), [x for c in cols for x in c]))(d)"
+
+# Recommend the book pair(s) {a,b} with the highest co-occurrence frequency
+# (sum over collections of count(a)*count(b)), encoded "a|b".
+def recommendPairs (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda pairs, best: sorted([a+'|'+b for (a,b) in pairs if best(a,b)==max(best(x,y) for (x,y) in pairs)]) if pairs else [])((lambda allb: [(allb[i],allb[j]) for i in range(len(allb)) for j in range(i+1,len(allb))])(sorted(set(x for c in cols for x in c))), lambda a,b: sum(c.count(a)*c.count(b) for c in cols)))(d)"
+
+# ── The chaffs (buggy recommenders) ─────────────────────────────────────────
+
+# Chaff 1: counts the number of collections a book appears in (presence),
+# not its total frequency.
+def countsBooksPresence (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda books: sorted([b for b in books if sum(1 for c in cols if b in c)==max(sum(1 for c in cols if x in c) for x in books)]) if books else [])(sorted(set(x for c in cols for x in c))))(d)"
+
+# Chaff 2: ranks pairs by collection presence, not co-occurrence frequency.
+def countsPairsPresence (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda pairs, best: sorted([a+'|'+b for (a,b) in pairs if best(a,b)==max(best(x,y) for (x,y) in pairs)]) if pairs else [])((lambda allb: [(allb[i],allb[j]) for i in range(len(allb)) for j in range(i+1,len(allb))])(sorted(set(x for c in cols for x in c))), lambda a,b: sum(1 for c in cols if a in c and b in c)))(d)"
+
+# Chaff 3: recommends only books that appear in more than one collection.
+def recommendMulti (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda cand, flat: sorted([b for b in cand if flat.count(b)==max(flat.count(x) for x in cand)]) if cand else [])([b for b in sorted(set(x for c in cols for x in c)) if sum(1 for c in cols if b in c)>1], [x for c in cols for x in c]))(d)"
+
+# Chaff 4: performs case-insensitive comparisons (Nile titles are case-sensitive).
+def caseInsensitiveBooks (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda books, flat: sorted([b for b in books if flat.count(b)==max(flat.count(x) for x in books)]) if books else [])(sorted(set(x.lower() for c in cols for x in c)), [x.lower() for c in cols for x in c]))(d)"
+
+# Chaff 5: recommends at most one book (drops ties).
+def atMostOneBook (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda books, flat: sorted([b for b in books if flat.count(b)==max(flat.count(x) for x in books)])[:1] if books else [])(sorted(set(x for c in cols for x in c)), [x for c in cols for x in c]))(d)"
+
+# Chaff 6: recommends at most one pair (drops ties).
+def atMostOnePair (d: DB) : (Array String) :=
+    native "(lambda cols: (lambda pairs, best: sorted([a+'|'+b for (a,b) in pairs if best(a,b)==max(best(x,y) for (x,y) in pairs)])[:1] if pairs else [])((lambda allb: [(allb[i],allb[j]) for i in range(len(allb)) for j in range(i+1,len(allb))])(sorted(set(x for c in cols for x in c))), lambda a,b: sum(c.count(a)*c.count(b) for c in cols)))(d)"
+
+# Two recommendations are observably different.
+def recDiffers (a: (Array String)) (b: (Array String)) : Bool := native "list(a) != list(b)"
+def recSame (a: (Array String)) (b: (Array String)) : Bool := native "list(a) == list(b)"
+
+# ── Databases (example inputs) ───────────────────────────────────────────────
+
+# 'a' twice, 'b' once  -> book recommendation ['a']
+def dbB1 : DB := native "[['a','a'],['b']]"
+# two 'a's and two 'b's -> tie ['a','b']
+def dbB2 : DB := native "[['a'],['b'],['a'],['b']]"
+# {a,b} co-occurs twice -> pair recommendation ['a|b']
+def dbP1 : DB := native "[['a','b'],['a','b']]"
+
+# Discriminating databases for the chaffs.
+def dbKB : DB := native "[['a','a','a'],['b'],['b']]"
+def dbKM : DB := native "[['a','a']]"
+def dbKC : DB := native "[['A'],['A'],['a']]"
+def dbKP : DB := native "[['a','a','b'],['a','c'],['c']]"
+def dbP2 : DB := native "[['a','b'],['a','c']]"
+
+# Expected wheat outputs.
+def expA  : (Array String) := native "['a']"
+def expAB : (Array String) := native "['a','b']"
+def expAbPair : (Array String) := native "['a|b']"
+
+# ── Every example passes the wheat ──────────────────────────────────────────
+
+@property(1)
+def test_examples_pass_wheat : Bool :=
+    allOf3 (assertTrue (recSame (recommendBooks dbB1) expA))
+           (assertTrue (recSame (recommendBooks dbB2) expAB))
+           (assertTrue (recSame (recommendPairs dbP1) expAbPair));
+
+# ── Every chaff is killed by some example ───────────────────────────────────
+
+# Presence-vs-frequency: 'a' occurs 3x in one collection; 'b' in two collections.
+@property(1)
+def test_kills_counts_books : Bool :=
+    assertTrue (recDiffers (recommendBooks dbKB) (countsBooksPresence dbKB));
+
+# Presence-vs-frequency for pairs (multiplicity within a collection matters).
+@property(1)
+def test_kills_counts_pairs : Bool :=
+    assertTrue (recDiffers (recommendPairs dbKP) (countsPairsPresence dbKP));
+
+# "Multiple collections" restriction: a single-collection book is dropped.
+@property(1)
+def test_kills_recommend_multi : Bool :=
+    assertTrue (recDiffers (recommendBooks dbKM) (recommendMulti dbKM));
+
+# Case-insensitivity merges 'A' and 'a', changing the winner.
+@property(1)
+def test_kills_case_insensitive : Bool :=
+    assertTrue (recDiffers (recommendBooks dbKC) (caseInsensitiveBooks dbKC));
+
+# At-most-one-book drops a tie.
+@property(1)
+def test_kills_at_most_one_book : Bool :=
+    assertTrue (recDiffers (recommendBooks dbB2) (atMostOneBook dbB2));
+
+# At-most-one-pair drops a tie.
+@property(1)
+def test_kills_at_most_one_pair : Bool :=
+    assertTrue (recDiffers (recommendPairs dbP2) (atMostOnePair dbP2));

--- a/examples/pbt_benchmarks/sortacle.ae
+++ b/examples/pbt_benchmarks/sortacle.ae
@@ -1,0 +1,169 @@
+# Sortacle — a Property-Based Testing benchmark.
+#
+# From:
+#   * Wrenn, Nelson, Krishnamurthi. "Using Relational Problems to Teach
+#     Property-Based Testing." Programming 2021 (pj21).
+#   * Nelson, Rivera, Soucie, Del Vecchio, Wrenn, Krishnamurthi. "Automated,
+#     Targeted Testing of Property-Based Testing Predicates." Programming 2022.
+#
+# Task: students write the *predicate* (the "is-valid" oracle) that decides
+# whether a purported sorting implementation's output is a correct sort of its
+# input. Inputs and outputs are lists of `Person` records; the key is `age`,
+# and `name` is extra payload that the sort must carry along. Stability is NOT
+# required.
+#
+# The correctness property decomposes into three subproperties (pj21 §4.3,
+# 2022 §9). We give each subproperty its own function and assemble `isValid`.
+# The 2022 paper distinguishes a *weak* (set-based, underspecified) permutation
+# check from the *strong* (multiset-based) one — both are provided here.
+#
+# Run with:  aeon --test examples/pbt_benchmarks/sortacle.ae
+
+open List
+open Testing
+
+# ── Domain ────────────────────────────────────────────────────────────────
+
+# A Person to be sorted: `age` is the sort key, `name` is carried payload.
+inductive Person
+| person (age: Int) (name: Int) : Person
+
+def ageOf (p: Person) : Int :=
+    match p with
+    | person a n => a;
+
+def nameOf (p: Person) : Int :=
+    match p with
+    | person a n => n;
+
+# ── List helpers (the minimal vocabulary these predicates need) ────────────
+
+# True when every element satisfies `f`.
+def allP (f: (x:Person) -> Bool) (l: (List Person)) : Bool :=
+    match l with
+    | nil => true
+    | cons hd tl => (f hd) && (allP f tl);
+
+# Structural membership.
+def elemP (x: Person) (l: (List Person)) : Bool :=
+    match l with
+    | nil => false
+    | cons hd tl => (hd = x) || (elemP x tl);
+
+# Number of occurrences of `x` (multiplicity).
+def countP (x: Person) (l: (List Person)) : Int :=
+    match l with
+    | nil => 0
+    | cons hd tl => (if hd = x then 1 else 0) + (countP x tl);
+
+# ── Subproperties ──────────────────────────────────────────────────────────
+
+# Same-Size: the output has as many elements as the input.
+def sameSize (i: (List Person)) (o: (List Person)) : Bool :=
+    length i = length o;
+
+# Same-Elements (WEAK / pj21): input and output contain the same *set* of
+# elements. This is the underspecified version: it ignores multiplicity, so it
+# accepts outputs that drop or duplicate equal records.
+def sameElementsWeak (i: (List Person)) (o: (List Person)) : Bool :=
+    (allP (fun x => elemP x o) i) && (allP (fun x => elemP x i) o);
+
+# Same-Elements (STRONG / 2022): input and output are the same *multiset*.
+# Equal length plus matching multiplicities for every input element implies a
+# genuine permutation.
+def sameElementsStrong (i: (List Person)) (o: (List Person)) : Bool :=
+    (length i = length o) && (allP (fun x => countP x i = countP x o) i);
+
+# Ordered: the output is non-decreasing by age.
+def ordered (l: (List Person)) : Bool :=
+    match l with
+    | nil => true
+    | cons hd tl =>
+        match tl with
+        | nil => true
+        | cons hd2 tl2 => (ageOf hd <= ageOf hd2) && (ordered tl);
+
+# The full correctness predicate students should write (strong version).
+def isValid (i: (List Person)) (o: (List Person)) : Bool :=
+    (sameSize i o) && (sameElementsStrong i o) && (ordered o);
+
+# ── Reference implementation (the "correct" sort under test) ────────────────
+
+def insert (x: Person) (l: (List Person)) : (List Person) :=
+    match l with
+    | nil => cons x nil
+    | cons hd tl =>
+        if ageOf x <= ageOf hd then cons x (cons hd tl)
+        else cons hd (insert x tl);
+
+def isort (l: (List Person)) : (List Person) :=
+    match l with
+    | nil => nil
+    | cons hd tl => insert hd (isort tl);
+
+# ── Positive PBT: the correct implementation always satisfies the oracle ────
+# Inputs (List Person) are generated automatically as constructor trees.
+
+@property(30)
+def prop_isort_isValid (i: (List Person)) : Bool :=
+    isValid i (isort i);
+
+@property(30)
+def prop_isort_ordered (i: (List Person)) : Bool :=
+    ordered (isort i);
+
+@property(30)
+def prop_isort_permutation (i: (List Person)) : Bool :=
+    sameElementsStrong i (isort i);
+
+# ── Negative unit tests: each subproperty catches the corresponding bug ─────
+# Concrete (input, output) pairs, each violating exactly one subproperty.
+
+# Fixtures.
+def a20 : Person := Person.person 20 1;
+def a30 : Person := Person.person 30 2;
+def a40 : Person := Person.person 40 3;
+
+# Same-Size fails: an element was dropped.
+@property(1)
+def test_catches_dropped : Bool :=
+    i := cons a20 (cons a30 nil);
+    o := cons a20 nil;
+    both (assertFalse (sameSize i o)) (assertFalse (isValid i o));
+
+# Same-Elements (strong) fails: a duplicate replaced a distinct element, so the
+# multiset differs even though the size matches.
+@property(1)
+def test_catches_wrong_elements : Bool :=
+    i := cons a20 (cons a30 nil);
+    o := cons a20 (cons a20 nil);
+    allOf3 (assertTrue (sameSize i o))
+           (assertFalse (sameElementsStrong i o))
+           (assertFalse (isValid i o));
+
+# The classic weak-vs-strong gap (2022 §9): duplicating one element and dropping
+# another keeps the *set* of elements equal, so the weak check is fooled while
+# the strong multiset check correctly rejects it.
+@property(1)
+def test_weak_permutation_is_fooled : Bool :=
+    i := cons a20 (cons a20 (cons a30 nil));
+    o := cons a20 (cons a30 (cons a30 nil));
+    allOf3 (assertTrue (sameElementsWeak i o))
+           (assertFalse (sameElementsStrong i o))
+           (assertFalse (isValid i o));
+
+# Ordered fails: right elements, wrong order.
+@property(1)
+def test_catches_unordered : Bool :=
+    i := cons a30 (cons a20 nil);
+    o := cons a30 (cons a20 nil);
+    allOf3 (assertTrue (sameSize i o))
+           (assertFalse (ordered o))
+           (assertFalse (isValid i o));
+
+# A genuinely correct output is accepted.
+@property(1)
+def test_accepts_correct : Bool :=
+    i := cons a30 (cons a20 (cons a40 nil));
+    o := cons a20 (cons a30 (cons a40 nil));
+    assertTrue (isValid i o);

--- a/examples/pbt_benchmarks/toposortacle.ae
+++ b/examples/pbt_benchmarks/toposortacle.ae
@@ -1,0 +1,228 @@
+# Toposortacle — a Property-Based Testing benchmark.
+#
+# From:
+#   * Wrenn, Nelson, Krishnamurthi. "Using Relational Problems to Teach
+#     Property-Based Testing." Programming 2021 (pj21).
+#   * Nelson, Rivera, Soucie, Del Vecchio, Wrenn, Krishnamurthi. "Automated,
+#     Targeted Testing of Property-Based Testing Predicates." Programming 2022.
+#     (Toposortacle is that paper's running example — see its Table 1.)
+#
+# Task: write the predicate that decides whether an output list of vertices is
+# a correct topological sort of an input DAG. The input is a set of directed
+# edges (m -> n means "m must come before n"); the output is an ordering of
+# the vertices. Students were told the input mentions every vertex.
+#
+# Correctness decomposes (2022, Table 1) into:
+#   No-New            every output vertex is mentioned by some input edge
+#   None-Dropped      every vertex mentioned by an edge appears in the output
+#   Uniqueness        the output has no duplicate vertices
+#   Sortedness        for positions i1 < i2, O[i2] cannot reach O[i1] in I*
+# and an *error subproperty* (2022, §3) used to catch a common mistake:
+#   Same-Num-Vertices |vertices(I)| = len(O)   (checking size, not contents)
+#
+# Run with:  aeon --test examples/pbt_benchmarks/toposortacle.ae
+
+open List
+open Testing
+
+# ── Domain ────────────────────────────────────────────────────────────────
+
+# A directed edge m -> n (m must precede n).
+inductive Edge
+| edge (src: Int) (dst: Int) : Edge
+
+def srcOf (e: Edge) : Int :=
+    match e with
+    | edge s d => s;
+
+def dstOf (e: Edge) : Int :=
+    match e with
+    | edge s d => d;
+
+# ── Int-list helpers ────────────────────────────────────────────────────────
+
+def elemInt (x: Int) (l: (List Int)) : Bool :=
+    match l with
+    | nil => false
+    | cons hd tl => (hd = x) || (elemInt x tl);
+
+def allInt (f: (x:Int) -> Bool) (l: (List Int)) : Bool :=
+    match l with
+    | nil => true
+    | cons hd tl => (f hd) && (allInt f tl);
+
+def addUniqueInt (x: Int) (l: (List Int)) : (List Int) :=
+    if elemInt x l then l else cons x l;
+
+def removeInt (x: Int) (l: (List Int)) : (List Int) :=
+    match l with
+    | nil => nil
+    | cons hd tl => if hd = x then tl else cons hd (removeInt x tl);
+
+# ── Graph helpers ────────────────────────────────────────────────────────────
+
+# The distinct vertices mentioned by the edge set.
+def verticesOf (i: (List Edge)) : (List Int) :=
+    match i with
+    | nil => nil
+    | cons e tl => addUniqueInt (srcOf e) (addUniqueInt (dstOf e) (verticesOf tl));
+
+# `v` occurs as a source or destination in some edge.
+def vertexInEdges (i: (List Edge)) (v: Int) : Bool :=
+    match i with
+    | nil => false
+    | cons e tl => (srcOf e = v) || (dstOf e = v) || (vertexInEdges tl v);
+
+# One reachability-expansion pass: add the destination of every edge whose
+# source is already reached.
+def expandStep (i: (List Edge)) (reached: (List Int)) : (List Int) :=
+    match i with
+    | nil => reached
+    | cons e tl =>
+        acc := expandStep tl reached;
+        if elemInt (srcOf e) reached then addUniqueInt (dstOf e) acc else acc;
+
+# Iterate the expansion `fuel` times (a DAG's longest path is bounded by the
+# number of edges).
+def closure (fuel: Int) (i: (List Edge)) (reached: (List Int)) : (List Int) :=
+    if fuel <= 0 then reached
+    else closure (fuel - 1) i (expandStep i reached);
+
+# True when there is a directed path a ->* b (path length >= 1). On a DAG a
+# never reaches itself, so requiring a != b keeps this a *proper* reachability.
+def reaches (i: (List Edge)) (a: Int) (b: Int) : Bool :=
+    (a != b) && (elemInt b (closure (length i + 1) i (cons a nil)));
+
+# ── Subproperties (2022, Table 1) ───────────────────────────────────────────
+
+# No-New: every output vertex is mentioned by the input.
+def noNew (i: (List Edge)) (o: (List Int)) : Bool :=
+    allInt (fun v => vertexInEdges i v) o;
+
+# None-Dropped: every vertex mentioned by an edge appears in the output.
+def noneDropped (i: (List Edge)) (o: (List Int)) : Bool :=
+    match i with
+    | nil => true
+    | cons e tl =>
+        (elemInt (srcOf e) o) && (elemInt (dstOf e) o) && (noneDropped tl o);
+
+# Uniqueness: no vertex is repeated.
+def uniqueInt (o: (List Int)) : Bool :=
+    match o with
+    | nil => true
+    | cons hd tl => (! (elemInt hd tl)) && (uniqueInt tl);
+
+# Sortedness: no later element can reach an earlier element. `hd` sits before
+# every element of `tl`, so no `y` in `tl` may reach `hd`.
+def sortedTopo (i: (List Edge)) (o: (List Int)) : Bool :=
+    match o with
+    | nil => true
+    | cons hd tl =>
+        (allInt (fun y => ! (reaches i y hd)) tl) && (sortedTopo i tl);
+
+# Error subproperty (2022, §3): the output has as many entries as the input has
+# distinct vertices. A student who checks *size* instead of *contents* passes
+# this while failing None-Dropped / Uniqueness.
+def sameNumVertices (i: (List Edge)) (o: (List Int)) : Bool :=
+    length (verticesOf i) = length o;
+
+# The correctness predicate students should write. (Same-Num-Vertices is
+# implied by these and is only used to diagnose the size-vs-contents mistake.)
+def isValid (i: (List Edge)) (o: (List Int)) : Bool :=
+    (noNew i o) && (noneDropped i o) && (uniqueInt o) && (sortedTopo i o);
+
+# ── Reference implementation: Kahn's algorithm ──────────────────────────────
+
+# `v` has an incoming edge from a vertex still in `remaining`.
+def hasIncomingFrom (i: (List Edge)) (remaining: (List Int)) (v: Int) : Bool :=
+    match i with
+    | nil => false
+    | cons e tl =>
+        ((dstOf e = v) && (srcOf e != v) && (elemInt (srcOf e) remaining))
+        || (hasIncomingFrom tl remaining v);
+
+# The first remaining vertex with no incoming edge (a "source").
+def pickSource (i: (List Edge)) (remaining: (List Int)) (cand: (List Int)) : Int :=
+    match cand with
+    | nil => 0
+    | cons hd tl =>
+        if ! (hasIncomingFrom i remaining hd) then hd
+        else pickSource i remaining tl;
+
+def kahn (fuel: Int) (i: (List Edge)) (remaining: (List Int)) : (List Int) :=
+    if fuel <= 0 then nil
+    else match remaining with
+         | nil => nil
+         | cons h t =>
+             v := pickSource i remaining remaining;
+             cons v (kahn (fuel - 1) i (removeInt v remaining));
+
+def toposort (i: (List Edge)) : (List Int) :=
+    vs := verticesOf i;
+    kahn (length vs) i vs;
+
+# ── Fixtures: the DAG I = [(1,2),(2,3)] from 2022 Table 1 ───────────────────
+
+def g : (List Edge) := cons (Edge.edge 1 2) (cons (Edge.edge 2 3) nil);
+
+# ── Positive tests: the reference sort is accepted ──────────────────────────
+
+@property(1)
+def test_reference_is_valid : Bool :=
+    assertTrue (isValid g (toposort g));
+
+@property(1)
+def test_accepts_correct_order : Bool :=
+    assertTrue (isValid g (cons 1 (cons 2 (cons 3 nil))));
+
+# A "diamond" DAG 1->2, 1->3, 2->4, 3->4 with a valid ordering.
+def diamond : (List Edge) :=
+    cons (Edge.edge 1 2) (cons (Edge.edge 1 3) (cons (Edge.edge 2 4) (cons (Edge.edge 3 4) nil)));
+
+@property(1)
+def test_reference_valid_diamond : Bool :=
+    assertTrue (isValid diamond (toposort diamond));
+
+# ── Negative tests: 2022 Table 1 example pairs, one per subproperty ─────────
+
+# No-New fails: O = [1,2,3,4] introduces vertex 4.
+@property(1)
+def test_no_new : Bool :=
+    o := cons 1 (cons 2 (cons 3 (cons 4 nil)));
+    allOf3 (assertFalse (noNew g o))
+           (assertTrue (noneDropped g o))
+           (assertFalse (isValid g o));
+
+# None-Dropped fails: O = [1,2] drops vertex 3.
+@property(1)
+def test_none_dropped : Bool :=
+    o := cons 1 (cons 2 nil);
+    allOf3 (assertFalse (noneDropped g o))
+           (assertTrue (noNew g o))
+           (assertFalse (isValid g o));
+
+# Uniqueness fails: O = [1,2,3,3] repeats vertex 3.
+@property(1)
+def test_uniqueness : Bool :=
+    o := cons 1 (cons 2 (cons 3 (cons 3 nil)));
+    both (assertFalse (uniqueInt o))
+         (assertFalse (isValid g o));
+
+# Sortedness fails: O = [3,1,2] violates the partial order (1 ->* 3, 2 ->* 3).
+@property(1)
+def test_sortedness : Bool :=
+    o := cons 3 (cons 1 (cons 2 nil));
+    allOf3 (assertFalse (sortedTopo g o))
+           (assertTrue (noNew g o))
+           (assertFalse (isValid g o));
+
+# The size-vs-contents mistake (2022, §3): O = [1,2,2] has the right *number*
+# of vertices, so Same-Num-Vertices is fooled, yet the output both drops 3 and
+# duplicates 2 — the error subproperty pinpoints this misconception.
+@property(1)
+def test_same_num_vertices_error : Bool :=
+    o := cons 1 (cons 2 (cons 2 nil));
+    allOf4 (assertTrue (sameNumVertices g o))
+           (assertFalse (noneDropped g o))
+           (assertFalse (uniqueInt o))
+           (assertFalse (isValid g o));


### PR DESCRIPTION
## Summary

Implements the complete benchmark problems from three property-based testing papers as runnable, `--test`-verified Aeon programs under `examples/pbt_benchmarks/`. The papers are the three PBT entries added in [ngernest/pbt-bibliography#14](https://github.com/ngernest/pbt-bibliography/pull/14):

- Wrenn, Nelson, Krishnamurthi. *Using Relational Problems to Teach Property-Based Testing.* Programming 2021.
- Nelson, Rivera, Soucie, Del Vecchio, Wrenn, Krishnamurthi. *Automated, Targeted Testing of Property-Based Testing Predicates.* Programming 2022.
- Prasad, Greenman, Nelson, Krishnamurthi. *Conceptual Mutation Testing for Student Programming Misconceptions.* Programming 2024.

These share two benchmark families, both implemented here.

### Relational problems (2021 / 2022) — the correctness *predicate* decomposed into subproperties
- `sortacle.ae` — Same-Size, Same-Elements (both the *weak* set version and the *strong* multiset version the 2022 paper distinguishes), Ordered; an insertion-sort reference driven by generated PBT.
- `toposortacle.ae` — No-New, None-Dropped, Uniqueness, Sortedness (via transitive closure), plus the Same-Num-Vertices *error subproperty*; a Kahn's-algorithm reference and the exact Table 1 example I/O pairs.
- `matcher.ae` — Stable (blocking-pair search), Uniqueness, Complete over preference profiles.

### Conceptual mutation testing (2024) — the Examplar wheat/chaff model
- `docdiff.ae` — cosine-style overlap "wheat" + 7 chaffs (case-sensitive, always-0/1, normalize-by-smaller, normalize-by-magnitude, subsumption, rounding).
- `nile.ae` — recommend-book and recommend-pair wheats + the 6 deployed chaffs (count-vs-frequency, multi-collection, case-insensitive, at-most-one).
- `filesystem.ae` — mutually-recursive `File`/`Dir` with `how-many`/`du-dir`/`can-find`/`fynd` (the HtDP/cs019 spec) + the 5 deployed chaffs and 4 extra candidate chaffs.

Each mutation-testing file encodes the Examplar contract directly: every example passes the wheat, and every chaff is killed by some example.

Design notes: the numeric/string cores in `docdiff` and `nile` use Aeon's Python FFI (mirroring the student implementations under test); the other four are pure Aeon over the inductive `List`. Sortacle uses fully generated property-based testing; the graph/matching problems use the papers' hand-crafted I/O suites, since generating valid DAGs and preference profiles isn't expressible through the input generator.

## Test plan

- [x] `aeon --test examples/pbt_benchmarks/sortacle.ae` — 8 passed
- [x] `aeon --test examples/pbt_benchmarks/toposortacle.ae` — 8 passed
- [x] `aeon --test examples/pbt_benchmarks/matcher.ae` — 5 passed
- [x] `aeon --test examples/pbt_benchmarks/docdiff.ae` — 8 passed
- [x] `aeon --test examples/pbt_benchmarks/nile.ae` — 7 passed
- [x] `aeon --test examples/pbt_benchmarks/filesystem.ae` — 14 passed

50 property/unit tests pass across the six files.

Made with [Cursor](https://cursor.com)