### PR TITLE
fix(synthesis): preserve Int decision tree split thresholds

### DIFF
--- a/aeon/prelude/prelude.py
+++ b/aeon/prelude/prelude.py
@@ -112,6 +112,7 @@ prelude = [
     ("*", "forall a:B, (n x:a) -> (n y:a) -> a", lambda x: lambda y: x * y),
     ("/", "forall a:B, (n x:a) -> (n y:a) -> a", lambda x: lambda y: x / y),
     ("%", "(n x:Int) -> (n y:Int) -> Int", lambda x: lambda y: x % y),
+    ("toFloat", "(x:Int) -> Float", lambda x: float(x)),
     ("&&", "(n x:Bool) -> (n y:Bool) -> Bool", lambda x: lambda y: x and y),
     ("||", "(n x:Bool) -> (n y:Bool) -> Bool", lambda x: lambda y: x or y),
     ("-->", "(n x:Bool) -> (n y:Bool) -> Bool", lambda x: lambda y: (not x) or y),

--- a/aeon/synthesis/modules/decision_tree/__init__.py
+++ b/aeon/synthesis/modules/decision_tree/__init__.py
@@ -43,9 +43,20 @@ def _numeric_literal(value: float, ty: Type) -> Term:
     return Literal(float(value), t_float)
 
 
-def _comparison_type(ty: Type) -> Type:
-    """Return Int or Float for a polymorphic comparison at parameter ``ty``."""
-    return t_int if base_type_of(ty) == t_int else t_float
+def _comparison_operand(arg_name: Name, arg_ty: Type) -> Term:
+    """Build the left-hand side of a tree split comparison."""
+    if base_type_of(arg_ty) == t_int:
+        return Application(Var(Name("toFloat", 0)), Var(arg_name))
+    return Var(arg_name)
+
+
+def _split_condition(arg_name: Name, arg_ty: Type, threshold: float) -> Term:
+    """``<=`` comparison preserving sklearn's floating-point split threshold."""
+    le_typed = TypeApplication(Var(Name("<=", 0)), t_float)
+    return Application(
+        Application(le_typed, _comparison_operand(arg_name, arg_ty)),
+        Literal(threshold, t_float),
+    )
 
 
 def _tree_to_term(
@@ -67,14 +78,8 @@ def _tree_to_term(
 
         feat_idx = feature[node_id]
         thresh = float(threshold[node_id])
-        arg_ty = arg_types[feat_idx]
-        cmp_ty = _comparison_type(arg_ty)
 
-        le_typed = TypeApplication(Var(Name("<=", 0)), cmp_ty)
-        cond = Application(
-            Application(le_typed, Var(arg_names[feat_idx])),
-            _numeric_literal(thresh, arg_ty),
-        )
+        cond = _split_condition(arg_names[feat_idx], arg_types[feat_idx], thresh)
         then_branch = build(tree_.children_left[node_id])
         else_branch = build(tree_.children_right[node_id])
         return If(cond, then_branch, else_branch)

--- a/tests/decision_tree_test.py
+++ b/tests/decision_tree_test.py
@@ -94,6 +94,43 @@ def test_decision_tree_single_example_int():
     assert list(mapping.values())[0] is not None
 
 
+def test_decision_tree_int_threshold_uses_float_split():
+    """Int feature splits compare ``toFloat n <= thresh`` to match sklearn thresholds."""
+    source = """
+        @example(double 3 = 6)
+        @example(double 4 = 8)
+        def double (n : Int) : Int := ?hole
+    """
+    core_ast_anf, ctx, ectx, metadata = check_and_return_core(source)
+    incomplete_functions = incomplete_functions_and_holes(ctx, core_ast_anf)
+    mapping = synthesize_holes(
+        ctx,
+        ectx,
+        core_ast_anf,
+        incomplete_functions,
+        metadata,
+        synthesizer=DecisionTreeSynthesizer(),
+        budget=5,
+    )
+    assert len(mapping) == 1
+    term = list(mapping.values())[0]
+    assert term is not None
+
+    from aeon.core.substitutions import substitution
+    from aeon.facade.driver import AeonConfig, AeonDriver
+    from aeon.synthesis.pbt import run_examples
+    from aeon.synthesis.uis.api import SynthesisUI
+
+    hole_name = incomplete_functions[0][1][0]
+    core_filled = substitution(core_ast_anf, term, hole_name)
+    driver = AeonDriver(AeonConfig(synthesizer="decision_tree", synthesis_ui=SynthesisUI(), synthesis_budget=5))
+    driver.core = core_filled
+    driver.evaluation_ctx = ectx
+    driver.metadata = metadata
+    results = run_examples(driver.evaluation_ctx, driver.core, driver.metadata)
+    assert all(r.passed for r in results), [r.summary() for r in results]
+
+
 def test_decision_tree_multiple_examples():
     """Multiple @example decorators merge into training data."""
     source = """


### PR DESCRIPTION
## Summary
- Add `toFloat : Int -> Float` to the prelude so decision-tree synthesis can compare Int features against sklearn's fractional split thresholds without rounding.
- Emit `toFloat arg <= threshold` (float literal) instead of rounding thresholds to `Int`, which broke examples like `double 4 = 8` when sklearn chose split at 3.5.
- Add regression test `test_decision_tree_int_threshold_uses_float_split` for the `double` @example case.

## Test plan
- [x] `uv run pytest tests/decision_tree_test.py::test_decision_tree_int_threshold_uses_float_split -x`
- [x] `uv run pytest tests/decision_tree_test.py -x`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)