### PR TITLE
chore(deps): pin and upgrade core dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         additional_dependencies:
           - types-requests
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,27 +21,24 @@ classifiers = [
 scripts.aeon = "aeon.__main__:main"
 
 dependencies = [
-    'argparse',
-    'configparser',
-    'lark',
+    'lark==1.3.1',
     'loguru',
     'geneticengine==0.8.10',
-    'multiprocess',
-    'numpy',
+    'multiprocess==0.70.19',
+    'numpy==2.2.6',
     'ollama',
-    'pathos',
+    'pathos==0.3.5',
     'pillow',
     'psb2',
     'pydantic==2.13.4',
     'pygls==2.1.1',
-    'pytest',
     'requests',
     'types-requests',
     'scikit-image',
     'sympy',
     'textdistance',
     'cvc5 >= 1.1',
-    'z3-solver >= 4',
+    'z3-solver==5.0.0.0',
     'zstandard==0.25.0',
     'zss',
     "llvmlite",
@@ -49,7 +46,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-    "pytest",
+    "pytest==9.1.1",
     "pytest-beartype"
 ]
 synthesis-ng = [
@@ -159,3 +156,12 @@ max-complexity = 10
 
 [tool.pytest.ini_options]
 beartype_packages = 'aeon.core'
+
+[tool.uv]
+override-dependencies = [
+    "dill==0.4.1",
+    "lark==1.3.1",
+    "pathos==0.3.5",
+    "pytest==9.1.1",
+    "z3-solver==5.0.0.0",
+]


### PR DESCRIPTION
## Summary
- **Task 1:** Pin and upgrade low-risk core deps — `lark==1.3.1`, `multiprocess==0.70.19`, `pathos==0.3.5`, `z3-solver==5.0.0.0`
- **Task 2:** Remove stdlib backports (`argparse`, `configparser`), move `pytest` to the `[tests]` extra, bump ruff pre-commit hook to `v0.16.1`
- **Task 3:** Pin `pytest==9.1.1` and `numpy==2.2.6` (see notes below)

`geneticengine==0.8.10` pins several transitive deps (`dill`, `lark`, `numpy`, `pathos`, `pytest`, `z3-solver`). Added `[tool.uv] override-dependencies` so the upgraded versions resolve cleanly.

**Note on numpy 2.5.x:** `numpy==2.5.1` requires Python ≥3.12, but this project supports Python 3.10+. Pinning `2.5.1` would break the 3.10/3.11 CI matrix. `numpy==2.2.6` is the latest version compatible with both Python 3.10 and `geneticengine`.

## Test plan
- [x] `uv pip install -e ".[tests,synthesis-ng,synthesis-ortools]"` resolves successfully
- [x] Key suites pass locally: SMT, end-to-end, liquid typing, float synthesis, synthesizer families (75 tests)
- [ ] CI (Python 3.10–3.14 matrix + pre-commit + examples)


Made with [Cursor](https://cursor.com)