### PR TITLE
feat(synthesis): support bare Int/Bool/Float holes in SyGuS backend

### DIFF
--- a/aeon/synthesis/modules/sygus/__init__.py
+++ b/aeon/synthesis/modules/sygus/__init__.py
@@ -5,10 +5,11 @@ translating them into a SyGuS problem, solving it with the cvc5 SyGuS
 engine (via its Python API), and translating the answer back into
 Aeon-core.
 
-The valid subset is the holes whose type is a refined base type
-``{v:T | phi}`` with ``T in {Int, Bool, Float}``.  SMT-typed context
-variables become the inputs of the function to synthesise, their
-refinements become preconditions, and ``phi`` becomes the specification.
+The valid subset is holes whose type is a base SMT type (``Int``, ``Bool``,
+``Float``) or a refinement ``{v:T | phi}`` over one of those.  SMT-typed
+context variables become the inputs of the function to synthesise, their
+refinements become preconditions, and ``phi`` (or ``true`` for bare types)
+becomes the specification.
 
 Polymorphism, non-native operators, and non-SMT types are out of scope:
 the translation then *fails gracefully* (returns ``None``) and the

--- a/aeon/synthesis/modules/sygus/synthesizer.py
+++ b/aeon/synthesis/modules/sygus/synthesizer.py
@@ -30,7 +30,7 @@ from aeon.utils.name import Name
 
 
 class SygusSynthesizer(Synthesizer):
-    """Synthesize refined-base-type holes by reduction to SyGuS, solved by cvc5."""
+    """Synthesize base-type holes (Int/Bool/Float) by reduction to SyGuS, solved by cvc5."""
 
     def synthesize(
         self,
@@ -50,7 +50,7 @@ class SygusSynthesizer(Synthesizer):
         if problem is None:
             raise SynthesisNotSuccessful(
                 f"SygusSynthesizer: hole of type {type} is outside the SyGuS-supported subset "
-                "(needs a refined Int/Bool/Float type over native operators).",
+                "(needs an Int/Bool/Float type, optionally refined, over native operators).",
             )
 
         logger.log("SYNTHESIZER", f"SyGuS problem:\n{problem_to_sl(problem)}")

--- a/aeon/synthesis/modules/sygus/translation.py
+++ b/aeon/synthesis/modules/sygus/translation.py
@@ -27,7 +27,7 @@ from aeon.core.liquid import (
 )
 from aeon.core.types import RefinedType, Type, TypeConstructor, t_bool, t_float, t_int
 from aeon.typechecking.context import TypingContext
-from aeon.utils.name import Name
+from aeon.utils.name import Name, fresh_counter
 
 # SyGuS / SMT-LIB sort for each Aeon base type.
 _SORT_OF_BASE: dict[TypeConstructor, str] = {t_int: "Int", t_bool: "Bool", t_float: "Real"}
@@ -139,21 +139,41 @@ def liquid_to_smt(t: LiquidTerm, names: dict[Name, str], is_real: bool) -> str |
             return None
 
 
+def _hole_spec(ty: Type) -> tuple[TypeConstructor, Name, LiquidTerm] | None:
+    """Return ``(base, binder, refinement)`` for a synthesisable hole type.
+
+    Refined base types keep their predicate; bare ``Int`` / ``Bool`` /
+    ``Float`` are treated as ``{v:T | true}``.
+    """
+    if isinstance(ty, RefinedType):
+        ret_base = ty.type
+        if not isinstance(ret_base, TypeConstructor):
+            return None
+        return ret_base, ty.name, ty.refinement
+    if isinstance(ty, TypeConstructor):
+        if ty not in _SORT_OF_BASE:
+            return None
+        binder = Name("_", fresh_counter.fresh())
+        return ty, binder, LiquidLiteralBool(True)
+    return None
+
+
 def build_sygus_problem(ctx: TypingContext, ty: Type, fun_name: str = "f") -> SygusProblem | None:
     """Translate a hole type + context into a ``SygusProblem`` (or None).
 
-    Supported subset: ``ty`` is ``{v:T | phi}`` with ``T`` a base SMT type,
-    ``phi`` built only from native operators over SMT-typed variables.
+    Supported subset: ``ty`` is a base SMT type (``Int``, ``Bool``, ``Float``)
+    or a refinement ``{v:T | phi}`` over one of those, with ``phi`` built only
+    from native operators over SMT-typed variables.
     """
-    if not isinstance(ty, RefinedType):
+    spec = _hole_spec(ty)
+    if spec is None:
         return None
-    ret_base = ty.type
+    ret_base, binder, refinement = spec
     ret_sort = smt_sort_of(ret_base)
-    if ret_sort is None or not isinstance(ret_base, TypeConstructor):
+    if ret_sort is None:
         return None
 
-    binder = ty.name
-    spec_vars = set(liquid_free_vars(ty.refinement))
+    spec_vars = set(liquid_free_vars(refinement))
 
     # Lift the SMT-typed context variables referenced by the spec into inputs.
     params: list[SygusParam] = []
@@ -170,7 +190,7 @@ def build_sygus_problem(ctx: TypingContext, ty: Type, fun_name: str = "f") -> Sy
 
     # The spec must render to SMT-LIB end-to-end; bail out otherwise.
     is_real = ret_sort == "Real" or any(p.sort == "Real" for p in params)
-    if liquid_to_smt(ty.refinement, names, is_real) is None:
+    if liquid_to_smt(refinement, names, is_real) is None:
         return None
 
     # Any free var of the spec that is neither the binder nor a lifted param
@@ -191,7 +211,7 @@ def build_sygus_problem(ctx: TypingContext, ty: Type, fun_name: str = "f") -> Sy
         ret_sort=ret_sort,
         ret_base=ret_base,
         binder=binder,
-        refinement=ty.refinement,
+        refinement=refinement,
         logic=logic,
     )
 

--- a/tests/sygus_synthesis_test.py
+++ b/tests/sygus_synthesis_test.py
@@ -100,15 +100,27 @@ def test_translation_emits_sygus_if():
     assert "(declare-var" in text
 
 
-def test_translation_rejects_non_refined_type():
-    """A plain (unrefined) type has no spec and is not handled here."""
+def test_translation_accepts_bare_smt_type():
+    """Plain Int/Bool/Float holes are treated as ``{v:T | true}``."""
     src = "def n : Int := ?hole"
     core, ctx, _, _ = check_and_return_core(src)
     targets = incomplete_functions_and_holes(ctx, core)
     holes = get_holes_info(ctx, core, top, targets, refined_types=True)
     (fn, hs) = targets[0]
     ty, tyctx = holes[hs[0]]
-    assert build_sygus_problem(tyctx, ty, fun_name=fn.name) is None
+    problem = build_sygus_problem(tyctx, ty, fun_name=fn.name)
+    assert problem is not None
+    assert problem.ret_sort == "Int"
+    text = problem_to_sl(problem)
+    assert "(constraint true)" in text
+    assert "(check-synth)" in text
+
+
+def test_bare_int_synthesis():
+    """A plain ``Int`` hole should synthesize some well-typed integer."""
+    _, _, mapping = _synthesize("def n : Int := ?hole;")
+    (term,) = mapping.values()
+    assert term is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extend the SyGuS synthesizer to accept bare `Int`, `Bool`, and `Float` hole types, not only refined ones
- Treat unrefined base SMT types as `{v:T | true}` when building the cvc5 SyGuS problem
- Add translation and end-to-end synthesis tests for plain `Int` holes

## Test plan
- [x] `uv run pytest tests/sygus_synthesis_test.py -x`
- [ ] CI passes on this PR


Made with [Cursor](https://cursor.com)