### PR TITLE
fix(lsp): offer BFS and Random Walk type-directed synthesis in menu

### DIFF
--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -56,7 +56,7 @@ from aeon.synthesis.modules.llm import llm_synthesizer_menu_ids
 SYNTHESIZERS = sort_synthesizer_ids(
     [
         "tdsyn_enumerative",
-        "tdsyn",
+        "tdsyn_random",
         "tactics",
         "gp",
         "enumerative",

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -56,7 +56,7 @@ SYNTHESIZER_FAMILY_ORDER: tuple[SynthesizerFamily, ...] = (
 SYNTHESIZER_LABELS: dict[str, str] = {
     "tdsyn": "Type-directed synthesis (BFS)",
     "tdsyn_enumerative": "Type-directed synthesis (BFS)",
-    "tdsyn_random": "Type-directed synthesis (random walk)",
+    "tdsyn_random": "Type-directed synthesis (Random Walk)",
     "synquid": "Synquid enumeration (Q-guided)",
     "tactics": "Tactic search (random)",
     "decision_tree": "Decision tree regression (from examples)",

--- a/tests/lsp_test.py
+++ b/tests/lsp_test.py
@@ -210,7 +210,7 @@ def test_synthesizers_list_non_empty():
 
 def test_synthesizers_includes_defaults():
     assert "tdsyn_enumerative" in SYNTHESIZERS
-    assert "tdsyn" in SYNTHESIZERS
+    assert "tdsyn_random" in SYNTHESIZERS
     assert "gp" in SYNTHESIZERS
     assert "enumerative" in SYNTHESIZERS
     assert "llm_qwen2.5-coder-32b" in SYNTHESIZERS


### PR DESCRIPTION
## Summary
- Replace the duplicate `tdsyn` alias in the LSP synthesis menu with `tdsyn_random`
- Label the two type-directed backends as **BFS** and **Random Walk** so they are distinct in the editor menu

## Test plan
- [x] `pytest tests/lsp_test.py::test_synthesizers_includes_defaults -x`
- [x] `pytest tests/lsp_test.py::test_code_action_titles_use_readable_labels -x`


Made with [Cursor](https://cursor.com)