### PR TITLE
fix(synthesis): exclude native, native_import, and print from all contexts

### DIFF
--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -25,7 +25,7 @@ from aeon.core.terms import (
 from aeon.core.types import Top
 from aeon.core.types import top, Type, t_float, t_int, t_string
 from aeon.decorators import Metadata
-from aeon.synthesis.scope import shadow_fitness_helpers
+from aeon.synthesis.scope import shadow_fitness_helpers, without_excluded_names
 from aeon.backend.evaluator import eval
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.synthesis.identification import get_holes_info
@@ -275,6 +275,7 @@ def _synthesize_one(
     # Let-shadow the fitness/example/cluster helpers to Unit at the hole, so
     # the synthesizer never builds them (replaces the __internal__ filter).
     tyctx = shadow_fitness_helpers(tyctx, metadata)
+    tyctx = without_excluded_names(tyctx)
     ui.start(tyctx, ectx, hole_name.name, ty, budget)
 
     replace = make_program(prog, hole_name)

--- a/aeon/synthesis/grammar/grammar_generation.py
+++ b/aeon/synthesis/grammar/grammar_generation.py
@@ -37,10 +37,10 @@ from aeon.core.types import t_float
 from aeon.core.types import t_int
 from aeon.core.types import t_string
 from aeon.decorators import Metadata
-from aeon.synthesis.scope import shadow_fitness_helpers
+from aeon.synthesis.scope import shadow_fitness_helpers, without_excluded_names
 from aeon.synthesis.grammar.mangling import mangle_name, mangle_var, mangle_type
 from aeon.synthesis.grammar.refinements import refined_type_to_metahandler
-from aeon.synthesis.grammar.utils import prelude_ops, aeon_to_python
+from aeon.synthesis.grammar.utils import prelude_ops, aeon_to_python, SYNTHESIS_EXCLUDED_NAMES
 from aeon.typechecking.context import (
     TypeBinder,
     TypeConstructorBinder,
@@ -958,6 +958,7 @@ def gen_grammar_nodes(
     # Let-shadow the fitness/example/cluster helpers to Unit so they are not
     # offered as building blocks (they stay in the program for evaluation).
     ctx = shadow_fitness_helpers(ctx, metadata)
+    ctx = without_excluded_names(ctx)
 
     # Clean context to remove non-interpreted functions from the context.
     # Simple refinements like 0 < n && n < 10 are kept.
@@ -971,7 +972,7 @@ def gen_grammar_nodes(
     def skip(name: Name) -> bool:
         if name == synth_func_name:
             return not is_recursion_allowed
-        elif name.name in ["native", "native_import", "print"]:
+        elif name.name in SYNTHESIS_EXCLUDED_NAMES:
             return True
         else:
             return False

--- a/aeon/synthesis/grammar/utils.py
+++ b/aeon/synthesis/grammar/utils.py
@@ -13,10 +13,10 @@ from aeon.core.types import t_string
 from aeon.core.types import Type
 from aeon.core.pprint import aeon_prelude_ops_to_text
 
-prelude_ops: list[str] = ["print", "native_import", "native"]
-
 # Names that must never appear in synthesized terms.
-SYNTHESIS_EXCLUDED_NAMES: frozenset[str] = frozenset({"native", "native_import"})
+SYNTHESIS_EXCLUDED_NAMES: frozenset[str] = frozenset({"native", "native_import", "print"})
+
+prelude_ops: list[str] = sorted(SYNTHESIS_EXCLUDED_NAMES)
 
 internal_functions: list[str] = []
 

--- a/aeon/synthesis/modules/afta/synthesizer.py
+++ b/aeon/synthesis/modules/afta/synthesizer.py
@@ -71,6 +71,7 @@ from aeon.core.types import (
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
 from aeon.synthesis.modules.bottom_up import (
     application,
     combos,
@@ -155,7 +156,7 @@ class AFTASynthesizer(Synthesizer):
         the search can build expressions over them, matching ``fta``."""
         from aeon.synthesis.grammar.grammar_generation import monomorphize_poly_type
 
-        skip_names = {fun_name.name, "native", "native_import", "print"}
+        skip_names = {fun_name.name} | SYNTHESIS_EXCLUDED_NAMES
         builders: dict[str, list[Component]] = {}
         atoms: dict[str, list[Var]] = {}
 

--- a/aeon/synthesis/modules/fta/synthesizer.py
+++ b/aeon/synthesis/modules/fta/synthesizer.py
@@ -72,6 +72,7 @@ from aeon.core.types import (
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
 from aeon.synthesis.modules.bottom_up import (
     application,
     combos,
@@ -163,7 +164,7 @@ class FTASynthesizer(Synthesizer):
         intrinsics are skipped, as in the grammar backend."""
         from aeon.synthesis.grammar.grammar_generation import monomorphize_poly_type
 
-        skip_names = {fun_name.name, "native", "native_import", "print"}
+        skip_names = {fun_name.name} | SYNTHESIS_EXCLUDED_NAMES
         builders: dict[str, list[_MonoComponent]] = {}
         atoms: dict[str, list[Var]] = {}
 

--- a/aeon/synthesis/modules/smt_synthesizer.py
+++ b/aeon/synthesis/modules/smt_synthesizer.py
@@ -47,6 +47,7 @@ from aeon.core.types import (
 )
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.typechecking.context import TypingContext, UninterpretedBinder
 from aeon.utils.name import Name, fresh_counter
@@ -558,8 +559,6 @@ class SMTSynthesizer(Synthesizer):
         if not isinstance(base, TypeConstructor):
             return None
 
-        _SYSTEM_NAMES = {"native", "native_import", "print"}
-
         # Shuffle context variable order to explore different terms on each attempt
         ctx_vars = list(ctx.concrete_vars())
         if rng is not None:
@@ -571,7 +570,7 @@ class SMTSynthesizer(Synthesizer):
                 if var_name == fun_name:
                     continue
                 # Skip system names (fitness helpers are shadowed to Unit upstream)
-                if var_name.name in _SYSTEM_NAMES:
+                if var_name.name in SYNTHESIS_EXCLUDED_NAMES:
                     continue
                 # Try to instantiate polymorphic functions
                 effective_ty: Type = var_ty

--- a/aeon/synthesis/modules/synquid/synthesizer.py
+++ b/aeon/synthesis/modules/synquid/synthesizer.py
@@ -10,6 +10,7 @@ from aeon.core.terms import Term
 from aeon.core.types import Type
 from aeon.decorators.api import Metadata
 from aeon.synthesis.api import Synthesizer, SynthesisNotSuccessful
+from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
 from aeon.synthesis.modules.synquid.search import iter_candidates_size_then_level, sorted_level_candidates
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.typechecking.context import TypingContext
@@ -63,7 +64,7 @@ class SynquidSynthesizer(Synthesizer):
         def skip(name: Name) -> bool:
             if name == fun_name:
                 return not is_recursion_allowed
-            elif name.name in ["native", "native_import", "print"]:
+            elif name.name in SYNTHESIS_EXCLUDED_NAMES:
                 return True
             else:
                 return False

--- a/aeon/synthesis/modules/tdsyn/helpers.py
+++ b/aeon/synthesis/modules/tdsyn/helpers.py
@@ -17,6 +17,7 @@ from aeon.core.types import (
     t_string,
 )
 from aeon.decorators.api import Metadata
+from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
 from aeon.typechecking.context import TypingContext
 from aeon.typechecking.entailment import entailment
 from aeon.utils.name import Name
@@ -70,7 +71,7 @@ def should_skip(name: Name, fun_name: Name, metadata: Metadata, is_recursion_all
     """Check if a variable should be skipped during synthesis."""
     if name == fun_name:
         return not is_recursion_allowed
-    if name.name in ("native", "native_import", "print"):
+    if name.name in SYNTHESIS_EXCLUDED_NAMES:
         return True
     return False
 

--- a/aeon/synthesis/scope.py
+++ b/aeon/synthesis/scope.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import dataclasses
 
 from aeon.core.types import t_unit
+from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
 from aeon.typechecking.context import (
     ReflectedBinder,
     TypingContext,
@@ -66,4 +67,17 @@ def shadow_fitness_helpers(ctx: TypingContext, metadata) -> TypingContext:
         return ctx
     entries = list(ctx.entries)
     entries.extend(VariableBinder(Name(name, 0), t_unit) for name in sorted(present))
+    return dataclasses.replace(ctx, entries=entries)
+
+
+def without_excluded_names(ctx: TypingContext) -> TypingContext:
+    """Drop ``native``, ``native_import``, and ``print`` from a synthesis context.
+
+    These prelude intrinsics must not be offered as building blocks to any
+    synthesizer backend."""
+    entries = [
+        e for e in ctx.entries if not (isinstance(e, _VALUE_BINDERS) and e.name.name in SYNTHESIS_EXCLUDED_NAMES)
+    ]
+    if len(entries) == len(ctx.entries):
+        return ctx
     return dataclasses.replace(ctx, entries=entries)


### PR DESCRIPTION
## Summary
- Add `print` to `SYNTHESIS_EXCLUDED_NAMES` and derive `prelude_ops` from that single source of truth.
- Filter `native`, `native_import`, and `print` out of typing contexts before synthesis via `without_excluded_names()`.
- Replace scattered hardcoded skip lists across synthesizer backends with the shared constant.

## Test plan
- [x] `uv run pytest tests/synthesis/ -x -q` (181 passed, 1 skipped)
- [ ] CI green on full test suite


Made with [Cursor](https://cursor.com)