### PR TITLE
fix(refinement-exec): reject open holes during compile-time evaluation

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -18,6 +18,7 @@ from aeon.facade.api import (
     LinearityError,
     MethodResolutionError,
     NonOrderableComparisonError,
+    RefinementExecutionHoleError,
     UndecidableRefinementError,
     UnificationFailedError,
     UnificationKindError,
@@ -278,6 +279,11 @@ def _error_kind_and_hint(err: AeonError) -> tuple[str, str | None]:
             return (
                 "Undecidable refinement",
                 "Keep refinements in the decidable fragment (linear arithmetic), or drop --strict-decidable.",
+            )
+        case RefinementExecutionHoleError():
+            return (
+                "Refinement execution blocked",
+                "Compile-time refinement execution cannot evaluate open synthesis holes.",
             )
         case MethodResolutionError():
             return "Method resolution error", "No method with this name is defined for the receiver's type."

--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -27,7 +27,7 @@ from aeon.facade.api import (
 from aeon.facade.driver import AeonConfig, AeonDriver
 from aeon.facade.exit_codes import ExitCode, error_exit_code
 from aeon.sugar.lowering import LiquefactionException
-from aeon.synthesis.api import SynthesisNotSuccessful
+from aeon.synthesis.api import SynthesisNotSuccessful, UnknownSynthesizerError
 from aeon.logger.logger import export_log
 from aeon.logger.logger import setup_logger
 from aeon.lsp.server import AeonLanguageServer
@@ -233,6 +233,16 @@ def synthesis_requested(argv: list[str] | None = None) -> bool:
     return False
 
 
+def validate_synthesizer_or_exit(name: str) -> None:
+    from aeon.synthesis.modules.synthesizerfactory import validate_synthesizer
+
+    try:
+        validate_synthesizer(name)
+    except UnknownSynthesizerError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(ExitCode.OTHER_ERROR)
+
+
 def format_location(err: AeonError) -> str:
     """Render an error's source span as ``file:line:col`` when positional
     information is available, otherwise fall back to ``str(location)``."""
@@ -342,6 +352,9 @@ def main() -> None:
     )
     driver = AeonDriver(cfg)
 
+    if synthesis_requested():
+        validate_synthesizer_or_exit(args.synthesizer)
+
     if hasattr(args, "language_server_mode"):
         aeon_lsp = AeonLanguageServer(driver)
         aeon_lsp.start(args.tcp)
@@ -413,6 +426,7 @@ def main() -> None:
                 case (True, _):
                     driver.pretty_print(args.filename, args.fix)
                 case (False, True):
+                    validate_synthesizer_or_exit(args.synthesizer)
                     try:
                         term = driver.synth()
                     except SynthesisNotSuccessful as e:

--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -221,6 +221,18 @@ def select_synthesis_ui() -> SynthesisUI:
     return TerminalUI()
 
 
+def synthesis_requested(argv: list[str] | None = None) -> bool:
+    """True when ``-s``/``--synthesizer`` or ``--budget`` was passed on the CLI."""
+    if argv is None:
+        argv = sys.argv[1:]
+    for arg in argv:
+        if arg in ("-s", "--synthesizer"):
+            return True
+        if arg == "--budget" or arg.startswith("--budget="):
+            return True
+    return False
+
+
 def format_location(err: AeonError) -> str:
     """Render an error's source span as ``file:line:col`` when positional
     information is available, otherwise fall back to ``str(location)``."""
@@ -394,6 +406,9 @@ def main() -> None:
                     sys.exit(0)
                 failures = driver.run_tests(seed=args.seed)
                 sys.exit(ExitCode.TESTS_FAILED_OR_CRASH if failures else ExitCode.SUCCESS)
+            if synthesis_requested() and not driver.has_synth():
+                print("No holes to synthesize.", file=sys.stderr)
+                sys.exit(ExitCode.SYNTHESIS_NOT_SUCCESSFUL)
             match (args.format, driver.has_synth()):
                 case (True, _):
                     driver.pretty_print(args.filename, args.fix)

--- a/aeon/backend/evaluator.py
+++ b/aeon/backend/evaluator.py
@@ -23,6 +23,10 @@ from aeon.llvm.core import LLVMPipeline
 real_eval = eval
 
 
+class HoleEvaluationError(Exception):
+    """Evaluation reached a synthesis hole in a context that rejects open holes."""
+
+
 class EvaluationContext:
     variables: dict[Name, Any]
     metadata: Metadata | None
@@ -38,6 +42,11 @@ class EvaluationContext:
     trace: list | None
     trace_stack: list | None
     contract_state: ContractState | None
+    # Only ``driver.run()`` sets this: compile-time refinement execution and other
+    # internal eval paths must never block on ``input()`` for open holes.
+    interactive_holes: bool
+    # Compile-time refinement execution and synthesis fitness evaluation reject holes.
+    reject_holes: bool
 
     def __init__(
         self,
@@ -47,6 +56,9 @@ class EvaluationContext:
         trace: list | None = None,
         trace_stack: list | None = None,
         contract_state: ContractState | None = None,
+        *,
+        interactive_holes: bool = False,
+        reject_holes: bool = False,
     ):
         if prev:
             self.variables = {k: v for (k, v) in prev.items()}
@@ -57,6 +69,8 @@ class EvaluationContext:
         self.trace = trace
         self.trace_stack = trace_stack
         self.contract_state = contract_state
+        self.interactive_holes = interactive_holes
+        self.reject_holes = reject_holes
 
     def with_var(self, name: Name, value: Any):
         assert isinstance(name, Name)
@@ -73,6 +87,8 @@ class EvaluationContext:
             trace=self.trace,
             trace_stack=self.trace_stack,
             contract_state=self.contract_state,
+            interactive_holes=self.interactive_holes,
+            reject_holes=self.reject_holes,
         )
 
     def get(self, name: Name):
@@ -273,15 +289,16 @@ def eval(t: Term, ctx: EvaluationContext = EvaluationContext()) -> Any:
                 )
             return value
         case Hole(name):
-            # Holes are filled by synthesis at the CLI. When stdin is not a TTY
-            # (e.g. the LSP uses it for JSON-RPC), prompting would block the
-            # server; refinement execution treats a failed hole eval as "skip".
-            if not sys.stdin.isatty():
-                raise ValueError(f"cannot evaluate hole {t} without a TTY")
-            args = ", ".join([str(n.name) for n in ctx.variables])
-            print(f"Context ({args})")
-            h = input(f"Enter value for hole {t} in Python: ")
-            return real_eval(h, {str(name): v for name, v in ctx.variables.items()})
+            if ctx.reject_holes:
+                raise HoleEvaluationError(f"cannot evaluate open hole {t}")
+            # Holes are filled by synthesis at the CLI. Only an explicit
+            # ``driver.run()`` with ``interactive_holes`` may ask on a TTY.
+            if ctx.interactive_holes and sys.stdin.isatty():
+                args = ", ".join([str(n.name) for n in ctx.variables])
+                print(f"Context ({args})")
+                h = input(f"Enter value for hole {t} in Python: ")
+                return real_eval(h, {str(name): v for name, v in ctx.variables.items()})
+            raise HoleEvaluationError(f"cannot evaluate open hole {t}")
 
         case TypeAbstraction(_, _, body):
             return eval(body, ctx)
@@ -310,6 +327,8 @@ def eval_with_trace(t: Term, ctx: EvaluationContext = EvaluationContext()) -> tu
         trace=sink,
         trace_stack=[],
         contract_state=ctx.contract_state,
+        interactive_holes=ctx.interactive_holes,
+        reject_holes=ctx.reject_holes,
     )
     value = eval(t, traced)
     return value, sink

--- a/aeon/compilation/compile.py
+++ b/aeon/compilation/compile.py
@@ -327,9 +327,25 @@ def compile_program(
         return _placeholder_unit(path, digest, dep_module_paths), elab_errors
 
     dep_list = [dep_units[m] for m in dep_module_paths if m in dep_units]
-    from aeon.verification.refinement_exec import execute_refinements_in_sterm
+    from aeon.backend.evaluator import HoleEvaluationError
+    from aeon.facade.api import RefinementExecutionHoleError
+    from aeon.utils.location import FileLocation
+    from aeon.verification.refinement_exec import execute_refinements_in_sterm, sterm_has_user_hole
 
-    sterm = execute_refinements_in_sterm(sterm, dep_list)
+    _loc = FileLocation(path, (0, 0), (0, 0))
+    if sterm_has_user_hole(sterm):
+        if not is_main:
+            return _placeholder_unit(path, digest, dep_module_paths), [
+                RefinementExecutionHoleError(
+                    "synthesis hole",
+                    loc=_loc,
+                )
+            ]
+    else:
+        try:
+            sterm = execute_refinements_in_sterm(sterm, dep_list)
+        except HoleEvaluationError as e:
+            return _placeholder_unit(path, digest, dep_module_paths), [RefinementExecutionHoleError(str(e), loc=_loc)]
 
     typing_ctx = lower_to_core_context(desugared.elabcontext)
     core_ast = lower_to_core(sterm)

--- a/aeon/facade/api.py
+++ b/aeon/facade/api.py
@@ -10,7 +10,7 @@ from aeon.sugar.program import ImportAe, STerm
 from aeon.sugar.stypes import SType
 from aeon.typechecking.context import TypingContext
 from aeon.sugar.program import Decorator
-from aeon.utils.location import Location
+from aeon.utils.location import Location, SynthesizedLocation
 from aeon.utils.name import Name
 from aeon.verification.vcs import Constraint
 from aeon.verification.helpers import pretty_print_constraint
@@ -142,6 +142,23 @@ class NonOrderableComparisonError(AeonError):
         return (
             f"Operator '{self.operator}' is not defined for type '{self.type_name}'; "
             f"ordered comparisons require Int, Float or String."
+        )
+
+    def position(self) -> Location:
+        return self.loc
+
+
+@dataclass
+class RefinementExecutionHoleError(AeonError):
+    """Compile-time refinement execution reached an open synthesis hole."""
+
+    hole: str
+    loc: Location = field(default_factory=lambda: SynthesizedLocation("refinement execution"))
+
+    def __str__(self) -> str:
+        return (
+            "Compile-time refinement execution cannot evaluate programs with open holes "
+            f"({self.hole}). Fill synthesis holes before running refinement execution."
         )
 
     def position(self) -> Location:

--- a/aeon/facade/driver.py
+++ b/aeon/facade/driver.py
@@ -126,6 +126,7 @@ class AeonDriver:
                 metadata=metadata,
                 pipeline=pipeline,
                 contract_state=contract_state,
+                reject_holes=True,
             )
 
         with RecordTime("LLVM compilation"):
@@ -135,7 +136,19 @@ class AeonDriver:
 
     def run(self) -> Any:
         with RecordTime("Evaluation"):
-            return eval(self.core, self.evaluation_ctx)
+            from aeon.backend.evaluator import EvaluationContext
+
+            run_ctx = EvaluationContext(
+                self.evaluation_ctx.variables,
+                metadata=self.evaluation_ctx.metadata,
+                pipeline=self.evaluation_ctx.pipeline,
+                trace=self.evaluation_ctx.trace,
+                trace_stack=self.evaluation_ctx.trace_stack,
+                contract_state=self.evaluation_ctx.contract_state,
+                interactive_holes=True,
+                reject_holes=False,
+            )
+            return eval(self.core, run_ctx)
 
     def trust_report(self, filename: str | None = None, for_func: str | None = None) -> str:
         """Render the program's trusted computing base — the axioms and refined

--- a/aeon/facade/exit_codes.py
+++ b/aeon/facade/exit_codes.py
@@ -28,6 +28,7 @@ from aeon.facade.api import (
     MethodResolutionError,
     ModuleNotFoundAeonError as AeonImportError,
     NonOrderableComparisonError,
+    RefinementExecutionHoleError,
     UndecidableRefinementError,
     UnificationFailedError,
     UnificationKindError,
@@ -82,6 +83,8 @@ def error_exit_code(err: AeonError) -> ExitCode:
             return ExitCode.NON_ORDERABLE_COMPARISON
         case UndecidableRefinementError():
             return ExitCode.UNDECIDABLE_REFINEMENT
+        case RefinementExecutionHoleError():
+            return ExitCode.INVALID_REFINEMENT
         case LinearityError():
             return ExitCode.LINEARITY_ERROR
         case CoreTypeCheckingError():

--- a/aeon/lsp/infoview.py
+++ b/aeon/lsp/infoview.py
@@ -622,14 +622,20 @@ def compute_info_view(
     synthesizers: list[SynthesizerInfo] = []
     if hole_name is not None and synthesizer_ids:
         from aeon.synthesis.modules.synthesizerfactory import (
+            is_known_synthesizer,
             sort_synthesizer_ids,
             synthesizer_family_label,
             synthesizer_label,
         )
 
+        for synthesizer_id in synthesizer_ids:
+            if not is_known_synthesizer(synthesizer_id):
+                error_infos.append(ErrorInfo(message=f"Unknown synthesizer: {synthesizer_id}"))
+
         synthesizers = [
             SynthesizerInfo(id=i, label=synthesizer_label(i), family=synthesizer_family_label(i))
             for i in sort_synthesizer_ids(synthesizer_ids)
+            if is_known_synthesizer(i)
         ]
 
     return InfoViewData(

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -52,7 +52,7 @@ from pygls.lsp.server import LanguageServer
 
 from aeon.facade.driver import AeonDriver
 
-from aeon.synthesis.modules.synthesizerfactory import sort_synthesizer_ids
+from aeon.synthesis.modules.synthesizerfactory import is_known_synthesizer, sort_synthesizer_ids
 from aeon.synthesis.modules.llm import llm_synthesizer_menu_ids
 
 SYNTHESIZERS = sort_synthesizer_ids(
@@ -388,6 +388,8 @@ class AeonLanguageServer(LanguageServer):
                 if not ls._ranges_overlap(hole.range, cursor_range):
                     continue
                 for synthesizer in SYNTHESIZERS:
+                    if not is_known_synthesizer(synthesizer):
+                        continue
                     label = synthesizer_label(synthesizer)
                     action = CodeAction(
                         title=f"Synthesize ?{hole.name} with {label}",
@@ -547,6 +549,7 @@ def _run_synthesis(
     """Blocking synthesis function, meant to run in a thread executor."""
     from . import aeon_adapter
     from aeon.synthesis.entrypoint import synthesize_holes
+    from aeon.synthesis.api import UnknownSynthesizerError
     from aeon.synthesis.modules.synthesizerfactory import make_synthesizer
     from aeon.lsp.synthesis_ui import LSPProgressUI
     from aeon.lsp.z3_errors import z3_synthesis_message
@@ -609,10 +612,8 @@ def _run_synthesis(
 
     try:
         synthesizer = make_synthesizer(synthesizer_name)
-    except AssertionError:
-        ls.window_show_message(
-            ShowMessageParams(type=MessageType.Error, message=f"Unknown synthesizer: {synthesizer_name}")
-        )
+    except UnknownSynthesizerError as e:
+        ls.window_show_message(ShowMessageParams(type=MessageType.Error, message=str(e)))
         return None
 
     try:

--- a/aeon/synthesis/api.py
+++ b/aeon/synthesis/api.py
@@ -23,6 +23,14 @@ class SynthesisNotSuccessful(SynthesisError):
     pass
 
 
+class UnknownSynthesizerError(SynthesisError):
+    """Raised when ``-s``/``--synthesizer`` names a backend that does not exist."""
+
+    def __init__(self, synthesizer_id: str):
+        self.synthesizer_id = synthesizer_id
+        super().__init__(f"Unknown synthesizer: {synthesizer_id}")
+
+
 class TimeoutInEvaluationException(SynthesisError):
     pass
 

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -97,6 +97,7 @@ def _ectx_for_workers(ectx: EvaluationContext) -> EvaluationContext:
         pipeline=None,
         trace=ectx.trace,
         trace_stack=ectx.trace_stack,
+        reject_holes=True,
     )
 
 

--- a/aeon/synthesis/grammar/utils.py
+++ b/aeon/synthesis/grammar/utils.py
@@ -22,6 +22,22 @@ internal_functions: list[str] = []
 
 text_to_aeon_prelude_ops: dict[str, str] = {v: k for k, v in aeon_prelude_ops_to_text.items()}
 
+
+def _prelude_binding_names() -> frozenset[str]:
+    from aeon.prelude.prelude import typing_vars
+
+    return frozenset(n.name for n in typing_vars)
+
+
+# Prelude operators and internal names tactics must not treat as hypotheses or
+# call targets (``==`` is not a Boolean scrutinee; ``$`` is not a user value).
+TACTIC_CONTEXT_EXCLUDED_NAMES: frozenset[str] = (
+    SYNTHESIS_EXCLUDED_NAMES
+    | _prelude_binding_names()
+    | frozenset(aeon_prelude_ops_to_text.keys())
+    | frozenset(text_to_aeon_prelude_ops.keys())
+)
+
 grammar_base_types: list[str] = ["t_Float", "t_Int", "t_String", "t_Bool"]
 
 aeon_to_python_types: dict[str, TypingType] = {"Int": int, "Bool": bool, "String": str, "Float": float}

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 import os
 
-from aeon.synthesis.api import ProgramSynthesizer, Synthesizer
+from aeon.synthesis.api import ProgramSynthesizer, Synthesizer, UnknownSynthesizerError
 from aeon.synthesis.grammar.ge_synthesis import GESynthesizer
 from aeon.synthesis.grammar.genomic_ng import GenomicNGSynthesizer
 from aeon.synthesis.modules.float_ng import FloatHoleNGSynthesizer
@@ -135,6 +135,53 @@ SYNTHESIZER_FAMILIES: dict[str, SynthesizerFamily] = {
     LLM_OPENAI_SYNTHESIZER_ID: SynthesizerFamily.LLM_ASSISTED,
 }
 
+_BUILTIN_SYNTHESIZER_IDS = frozenset(
+    {
+        "random_search",
+        "enumerative",
+        "gp",
+        "1p1",
+        "hc",
+        "genomic_ng",
+        "ng",
+        "ng_cma",
+        "ng_de",
+        "ng_pso",
+        "ng_float",
+        "float_ng",
+        "ng_float_cma",
+        "ortools",
+        "ortools_int",
+        "cpsat",
+        "synquid",
+        "decision_tree",
+        "smt",
+        "sygus",
+        "tdsyn",
+        "tdsyn_enumerative",
+        "tdsyn_random",
+        "tactics",
+        "lta",
+        "symetric",
+        "xfta",
+        "fta",
+        "afta",
+        "cata",
+        "contata",
+    }
+)
+
+
+def is_known_synthesizer(module: str) -> bool:
+    """Whether ``module`` is a valid ``-s``/``--synthesizer`` backend id."""
+    return module in _BUILTIN_SYNTHESIZER_IDS or module in LLM_OLLAMA_MODELS
+
+
+def validate_synthesizer(module: str) -> None:
+    """Raise :class:`UnknownSynthesizerError` when ``module`` is not a known backend."""
+    if not is_known_synthesizer(module):
+        raise UnknownSynthesizerError(module)
+
 
 def synthesizer_label(module: str) -> str:
     """A readable display name for synthesizer id ``module`` (falls back to the
@@ -163,6 +210,7 @@ def sort_synthesizer_ids(ids: list[str]) -> list[str]:
 
 
 def make_synthesizer(module: str) -> Synthesizer | ProgramSynthesizer:
+    validate_synthesizer(module)
     # The random seed for stochastic backends is taken from the AEON_SEED
     # environment variable (default 0), so experiments can vary it across runs
     # (e.g. multi-seed benchmarks) without a dedicated CLI flag.
@@ -222,4 +270,4 @@ def make_synthesizer(module: str) -> Synthesizer | ProgramSynthesizer:
         case "contata":
             return ContataSynthesizer()
         case _:
-            assert False, f"Not supported synthesizer with name {module}"
+            raise UnknownSynthesizerError(module)

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -13,6 +13,7 @@ from aeon.synthesis.modules.llm import (
     LLM_OLLAMA_MODELS,
     LLM_OPENAI_SYNTHESIZER_ID,
     LLMSynthesizer,
+    is_llm_synthesizer,
     llm_synthesizer_label,
     resolve_llm_backend,
 )
@@ -174,7 +175,7 @@ _BUILTIN_SYNTHESIZER_IDS = frozenset(
 
 def is_known_synthesizer(module: str) -> bool:
     """Whether ``module`` is a valid ``-s``/``--synthesizer`` backend id."""
-    return module in _BUILTIN_SYNTHESIZER_IDS or module in LLM_OLLAMA_MODELS
+    return module in _BUILTIN_SYNTHESIZER_IDS or is_llm_synthesizer(module)
 
 
 def validate_synthesizer(module: str) -> None:

--- a/aeon/synthesis/tactics/assumption.py
+++ b/aeon/synthesis/tactics/assumption.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from aeon.core.terms import Var
-from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
+from aeon.synthesis.grammar.utils import TACTIC_CONTEXT_EXCLUDED_NAMES
 from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole
 from aeon.synthesis.tactics.state import TacticState
 from aeon.synthesis.tactics.subtyping import fits
@@ -24,7 +24,7 @@ def tactic_assumption(state: TacticState, hole_name: Name) -> TacticState | None
     goal_ty, hole_ctx = holes[hole_name]
 
     for x, xty in hole_ctx.concrete_vars():
-        if x.name in SYNTHESIS_EXCLUDED_NAMES:
+        if x.name in TACTIC_CONTEXT_EXCLUDED_NAMES:
             continue
         if fits(hole_ctx, xty, goal_ty) and fits(hole_ctx, goal_ty, xty):
             return TacticState(state.ctx, replace_hole(state.term, hole_name, Var(x, _loc)), state.goal)

--- a/aeon/synthesis/tactics/builtin.py
+++ b/aeon/synthesis/tactics/builtin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from aeon.core.substitutions import substitution_in_type
 from aeon.core.terms import Abstraction, Annotation, Application, Hole, Term, Var
 from aeon.core.types import AbstractionType, Type
-from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
+from aeon.synthesis.grammar.utils import TACTIC_CONTEXT_EXCLUDED_NAMES
 from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole
 from aeon.synthesis.tactics.state import TacticState
 from aeon.synthesis.tactics.subtyping import fits
@@ -29,7 +29,7 @@ def tactic_apply_question(state: TacticState, hole_name: Name) -> TacticState | 
         return None
     goal_ty, hole_ctx = holes[hole_name]
     for x, xty in hole_ctx.concrete_vars():
-        if x.name in SYNTHESIS_EXCLUDED_NAMES:
+        if x.name in TACTIC_CONTEXT_EXCLUDED_NAMES:
             continue
         if fits(hole_ctx, xty, goal_ty):
             return TacticState(state.ctx, replace_hole(state.term, hole_name, Var(x, _loc)), state.goal)
@@ -53,7 +53,7 @@ def tactic_constructor(state: TacticState, hole_name: Name) -> TacticState | Non
             return TacticState(state.ctx, replace_hole(state.term, hole_name, lam), state.goal)
 
     for f, fty in hole_ctx.concrete_vars():
-        if f.name in SYNTHESIS_EXCLUDED_NAMES:
+        if f.name in TACTIC_CONTEXT_EXCLUDED_NAMES:
             continue
         params, ret = _split_arrow_spine(fty)
         if not params:

--- a/aeon/synthesis/tactics/by_cases.py
+++ b/aeon/synthesis/tactics/by_cases.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from aeon.core.terms import Annotation, Hole, If, Term, Var
 from aeon.core.types import Type, t_bool
-from aeon.synthesis.grammar.utils import SYNTHESIS_EXCLUDED_NAMES
+from aeon.synthesis.grammar.utils import TACTIC_CONTEXT_EXCLUDED_NAMES
 from aeon.synthesis.tactics.holes import collect_hole_judgments, replace_hole
 from aeon.synthesis.tactics.state import TacticState
 from aeon.synthesis.tactics.subtyping import fits
@@ -25,7 +25,7 @@ def tactic_by_cases(state: TacticState, hole_name: Name) -> TacticState | None:
     goal_ty, hole_ctx = holes[hole_name]
 
     for b, bty in hole_ctx.concrete_vars():
-        if b.name in SYNTHESIS_EXCLUDED_NAMES:
+        if b.name in TACTIC_CONTEXT_EXCLUDED_NAMES:
             continue
         if not fits(hole_ctx, bty, t_bool):
             continue

--- a/aeon/synthesis/tactics/choose_literal.py
+++ b/aeon/synthesis/tactics/choose_literal.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from aeon.core.liquid import LiquidLiteralBool
-from aeon.core.terms import Literal, Term
+from aeon.core.terms import Annotation, Literal, Term
 from aeon.core.types import RefinedType, Type, TypeConstructor, t_bool, t_float, t_int
 from aeon.synthesis.modules.tdsyn.helpers import base_type_of
 from aeon.synthesis.modules.tdsyn.smt_solve import solve_literals
@@ -65,5 +65,11 @@ def tactic_choose_literal(state: TacticState, hole_name: Name) -> TacticState | 
         lit = _default_literal(base)
         if lit is None:
             return None
+
+    # Drop ascribed refinements peeled by ``split`` so final ``validate`` checks the
+    # root goal, not an intermediate annotation.
+    match lit:
+        case Annotation(expr=e, type=_):
+            lit = e
 
     return TacticState(state.ctx, replace_hole(state.term, hole_name, lit), state.goal)

--- a/aeon/synthesis/tactics/inst.py
+++ b/aeon/synthesis/tactics/inst.py
@@ -40,7 +40,7 @@ def tactic_inst(state: TacticState, hole_name: Name) -> TacticState | None:
             continue
         inst_ty = type_substitution(pbody, pname, tau)
         hn = Name("_ti", fresh_counter.fresh())
-        inner: Term = Annotation(Hole(hn, loc=_loc), goal_ty, loc=_loc)
+        inner: Term = Annotation(Hole(hn, loc=_loc), inst_ty, loc=_loc)
         wrapped = TypeApplication(inner, tau, loc=_loc)
         new_term = replace_focal_hole(state.term, hole_name, wrapped)
         new_goal = inst_ty if goal_ty == state.goal else state.goal

--- a/aeon/verification/refinement_exec.py
+++ b/aeon/verification/refinement_exec.py
@@ -16,7 +16,7 @@ Example::
 
 from __future__ import annotations
 
-from aeon.backend.evaluator import EvaluationContext, eval
+from aeon.backend.evaluator import EvaluationContext, HoleEvaluationError, eval
 from aeon.compilation.link import link_rec_spines
 from aeon.compilation.unit import CompiledUnit
 from aeon.core.terms import Rec, Term
@@ -27,6 +27,7 @@ from aeon.sugar.program import (
     SAbstraction,
     SAnnotation,
     SApplication,
+    SHole,
     SIf,
     SLet,
     SLiteral,
@@ -47,6 +48,39 @@ from aeon.sugar.stypes import (
     STypePolymorphism,
 )
 from aeon.utils.name import Name
+
+
+def _refinement_eval_context() -> EvaluationContext:
+    return EvaluationContext(evaluation_vars, reject_holes=True)
+
+
+def sterm_has_user_hole(term: STerm) -> bool:
+    """True when the program still contains a synthesis hole other than ``?main``."""
+    match term:
+        case SHole(name):
+            return name.name != "main"
+        case SApplication(fun, arg, _):
+            return sterm_has_user_hole(fun) or sterm_has_user_hole(arg)
+        case SAbstraction(_, body, _):
+            return sterm_has_user_hole(body)
+        case SLet(_, var_value, body, _, _):
+            return sterm_has_user_hole(var_value) or sterm_has_user_hole(body)
+        case SRec(_, _, var_value, body, _, _, _, _, _):
+            return sterm_has_user_hole(var_value) or sterm_has_user_hole(body)
+        case SIf(cond, then, otherwise, _):
+            return sterm_has_user_hole(cond) or sterm_has_user_hole(then) or sterm_has_user_hole(otherwise)
+        case SAnnotation(expr, _, _):
+            return sterm_has_user_hole(expr)
+        case STypeApplication(expr, _, _):
+            return sterm_has_user_hole(expr)
+        case SRefinementApplication(body, refinement, _):
+            return sterm_has_user_hole(body) or sterm_has_user_hole(refinement)
+        case STypeAbstraction(_, _, body):
+            return sterm_has_user_hole(body)
+        case SRefinementAbstraction(_, _, body):
+            return sterm_has_user_hole(body)
+        case _:
+            return False
 
 
 def sterm_free_vars(term: STerm, *, bound: frozenset[Name] = frozenset()) -> set[Name]:
@@ -118,7 +152,9 @@ def _try_execute_subexpr(
     try:
         ref_core = lower_to_core(term)
         linked = _eval_context_for_refinement(ref_core, program_sterm, dependency_units)
-        result = eval(linked, EvaluationContext(evaluation_vars))
+        result = eval(linked, _refinement_eval_context())
+    except HoleEvaluationError:
+        return None
     except Exception:
         return None
     return _sterm_from_runtime_value(result)
@@ -232,7 +268,9 @@ def try_execute_refinement(
     try:
         ref_core = lower_to_core(ref)
         linked = _eval_context_for_refinement(ref_core, program_sterm, dependency_units)
-        result = eval(linked, EvaluationContext(evaluation_vars))
+        result = eval(linked, _refinement_eval_context())
+    except HoleEvaluationError:
+        return None
     except Exception:
         return None
     if isinstance(result, bool):
@@ -288,6 +326,8 @@ def execute_refinements_in_sterm(
     term: STerm,
     dependency_units: list[CompiledUnit],
 ) -> STerm:
+    if sterm_has_user_hole(term):
+        raise HoleEvaluationError("compile-time refinement execution cannot run on programs with open synthesis holes")
     return _execute_refinements_in_sterm(term, term, dependency_units)
 
 

--- a/examples/demos/4_errorcode.ae
+++ b/examples/demos/4_errorcode.ae
@@ -1,2 +1,2 @@
 @prompt("HTTP Error code for not found, plus 200")
-def not_found : {v:Int | v >= 100 && v <= 599} := ?hole;
+def not_found : {v:Int | v >= 100 && v <= 599} := ?sorry;

--- a/examples/tactics/01_choose_literal.ae
+++ b/examples/tactics/01_choose_literal.ae
@@ -1,0 +1,5 @@
+# Tactic: choose_literal — fill a base-type hole with a Z3 model (or 0 / true / 0.0).
+#
+#   uv run python -m aeon --no-main examples/tactics/01_choose_literal.ae
+
+def target : Int := by choose_literal

--- a/examples/tactics/02_choose_literal_refined.ae
+++ b/examples/tactics/02_choose_literal_refined.ae
@@ -1,0 +1,5 @@
+# Tactic: choose_literal — same tactic on a refined Int (Z3 finds a witness).
+#
+#   uv run python -m aeon --no-main examples/tactics/02_choose_literal_refined.ae
+
+def target : {z:Int | z > 2} := by choose_literal

--- a/examples/tactics/03_assumption.ae
+++ b/examples/tactics/03_assumption.ae
@@ -1,0 +1,5 @@
+# Tactic: assumption — close the goal with a hypothesis of the same (liquid) type.
+#
+#   uv run python -m aeon --no-main examples/tactics/03_assumption.ae
+
+def target (x:{v:Int | v > 0}) : {w:Int | w > 0} := by assumption

--- a/examples/tactics/04_apply.ae
+++ b/examples/tactics/04_apply.ae
@@ -1,0 +1,5 @@
+# Tactic: apply? — use a hypothesis whose type is a subtype of the goal.
+#
+#   uv run python -m aeon --no-main examples/tactics/04_apply.ae
+
+def target (x:{v:Int | v > 0}) : Int := by apply?

--- a/examples/tactics/05_constructor_intro.ae
+++ b/examples/tactics/05_constructor_intro.ae
@@ -1,0 +1,9 @@
+# Tactic: constructor — function-type introduction (lambda with a fresh body hole),
+# then apply the custom `Box` constructor on the body.
+#
+#   uv run python -m aeon --no-main examples/tactics/05_constructor_intro.ae
+
+inductive Box
+| mk (value:Int) : Box
+
+def target : (x:Int) -> Box := by (constructor; constructor; choose_literal)

--- a/examples/tactics/06_constructor_apply.ae
+++ b/examples/tactics/06_constructor_apply.ae
@@ -1,0 +1,9 @@
+# Tactic: constructor — apply the `mk` constructor of a custom type, leaving a
+# hole for the `Int` field that `choose_literal` fills.
+#
+#   uv run python -m aeon --no-main examples/tactics/06_constructor_apply.ae
+
+inductive Box
+| mk (value:Int) : Box
+
+def target : Box := by (constructor; choose_literal)

--- a/examples/tactics/07_inst.ae
+++ b/examples/tactics/07_inst.ae
@@ -1,0 +1,5 @@
+# Tactic: inst — instantiate a polymorphic goal (forall a:B, a) with a concrete type.
+#
+#   uv run python -m aeon --no-main examples/tactics/07_inst.ae
+
+def target : forall a:B, a := by (inst; choose_literal)

--- a/examples/tactics/08_split.ae
+++ b/examples/tactics/08_split.ae
@@ -1,0 +1,5 @@
+# Tactic: split — peel a top-level && in the goal refinement, then solve the rest.
+#
+#   uv run python -m aeon --no-main examples/tactics/08_split.ae
+
+def target : {z:Int | z > 0 && z < 10} := by (split; choose_literal)

--- a/examples/tactics/09_by_cases.ae
+++ b/examples/tactics/09_by_cases.ae
@@ -1,0 +1,5 @@
+# Tactic: by_cases — case-split on a Bool hypothesis, then close each branch.
+#
+#   uv run python -m aeon --no-main examples/tactics/09_by_cases.ae
+
+def target (b:Bool) : Int := by (by_cases; choose_literal; choose_literal)

--- a/examples/tactics/10_pipeline.ae
+++ b/examples/tactics/10_pipeline.ae
@@ -1,0 +1,7 @@
+# Combined script: apply? then constructor on the result spine.
+#
+#   uv run python -m aeon --no-main examples/tactics/10_pipeline.ae
+
+def add_one (x:Int) : Int := x + 1
+
+def target (x:{v:Int | v > 0}) : Int := by (apply?; constructor; choose_literal)

--- a/examples/talk/00_basic_synthesis.ae
+++ b/examples/talk/00_basic_synthesis.ae
@@ -1,0 +1,5 @@
+# Basic Synthesis problem. Return an integer.
+
+def fun (x:Int) (y:Int) : Int := ?hole
+# GP
+# GS - R+E

--- a/examples/talk/01_example.ae
+++ b/examples/talk/01_example.ae
@@ -1,0 +1,8 @@
+# Basic Synthesis problem. Return an integer.
+
+@example(f 1 3 = 4)
+@example(f 5 6 = 11)
+def f (x:Int) (y:Int) : Int := ?hole
+
+# DT
+# SMT

--- a/examples/talk/01_multiple_examples.ae
+++ b/examples/talk/01_multiple_examples.ae
@@ -1,0 +1,7 @@
+# Last-mile logistics: learn shipping cost from historical weight (kg) and distance (km) rows.
+#
+#   uv run python -m aeon --no-main -s decision_tree --budget 20 talk/03_csv.ae
+#   uv run python -m aeon --no-main -s gp --budget 20 talk/03_csv.ae
+
+@csv_data("1.0,10.0,14.0\n2.0,10.0,16.0\n1.0,50.0,22.0\n5.0,100.0,40.0")
+def shipping_cost (weight:Float) (distance:Float) : Float := ?hole

--- a/examples/talk/02_refinements.ae
+++ b/examples/talk/02_refinements.ae
@@ -1,0 +1,4 @@
+def f (x:Int) (y:Int) : {r:Int|r > x} := ?hole
+
+# SyGuS
+# Synquid

--- a/examples/talk/03_polymorphism.ae
+++ b/examples/talk/03_polymorphism.ae
@@ -1,0 +1,7 @@
+import List
+
+def f (x:a) (y:(List a)) : {r:(List a) | List.size r <= List.size y } :=
+    ?hole
+
+# Synquid
+#let k : {k:Int | k = 1} := 1 in

--- a/examples/talk/04_refinements_and_examples.ae
+++ b/examples/talk/04_refinements_and_examples.ae
@@ -1,0 +1,60 @@
+# CRM data cleanup: extract the three-digit US area code from a formatted phone number.
+#
+#   uv run python -m aeon --test talk/04_refinements_and_examples.ae
+#   uv run python -m aeon --no-main -s afta --budget 30 talk/04_refinements_and_examples.ae
+#   uv run python -m aeon --no-main -s gp --budget 15 talk/04_refinements_and_examples.ae
+
+open String
+
+@example(area_code "938-242-504" = "938")
+@example(area_code "308-916-545" = "308")
+@example(area_code "623-599-749" = "623")
+def area_code (phone:{x:String | String_len x > 3}) : {r:String | String_len r = 3} :=
+    ?hole
+
+
+
+# Finite Tree Automata - FTA
+# Key idea: reuse intermediate results.
+
+# x             [1,2,3]
+# y             [4,3,2]
+
+# x+y           [5,5,5]
+# x-y           [-3, -1, 1]
+
+
+# Target!!!    ["938", "308", "623"]
+
+# phone                             ["938-242-504", "308-916-545", "623-599-749"]
+# String.concat phone "3"           ["938-242-5043", "308-916-5453", "623-599-7493"]
+# ...
+# String.slice 0 3                  ["938", "308", "623"]
+
+
+
+
+
+
+
+# Abstract-Refinement FTA
+
+# Target!!!    [3, 3, 3]
+
+# "hello"                           [5,5,5]
+# String.concat "hello" x           [16,16,16]
+# ...
+# String.slice x 0 3                [3,3,3]
+
+
+
+
+
+# Liquid Tree Automata
+
+# Target!!!    {r:String | String_len r = 3}
+
+# "hello"                           {r:String | String_len r == 5}
+# String.concat "hello" x           {r:String | String_len r == 5 + String_len x}
+# ...
+# String.slice x 0 3                {r:String | String_len r == 3}

--- a/examples/talk/05_mutual_examples.ae
+++ b/examples/talk/05_mutual_examples.ae
@@ -1,0 +1,25 @@
+# SRE on-call: two teams alternate weekly primary pager duty from a week counter.
+#
+#   uv run python -m aeon --no-main -s contata --budget 20 examples/talk/05_mutual_examples.ae
+
+mutual
+  @example(team_a_on_call 0 = true)
+  @example(team_a_on_call 1 = false)
+  @example(team_a_on_call 2 = true)
+  @example(team_a_on_call 3 = false)
+  def team_a_on_call (week: {w:Int | w >= 0}) : Bool decreasing_by [week] := ?ha
+
+  @example(team_b_on_call 0 = false)
+  @example(team_b_on_call 1 = true)
+  @example(team_b_on_call 2 = false)
+  @example(team_b_on_call 3 = true)
+  def team_b_on_call (week: {w:Int | w >= 0}) : Bool decreasing_by [week] := ?hb
+end
+
+
+
+
+# Constraint-Annotated Tree Automata (CATA)
+
+# Similar to Liquid Tree Automata, but supports recursion and logical if statements.
+# CATA focus more on the relation between input and output. LTA focus on composing existing functions, in a type-safe manner.

--- a/examples/talk/06_minimize.ae
+++ b/examples/talk/06_minimize.ae
@@ -1,0 +1,8 @@
+# Procurement: a bakery needs 25 croissants; cases hold 12 — order the fewest full cases.
+#
+#   uv run python -m aeon --no-main -s smt --budget 15 talk/04_minimize.ae
+#   uv run python -m aeon --no-main -s ortools --budget 15 talk/04_minimize.ae
+#   uv run python -m aeon --no-main -s gp --budget 15 talk/04_minimize.ae
+
+@minimize_int(cases_to_order)
+def cases_to_order : {c:Int | c > 0 && c * 12 >= 25} := ?hole

--- a/examples/talk/08_prompt.ae
+++ b/examples/talk/08_prompt.ae
@@ -1,0 +1,7 @@
+# Infrastructure config: fill in the standard TCP port assigned to HTTPS (IANA).
+#
+#   uv run python -m aeon --no-main -s llm --budget 30 talk/05_prompt.ae
+#   uv run python -m aeon --no-main -s llm_deepseek-coder-6.7b --budget 30 talk/05_prompt.ae
+
+@prompt("Default TCP port used by HTTPS servers (IANA-assigned).")
+def https_port : {p:Int | p > 0 && p < 65536} := ?hole

--- a/tests/exit_codes_test.py
+++ b/tests/exit_codes_test.py
@@ -98,6 +98,20 @@ def test_cli_synthesis_requested_no_holes(tmp_path):
     assert "No holes to synthesize." in r.stderr
 
 
+def test_cli_unknown_synthesizer(tmp_path):
+    f = tmp_path / "prog.ae"
+    f.write_text("def main (x:Int) : Unit := print 42;\n")
+    r = subprocess.run(
+        [sys.executable, "-m", "aeon", "--no-main", "-s", "not_a_real_synthesizer", str(f)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=240,
+    )
+    assert r.returncode == ExitCode.OTHER_ERROR
+    assert "Unknown synthesizer: not_a_real_synthesizer" in r.stderr
+
+
 def test_cli_syntax_error(tmp_path):
     r = run_aeon(tmp_path, "def main (x:Int) : Unit := print (1 +;\n")
     assert r.returncode == ExitCode.SYNTAX_ERROR

--- a/tests/exit_codes_test.py
+++ b/tests/exit_codes_test.py
@@ -27,6 +27,7 @@ from aeon.facade.api import (
     UnificationUnknownTypeError,
 )
 from aeon.facade.exit_codes import ExitCode, error_exit_code
+from aeon.__main__ import synthesis_requested
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -62,11 +63,14 @@ def test_error_exit_code_mapping(cls, expected):
 # --- End to end: the CLI process exit status ---------------------------------
 
 
-def run_aeon(tmp_path: Path, source: str) -> subprocess.CompletedProcess:
+def run_aeon(tmp_path: Path, source: str, *, synthesis: bool = True) -> subprocess.CompletedProcess:
     f = tmp_path / "prog.ae"
     f.write_text(source)
+    cmd = [sys.executable, "-m", "aeon", "--no-main", str(f)]
+    if synthesis:
+        cmd.extend(["--budget", "1"])
     return subprocess.run(
-        [sys.executable, "-m", "aeon", "--no-main", "--budget", "1", str(f)],
+        cmd,
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -74,9 +78,24 @@ def run_aeon(tmp_path: Path, source: str) -> subprocess.CompletedProcess:
     )
 
 
+def test_synthesis_requested_detects_flags():
+    assert synthesis_requested(["file.ae", "-s", "gp"])
+    assert synthesis_requested(["file.ae", "--synthesizer", "gp"])
+    assert synthesis_requested(["file.ae", "--budget", "10"])
+    assert synthesis_requested(["file.ae", "--budget=10"])
+    assert not synthesis_requested(["file.ae", "--no-main"])
+    assert not synthesis_requested(["file.ae"])
+
+
 def test_cli_success_exits_zero(tmp_path):
-    r = run_aeon(tmp_path, "def main (x:Int) : Unit := print 42;\n")
+    r = run_aeon(tmp_path, "def main (x:Int) : Unit := print 42;\n", synthesis=False)
     assert r.returncode == ExitCode.SUCCESS, r.stderr
+
+
+def test_cli_synthesis_requested_no_holes(tmp_path):
+    r = run_aeon(tmp_path, "def main (x:Int) : Unit := print 42;\n")
+    assert r.returncode == ExitCode.SYNTHESIS_NOT_SUCCESSFUL
+    assert "No holes to synthesize." in r.stderr
 
 
 def test_cli_syntax_error(tmp_path):

--- a/tests/lsp_infoview_test.py
+++ b/tests/lsp_infoview_test.py
@@ -367,6 +367,18 @@ def test_synthesizers_absent_when_not_on_hole():
     assert info.synthesizers == []
 
 
+def test_unknown_synthesizer_reported_in_infoview():
+    info = info_at_with_synth(
+        HOLE_SRC,
+        2,
+        col_of(HOLE_SRC, 2, "?h") + 1,
+        ["gp", "not_a_real_synthesizer"],
+    )
+    assert info.hole == "h"
+    assert [s.id for s in info.synthesizers] == ["gp"]
+    assert any("Unknown synthesizer: not_a_real_synthesizer" in e.message for e in info.errors)
+
+
 def test_graceful_without_analysis_state():
     info = compute_info_view(SRC, 2, 5, None, None, None)
     assert info.target is None

--- a/tests/refinement_exec_test.py
+++ b/tests/refinement_exec_test.py
@@ -15,6 +15,8 @@ from aeon.verification.refinement_exec import (
     execute_refinements_in_stype,
     sterm_free_vars,
 )
+from aeon.backend.evaluator import HoleEvaluationError
+import pytest
 
 
 def _parse_ok(src: str):
@@ -66,6 +68,32 @@ def test_parse_with_hole_does_not_block_when_stdin_is_not_tty():
     )
     assert proc.returncode == 0, proc.stderr
     assert "errors 0" in proc.stdout
+
+
+def test_parse_minimize_with_hole_skips_refinement_exec_and_does_not_prompt():
+    """Main programs with synthesis holes defer compile-time refinement execution."""
+    import sys
+    import unittest.mock as mock
+
+    src = """@minimize_int(cases_to_order)
+def cases_to_order : {c:Int | c > 0 && c * 12 >= 25} := ?hole
+"""
+    with mock.patch.object(sys.stdin, "isatty", return_value=True):
+        assert _parse_ok(src) == []
+
+
+def test_execute_refinements_raises_on_hole_program():
+    src = """@minimize_int(cases_to_order)
+def cases_to_order : {c:Int | c > 0 && c * 12 >= 25} := ?hole
+"""
+    from aeon.sugar.bind import bind_program
+    from aeon.sugar.desugar import desugar
+    from aeon.sugar.parser import parse_main_program
+
+    prog = bind_program(parse_main_program(src, "<t>"), [])
+    desugared = desugar(prog, is_main_hole=False)
+    with pytest.raises(HoleEvaluationError):
+        execute_refinements_in_sterm(desugared.program, [])
 
 
 def test_sterm_free_vars_ignores_binder():

--- a/tests/synthesizer_families_test.py
+++ b/tests/synthesizer_families_test.py
@@ -2,18 +2,29 @@
 
 from __future__ import annotations
 
+import pytest
+
 from aeon.lsp.server import SYNTHESIZERS
 from aeon.synthesis.modules.synthesizerfactory import (
     SYNTHESIZER_FAMILY_ORDER,
     SynthesizerFamily,
+    is_known_synthesizer,
     sort_synthesizer_ids,
     synthesizer_family,
+    validate_synthesizer,
 )
+from aeon.synthesis.api import UnknownSynthesizerError
 
 
 def test_every_lsp_synthesizer_has_a_family():
     for module in SYNTHESIZERS:
+        assert is_known_synthesizer(module)
         assert synthesizer_family(module) in SYNTHESIZER_FAMILY_ORDER
+
+
+def test_unknown_synthesizer_raises():
+    with pytest.raises(UnknownSynthesizerError, match="Unknown synthesizer: no_such_backend"):
+        validate_synthesizer("no_such_backend")
 
 
 def test_sort_groups_by_family_then_label():


### PR DESCRIPTION
## Summary

- Reject open synthesis holes during compile-time refinement execution and synthesis fitness evaluation (`reject_holes=True`), raising `HoleEvaluationError` instead of blocking on `input()` when stdin is a TTY.
- Keep interactive `driver.run()` behavior unchanged: TTY hole prompting only when `interactive_holes=True`.
- Main synthesis programs with holes skip the refinement-exec pass at compile time so synthesis can start; non-main modules with holes report `RefinementExecutionHoleError`.
- Add tactic example programs under `examples/tactics/` and small tactic fixes (`inst`, `choose_literal`, context variable filtering).
- Include related CLI/LSP fixes: require synthesis when `-s`/`--budget` is passed, validate synthesizer names before synthesis, and add talk examples.

## Test plan

- [x] `uv run pytest tests/refinement_exec_test.py -q` (13 passed)
- [x] `uv run pytest tests/refinement_exec_test.py tests/end_to_end_test.py -q` (25 passed)
- [x] `uv run python -m aeon examples/talk/06_minimize.ae --budget 2 -s gp` synthesizes without prompting on a TTY
- [ ] Full test suite (`uv run pytest`)


Made with [Cursor](https://cursor.com)