### PR TITLE
chore(release): 4.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AeonLang"
-version = "4.7.0"
+version = "4.8.0"
 description = "Language with Refinement Types"
 authors = [
     { name = "Alcides Fonseca", email = "me@alcidesfonseca.com" }


### PR DESCRIPTION
## Summary

Bump version to **4.8.0** for the next PyPI/GitHub release.

## Changes since 4.7.0

- **LSP:** surface invalid source as diagnostics instead of crashing (#481)
- **LSP:** offer BFS and Random Walk type-directed synthesis in menu (#478)
- **CLI:** add `--version` flag
- **Synthesis:** exclude `native`, `native_import`, and `print` from all contexts (#479)
- **Synthesis:** preserve sklearn split thresholds for Int decision trees (#476)
- **Synthesis:** OpenAI-compatible endpoint support for LLM synthesizer
- **GPU:** scope builtins to the `Gpu` module imported by `@gpu` (#480)
- **CI:** skip synthesis integration tests when budget expires without a candidate (#477)

## Test plan

- [x] Version bump only (`pyproject.toml`)
- [ ] CI on this PR
- [ ] Tag `v4.8.0` and publish after merge


Made with [Cursor](https://cursor.com)