### PR TITLE
Scope GPU builtins to Gpu module imported by @gpu

### DIFF
--- a/aeon/bindings/gpu.py
+++ b/aeon/bindings/gpu.py
@@ -1,0 +1,63 @@
+"""Python bindings for the Aeon ``Gpu`` library.
+
+GPU primitives are exposed only when the ``Gpu`` module is imported (explicitly
+via ``open Gpu`` or automatically by the ``@gpu`` decorator).
+"""
+
+from __future__ import annotations
+
+
+def gpu_map(f):
+    def run(t, conf=None):
+        # TODO add gpu support
+        return [f(x) for x in t]
+
+    return run
+
+
+def gpu_imap(f):
+    def run(t, conf=None):
+        # TODO add gpu support
+        return [f(i) for i in range(len(t))]
+
+    return run
+
+
+def gpu_reduce(f):
+    def with_initial(i):
+        def run(t, conf=None):
+            import functools
+
+            # TODO add gpu support
+            return functools.reduce(lambda x, y: f(x)(y), t, i)
+
+        return run
+
+    return with_initial
+
+
+def gpu_filter(f):
+    def run(t, conf=None):
+        # TODO add gpu support
+        return [x for x in t if f(x)]
+
+    return run
+
+
+def gpu_dot(a):
+    def with_b(b):
+        # TODO add gpu support
+        return sum(x * y for x, y in zip(a, b))
+
+    return with_b
+
+
+def gpu_run(k):
+    def with_config(c):
+        def with_input(t):
+            print(f"Executing kernel on CPU (for now) with config {c}...")
+            return k(t)
+
+        return with_input
+
+    return with_config

--- a/aeon/core/types.py
+++ b/aeon/core/types.py
@@ -232,9 +232,8 @@ t_float = TypeConstructor(Name("Float", 0), [])
 t_string = TypeConstructor(Name("String", 0), [])
 t_set = TypeConstructor(Name("Set", 0), [])
 t_tensor = TypeConstructor(Name("Tensor", 0), [])
-t_gpu_config = TypeConstructor(Name("GpuConfig", 0), [])
 
-builtin_core_types = [t_unit, t_bool, t_int, t_float, t_string, t_set, t_tensor, t_gpu_config]
+builtin_core_types = [t_unit, t_bool, t_int, t_float, t_string, t_set, t_tensor]
 
 top = Top()
 

--- a/aeon/libraries/Gpu.ae
+++ b/aeon/libraries/Gpu.ae
@@ -1,0 +1,24 @@
+# GPU computation primitives.
+#
+# This module is imported automatically by the ``@gpu`` decorator, or can be
+# brought in explicitly with ``open Gpu``.
+
+type GpuConfig
+
+def gpu_map (f: (x:a) -> b) (t: Tensor) : Tensor :=
+    native "__import__('aeon.bindings.gpu').bindings.gpu.gpu_map(f)(t)";
+
+def gpu_imap (f: (i:Int) -> b) (t: Tensor) : Tensor :=
+    native "__import__('aeon.bindings.gpu').bindings.gpu.gpu_imap(f)(t)";
+
+def gpu_reduce (f: (acc:a) -> (x:a) -> a) (initial: a) (t: Tensor) : a :=
+    native "__import__('aeon.bindings.gpu').bindings.gpu.gpu_reduce(f)(initial)(t)";
+
+def gpu_filter (f: (x:a) -> Bool) (t: Tensor) : Tensor :=
+    native "__import__('aeon.bindings.gpu').bindings.gpu.gpu_filter(f)(t)";
+
+def gpu_dot (a: Tensor) (b: Tensor) : Float :=
+    native "__import__('aeon.bindings.gpu').bindings.gpu.gpu_dot(a)(b)";
+
+def run_gpu (kernel: (x:Tensor) -> a) (config: GpuConfig) (input: Tensor) : a :=
+    native "__import__('aeon.bindings.gpu').bindings.gpu.gpu_run(kernel)(config)(input)";

--- a/aeon/prelude/prelude.py
+++ b/aeon/prelude/prelude.py
@@ -32,65 +32,7 @@ native_types: list[Name] = [
     Name("String", 0),
     Name("Set", 0),
     Name("Tensor", 0),
-    Name("GpuConfig", 0),
 ]
-
-
-def gpu_map(f):
-    def run(t, conf=None):
-        # TODO add gpu support
-        return [f(x) for x in t]
-
-    return run
-
-
-def gpu_imap(f):
-    def run(t, conf=None):
-        # TODO add gpu support
-        return [f(i) for i in range(len(t))]
-
-    return run
-
-
-def gpu_reduce(f):
-    def with_initial(i):
-        def run(t, conf=None):
-            import functools
-
-            # TODO add gpu support
-            return functools.reduce(lambda x, y: f(x)(y), t, i)
-
-        return run
-
-    return with_initial
-
-
-def gpu_filter(f):
-    def run(t, conf=None):
-        # TODO add gpu support
-        return [x for x in t if f(x)]
-
-    return run
-
-
-def gpu_dot(a):
-    def with_b(b):
-        # TODO add gpu support
-        return sum(x * y for x, y in zip(a, b))
-
-    return with_b
-
-
-def gpu_run(k):
-    def with_config(c):
-        def with_input(t):
-            print(f"Executing kernel on CPU (for now) with config {c}...")
-            return k(t)
-
-        return with_input
-
-    return with_config
-
 
 prelude = [
     ("native", "forall a:B, (x:String) -> {x:a | false}", eval),
@@ -129,33 +71,7 @@ prelude = [
         "forall a:B, forall b:B, forall <p:a -> Bool>, forall <q:b -> Bool>, (f:(x:a<p>) -> b<q>) -> (x:a<p>) -> b<q>",
         lambda f: lambda x: f(x),
     ),
-    ("gpu_map", "forall a:B, forall b:B, (f:(x:a) -> b) -> (t:Tensor) -> Tensor", gpu_map),
-    (
-        "gpu_imap",
-        "forall b:B, (f:(i:Int) -> b) -> (t:Tensor) -> Tensor",
-        gpu_imap,
-    ),
     ("__index__", "forall a:B, (t:Tensor) -> (i:Int) -> a", lambda t: lambda i: t[i]),
-    (
-        "gpu_reduce",
-        "forall a:B, (f:(acc:a) -> (x:a) -> a) -> (initial:a) -> (t:Tensor) -> a",
-        gpu_reduce,
-    ),
-    (
-        "gpu_filter",
-        "forall a:B, (f:(x:a) -> Bool) -> (t:Tensor) -> Tensor",
-        gpu_filter,
-    ),
-    (
-        "gpu_dot",
-        "(a:Tensor) -> (b:Tensor) -> Float",
-        gpu_dot,
-    ),
-    (
-        "run_gpu",
-        "forall a:B, (kernel:(x:Tensor) -> a) -> (config:GpuConfig) -> (input:Tensor) -> a",
-        gpu_run,
-    ),
 ]
 
 typing_vars: dict[Name, SType] = {}

--- a/aeon/sugar/ast_helpers.py
+++ b/aeon/sugar/ast_helpers.py
@@ -15,7 +15,6 @@ st_float = STypeConstructor(Name("Float", 0))
 st_string = STypeConstructor(Name("String", 0))
 st_set = STypeConstructor(Name("Set", 0))
 st_tensor = STypeConstructor(Name("Tensor", 0))
-st_gpu_config = STypeConstructor(Name("GpuConfig", 0))
 
 true = SLiteral(True, st_bool)
 false = SLiteral(False, st_bool)

--- a/aeon/sugar/desugar.py
+++ b/aeon/sugar/desugar.py
@@ -612,6 +612,35 @@ def resolve_qualified_names_in_definition(
     )
 
 
+def _program_uses_gpu_decorator(definitions: list[Definition]) -> bool:
+    for definition in definitions:
+        for decorator in definition.decorators:
+            if decorator.name.name == "gpu":
+                return True
+    return False
+
+
+def _has_gpu_import(imports: list[ImportAe]) -> bool:
+    for imp in imports:
+        if imp.module_path.split(".")[0] == "Gpu":
+            return True
+    return False
+
+
+def _inject_gpu_import_if_needed(p: Program) -> Program:
+    """``@gpu`` brings GPU primitives into scope via ``open Gpu``."""
+    if not _program_uses_gpu_decorator(p.definitions) or _has_gpu_import(p.imports):
+        return p
+    return Program(
+        imports=[ImportAe(module_path="Gpu", is_open=True)] + p.imports,
+        type_decls=p.type_decls,
+        inductive_decls=p.inductive_decls,
+        definitions=p.definitions,
+        class_decls=p.class_decls,
+        instance_decls=p.instance_decls,
+    )
+
+
 def desugar(
     p: Program,
     is_main_hole: bool = True,
@@ -629,6 +658,8 @@ def desugar(
     mutual_group_by_name: dict[Name, int] = {
         d.name: d.mutual_group_id for d in p.definitions if d.mutual_group_id is not None
     }
+
+    p = _inject_gpu_import_if_needed(p)
 
     # Pull class/instance declarations from imported modules into the main
     # program so they are expanded by the single ``expand_typeclasses`` pass

--- a/aeon/sugar/stypes.py
+++ b/aeon/sugar/stypes.py
@@ -97,7 +97,7 @@ class STypeConstructor(SType):
         return hash(self.name) + sum(hash(c) for c in self.args)
 
 
-builtin_types = ["Top", "Bool", "Int", "Float", "String", "Unit", "Set", "Tensor", "GpuConfig"]
+builtin_types = ["Top", "Bool", "Int", "Float", "String", "Unit", "Set", "Tensor"]
 
 
 def get_type_vars(ty: SType) -> set[STypeVar]:

--- a/tests/gpu_module_test.py
+++ b/tests/gpu_module_test.py
@@ -1,0 +1,98 @@
+"""GPU module is scoped to ``@gpu`` / ``open Gpu``, not the global prelude."""
+
+from __future__ import annotations
+
+import tempfile
+
+from aeon.compilation.compile import clear_unit_cache, compile_and_link_program
+from aeon.elaboration.context import (
+    ElabTypeDecl,
+    ElabTypeVarBinder,
+    ElabUninterpretedBinder,
+    ElabVariableBinder,
+)
+from aeon.prelude.prelude import typing_vars
+from aeon.sugar.desugar import desugar
+from aeon.sugar.parser import parse_program
+
+
+def _typing_names(source: str) -> set[str]:
+    desugared = desugar(parse_program(source))
+    names: set[str] = set()
+    for entry in desugared.elabcontext.entries:
+        match entry:
+            case ElabVariableBinder(name=name) | ElabUninterpretedBinder(name=name):
+                names.add(name.name)
+            case ElabTypeDecl(name=name) | ElabTypeVarBinder(name=name):
+                names.add(name.name)
+    return names
+
+
+def _compile_errors(source: str) -> list[str]:
+    clear_unit_cache()
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ae", delete=False, encoding="utf-8") as tmp:
+        tmp.write(source)
+        path = tmp.name
+    _, _, _, _, _, errors = compile_and_link_program(source, filename=path, is_main=True)
+    return [str(e) for e in (errors or [])]
+
+
+def test_gpu_builtins_not_in_prelude():
+    prelude_names = {name.name for name in typing_vars}
+    for gpu_name in ("gpu_map", "gpu_imap", "gpu_reduce", "gpu_filter", "gpu_dot", "run_gpu"):
+        assert gpu_name not in prelude_names
+
+
+def test_gpu_functions_unavailable_without_import():
+    source = """
+        def main (args:Int) : Int := gpu_map;
+    """
+    errors = _compile_errors(source)
+    assert any("gpu_map" in err and "does not exist" in err for err in errors)
+
+
+def test_gpu_decorator_imports_gpu_module():
+    source = """
+        @gpu
+        def kernel (a:Int) (b:Int) : Int := a + b;
+
+        def main (args:Int) : Int := gpu_map;
+    """
+    assert "GpuConfig" in _typing_names(source)
+    errors = _compile_errors(source)
+    assert errors
+    assert not any("gpu_map" in err and "does not exist" in err for err in errors)
+
+
+def test_open_gpu_makes_functions_available():
+    source = """
+        open Gpu
+
+        def main (args:Int) : Int := gpu_map;
+    """
+    assert "GpuConfig" in _typing_names(source)
+    errors = _compile_errors(source)
+    assert errors
+    assert not any("gpu_map" in err and "does not exist" in err for err in errors)
+
+
+def test_gpu_decorator_does_not_duplicate_import():
+    source = """
+        open Gpu
+
+        @gpu
+        def kernel (a:Int) (b:Int) : Int := a + b;
+
+        def main (args:Int) : Int := 0;
+    """
+    errors = _compile_errors(source)
+    assert errors == []
+
+
+def test_non_gpu_program_has_no_gpu_context():
+    source = """
+        def main (args:Int) : Int := args + 1;
+    """
+    names = _typing_names(source)
+    assert "GpuConfig" not in names
+    assert not any("gpu" in name.lower() for name in names)


### PR DESCRIPTION
## Summary
- Move GPU primitives (`gpu_map`, `run_gpu`, `GpuConfig`, etc.) from the global prelude into a new `Gpu` library module with Python bindings.
- Auto-inject `open Gpu` during desugar when a program uses `@gpu`, so GPU functions are available only where needed.
- Remove `GpuConfig` from global builtin types so non-GPU programs no longer see GPU symbols in their type context.

## Test plan
- [x] Added `tests/gpu_module_test.py` covering prelude isolation, `@gpu` auto-import, manual `open Gpu`, and duplicate-import safety
- [x] Existing LLVM GPU/decorator tests pass locally
- [x] LSP infoview and end-to-end regression tests pass locally


Made with [Cursor](https://cursor.com)