### PR TITLE
feat(lsp): expose AeonLang version in info view payload

### DIFF
--- a/aeon/lsp/infoview.py
+++ b/aeon/lsp/infoview.py
@@ -68,6 +68,16 @@ def _strip_ids(s: str) -> str:
     return s.translate(_SUPERSCRIPT_DIGITS)
 
 
+def aeon_version() -> str:
+    """Installed ``AeonLang`` package version (shown in the IDE info view)."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("AeonLang")
+    except PackageNotFoundError:
+        return "unknown"
+
+
 # Term-level binders that introduce a usable ``name : type`` value into scope.
 # Type-level binders (``TypeBinder``/``TypeConstructorBinder``) are deliberately
 # excluded — they bind types, not variables.
@@ -165,6 +175,7 @@ class InfoViewData:
     # The hole under the cursor (drives the synthesis tab), if any.
     hole: Optional[str] = None
     synthesizers: list[SynthesizerInfo] = field(default_factory=list)
+    aeonVersion: str = field(default_factory=aeon_version)
 
     def to_dict(self) -> dict:
         """A JSON-serialisable payload for the ``aeon/infoView`` response."""

--- a/tests/lsp_infoview_test.py
+++ b/tests/lsp_infoview_test.py
@@ -375,6 +375,13 @@ def test_graceful_without_analysis_state():
     assert info.synthesizers == []
 
 
+def test_info_view_includes_aeon_version():
+    info = info_at(SRC, 2, 5)
+    assert info.aeonVersion
+    assert info.aeonVersion != "unknown"
+    assert info.to_dict()["aeonVersion"] == info.aeonVersion
+
+
 def test_to_dict_is_json_serialisable():
     import json
 


### PR DESCRIPTION
## Summary

- Add `aeonVersion` to `InfoViewData` (from installed `AeonLang` package metadata)
- Enables the VS Code info view to show which compiler version is serving the panel

## Test plan

- [x] `pytest tests/lsp_infoview_test.py::test_info_view_includes_aeon_version`


Made with [Cursor](https://cursor.com)