### PR TITLE
fix(synthesis): read Ollama model tags without accessing .name

### DIFF
--- a/aeon/synthesis/modules/llm/ollama_manager.py
+++ b/aeon/synthesis/modules/llm/ollama_manager.py
@@ -50,12 +50,24 @@ class RunningModel:
     size_vram: int
 
 
+def _ollama_model_tag(entry) -> str | None:
+    """Resolve a model tag from an Ollama ``list``/``ps`` response entry.
+
+    Current ollama-python exposes ``model``; older responses also carried ``name``.
+    """
+    for attr in ("model", "name"):
+        value = getattr(entry, attr, None)
+        if value:
+            return str(value)
+    return None
+
+
 def _installed_model_names() -> set[str]:
     names: set[str] = set()
     for entry in ollama.list().models:
-        names.add(entry.model)
-        if entry.name:
-            names.add(entry.name)
+        tag = _ollama_model_tag(entry)
+        if tag:
+            names.add(tag)
     return names
 
 
@@ -76,7 +88,7 @@ def _running_models() -> list[RunningModel]:
         return []
     running: list[RunningModel] = []
     for entry in response.models:
-        name = entry.model or entry.name
+        name = _ollama_model_tag(entry)
         if not name:
             continue
         running.append(RunningModel(name=name, size_vram=int(getattr(entry, "size_vram", 0) or 0)))

--- a/tests/ollama_manager_test.py
+++ b/tests/ollama_manager_test.py
@@ -98,3 +98,16 @@ def test_release_noop_when_disabled(monkeypatch):
         lambda _model: (_ for _ in ()).throw(AssertionError("should not unload")),
     )
     mgr.release_ollama_model("qwen2.5-coder:14b")
+
+
+def test_installed_model_names_when_name_attr_missing(monkeypatch):
+    """ollama-python list entries expose ``model`` but not ``name``."""
+    entry = types.SimpleNamespace(model="qwen2.5-coder:14b")
+    monkeypatch.setattr(mgr.ollama, "list", lambda: types.SimpleNamespace(models=[entry]))
+    assert mgr.is_model_installed("qwen2.5-coder:14b")
+
+
+def test_running_models_when_name_attr_missing(monkeypatch):
+    entry = types.SimpleNamespace(model="codellama:13b", size_vram=8 * 1024**3)
+    monkeypatch.setattr(mgr.ollama, "ps", lambda: types.SimpleNamespace(models=[entry]))
+    assert mgr._running_models() == [mgr.RunningModel(name="codellama:13b", size_vram=8 * 1024**3)]


### PR DESCRIPTION
Fix LLM synthesizers broken by ollama-python entries exposing only .model, not .name.

Made with [Cursor](https://cursor.com)