### PR TITLE
fix: improve Windows compatibility for synthesis and imports

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -33,7 +33,7 @@ from aeon.logger.logger import export_log
 from aeon.logger.logger import setup_logger
 from aeon.lsp.server import AeonLanguageServer
 from aeon.synthesis.uis.api import SynthesisUI, SynthesisFormat
-from aeon.synthesis.uis.terminal import TerminalUI
+from aeon.synthesis.uis.terminal import TerminalUI, VerboseTerminalUI
 from aeon.utils.pprint import pretty_print_sterm
 from aeon.documentation import generate_documentation
 
@@ -158,6 +158,12 @@ def _parse_common_arguments(parser: ArgumentParser):
     )
 
     parser.add_argument(
+        "--verbose-synthesis",
+        action="store_true",
+        help="Print every synthesis candidate to stdout (noisy; off by default for Windows compatibility).",
+    )
+
+    parser.add_argument(
         "--synthesis-format",
         type=str,
         choices=["default", "json"],
@@ -218,7 +224,9 @@ def _parse_common_arguments(parser: ArgumentParser):
     )
 
 
-def select_synthesis_ui() -> SynthesisUI:
+def select_synthesis_ui(verbose: bool = False) -> SynthesisUI:
+    if verbose:
+        return VerboseTerminalUI()
     return TerminalUI()
 
 
@@ -345,7 +353,7 @@ def main() -> None:
         print("warning: --no-main is ignored under --test (a main slot is needed to evaluate properties).")
     cfg = AeonConfig(
         synthesizer=args.synthesizer,
-        synthesis_ui=select_synthesis_ui(),
+        synthesis_ui=select_synthesis_ui(verbose=getattr(args, "verbose_synthesis", False)),
         synthesis_budget=args.budget,
         timings=args.timings,
         # ``--export`` forces ``no_main`` (no synthesis hole in main), but

--- a/aeon/compilation/compile.py
+++ b/aeon/compilation/compile.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from importlib.metadata import version
 from pathlib import Path
 
@@ -10,7 +9,7 @@ from aeon.compilation.link import (
     link_rec_spines,
     link_typing_context,
 )
-from aeon.compilation.resolve import get_package_libraries_dir, resolve_import_path
+from aeon.compilation.resolve import import_search_containers, resolve_import_path, resolve_module_source
 from aeon.compilation.serialize import read_unit, source_hash, write_unit
 from aeon.compilation.unit import AEC_FORMAT_VERSION, CompiledUnit, ModuleExport
 from aeon.core.bind import bind_ids, populate_mutual_companions
@@ -45,19 +44,7 @@ def clear_unit_cache() -> None:
 
 def _resolve_module_source(module_path: str) -> str | None:
     """Resolve a module path (e.g. ``String``) to an absolute ``.ae`` file path."""
-    rel = module_path.replace(".", "/") + ".ae"
-    possible_containers = [Path.cwd(), Path.cwd() / "libraries"]
-    pkg_libs = get_package_libraries_dir()
-    if pkg_libs:
-        possible_containers.append(pkg_libs)
-    aeonpath = os.environ.get("AEONPATH", "")
-    if aeonpath:
-        possible_containers.extend(Path(s) for s in aeonpath.split(";") if s)
-    for container in possible_containers:
-        candidate = container / rel
-        if candidate.exists():
-            return str(candidate.resolve())
-    return None
+    return resolve_module_source(module_path)
 
 
 def _ensure_dependencies_cached(module_paths: list[str]) -> None:
@@ -285,7 +272,7 @@ def compile_program(
     dep_errors: list[AeonError] = []
     for imp in file_imports:
         if resolve_import_path(imp) is None:
-            dep_errors.append(ModuleNotFoundAeonError(importel=imp, possible_containers=[Path.cwd()]))
+            dep_errors.append(ModuleNotFoundAeonError(importel=imp, possible_containers=import_search_containers()))
     if dep_errors:
         return _placeholder_unit(path, digest, [imp.module_path for imp in file_imports]), dep_errors
 

--- a/aeon/compilation/resolve.py
+++ b/aeon/compilation/resolve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import aeon
@@ -35,38 +36,62 @@ def get_package_libraries_dir() -> Path | None:
     return None
 
 
-def resolve_import_path(imp: ImportAe) -> str | None:
-    """Resolve an import to an absolute source file path, or ``None`` if not found."""
-    path = imp.file_path
-    possible_containers = [Path.cwd(), Path.cwd() / "libraries"]
+def split_aeonpath() -> list[Path]:
+    """Split ``AEONPATH`` using the platform path separator (``;`` on Windows)."""
+    raw = os.environ.get("AEONPATH", "")
+    if not raw:
+        return []
+    return [Path(s) for s in raw.split(os.pathsep) if s]
+
+
+def import_search_containers() -> list[Path]:
+    """Ordered import roots: cwd, ``cwd/libraries/``, package ``libraries/``, ``AEONPATH``."""
+    seen: set[Path] = set()
+    containers: list[Path] = []
+
+    def add(path: Path) -> None:
+        resolved = path.resolve()
+        if resolved in seen:
+            return
+        seen.add(resolved)
+        containers.append(path)
+
+    add(Path.cwd())
+    add(Path.cwd() / "libraries")
+
     pkg_libs = get_package_libraries_dir()
     if pkg_libs:
-        possible_containers.append(pkg_libs)
-    import os
+        add(pkg_libs)
 
-    aeonpath = os.environ.get("AEONPATH", "")
-    if aeonpath:
-        possible_containers.extend(Path(s) for s in aeonpath.split(";") if s)
-    for container in possible_containers:
-        file = container / path
-        if file.exists():
-            return str(file.resolve())
+    for entry in split_aeonpath():
+        add(entry)
+
+    return containers
+
+
+def resolve_module_source(module_path: str) -> str | None:
+    """Resolve a dotted module path (e.g. ``Math.Basic``) to an absolute ``.ae`` file."""
+    rel = module_path.replace(".", "/") + ".ae"
+    for container in import_search_containers():
+        candidate = container / rel
+        if candidate.exists():
+            return str(candidate.resolve())
     return None
+
+
+def resolve_import_path(imp: ImportAe) -> str | None:
+    """Resolve an import to an absolute source file path, or ``None`` if not found."""
+    return resolve_module_source(imp.module_path)
 
 
 def resolve_import(imp: ImportAe) -> Program:
     """Parse a module referenced by ``imp``, using the standard search path."""
     resolved = resolve_import_path(imp)
     if resolved is None:
-        possible_containers = [Path.cwd(), Path.cwd() / "libraries"]
-        pkg_libs = get_package_libraries_dir()
-        if pkg_libs:
-            possible_containers.append(pkg_libs)
-        raise ModuleNotFoundAeonError(importel=imp, possible_containers=possible_containers)
+        raise ModuleNotFoundAeonError(importel=imp, possible_containers=import_search_containers())
 
     if resolved in _currently_importing:
-        possible_containers = [Path.cwd()]
-        raise ModuleNotFoundAeonError(importel=imp, possible_containers=possible_containers)
+        raise ModuleNotFoundAeonError(importel=imp, possible_containers=[Path.cwd()])
 
     if resolved in _import_cache:
         return _import_cache[resolved]

--- a/aeon/logger/logger.py
+++ b/aeon/logger/logger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import sys
 
 from loguru import logger
@@ -41,9 +42,16 @@ def setup_logger():
     return logger
 
 
+def _stderr_colorize() -> bool:
+    """Disable ANSI coloring on Windows where TERM/VT handling is unreliable."""
+    if os.name == "nt":
+        return False
+    return sys.stderr.isatty()
+
+
 def export_log(logs: list, export_file: bool = False, logfile_name: str = ""):
     if export_file:
         logfile = f"logs/{logfile_name}_{datetime.datetime.now().strftime('%Y_%m_%d %H_%M_%S')}.log"
         return logger.add(logfile, filter=levels_filter(logs))
     else:
-        return logger.add(sys.stderr, filter=levels_filter(logs))
+        return logger.add(sys.stderr, filter=levels_filter(logs), colorize=_stderr_colorize())

--- a/aeon/synthesis/uis/terminal.py
+++ b/aeon/synthesis/uis/terminal.py
@@ -42,8 +42,46 @@ def _pretty_program(solution: Term) -> str:
 
 
 class TerminalUI(SynthesisUI):
+    """Plain-text synthesis feedback safe on Windows terminals (no progress bars or ANSI)."""
+
     best_solution: Term
     best_quality: list[float] | None
+
+    def start(
+        self,
+        typing_ctx: TypingContext,
+        evaluation_ctx: EvaluationContext,
+        target_name: str,
+        target_type: Type,
+        budget: Any,
+    ):
+        self.target_name = target_name
+        self.target_type = target_type
+        self.budget = budget
+        self.best_solution = Hole(Name("sorry", -1))
+        self.best_quality = None
+        print(f"# Synthesizing ?{target_name} (budget={budget}s)", flush=True)
+
+    def register(
+        self,
+        solution: Term,
+        quality: Any,
+        elapsed_time: float,
+        is_best: bool,
+    ):
+        if not is_best:
+            return
+        self.best_solution = solution
+        self.best_quality = quality
+        q_cur = _format_quality(quality)
+        print(f"# best t={elapsed_time:.1f}s/{self.budget}s fitness {q_cur}", flush=True)
+
+    def end(self, solution: Term, quality: Any):
+        pass
+
+
+class VerboseTerminalUI(TerminalUI):
+    """Per-candidate synthesis log (can be noisy and slow on some terminals)."""
 
     def start(
         self,
@@ -89,6 +127,3 @@ class TerminalUI(SynthesisUI):
         )
         print(cur_pp, flush=True)
         print("---", flush=True)
-
-    def end(self, solution: Term, quality: Any):
-        pass

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -135,6 +135,30 @@ class TestImportResolution:
             finally:
                 os.chdir(old_cwd)
 
+    def test_import_from_aeonpath_with_pathsep(self):
+        """Test AEONPATH entries separated by os.pathsep."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_dir = Path(tmpdir) / "custom_libs"
+            custom_dir.mkdir()
+            test_module = custom_dir / "SepMod.ae"
+            test_module.write_text("def sep_func : Int := 456;")
+
+            old_cwd = os.getcwd()
+            old_aeonpath = os.environ.get("AEONPATH")
+            try:
+                os.chdir(tmpdir)
+                os.environ["AEONPATH"] = str(custom_dir)
+                imp = ImportAe(module_path="SepMod")
+                program = resolve_import(imp)
+                def_names = [d.name.name for d in program.definitions]
+                assert "sep_func" in def_names
+            finally:
+                os.chdir(old_cwd)
+                if old_aeonpath is None:
+                    os.environ.pop("AEONPATH", None)
+                else:
+                    os.environ["AEONPATH"] = old_aeonpath
+
     def test_import_not_found_raises(self):
         """Test that importing a non-existent module raises an error."""
         imp = ImportAe(module_path="NonExistentModule12345")


### PR DESCRIPTION
## Summary
- Simplify the default synthesis terminal UI so it only prints a start line and best-candidate updates, avoiding verbose per-candidate output that breaks on Windows terminals with awkward `TERM` handling.
- Disable loguru ANSI colors on Windows to prevent colorama/VT issues in common shells.
- Consolidate import resolution in `resolve.py`, split `AEONPATH` with `os.pathsep` (`;` on Windows), and add `--verbose-synthesis` to opt back into the old per-candidate log.

## Test plan
- [x] `pytest tests/test_imports.py`
- [ ] Run synthesis on Windows: `python -m aeon --budget 10 -s gp examples/synthesis/int.ae`
- [ ] Confirm `--verbose-synthesis` restores per-candidate output
- [ ] Confirm imports resolve with `AEONPATH` using `;`-separated paths on Windows


Made with [Cursor](https://cursor.com)