### PR TITLE
SMT @example synthesis and LSP Z3 error handling

### DIFF
--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -19,15 +19,22 @@ import logging
 import re
 import urllib.parse
 from dataclasses import dataclass, field
-from typing import Dict, List, TextIO
+from typing import Dict, List, TextIO, cast
 
 import requests
 from lark.exceptions import UnexpectedToken
 from lsprotocol.types import Diagnostic, DiagnosticSeverity
 from lsprotocol.types import Position, Range
 
+from z3.z3types import Z3Exception
+
 from aeon.facade.driver import AeonDriver
+from aeon.backend.evaluator import EvaluationContext
+from aeon.core.terms import Term
+from aeon.decorators.api import Metadata
 from aeon.lsp.server import AeonLanguageServer, _loc_to_range
+from aeon.lsp.z3_errors import z3_diagnostic_message
+from aeon.typechecking.context import TypingContext
 
 requests_session = requests.Session()
 
@@ -59,6 +66,9 @@ class ParseResult:
 _type_index_cache: "Dict[URI, object]" = {}
 _typing_ctx_cache: "Dict[URI, object]" = {}
 _core_cache: "Dict[URI, object]" = {}
+_metadata_cache: "Dict[URI, object]" = {}
+_evaluation_ctx_cache: "Dict[URI, object]" = {}
+_constructor_names_cache: "Dict[URI, object]" = {}
 # Structured semantic errors from the most recent parse of each document. Unlike
 # the caches above these track the *current* parse (cleared on every reparse) so
 # the info view's error tab can present the live verification failures — their
@@ -81,6 +91,39 @@ def get_core(uri: URI):
     return _core_cache.get(uri)
 
 
+def get_metadata(uri: URI):
+    """The metadata from the last parse of ``uri`` that reached core generation."""
+    return _metadata_cache.get(uri)
+
+
+def cache_driver_analysis(driver: AeonDriver, uri: URI) -> None:
+    """Snapshot ``driver``'s analysis fields for ``uri`` (LSP feature cache)."""
+    _refresh_analysis(driver, uri)
+
+
+def restore_driver_from_cache(driver: AeonDriver, uri: URI) -> bool:
+    """Repopulate ``driver`` analysis fields from the last good parse of ``uri``.
+
+    Used when a fresh parse aborts with :class:`Z3Exception` but an earlier
+    successful parse left enough state to run synthesis or type-aware features.
+    """
+    core = _core_cache.get(uri)
+    typing_ctx = _typing_ctx_cache.get(uri)
+    metadata = _metadata_cache.get(uri)
+    if core is None or typing_ctx is None or metadata is None:
+        return False
+    driver.core = cast(Term, core)
+    driver.typing_ctx = cast(TypingContext, typing_ctx)
+    driver.metadata = cast(Metadata, metadata)
+    evaluation_ctx = _evaluation_ctx_cache.get(uri)
+    if evaluation_ctx is not None:
+        driver.evaluation_ctx = cast(EvaluationContext, evaluation_ctx)
+    constructor_names = _constructor_names_cache.get(uri)
+    if constructor_names is not None:
+        driver.constructor_names = cast(set[str], constructor_names)
+    return True
+
+
 def get_errors(uri: URI) -> list:
     """The structured semantic errors (``AeonError``) of ``uri``'s last parse."""
     return _errors_cache.get(uri, [])
@@ -99,6 +142,15 @@ def _refresh_analysis(driver: AeonDriver, uri: URI) -> None:
         _type_index_cache[uri] = build_type_index(typing_ctx, core)
         _typing_ctx_cache[uri] = typing_ctx
         _core_cache[uri] = core
+        metadata = getattr(driver, "metadata", None)
+        if metadata is not None:
+            _metadata_cache[uri] = metadata
+        evaluation_ctx = getattr(driver, "evaluation_ctx", None)
+        if evaluation_ctx is not None:
+            _evaluation_ctx_cache[uri] = evaluation_ctx
+        constructor_names = getattr(driver, "constructor_names", None)
+        if constructor_names is not None:
+            _constructor_names_cache[uri] = constructor_names
     except Exception:
         logger.exception("Failed to build type index for %s", uri)
 
@@ -254,6 +306,21 @@ async def _parse(
                 severity=DiagnosticSeverity.Error,
             )
         )
+    except Z3Exception as e:
+        logger.warning("Z3 verification failed while parsing %s: %s", uri, e)
+        diagnostics.append(
+            Diagnostic(
+                message=z3_diagnostic_message(e),
+                range=Range(
+                    start=Position(line=0, character=0),
+                    end=Position(line=0, character=0),
+                ),
+                source="aeon",
+                severity=DiagnosticSeverity.Warning,
+            )
+        )
+        if _core_cache.get(uri) is not None:
+            return ParseResult(diagnostics, find_holes_in_source(content))
     except Exception as e:
         logger.exception("Unhandled exception while parsing")
         diagnostics.append(

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -516,19 +516,42 @@ def _run_synthesis(
     from aeon.synthesis.entrypoint import synthesize_holes
     from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
     from aeon.lsp.synthesis_ui import LSPProgressUI
+    from aeon.lsp.z3_errors import z3_synthesis_message
     from aeon.sugar.lifting import lift
     from aeon.utils.pprint import pretty_print_sterm
+    from z3.z3types import Z3Exception
 
     document = ls.workspace.get_text_document(uri)
     source = document.source
 
     try:
         errors = list(driver.parse(filename=uri, aeon_code=source))
+    except Z3Exception as e:
+        if aeon_adapter.restore_driver_from_cache(driver, uri):
+            ls.window_show_message(
+                ShowMessageParams(
+                    type=MessageType.Warning,
+                    message=(f"{z3_synthesis_message(e)}; synthesizing from the last successful parse of this file"),
+                )
+            )
+            errors = []
+        else:
+            ls.window_show_message(
+                ShowMessageParams(
+                    type=MessageType.Error,
+                    message=f"Cannot synthesize: {z3_synthesis_message(e)}",
+                )
+            )
+            return None
     except Exception as e:
         ls.window_show_message(
             ShowMessageParams(type=MessageType.Error, message=f"Cannot synthesize: parse failed ({e})")
         )
         return None
+
+    if not errors:
+        aeon_adapter.cache_driver_analysis(driver, uri)
+
     if errors:
         ls.window_show_message(
             ShowMessageParams(type=MessageType.Error, message=f"Cannot synthesize: file has {len(errors)} error(s)")

--- a/aeon/lsp/z3_errors.py
+++ b/aeon/lsp/z3_errors.py
@@ -1,0 +1,27 @@
+"""Helpers for surfacing Z3 failures in LSP diagnostics and messages."""
+
+from __future__ import annotations
+
+from z3.z3types import Z3Exception
+
+
+def z3_exception_message(exc: Z3Exception) -> str:
+    """Return a readable message from a :class:`Z3Exception`.
+
+    Z3's C++ layer sometimes passes byte-string messages (e.g.
+    ``b'ast is not an expression'``); decode those for user-facing text.
+    """
+    if not exc.args:
+        return str(exc)
+    msg = exc.args[0]
+    if isinstance(msg, bytes):
+        return msg.decode("utf-8", errors="replace")
+    return str(msg)
+
+
+def z3_diagnostic_message(exc: Z3Exception) -> str:
+    return f"Z3 verification error: {z3_exception_message(exc)}"
+
+
+def z3_synthesis_message(exc: Z3Exception) -> str:
+    return f"Z3 verification error: {z3_exception_message(exc)}"

--- a/aeon/synthesis/modules/smt_synthesizer.py
+++ b/aeon/synthesis/modules/smt_synthesizer.py
@@ -1,15 +1,14 @@
 """SMT-guided synthesizer.
 
 Builds expression trees top-down:
-- Non-SMT types: look for constructors/functions in the context, recurse into their arguments.
-- SMT types (Int, Bool, Float): create a z3 placeholder variable and add any refinement
-  constraints to the solver.
+- Looks in the typing context for variables and applications that produce the goal type.
+- Falls back to Z3 placeholder variables for bare SMT literals (Int/Bool/Float) when
+  refinements demand a concrete constant.
+- ``@example`` I/O pairs (``io_examples`` metadata) become hard Z3 constraints on the
+  synthesized term at each example's inputs.
 
 After the tree is built, solve the z3 constraints and replace placeholders with concrete
 literal values, then validate the result.
-
-The synthesizer loops until the time budget is exhausted, shuffling the context variable
-ordering on each attempt to explore different term structures.
 """
 
 from __future__ import annotations
@@ -32,6 +31,7 @@ from aeon.core.liquid import (
 )
 from aeon.core.substitutions import substitute_vartype
 from aeon.core.terms import Application, Literal, Term, TypeApplication, Var
+from aeon.core.types import t_string
 from aeon.core.types import (
     AbstractionType,
     LiquidHornApplication,
@@ -97,6 +97,138 @@ def _get_params(ty: Type) -> list[tuple[Name, Type]]:
         params.append((current.var_name, current.var_type))
         current = current.type
     return params
+
+
+def _app_spine(term: Term) -> tuple[Term, list[Term]]:
+    """Flatten a curried ``Application`` chain into ``(head, args)``."""
+    args: list[Term] = []
+    current: Term = term
+    while isinstance(current, Application):
+        args.append(current.arg)
+        current = current.fun
+    args.reverse()
+    return current, args
+
+
+def _literal_to_z3(term: Literal) -> object | None:
+    base = _base_type(term.type)
+    value = term.value
+    if base == t_int and isinstance(value, int) and not isinstance(value, bool):
+        return z3.IntVal(value)
+    if base == t_bool and isinstance(value, bool):
+        return z3.BoolVal(value)
+    if base == t_float and isinstance(value, (int, float)) and not isinstance(value, bool):
+        return z3.RealVal(float(value))
+    if base == t_string and isinstance(value, str):
+        return z3.StringVal(value)
+    return None
+
+
+def _python_to_z3(value: object) -> object | None:
+    if isinstance(value, bool):
+        return z3.BoolVal(value)
+    if isinstance(value, int):
+        return z3.IntVal(value)
+    if isinstance(value, float):
+        return z3.RealVal(value)
+    if isinstance(value, str):
+        return z3.StringVal(value)
+    return None
+
+
+def _term_to_z3(
+    term: Term,
+    holes: dict[Name, tuple[object, TypeConstructor]],
+    ctx_z3_vars: dict[str, object],
+    uninterp_ctx: dict[str, object],
+) -> object | None:
+    """Translate a synthesized core term to a Z3 expression."""
+    if isinstance(term, TypeApplication):
+        return _term_to_z3(term.body, holes, ctx_z3_vars, uninterp_ctx)
+    if isinstance(term, Literal):
+        return _literal_to_z3(term)
+    if isinstance(term, Var):
+        if term.name in holes:
+            return holes[term.name][0]
+        key = str(term.name)
+        if key in ctx_z3_vars:
+            return ctx_z3_vars[key]
+        fun = base_functions.get(term.name.name)
+        if fun is not None:
+            return fun
+        return uninterp_ctx.get(key)
+    if isinstance(term, Application):
+        head, args = _app_spine(term)
+        fn = _term_to_z3(head, holes, ctx_z3_vars, uninterp_ctx)
+        if fn is None:
+            return None
+        z3_args = [_term_to_z3(arg, holes, ctx_z3_vars, uninterp_ctx) for arg in args]
+        if any(arg is None for arg in z3_args):
+            return None
+        try:
+            if callable(fn) and not isinstance(fn, z3.FuncDeclRef):
+                return fn(*z3_args)
+            if isinstance(fn, z3.FuncDeclRef):
+                return fn(*z3_args)
+        except Exception:
+            return None
+    return None
+
+
+def _add_refinement_constraint(
+    solver: z3.Solver,
+    target_type: Type,
+    term: Term,
+    holes: dict[Name, tuple[object, TypeConstructor]],
+    ctx_z3_vars: dict[str, object],
+    uninterp_ctx: dict[str, object],
+) -> bool:
+    if not isinstance(target_type, RefinedType):
+        return True
+    expr = _term_to_z3(term, holes, ctx_z3_vars, uninterp_ctx)
+    if expr is None:
+        return False
+    binder_str = str(target_type.name)
+    all_vars = {**ctx_z3_vars, binder_str: expr}
+    constraint = _translate_liq(target_type.refinement, all_vars, uninterp_ctx)
+    if constraint is not None and not isinstance(constraint, bool):
+        solver.add(constraint)
+    return True
+
+
+def _add_io_example_constraints(
+    solver: z3.Solver,
+    term: Term,
+    holes: dict[Name, tuple[object, TypeConstructor]],
+    ctx_z3_vars: dict[str, object],
+    uninterp_ctx: dict[str, object],
+    io_examples: list[tuple[list, object]],
+    io_params: list[Name],
+) -> bool:
+    """Add ``@example`` I/O equalities as hard Z3 constraints on the candidate term."""
+    if not io_examples or not io_params:
+        return True
+    expr = _term_to_z3(term, holes, ctx_z3_vars, uninterp_ctx)
+    if expr is None:
+        return False
+    for inputs, output in io_examples:
+        if len(inputs) != len(io_params):
+            return False
+        pairs: list[tuple[object, object]] = []
+        for param, value in zip(io_params, inputs):
+            key = str(param)
+            if key not in ctx_z3_vars:
+                return False
+            concrete = _python_to_z3(value)
+            if concrete is None:
+                return False
+            pairs.append((ctx_z3_vars[key], concrete))
+        at_inputs = z3.substitute(expr, pairs)
+        expected = _python_to_z3(output)
+        if expected is None:
+            return False
+        solver.add(at_inputs == expected)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +405,9 @@ class SMTSynthesizer(Synthesizer):
                         ctx_constraints.append(constraint)
 
         has_goals = bool(current_meta.get("goals"))
+        io_examples: list[tuple[list, object]] = current_meta.get("io_examples", [])
+        io_params: list[Name] = current_meta.get("io_params", [])
+        has_io_examples = bool(io_examples and io_params)
         rng = random.Random(42)
         best_score: list[float] = []
         best_term: Term | None = None
@@ -305,6 +440,12 @@ class SMTSynthesizer(Synthesizer):
             if term is None:
                 continue
 
+            if not _add_refinement_constraint(solver, type, term, holes, ctx_z3_vars, uninterp_ctx):
+                continue
+
+            if not _add_io_example_constraints(solver, term, holes, ctx_z3_vars, uninterp_ctx, io_examples, io_params):
+                continue
+
             result = solver.check()
             if result != z3.sat:
                 continue
@@ -319,6 +460,12 @@ class SMTSynthesizer(Synthesizer):
             except Exception:
                 ui.register(concrete_term, "Invalid", time.time() - start_time, False)
                 continue
+
+            # @example I/O constraints are already discharged in Z3 — return the
+            # first type-valid candidate without a multiprocessing fitness round-trip.
+            if has_io_examples:
+                ui.register(concrete_term, [], time.time() - start_time, True)
+                return concrete_term
 
             # No optimization goals — return immediately
             if not has_goals:
@@ -359,22 +506,53 @@ class SMTSynthesizer(Synthesizer):
 
         base = _base_type(target_type)
 
-        if _is_smt_base(base):
+        if _is_smt_base(base) and isinstance(target_type, RefinedType):
             assert isinstance(base, TypeConstructor)
-            # Create a fresh z3 hole
             hole_name = Name(f"__smt_hole_{fresh_counter.fresh()}", 0)
             z3_var = make_variable(str(hole_name), base)
             holes[hole_name] = (z3_var, base)
-
-            # Add refinement constraint
-            if isinstance(target_type, RefinedType):
-                binder_str = str(target_type.name)
-                all_vars = {**ctx_z3_vars, binder_str: z3_var}
-                constraint = _translate_liq(target_type.refinement, all_vars, uninterp_ctx)
-                if constraint is not None and not isinstance(constraint, bool):
-                    solver.add(constraint)
-
             return Var(hole_name)
+
+        built = self._build_from_context(
+            ctx=ctx,
+            target_type=target_type,
+            fun_name=fun_name,
+            solver=solver,
+            holes=holes,
+            ctx_z3_vars=ctx_z3_vars,
+            uninterp_ctx=uninterp_ctx,
+            depth=depth,
+            rng=rng,
+            base=base,
+        )
+        if built is not None:
+            return built
+
+        if _is_smt_base(base):
+            assert isinstance(base, TypeConstructor)
+            # Fallback: a fresh Z3 placeholder for a bare SMT literal.
+            hole_name = Name(f"__smt_hole_{fresh_counter.fresh()}", 0)
+            z3_var = make_variable(str(hole_name), base)
+            holes[hole_name] = (z3_var, base)
+            return Var(hole_name)
+
+        return None
+
+    def _build_from_context(
+        self,
+        ctx: TypingContext,
+        target_type: Type,
+        fun_name: Name,
+        solver: z3.Solver,
+        holes: dict[Name, tuple[object, TypeConstructor]],
+        ctx_z3_vars: dict[str, object],
+        uninterp_ctx: dict[str, object],
+        depth: int,
+        rng: random.Random | None,
+        base: Type,
+    ) -> Term | None:
+        if depth > self.max_depth:
+            return None
 
         # Non-SMT: find a function in ctx whose return base type matches
         if not isinstance(base, TypeConstructor):
@@ -387,68 +565,72 @@ class SMTSynthesizer(Synthesizer):
         if rng is not None:
             rng.shuffle(ctx_vars)
 
-        for var_name, var_ty in ctx_vars:
-            # Skip the function being synthesized (no self-recursion)
-            if var_name == fun_name:
-                continue
-            # Skip system names (fitness helpers are shadowed to Unit upstream)
-            if var_name.name in _SYSTEM_NAMES:
-                continue
-            # Try to instantiate polymorphic functions
-            effective_ty: Type = var_ty
-            type_apps: list[Type] = []
-            if isinstance(var_ty, TypePolymorphism):
-                result = _try_instantiate_poly(var_ty, base)
-                if result is None:
+        for applications_first in ((depth == 0), (depth > 0)):
+            for var_name, var_ty in ctx_vars:
+                # Skip the function being synthesized (no self-recursion)
+                if var_name == fun_name:
                     continue
-                effective_ty, type_apps = result
+                # Skip system names (fitness helpers are shadowed to Unit upstream)
+                if var_name.name in _SYSTEM_NAMES:
+                    continue
+                # Try to instantiate polymorphic functions
+                effective_ty: Type = var_ty
+                type_apps: list[Type] = []
+                if isinstance(var_ty, TypePolymorphism):
+                    result = _try_instantiate_poly(var_ty, base)
+                    if result is None:
+                        continue
+                    effective_ty, type_apps = result
 
-            # Skip non-functions (plain values of non-SMT type could be vars)
-            if not isinstance(effective_ty, AbstractionType):
-                # A plain variable (non-function) whose base type matches
-                plain_base = _base_type(effective_ty)
-                if isinstance(plain_base, TypeConstructor) and plain_base == base:
-                    head: Term = Var(var_name)
+                is_function = isinstance(effective_ty, AbstractionType)
+                if applications_first != is_function:
+                    continue
+
+                if not is_function:
+                    # A plain variable whose base type matches
+                    plain_base = _base_type(effective_ty)
+                    if isinstance(plain_base, TypeConstructor) and plain_base == base:
+                        head: Term = Var(var_name)
+                        for ta in type_apps:
+                            head = TypeApplication(head, ta)
+                        return head
+                    continue
+
+                ret_base = _return_base_type(effective_ty)
+                if not isinstance(ret_base, TypeConstructor):
+                    continue
+                if ret_base != base:
+                    continue
+
+                # This function can produce the needed type — try to build args
+                params = _get_params(effective_ty)
+                args: list[Term] = []
+                success = True
+
+                for _param_name, param_type in params:
+                    arg = self._build_term(
+                        ctx=ctx,
+                        target_type=param_type,
+                        fun_name=fun_name,
+                        solver=solver,
+                        holes=holes,
+                        ctx_z3_vars=ctx_z3_vars,
+                        uninterp_ctx=uninterp_ctx,
+                        depth=depth + 1,
+                        rng=rng,
+                    )
+                    if arg is None:
+                        success = False
+                        break
+                    args.append(arg)
+
+                if success:
+                    result_term: Term = Var(var_name)
                     for ta in type_apps:
-                        head = TypeApplication(head, ta)
-                    return head
-                continue
-
-            ret_base = _return_base_type(effective_ty)
-            if not isinstance(ret_base, TypeConstructor):
-                continue
-            if ret_base != base:
-                continue
-
-            # This function can produce the needed type — try to build args
-            params = _get_params(effective_ty)
-            args: list[Term] = []
-            success = True
-
-            for _param_name, param_type in params:
-                arg = self._build_term(
-                    ctx=ctx,
-                    target_type=param_type,
-                    fun_name=fun_name,
-                    solver=solver,
-                    holes=holes,
-                    ctx_z3_vars=ctx_z3_vars,
-                    uninterp_ctx=uninterp_ctx,
-                    depth=depth + 1,
-                    rng=rng,
-                )
-                if arg is None:
-                    success = False
-                    break
-                args.append(arg)
-
-            if success:
-                result_term: Term = Var(var_name)
-                for ta in type_apps:
-                    result_term = TypeApplication(result_term, ta)
-                for arg in args:
-                    result_term = Application(result_term, arg)
-                return result_term
+                        result_term = TypeApplication(result_term, ta)
+                    for arg in args:
+                        result_term = Application(result_term, arg)
+                    return result_term
 
         return None
 

--- a/tests/lsp_test.py
+++ b/tests/lsp_test.py
@@ -377,3 +377,82 @@ def test_run_synthesis_each_synthesizer(synthesizer, monkeypatch):
     assert isinstance(synthesized_str, str) and len(synthesized_str) > 0
     assert hole_range.start.line == 0
     assert hole_range.start.character == source.index("?")
+
+
+# ---------------------------------------------------------------------------
+# Z3 verification errors
+# ---------------------------------------------------------------------------
+
+
+def test_z3_exception_message_decodes_bytes():
+    from z3.z3types import Z3Exception
+
+    from aeon.lsp.z3_errors import z3_diagnostic_message, z3_exception_message
+
+    exc = Z3Exception(b"ast is not an expression")
+    assert z3_exception_message(exc) == "ast is not an expression"
+    assert z3_diagnostic_message(exc) == "Z3 verification error: ast is not an expression"
+
+
+def test_parse_z3_exception_keeps_cached_holes(monkeypatch):
+    import asyncio
+    import io
+
+    from z3.z3types import Z3Exception
+
+    from aeon.lsp import aeon_adapter
+    from aeon.lsp.aeon_adapter import _parse
+    from lsprotocol.types import DiagnosticSeverity
+
+    uri = "file:///z3_test.ae"
+    source = "def synth : Int := ?hole;"
+    driver = make_driver()
+    driver.parse(filename=uri, aeon_code=source)
+    aeon_adapter.cache_driver_analysis(driver, uri)
+
+    def boom(*_args, **_kwargs):
+        raise Z3Exception(b"ast is not an expression")
+
+    monkeypatch.setattr(driver, "parse", boom)
+
+    result = asyncio.run(_parse(io.StringIO(source), driver, uri))
+
+    assert len(result.holes) == 1
+    assert result.holes[0].name == "hole"
+    assert any(
+        d.severity == DiagnosticSeverity.Warning and "Z3 verification error" in d.message for d in result.diagnostics
+    )
+
+
+def test_run_synthesis_recovers_from_z3_with_cached_parse(monkeypatch):
+    from z3.z3types import Z3Exception
+
+    from aeon.lsp import aeon_adapter
+
+    source = """
+    @example(double 3 = 6)
+    @example(double 4 = 8)
+    def double (n:Int) : Int := ?hole;
+    """
+    uri = "file:///z3_synth.ae"
+    mock_ls = MockLS(source)
+    driver = make_driver()
+    driver.parse(filename=uri, aeon_code=source)
+    aeon_adapter.cache_driver_analysis(driver, uri)
+
+    real_parse = driver.parse
+
+    def parse_then_z3(*args, **kwargs):
+        real_parse(*args, **kwargs)
+        raise Z3Exception(b"ast is not an expression")
+
+    monkeypatch.setattr(driver, "parse", parse_then_z3)
+
+    result = _run_synthesis(driver, mock_ls, uri, "hole", "smt", budget_seconds=10)
+
+    assert result is not None
+    synthesized_str, _hole_range = result
+    assert "n" in synthesized_str
+    warning_msgs = [msg for msg, typ in mock_ls.messages if typ == MessageType.Warning]
+    assert any("Z3 verification error" in msg for msg in warning_msgs)
+    assert not any("parse failed" in msg for msg, _ in mock_ls.messages)

--- a/tests/smt_synthesizer_test.py
+++ b/tests/smt_synthesizer_test.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from aeon.core.terms import Literal
 from aeon.synthesis.entrypoint import synthesize_holes
 from aeon.synthesis.identification import incomplete_functions_and_holes
-from aeon.synthesis.modules.smt_synthesizer import SMTSynthesizer
+from aeon.synthesis.modules.smt_synthesizer import SMTSynthesizer, _app_spine
 from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
 
 from tests.driver import check_and_return_core
@@ -52,3 +52,18 @@ def test_solves_bool_refinement():
 def test_solves_float_refinement():
     t = _solve("def p : {x:Float | x = 2.5} := ?hole;")
     assert isinstance(t, Literal) and t.value == 2.5
+
+
+def test_solves_double_from_examples():
+    code = """
+    @example(double 3 = 6)
+    @example(double 4 = 8)
+    def double (n:Int) : Int := ?hole;
+    """
+    t = _solve(code)
+    from aeon.core.terms import Application, Var
+
+    assert isinstance(t, Application)
+    _, args = _app_spine(t)
+    assert len(args) == 2
+    assert all(isinstance(arg, Var) and arg.name.name == "n" for arg in args)


### PR DESCRIPTION
## Summary
- Teach the `smt` synthesizer to encode `@example` I/O pairs as hard Z3 constraints, enabling expression synthesis (e.g. `n + n` for `double`) instead of constants only.
- Handle `Z3Exception` separately in the LSP: show a proper Z3 verification message and fall back to the last successful cached parse for synthesis when re-parsing fails.

## Test plan
- [x] `pytest tests/smt_synthesizer_test.py -q`
- [x] `pytest tests/lsp_test.py::test_z3_exception_message_decodes_bytes tests/lsp_test.py::test_parse_z3_exception_keeps_cached_holes tests/lsp_test.py::test_run_synthesis_recovers_from_z3_with_cached_parse -q`
- [ ] CI green


Made with [Cursor](https://cursor.com)