### PR TITLE
fix(lsp): surface invalid source as diagnostics instead of crashing

### DIFF
--- a/aeon/lsp/aeon_adapter.py
+++ b/aeon/lsp/aeon_adapter.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, TextIO, cast
 
 import requests
-from lark.exceptions import UnexpectedToken
+from lark.exceptions import UnexpectedCharacters, UnexpectedInput, UnexpectedToken
 from lsprotocol.types import Diagnostic, DiagnosticSeverity
 from lsprotocol.types import Position, Range
 
@@ -201,17 +201,89 @@ async def parse(
         except requests.RequestException:
             fp = io.StringIO("")
     else:
-        document = aeon_lsp.workspace.get_text_document(uri)
         try:
+            document = aeon_lsp.workspace.get_text_document(uri)
             fp = io.StringIO(document.source)
-        except IOError:
+        except (IOError, KeyError, AttributeError) as exc:
             if not allow_errors:
                 raise
-            fp = io.StringIO("")
+            logger.warning("Could not read document %s: %s", uri, exc)
+            return ParseResult(
+                diagnostics=[
+                    Diagnostic(
+                        message=f"Could not read document: {exc}",
+                        range=Range(
+                            start=Position(line=0, character=0),
+                            end=Position(line=0, character=0),
+                        ),
+                        source="aeon",
+                        severity=DiagnosticSeverity.Error,
+                    )
+                ]
+            )
 
     parse_result = await _parse(fp, aeon_lsp.aeon_driver, uri)
     _parse_result_cache[uri] = parse_result
     return parse_result
+
+
+def _unexpected_token_diagnostic(e: UnexpectedToken) -> Diagnostic:
+    token_length = 1
+    try:
+        token_length = len(str(e.token.value))
+    except Exception:
+        pass
+
+    token_type = e.token.type if e.token.type else "unknown"
+    token_value = e.token.value if e.token.value else str(e.token)
+
+    error_message = (
+        f"Unexpected {token_type} '{token_value}' at line {e.line}, column {e.column}.\n"
+        f"Expected: {', '.join(e.expected)}"
+    )
+
+    error_range = Range(
+        start=Position(line=e.line - 1, character=e.column - 1),
+        end=Position(line=e.line - 1, character=e.column - 1 + token_length),
+    )
+
+    return Diagnostic(
+        message=error_message,
+        range=error_range,
+        source="aeon",
+        severity=DiagnosticSeverity.Error,
+    )
+
+
+def _unexpected_input_diagnostic(e: UnexpectedInput) -> Diagnostic:
+    if isinstance(e, UnexpectedCharacters):
+        char = e.char or ""
+        token_length = max(len(char), 1)
+        char_display = repr(char)[1:-1] if char else "character"
+        allowed = sorted(e.allowed) if e.allowed else []
+        error_message = (
+            f"Unexpected character '{char_display}' at line {e.line}, column {e.column}.\n"
+            f"Expected: {', '.join(allowed)}"
+        )
+        error_range = Range(
+            start=Position(line=e.line - 1, character=e.column - 1),
+            end=Position(line=e.line - 1, character=e.column - 1 + token_length),
+        )
+    else:
+        error_message = str(e)
+        line = getattr(e, "line", 1) or 1
+        column = getattr(e, "column", 1) or 1
+        error_range = Range(
+            start=Position(line=line - 1, character=column - 1),
+            end=Position(line=line - 1, character=column),
+        )
+
+    return Diagnostic(
+        message=error_message,
+        range=error_range,
+        source="aeon",
+        severity=DiagnosticSeverity.Error,
+    )
 
 
 async def _parse(
@@ -238,21 +310,10 @@ async def _parse(
         _refresh_analysis(driver, uri)
 
         for error in errors:
-            error_message = str(error)
-            error_position = error.position()
-
-            error_start_line, error_start_character = error_position.get_start()
-            error_end_line, error_end_character = error_position.get_end()
-
-            error_range = Range(
-                start=Position(line=error_start_line, character=error_start_character),
-                end=Position(line=error_end_line, character=error_end_character),
-            )
-
             diagnostics.append(
                 Diagnostic(
-                    message=error_message,
-                    range=error_range,
+                    message=str(error),
+                    range=_loc_to_range(error.position()),
                     source="aeon",
                     severity=DiagnosticSeverity.Error,
                 )
@@ -279,33 +340,9 @@ async def _parse(
             return ParseResult(diagnostics, holes)
 
     except UnexpectedToken as e:
-        token_length = 1
-        try:
-            token_length = len(str(e.token.value))
-        except Exception:
-            pass
-
-        token_type = e.token.type if e.token.type else "unknown"
-        token_value = e.token.value if e.token.value else str(e.token)
-
-        error_message = (
-            f"Unexpected {token_type} '{token_value}' at line {e.line}, column {e.column}.\n"
-            f"Expected: {', '.join(e.expected)}"
-        )
-
-        error_range = Range(
-            start=Position(line=e.line - 1, character=e.column - 1),
-            end=Position(line=e.line - 1, character=e.column - 1 + token_length),
-        )
-
-        diagnostics.append(
-            Diagnostic(
-                message=error_message,
-                range=error_range,
-                source="aeon",
-                severity=DiagnosticSeverity.Error,
-            )
-        )
+        diagnostics.append(_unexpected_token_diagnostic(e))
+    except UnexpectedInput as e:
+        diagnostics.append(_unexpected_input_diagnostic(e))
     except Z3Exception as e:
         logger.warning("Z3 verification failed while parsing %s: %s", uri, e)
         diagnostics.append(

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import List, Optional, AsyncIterable
 
 from lsprotocol.types import (
@@ -27,6 +28,7 @@ from lsprotocol.types import (
     DidChangeWatchedFilesParams,
     DidOpenTextDocumentParams,
     Diagnostic,
+    DiagnosticSeverity,
     DocumentSymbol,
     DocumentSymbolParams,
     Hover,
@@ -83,6 +85,8 @@ SYNTHESIZE_COMMAND = "aeon.synthesize"
 # :class:`aeon.lsp.infoview.InfoViewData`.
 INFOVIEW_REQUEST = "aeon/infoView"
 
+logger = logging.getLogger(__name__)
+
 
 class AeonLanguageServer(LanguageServer):
     def __init__(self, aeon_driver: AeonDriver):
@@ -103,10 +107,24 @@ class AeonLanguageServer(LanguageServer):
 
     async def _parse_and_send_diagnostics(self, uri) -> None:
         await asyncio.sleep(self.debounce_delay)
-        diagnostics = []
-        async for diag in self._get_diagnostics(uri):
-            diagnostics.append(diag)
-        self.text_document_publish_diagnostics(PublishDiagnosticsParams(uri=uri, diagnostics=diagnostics))
+        diagnostics: list[Diagnostic] = []
+        try:
+            async for diag in self._get_diagnostics(uri):
+                diagnostics.append(diag)
+        except Exception:
+            logger.exception("Failed to produce diagnostics for %s", uri)
+            diagnostics = [
+                Diagnostic(
+                    message="Internal error while analysing this file",
+                    range=Range(start=Position(line=0, character=0), end=Position(line=0, character=0)),
+                    source="aeon",
+                    severity=DiagnosticSeverity.Error,
+                )
+            ]
+        try:
+            self.text_document_publish_diagnostics(PublishDiagnosticsParams(uri=uri, diagnostics=diagnostics))
+        except Exception:
+            logger.exception("Failed to publish diagnostics for %s", uri)
 
     async def _get_diagnostics(self, uri: str) -> AsyncIterable[Diagnostic]:
         from . import aeon_adapter
@@ -161,44 +179,47 @@ class AeonLanguageServer(LanguageServer):
             from . import aeon_adapter
             from aeon.lsp.completion import format_type
 
-            document = ls.workspace.get_text_document(params.text_document.uri)
-            source = document.source
-            line, character = params.position.line, params.position.character
-            word = _get_word_at_position(source, line, character)
+            try:
+                document = ls.workspace.get_text_document(params.text_document.uri)
+                source = document.source
+                line, character = params.position.line, params.position.character
+                word = _get_word_at_position(source, line, character)
 
-            # Position-accurate hover: the inferred (refined) type of the
-            # expression under the cursor, from the type index.
-            index = aeon_adapter.get_type_index(params.text_document.uri)
-            if index is not None:
-                result = index.type_at(line, character)
-                if result is not None:
-                    ty, loc = result
-                    lhs = f"{word} : " if word else ""
-                    return Hover(
-                        contents=MarkupContent(
-                            kind=MarkupKind.Markdown,
-                            value=f"```aeon\n{lhs}{format_type(ty)}\n```",
-                        ),
-                        range=_loc_to_range(loc),
-                    )
-
-            # Fallback: top-level name match (e.g. hovering a definition's name,
-            # which is a binder and has no synthesized-expression observation).
-            if not word:
-                return None
-            typing_ctx = aeon_adapter.get_typing_ctx(params.text_document.uri) or getattr(
-                ls.aeon_driver, "typing_ctx", None
-            )
-            if typing_ctx is None:
-                return None
-            for name, type_ in typing_ctx.vars():
-                if name.pretty() == word:
-                    return Hover(
-                        contents=MarkupContent(
-                            kind=MarkupKind.Markdown,
-                            value=f"```aeon\n{word} : {format_type(type_)}\n```",
+                # Position-accurate hover: the inferred (refined) type of the
+                # expression under the cursor, from the type index.
+                index = aeon_adapter.get_type_index(params.text_document.uri)
+                if index is not None:
+                    result = index.type_at(line, character)
+                    if result is not None:
+                        ty, loc = result
+                        lhs = f"{word} : " if word else ""
+                        return Hover(
+                            contents=MarkupContent(
+                                kind=MarkupKind.Markdown,
+                                value=f"```aeon\n{lhs}{format_type(ty)}\n```",
+                            ),
+                            range=_loc_to_range(loc),
                         )
-                    )
+
+                # Fallback: top-level name match (e.g. hovering a definition's name,
+                # which is a binder and has no synthesized-expression observation).
+                if not word:
+                    return None
+                typing_ctx = aeon_adapter.get_typing_ctx(params.text_document.uri) or getattr(
+                    ls.aeon_driver, "typing_ctx", None
+                )
+                if typing_ctx is None:
+                    return None
+                for name, type_ in typing_ctx.vars():
+                    if name.pretty() == word:
+                        return Hover(
+                            contents=MarkupContent(
+                                kind=MarkupKind.Markdown,
+                                value=f"```aeon\n{word} : {format_type(type_)}\n```",
+                            )
+                        )
+            except Exception:
+                logger.exception("Hover failed for %s", params.text_document.uri)
             return None
 
         @self.feature(TEXT_DOCUMENT_COMPLETION, CompletionOptions(trigger_characters=["."]))
@@ -231,24 +252,28 @@ class AeonLanguageServer(LanguageServer):
             from . import aeon_adapter
             from aeon.lsp.navigation import inlay_hints
 
-            uri = params.text_document.uri
-            core = aeon_adapter.get_core(uri)
-            index = aeon_adapter.get_type_index(uri)
-            if core is None or index is None:
-                return []
-            document = ls.workspace.get_text_document(uri)
-            hints = []
-            for h in inlay_hints(core, document.source, index):
-                # 1-indexed core positions -> 0-indexed LSP.
-                hints.append(
-                    InlayHint(
-                        position=Position(line=h.line - 1, character=h.character - 1),
-                        label=h.label,
-                        kind=InlayHintKind.Type,
-                        padding_left=True,
+            try:
+                uri = params.text_document.uri
+                core = aeon_adapter.get_core(uri)
+                index = aeon_adapter.get_type_index(uri)
+                if core is None or index is None:
+                    return []
+                document = ls.workspace.get_text_document(uri)
+                hints = []
+                for h in inlay_hints(core, document.source, index):
+                    # 1-indexed core positions -> 0-indexed LSP.
+                    hints.append(
+                        InlayHint(
+                            position=Position(line=h.line - 1, character=h.character - 1),
+                            label=h.label,
+                            kind=InlayHintKind.Type,
+                            padding_left=True,
+                        )
                     )
-                )
-            return hints
+                return hints
+            except Exception:
+                logger.exception("Inlay hints failed for %s", params.text_document.uri)
+                return []
 
         @self.feature(TEXT_DOCUMENT_DEFINITION)
         async def definition(
@@ -258,16 +283,20 @@ class AeonLanguageServer(LanguageServer):
             from . import aeon_adapter
             from aeon.lsp.navigation import build_def_index
 
-            uri = params.text_document.uri
-            core = aeon_adapter.get_core(uri)
-            if core is None:
+            try:
+                uri = params.text_document.uri
+                core = aeon_adapter.get_core(uri)
+                if core is None:
+                    return None
+                document = ls.workspace.get_text_document(uri)
+                def_index = build_def_index(core, document.source)
+                span = def_index.definition_at(params.position.line, params.position.character)
+                if span is None:
+                    return None
+                return Location(uri=uri, range=_span_to_range(span))
+            except Exception:
+                logger.exception("Definition lookup failed for %s", params.text_document.uri)
                 return None
-            document = ls.workspace.get_text_document(uri)
-            def_index = build_def_index(core, document.source)
-            span = def_index.definition_at(params.position.line, params.position.character)
-            if span is None:
-                return None
-            return Location(uri=uri, range=_span_to_range(span))
 
         @self.feature(TEXT_DOCUMENT_DOCUMENT_SYMBOL)
         async def document_symbol(
@@ -277,23 +306,27 @@ class AeonLanguageServer(LanguageServer):
             from . import aeon_adapter
             from aeon.lsp.navigation import document_symbols
 
-            uri = params.text_document.uri
-            core = aeon_adapter.get_core(uri)
-            if core is None:
-                return []
-            document = ls.workspace.get_text_document(uri)
-            out = []
-            for s in document_symbols(core, document.source):
-                out.append(
-                    DocumentSymbol(
-                        name=s.name,
-                        detail=s.detail,
-                        kind=SymbolKind.Function if s.is_function else SymbolKind.Variable,
-                        range=_span_to_range(s.full_range),
-                        selection_range=_span_to_range(s.selection_range),
+            try:
+                uri = params.text_document.uri
+                core = aeon_adapter.get_core(uri)
+                if core is None:
+                    return []
+                document = ls.workspace.get_text_document(uri)
+                out = []
+                for s in document_symbols(core, document.source):
+                    out.append(
+                        DocumentSymbol(
+                            name=s.name,
+                            detail=s.detail,
+                            kind=SymbolKind.Function if s.is_function else SymbolKind.Variable,
+                            range=_span_to_range(s.full_range),
+                            selection_range=_span_to_range(s.selection_range),
+                        )
                     )
-                )
-            return out
+                return out
+            except Exception:
+                logger.exception("Document symbols failed for %s", params.text_document.uri)
+                return []
 
         @self.feature(INFOVIEW_REQUEST)
         async def info_view(

--- a/tests/lsp_test.py
+++ b/tests/lsp_test.py
@@ -380,6 +380,77 @@ def test_run_synthesis_each_synthesizer(synthesizer, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Parse diagnostics for invalid source
+# ---------------------------------------------------------------------------
+
+
+def test_parse_syntax_error_returns_diagnostic():
+    import asyncio
+    import io
+
+    from aeon.lsp.aeon_adapter import _parse
+    from lsprotocol.types import DiagnosticSeverity
+
+    driver = make_driver()
+    result = asyncio.run(_parse(io.StringIO("this is not valid aeon !!!"), driver, "file:///test.ae"))
+
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].severity == DiagnosticSeverity.Error
+    assert "Unexpected" in result.diagnostics[0].message
+
+
+def test_parse_unexpected_characters_returns_syntax_diagnostic():
+    import asyncio
+    import io
+
+    from aeon.lsp.aeon_adapter import _parse
+    from lsprotocol.types import DiagnosticSeverity
+
+    driver = make_driver()
+    result = asyncio.run(_parse(io.StringIO('def x : Int := "unclosed'), driver, "file:///test.ae"))
+
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].severity == DiagnosticSeverity.Error
+    assert "Unknown exception" not in result.diagnostics[0].message
+    assert "Unexpected character" in result.diagnostics[0].message
+
+
+def test_parse_incomplete_definition_returns_diagnostic():
+    import asyncio
+    import io
+
+    from aeon.lsp.aeon_adapter import _parse
+    from lsprotocol.types import DiagnosticSeverity
+
+    driver = make_driver()
+    result = asyncio.run(_parse(io.StringIO("def x : Int :="), driver, "file:///test.ae"))
+
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].severity == DiagnosticSeverity.Error
+
+
+def test_parse_missing_document_returns_diagnostic():
+    import asyncio
+
+    from aeon.lsp.aeon_adapter import parse
+    from lsprotocol.types import DiagnosticSeverity
+
+    class MissingDocWorkspace:
+        def get_text_document(self, uri):
+            raise KeyError("Document not found")
+
+    class MissingDocLS:
+        aeon_driver = make_driver()
+        workspace = MissingDocWorkspace()
+
+    result = asyncio.run(parse(MissingDocLS(), "file:///missing.ae"))
+
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].severity == DiagnosticSeverity.Error
+    assert "Could not read document" in result.diagnostics[0].message
+
+
+# ---------------------------------------------------------------------------
 # Z3 verification errors
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Harden the LSP parse pipeline so syntax errors, lexer failures, and unreadable documents publish diagnostics instead of crashing the server
- Guard hover, inlay hints, go-to-definition, and document symbols handlers to return safe empty results on failure
- Add tests covering invalid syntax, unexpected characters, incomplete definitions, and missing documents

## Test plan
- [x] `pytest tests/lsp_test.py -q` (56 passed)
- [x] Verified invalid source (`this is not valid aeon !!!`, unclosed strings, partial decorators) returns LSP diagnostics


Made with [Cursor](https://cursor.com)