### PR TITLE
fix(synquid): track Pareto front for multi-objective search

### DIFF
--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 from aeon.core.terms import Term
 from aeon.core.types import Type
 from aeon.decorators.api import Metadata
-from aeon.synthesis.api import Synthesizer
+from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
 from aeon.synthesis.modules.synquid.search import iter_candidates_size_then_level, sorted_level_candidates
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.typechecking.context import TypingContext
@@ -17,10 +17,23 @@ from aeon.typechecking.typeinfer import check_type
 from aeon.utils.name import Name
 
 
-def is_better(v1, v2):
-    if not v2:
-        return True
-    return all(x < y for x, y in zip(v1, v2))
+def _dominates(a: list[float], b: list[float]) -> bool:
+    return all(x <= y for x, y in zip(a, b)) and any(x < y for x, y in zip(a, b))
+
+
+def _update_pareto_front(
+    front: list[tuple[list[float], Any]],
+    score: list[float],
+    result: Any,
+) -> list[tuple[list[float], Any]]:
+    if any(_dominates(existing_score, score) for existing_score, _ in front):
+        return front
+    return [(s, r) for s, r in front if not _dominates(score, s)] + [(score, result)]
+
+
+def _pick_pareto_member(front: list[tuple[list[float], Any]]) -> Any:
+    _, result = min(front, key=lambda item: (sum(item[0]), item[0]))
+    return result
 
 
 def get_elapsed_time(start_time) -> float:
@@ -58,7 +71,7 @@ class SynquidSynthesizer(Synthesizer):
         start_time = monotonic_ns()
         done = True
         level = 0
-        best: tuple[list[float], Any] = ([], None)
+        pareto_front: list[tuple[list[float], Any]] = []
         mem: dict = {}
         ui.register(None, None, 0, True)
         goals = current_metadata.get("goals", [])
@@ -82,8 +95,13 @@ class SynquidSynthesizer(Synthesizer):
             except Exception:
                 return False
 
+        def finish() -> Term:
+            if not pareto_front:
+                raise SynthesisNotSuccessful("SynquidSynthesizer: no valid candidate found within budget")
+            return _pick_pareto_member(pareto_front)
+
         def consider(result: Term) -> bool:
-            nonlocal best, done
+            nonlocal pareto_front, done
             if typecheck_candidate_first and not _safe_check(check_type, ctx, result, type):
                 ui.register(result, "Invalid (hole-local)", get_elapsed_time(start_time), False)
                 if get_elapsed_time(start_time) > budget:
@@ -94,11 +112,11 @@ class SynquidSynthesizer(Synthesizer):
                 if not goals:
                     ui.register(result, score, get_elapsed_time(start_time), True)
                     return True
-                if is_better(score, best[0]):
-                    best = (score, result)
-                    ui.register(result, score, get_elapsed_time(start_time), True)
-                else:
-                    ui.register(result, score, get_elapsed_time(start_time), False)
+                pareto_front = _update_pareto_front(pareto_front, score, result)
+                on_front = any(r is result for _, r in pareto_front)
+                ui.register(result, score, get_elapsed_time(start_time), on_front)
+                if all(s == 0.0 for s in score):
+                    return True
             else:
                 ui.register(result, "Invalid", get_elapsed_time(start_time), False)
             if get_elapsed_time(start_time) > budget:
@@ -121,7 +139,7 @@ class SynquidSynthesizer(Synthesizer):
                 if cap_done:
                     break
                 level += 1
-            return best[1]
+            return finish()
 
         for result in iter_candidates_size_then_level(
             ctx, type, skip, mem, max_level=max_level, seed_levels=seed_levels
@@ -133,4 +151,4 @@ class SynquidSynthesizer(Synthesizer):
                 return result
             if not done:
                 break
-        return best[1]
+        return finish()

--- a/tests/synquid_test.py
+++ b/tests/synquid_test.py
@@ -1,7 +1,59 @@
+import pytest
+
+from aeon.core.types import TypeConstructor
+from aeon.synthesis.api import SynthesisNotSuccessful
 from aeon.synthesis.entrypoint import synthesize_holes
 from aeon.synthesis.identification import incomplete_functions_and_holes
-from aeon.synthesis.modules.synquid.synthesizer import SynquidSynthesizer
+from aeon.synthesis.modules.synquid.synthesizer import (
+    SynquidSynthesizer,
+    _dominates,
+    _pick_pareto_member,
+    _update_pareto_front,
+)
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
 from tests.driver import check_and_return_core
+
+_INT = TypeConstructor(Name("Int", 0), [])
+
+
+def test_dominates():
+    assert _dominates([1.0, 2.0], [2.0, 3.0])
+    assert not _dominates([1.0, 2.0], [1.0, 2.0])
+    assert not _dominates([1.0, 3.0], [2.0, 2.0])
+
+
+def test_update_pareto_front():
+    front = _update_pareto_front([], [1.0, 2.0], "a")
+    assert front == [([1.0, 2.0], "a")]
+
+    front = _update_pareto_front(front, [2.0, 1.0], "b")
+    assert len(front) == 2
+
+    front = _update_pareto_front(front, [0.5, 0.5], "c")
+    assert front == [([0.5, 0.5], "c")]
+
+
+def test_pick_pareto_member_prefers_lower_sum():
+    front = [([2.0, 1.0], "b"), ([1.0, 2.0], "a")]
+    assert _pick_pareto_member(front) == "a"
+
+
+def test_synquid_raises_when_no_valid_candidate():
+    ctx = TypingContext()
+    fun_name = Name("f", 0)
+    metadata = {fun_name: {"goals": ["dummy"], "synquid_max_candidates": 0}}
+
+    with pytest.raises(SynthesisNotSuccessful, match="SynquidSynthesizer: no valid candidate found within budget"):
+        SynquidSynthesizer().synthesize(
+            ctx,
+            _INT,
+            validate=lambda _: False,
+            evaluate=lambda _: [1.0],
+            fun_name=fun_name,
+            metadata=metadata,
+            budget=1.0,
+        )
 
 
 def test_synquid():


### PR DESCRIPTION
## Summary
- Replace Synquid's single `best` candidate tracking with a Pareto front for multi-objective goals
- Add `_dominates`, `_update_pareto_front`, and `_pick_pareto_member` helpers
- Raise `SynthesisNotSuccessful` when no valid candidate is found within budget
- Add unit tests for Pareto helpers and the no-candidate failure path

## Test plan
- [x] `uv run pytest tests/synquid_test.py tests/synquid_search_test.py -x`

Made with [Cursor](https://cursor.com)