### PR TITLE
feat(lsp): enrich infoView with errors, VC steps, and synthesizers

### DIFF
--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -59,6 +59,11 @@ class ParseResult:
 _type_index_cache: "Dict[URI, object]" = {}
 _typing_ctx_cache: "Dict[URI, object]" = {}
 _core_cache: "Dict[URI, object]" = {}
+# Structured semantic errors from the most recent parse of each document. Unlike
+# the caches above these track the *current* parse (cleared on every reparse) so
+# the info view's error tab can present the live verification failures — their
+# counterexamples and the simplification chain of the failing VC.
+_errors_cache: "Dict[URI, list]" = {}
 
 
 def get_type_index(uri: URI):
@@ -74,6 +79,11 @@ def get_typing_ctx(uri: URI):
 def get_core(uri: URI):
     """The last successfully-generated core program for ``uri`` (or ``None``)."""
     return _core_cache.get(uri)
+
+
+def get_errors(uri: URI) -> list:
+    """The structured semantic errors (``AeonError``) of ``uri``'s last parse."""
+    return _errors_cache.get(uri, [])
 
 
 def _refresh_analysis(driver: AeonDriver, uri: URI) -> None:
@@ -115,6 +125,7 @@ def clear_cache(uri: URI) -> None:
     """
     logger.debug("Clearing cache for %s", uri)
     _parse_result_cache.pop(uri, None)
+    _errors_cache.pop(uri, None)
     logger.debug("DONE!")
 
 
@@ -157,10 +168,18 @@ async def _parse(
     uri: URI,
 ) -> ParseResult:
     diagnostics = []
+    # Reset structured errors for this parse; only a parse that returns semantic
+    # errors below repopulates them (a syntax error leaves this empty and the
+    # error is surfaced as a diagnostic instead).
+    _errors_cache[uri] = []
 
     try:
         content = fp.read()
-        errors = driver.parse(filename=uri, aeon_code=content)
+        errors = list(driver.parse(filename=uri, aeon_code=content))
+
+        # Keep the structured errors of this parse so the info view can render
+        # their counterexamples and the failing VC's simplification chain.
+        _errors_cache[uri] = errors
 
         # Refresh the type-aware analysis caches (kept even when `errors` is
         # non-empty, as long as the program reached core generation).

--- a/aeon/lsp/infoview.py
+++ b/aeon/lsp/infoview.py
@@ -117,10 +117,52 @@ class TargetInfo:
 
 
 @dataclass(frozen=True)
+class VCStep:
+    """One entry of a failing VC's simplification chain: a human ``label`` for
+    the step and the constraint rendered ``text`` at that stage. Ordered
+    original → simplified, so the final entry is the VC shown in the error."""
+
+    label: str
+    text: str
+
+
+@dataclass(frozen=True)
+class ErrorInfo:
+    """One diagnostic for the info view's error tab. Liquid type-checking
+    failures carry a ``counterexample`` (a concrete falsifying assignment, when
+    available) and ``vcSteps`` — the simplification chain of the failing
+    verification condition — so the view can present the simplified VC and let
+    the user expand back through each step. ``line``/``endLine`` are the
+    0-indexed source span; ``atCursor`` flags the error(s) covering the cursor."""
+
+    message: str
+    severity: str = "error"
+    counterexample: Optional[str] = None
+    vcSteps: list[VCStep] = field(default_factory=list)
+    line: Optional[int] = None
+    endLine: Optional[int] = None
+    atCursor: bool = False
+
+
+@dataclass(frozen=True)
+class SynthesizerInfo:
+    """An available synthesis backend, offered for the hole under the cursor:
+    the internal ``id`` (passed to the ``aeon.synthesize`` command) and a
+    human-readable ``label``."""
+
+    id: str
+    label: str
+
+
+@dataclass(frozen=True)
 class InfoViewData:
     target: Optional[TargetInfo] = None
     locals: list[InfoEntry] = field(default_factory=list)
     globals: list[InfoEntry] = field(default_factory=list)
+    errors: list[ErrorInfo] = field(default_factory=list)
+    # The hole under the cursor (drives the synthesis tab), if any.
+    hole: Optional[str] = None
+    synthesizers: list[SynthesizerInfo] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """A JSON-serialisable payload for the ``aeon/infoView`` response."""
@@ -456,6 +498,66 @@ def _goal_for_hole(hole_name: str, typing_ctx, core) -> Optional[tuple[Type, Opt
     return None
 
 
+def _build_errors(errors, cursor_line: int) -> list[ErrorInfo]:
+    """Turn the parse's structured ``AeonError`` list into error-tab entries.
+
+    Liquid type-checking failures contribute their concise goal, a
+    counterexample and the failing VC's simplification chain; every other error
+    contributes its rendered message. Errors covering the cursor line are listed
+    first so the relevant one is on top."""
+    from aeon.facade.api import LiquidTypeCheckingFailedRelation
+    from aeon.verification.helpers import constraint_goal, vc_simplification_steps
+
+    out: list[ErrorInfo] = []
+    for err in errors or []:
+        try:
+            loc = err.position()
+            sl, _ = loc.get_start()
+            el, _ = loc.get_end()
+            # Core source lines are 1-indexed; the info view is 0-indexed (LSP).
+            start_line: Optional[int] = max(sl - 1, 0)
+            end_line: Optional[int] = max(el - 1, 0)
+        except Exception:
+            start_line = end_line = None
+
+        counterexample: Optional[str] = None
+        vc_steps: list[VCStep] = []
+        if isinstance(err, LiquidTypeCheckingFailedRelation):
+            goal = constraint_goal(err.vc)
+            goal_str = _strip_ids(_pp_liquid(goal)) if goal is not None else None
+            message = f"Failed to prove: {goal_str}" if goal_str else "Failed to prove refinement"
+            try:
+                cex = err.counterexample()
+                counterexample = _strip_ids(cex) if cex is not None else None
+            except Exception:
+                counterexample = None
+            try:
+                vc_steps = [VCStep(label=lbl, text=_strip_ids(txt)) for lbl, txt in vc_simplification_steps(err.vc)]
+            except Exception:
+                vc_steps = []
+        else:
+            try:
+                message = _strip_ids(str(err))
+            except Exception:
+                message = "Error"
+
+        at_cursor = start_line is not None and end_line is not None and start_line <= cursor_line <= end_line
+        out.append(
+            ErrorInfo(
+                message=message,
+                severity="error",
+                counterexample=counterexample,
+                vcSteps=vc_steps,
+                line=start_line,
+                endLine=end_line,
+                atCursor=at_cursor,
+            )
+        )
+    # Stable sort: errors covering the cursor first, original order otherwise.
+    out.sort(key=lambda e: 0 if e.atCursor else 1)
+    return out
+
+
 def compute_info_view(
     source: str,
     line: int,
@@ -463,13 +565,17 @@ def compute_info_view(
     typing_ctx: Optional[TypingContext],
     type_index=None,
     core=None,
+    errors=None,
+    synthesizer_ids: Optional[list[str]] = None,
 ) -> InfoViewData:
     """Top-level entry: the info view contents for the 0-indexed cursor.
 
     ``type_index`` is the last successfully-built
     :class:`~aeon.lsp.typeindex.TypeIndex` for the document; ``typing_ctx`` is
     the top-level context and ``core`` the last good core program (both used to
-    recover hole goals)."""
+    recover hole goals). ``errors`` is the structured error list of the current
+    parse (for the error tab) and ``synthesizer_ids`` the backends offered for a
+    hole under the cursor (for the synthesis tab)."""
     target_ty: Optional[Type] = None
     scope_ctx: Optional[TypingContext] = None
 
@@ -497,4 +603,20 @@ def compute_info_view(
         target = TargetInfo(type=base, predicate=predicate)
 
     locals_, globals_ = _split_scope(typing_ctx, scope_ctx, _top_level_names(core))
-    return InfoViewData(target=target, locals=locals_, globals=globals_)
+
+    error_infos = _build_errors(errors, line)
+
+    synthesizers: list[SynthesizerInfo] = []
+    if hole_name is not None and synthesizer_ids:
+        from aeon.synthesis.modules.synthesizerfactory import synthesizer_label
+
+        synthesizers = [SynthesizerInfo(id=i, label=synthesizer_label(i)) for i in synthesizer_ids]
+
+    return InfoViewData(
+        target=target,
+        locals=locals_,
+        globals=globals_,
+        errors=error_infos,
+        hole=hole_name,
+        synthesizers=synthesizers,
+    )

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -311,8 +311,18 @@ class AeonLanguageServer(LanguageServer):
             index = aeon_adapter.get_type_index(uri)
             typing_ctx = aeon_adapter.get_typing_ctx(uri) or getattr(ls.aeon_driver, "typing_ctx", None)
             core = aeon_adapter.get_core(uri)
+            errors = aeon_adapter.get_errors(uri)
             try:
-                data = compute_info_view(document.source, line, character, typing_ctx, index, core)
+                data = compute_info_view(
+                    document.source,
+                    line,
+                    character,
+                    typing_ctx,
+                    index,
+                    core,
+                    errors=errors,
+                    synthesizer_ids=SYNTHESIZERS,
+                )
             except Exception:
                 return InfoViewData().to_dict()
             return data.to_dict()

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -958,6 +958,22 @@ def _eligible_refinement_base_for_inductive(ind: InductiveDecl, base: SType) -> 
             return False
 
 
+def _is_implicit_refinement_param(p: Name, bound_rho: set[Name]) -> bool:
+    """Whether a predicate name ``p`` in a refinement ``{v | p v}`` should be
+    treated as an *implicit* (abstract) refinement parameter to be universally
+    generalised, rather than a reference to a defined function.
+
+    An implicit refinement parameter is an *unbound* predicate variable
+    (``Name.id == -1``): binding leaves it unresolved because it has no binder.
+    A predicate that resolves to a real symbol — a top-level ``def`` (e.g. an
+    ``uninterpreted`` predicate like ``admin``), a builtin, or an import — is
+    bound to a concrete ``id`` and must be kept as an ordinary application so
+    its refinement stays a checked obligation (issue #468). Explicitly-bound
+    ``forall <p>`` parameters live in ``bound_rho`` and are also excluded.
+    """
+    return p.id == -1 and p not in bound_rho
+
+
 def _collect_implicit_refinement_params_for_inductive(
     ind: InductiveDecl, ty: SType, bound_rho: set[Name], acc: dict[Name, SType]
 ) -> None:
@@ -978,7 +994,7 @@ def _collect_implicit_refinement_params_for_inductive(
         case SRefinedType(binder, base, ref):
             rec(base, bound_rho)
             match ref:
-                case SApplication(SVar(p), SVar(b)) if b == binder and p not in bound_rho:
+                case SApplication(SVar(p), SVar(b)) if b == binder and _is_implicit_refinement_param(p, bound_rho):
                     # The inferred sort is the full predicate type ``base -> Bool``.
                     pred_ty = SAbstractionType(Name("_"), base, st_bool)
                     if not _eligible_refinement_base_for_inductive(ind, base):
@@ -1699,7 +1715,7 @@ def _collect_implicit_refinement_params(ty: SType, bound_rho: set[Name], acc: di
         case SRefinedType(binder, base, ref):
             rec(base, bound_rho)
             match ref:
-                case SApplication(SVar(p), SVar(b)) if b == binder and p not in bound_rho:
+                case SApplication(SVar(p), SVar(b)) if b == binder and _is_implicit_refinement_param(p, bound_rho):
                     # The inferred sort is the full predicate type ``base -> Bool``.
                     pred_ty = SAbstractionType(Name("_"), base, st_bool)
                     if p in acc:

--- a/aeon/verification/helpers.py
+++ b/aeon/verification/helpers.py
@@ -956,6 +956,69 @@ def prepare_vc_for_display(c: Constraint) -> Constraint:
     return cons_clean
 
 
+def render_constraint_for_display(c: Constraint) -> str:
+    """Render a constraint as (multi-line) text *without* simplifying it.
+
+    Unlike :func:`pretty_print_constraint` this does not run
+    :func:`prepare_vc_for_display` first, so it can show a specific intermediate
+    form of a VC verbatim (used by :func:`vc_simplification_steps`). Conjunctions
+    are still split via CNF and trivial ``… -> true`` parts dropped, and each
+    conjunct is indented with two spaces per level so it reads well in a plain
+    ``<pre>`` block."""
+    parts: list[str] = []
+    for cons in conjunctive_normal_form(c):
+        if is_implication_true(cons):
+            continue
+        lines = [indent * "  " + item for item, indent in pretty_print_generator(cons)]
+        parts.append("\n".join(lines))
+    if not parts:
+        return "true"
+    return "\n\n".join(parts)
+
+
+def vc_simplification_steps(c: Constraint, max_steps: int = 32) -> list[tuple[str, str]]:
+    """The labelled progression of a VC from its original form to the fully
+    simplified form shown in error messages.
+
+    Returns a list of ``(label, rendered_text)`` pairs ordered original →
+    simplified; the final element is exactly what :func:`prepare_vc_for_display`
+    produces. This mirrors :func:`prepare_vc_for_display` step by step —
+    per-iteration constraint rewriting, then inert-precondition removal, then
+    unrelated-context pruning — so an editor can present the simplified VC and
+    let the user expand back through each simplification step to the version
+    that preceded it. Steps whose rendered text is identical to the previous
+    one are collapsed (the later, more descriptive label is kept)."""
+    stages: list[tuple[str, Constraint]] = [("Original", c)]
+
+    cur = c
+    for i in range(max_steps):
+        nxt = simplify_constraint(cur)
+        if nxt == cur:
+            break
+        cur = nxt
+        stages.append((f"Rewrite pass {i + 1}", cur))
+
+    cons_clean = remove_inert_preconditions(cur)
+    stages.append(("Drop inert preconditions", cons_clean))
+
+    cons_pruned, _ = remove_unrelated_context(cons_clean, ignore_vars=set())
+    stages.append(("Prune unrelated context", cons_pruned))
+
+    out: list[tuple[str, str]] = []
+    for label, cons in stages:
+        try:
+            text = render_constraint_for_display(cons)
+        except Exception:
+            continue
+        # Collapse steps that render identically, keeping the earlier (more
+        # faithful) label; the final entry still carries the fully simplified
+        # text that ``prepare_vc_for_display`` produces.
+        if out and out[-1][1] == text:
+            continue
+        out.append((label, text))
+    return out
+
+
 def pretty_print_generator(c: Constraint) -> Generator[tuple[str, int], None, None]:
     """Recursive generates a list of items to print, with the respective
     indentation level."""

--- a/tests/lsp_infoview_test.py
+++ b/tests/lsp_infoview_test.py
@@ -34,6 +34,13 @@ def info_at(src: str, line: int, character: int):
     return compute_info_view(src, line, character, d.typing_ctx, index, getattr(d, "core", None))
 
 
+def info_at_with_synth(src: str, line: int, character: int, synthesizer_ids: list[str]):
+    d, index, _ = analyse(src)
+    return compute_info_view(
+        src, line, character, d.typing_ctx, index, getattr(d, "core", None), synthesizer_ids=synthesizer_ids
+    )
+
+
 def col_of(src: str, line0: int, needle: str) -> int:
     """0-indexed column of ``needle`` on (0-indexed) ``line0``."""
     return src.splitlines()[line0].index(needle)
@@ -296,10 +303,74 @@ def test_goal_context_includes_locals():
 # --------------------------------------------------------------------------- #
 
 
+# --------------------------------------------------------------------------- #
+# Error tab: counterexamples and the VC simplification chain
+# --------------------------------------------------------------------------- #
+
+FAILING_SRC = "def f (x:Int) : {y:Int | y > 0} := x;\n"
+
+
+def test_error_tab_reports_counterexample_and_vc_steps():
+    d, index, errors = analyse(FAILING_SRC)
+    assert errors, "expected the refinement to fail to verify"
+    info = compute_info_view(
+        FAILING_SRC, 0, col_of(FAILING_SRC, 0, ":= x") + 3, d.typing_ctx, index, getattr(d, "core", None), errors=errors
+    )
+    assert len(info.errors) >= 1
+    err = info.errors[0]
+    # The concise goal is surfaced, not the whole constraint dump.
+    assert "Failed to prove" in err.message and "x > 0" in err.message
+    # A concrete falsifying assignment is available.
+    assert err.counterexample is not None and "x" in err.counterexample
+    # The simplification chain ends at the VC actually shown in the error.
+    assert len(err.vcSteps) >= 1
+    assert all(step.text for step in err.vcSteps)
+    # No checker-internal ids leak into the rendered VC.
+    assert all(not _has_id(step.text) for step in err.vcSteps)
+
+
+def test_error_tab_empty_when_program_type_checks():
+    d, index, errors = analyse(SRC)
+    assert not errors
+    info = compute_info_view(SRC, 3, col_of(SRC, 3, "x"), d.typing_ctx, index, getattr(d, "core", None), errors=errors)
+    assert info.errors == []
+
+
+def test_error_at_cursor_is_listed_first():
+    d, index, errors = analyse(FAILING_SRC)
+    info = compute_info_view(FAILING_SRC, 0, 0, d.typing_ctx, index, getattr(d, "core", None), errors=errors)
+    # Every reported error carries a 0-indexed source span.
+    for e in info.errors:
+        assert e.line is None or e.line >= 0
+
+
+# --------------------------------------------------------------------------- #
+# Synthesis tab: available algorithms at a hole
+# --------------------------------------------------------------------------- #
+
+
+def test_synthesizers_listed_when_cursor_on_hole():
+    info = info_at_with_synth(HOLE_SRC, 2, col_of(HOLE_SRC, 2, "?h") + 1, ["gp", "fta", "enumerative"])
+    assert info.hole == "h"
+    ids = [s.id for s in info.synthesizers]
+    assert ids == ["gp", "fta", "enumerative"]
+    # Each carries a human-readable label.
+    gp = next(s for s in info.synthesizers if s.id == "gp")
+    assert gp.label and gp.label != "gp"
+
+
+def test_synthesizers_absent_when_not_on_hole():
+    info = info_at_with_synth(HOLE_SRC, 1, col_of(HOLE_SRC, 1, "let"), ["gp", "fta"])
+    assert info.hole is None
+    assert info.synthesizers == []
+
+
 def test_graceful_without_analysis_state():
     info = compute_info_view(SRC, 2, 5, None, None, None)
     assert info.target is None
     assert info.locals == [] and info.globals == []
+    assert info.errors == []
+    assert info.synthesizers == []
 
 
 def test_to_dict_is_json_serialisable():

--- a/tests/parametric_refinements_test.py
+++ b/tests/parametric_refinements_test.py
@@ -237,3 +237,64 @@ def main (args:Int) : Unit :=
     print (r)
 """
     assert check_compile(source, st_top)
+
+
+# --- issue #468: a *defined* predicate in a parameter refinement is a checked
+# obligation, not an implicit (abstract) refinement parameter. Only an *unbound*
+# predicate name should be universally generalised; a name resolving to a real
+# ``def`` (here an ``uninterpreted`` one) must stay an ordinary application so
+# the refinement is actually verified at each call site.
+
+
+def test_uninterpreted_predicate_refinement_rejects_unproven_argument():
+    """An argument that is not known to satisfy an uninterpreted-predicate
+    precondition must be rejected (regression for issue #468, where it was
+    silently accepted because ``admin`` was generalised into a synthesis hole)."""
+    source = """
+type Person
+
+def admin (p:Person) : Bool := uninterpreted
+
+def register_user (name:String) (age:Int) : Person := native "(name, age)"
+
+def rm (p:Person | admin p) (f:String | f != "/") : Unit := unit
+
+def main (_:Int) : Unit :=
+    let u := register_user "Joe" 30 in
+    rm u "/folder"
+"""
+    assert not check_compile(source, st_top)
+
+
+def test_uninterpreted_predicate_refinement_accepts_proven_argument():
+    """When the argument is known to satisfy the uninterpreted predicate (its
+    type carries the refinement), the call type-checks."""
+    source = """
+type Person
+
+def admin (p:Person) : Bool := uninterpreted
+
+def make_admin (name:String) : {p:Person | admin p} := native "name"
+
+def rm (p:Person | admin p) : Unit := unit
+
+def main (_:Int) : Unit :=
+    let u := make_admin "Joe" in
+    rm u
+"""
+    assert check_compile(source, st_top)
+
+
+def test_defined_bool_predicate_refinement_is_checked():
+    """A refinement mentioning a regular defined boolean function is a checked
+    obligation: ``rm 3`` violates ``admin p`` (``p > 5``) and is rejected."""
+    source = """
+def admin (p:Int) : Bool := p > 5
+
+def rm (p:Int | admin p) : Unit := unit
+
+def main (_:Int) : Unit :=
+    let u := 3 in
+    rm u
+"""
+    assert not check_compile(source, st_top)

--- a/tests/simplification_constraints_test.py
+++ b/tests/simplification_constraints_test.py
@@ -8,9 +8,11 @@ from aeon.core.types import t_int, TypeConstructor
 from aeon.verification.helpers import parse_liquid
 from aeon.verification.helpers import prepare_vc_for_display
 from aeon.verification.helpers import remove_inert_preconditions
+from aeon.verification.helpers import render_constraint_for_display
 from aeon.verification.helpers import simplify_constraint
 from aeon.verification.helpers import simplify_constraint_fixpoint
 from aeon.verification.helpers import simplify_expr
+from aeon.verification.helpers import vc_simplification_steps
 from aeon.verification.helpers import split_and_in_conclusion
 from aeon.verification.helpers import split_or_disjuncts
 from aeon.verification.helpers import split_or_in_conclusion
@@ -52,6 +54,35 @@ def test_simplify_constraint_implication():
     x = Implication(Name("x"), t_int, parse_liquid("true"), LiquidConstraint(parse_liquid("a > 0")))
     r = simplify_constraint(x)
     assert r == LiquidConstraint(parse_liquid("a > 0"))
+
+
+def test_vc_simplification_steps_are_ordered_and_end_simplified():
+    # A VC with a trivially-true precondition and an already-present conjunct in
+    # the conclusion has room to simplify, so the chain has more than one step.
+    x = Implication(Name("x"), t_int, parse_liquid("true"), LiquidConstraint(parse_liquid("a > 0")))
+    steps = vc_simplification_steps(x)
+    assert len(steps) >= 1
+    # Every step is a (label, text) pair.
+    for label, text in steps:
+        assert isinstance(label, str) and isinstance(text, str)
+    # The last step must equal the fully simplified rendering used in errors.
+    assert steps[-1][1] == render_constraint_for_display(prepare_vc_for_display(x))
+    # Consecutive steps never render identically (duplicates are collapsed).
+    texts = [t for _, t in steps]
+    assert all(texts[i] != texts[i + 1] for i in range(len(texts) - 1))
+
+
+def test_vc_simplification_steps_show_progression():
+    # ∀x, true => (a > 0) simplifies to just (a > 0): the original shows the
+    # implication turnstile, the final drops it, so there are two distinct steps.
+    x = Implication(Name("x"), t_int, parse_liquid("true"), LiquidConstraint(parse_liquid("a > 0")))
+    steps = vc_simplification_steps(x)
+    labels = [label for label, _ in steps]
+    assert labels[0] == "Original"
+    assert len(steps) >= 2
+    # The original renders the implication turnstile; the simplified form does not.
+    assert "====>" in steps[0][1]
+    assert "====>" not in steps[-1][1]
 
 
 def test_simplify_constraint_implication2():


### PR DESCRIPTION
## Summary
Extend the `aeon/infoView` LSP payload so an editor can present a three-tab info view (companion PR: `alcides/vscode-aeon#224`):
- **Error messages**: counterexamples plus the failing VC's simplification chain (`vcSteps`), rendered original → simplified without re-simplifying.
- **Context**: the existing typing context.
- **Synthesis**: `hole` and the `synthesizers[]` available for the hole under the cursor.

Key changes:
- `vc_simplification_steps` / `render_constraint_for_display` in `aeon/verification/helpers.py`.
- Cache each document's structured parse errors in the LSP adapter (`get_errors`).
- Surface `errors[]`, `hole`, `synthesizers[]` from `compute_info_view`; wire the server handler to pass them.

## Test plan
- [x] `pytest tests/lsp_infoview_test.py tests/simplification_constraints_test.py tests/lsp_test.py tests/vc_error_printing_test.py tests/counterexample_test.py`
- [x] `mypy` on the changed modules
- [ ] CI green

> Note: this branch also carries earlier not-yet-in-master commits from prior refinement/verification work; the infoView change is the new commit `22b27516`.

Made with [Cursor](https://cursor.com)