### PR TITLE
Integrate properties into synthesis fitness

### DIFF
--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -632,6 +632,7 @@ def _run_synthesis(
             synthesizer,
             budget=budget,
             ui=ui,
+            constructor_names=driver.constructor_names,
         )
     except Exception as e:
         ls.window_show_message(ShowMessageParams(type=MessageType.Error, message=f"Synthesis failed: {e}"))

--- a/aeon/synthesis/decorators.py
+++ b/aeon/synthesis/decorators.py
@@ -22,7 +22,9 @@ class Goal(NamedTuple):
     # fitness function and returns its numeric result. ``"cputime"`` measures
     # the CPU time consumed evaluating it. ``"energy"`` measures the energy
     # consumed evaluating it (via RAPL when available, otherwise a CPU-time
-    # proxy). See ``aeon/synthesis/entrypoint.py``.
+    # proxy). ``"property"`` is a runtime objective backed by a fixed corpus;
+    # its ``function`` identifies the property rather than a generated numeric
+    # helper. See ``aeon/synthesis/entrypoint.py``.
     kind: str = "expression"
 
 
@@ -257,8 +259,11 @@ def property_test(
 
     The function's arguments are the universally-quantified inputs; their types
     (including refinements, which act as preconditions) drive automatic input
-    generation by reusing the synthesis grammar machinery. The definition is
-    left unchanged — this decorator only records metadata.
+    generation by reusing the synthesis grammar machinery. When the property
+    directly mentions a function with a synthesis hole, runtime-fitness backends
+    also minimize the number of failures over one deterministic corpus generated
+    before search. The definition is left unchanged — this decorator only records
+    metadata.
 
     Usage::
 

--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -29,6 +29,7 @@ from aeon.synthesis.scope import shadow_fitness_helpers, without_excluded_names
 from aeon.backend.evaluator import eval
 from aeon.synthesis.uis.api import SynthesisUI
 from aeon.synthesis.identification import get_holes_info
+from aeon.synthesis.pbt.runner import make_property_fitness, property_corpora_for_target
 from aeon.typechecking.context import TypingContext
 from aeon.typechecking.typeinfer import check_type
 from aeon.utils.name import Name
@@ -102,7 +103,8 @@ def _ectx_for_workers(ectx: EvaluationContext) -> EvaluationContext:
 
 
 def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float]:
-    """Build a fitness function for a single goal, dispatching on ``goal.kind``."""
+    """Build a fitness function for a generated-helper goal."""
+    assert goal.kind != "property", "Property goals are backed by fixed-corpus evaluators"
 
     def fitness(v: Term) -> float:
         # Evaluate the goal's objective function (a nullary top-level binding,
@@ -133,14 +135,29 @@ def _make_fitness(goal: Goal, ectx: EvaluationContext) -> Callable[[Term], float
     return fitness
 
 
-def make_evaluators(ectx: EvaluationContext, fun_name: Name, metadata: Metadata) -> Evaluators:
-    """Returns a list of functions that take the original program and return each fitness value"""
+def make_evaluators(
+    ectx: EvaluationContext,
+    fun_name: Name,
+    metadata: Metadata,
+    property_evaluators: Evaluators | None = None,
+) -> Evaluators:
+    """Build evaluators in the same component order as the target's goals."""
 
     goals: list[Goal] = metadata.get(fun_name, {}).get("goals", [])
+    properties = iter(property_evaluators or [])
     fitnesses: list[Callable[[Term], float]] = []
     for goal in goals:
         assert goal.length == 1, "Currently, we only support 1 fitness value per function"
-        fitnesses.append(_make_fitness(goal, ectx))
+        if goal.kind == "property":
+            fitnesses.append(next(properties))
+        else:
+            fitnesses.append(_make_fitness(goal, ectx))
+    try:
+        next(properties)
+    except StopIteration:
+        pass
+    else:
+        raise AssertionError("Property evaluator has no matching property goal")
     return fitnesses
 
 
@@ -266,6 +283,8 @@ def _synthesize_one(
     budget: float,
     ui: SynthesisUI,
     budget_eval: float,
+    constructor_names: set[str] | None = None,
+    open_targets: set[Name] | None = None,
 ) -> Term:
     """Synthesize a single hole in ``prog``.
 
@@ -281,10 +300,34 @@ def _synthesize_one(
 
     replace = make_program(prog, hole_name)
     validator = make_validator(ctx, replace)
-    evaluators = make_evaluators(ectx, fun_name, metadata)
+
+    # Properties are runtime objectives rather than generated Aeon helper
+    # bindings. Give the selected target a synthesis-local property goal for each
+    # deterministic corpus so every fitness backend sees the right objective
+    # count and orientation without mutating metadata shared by other targets.
+    synthesis_metadata = metadata
+    property_evaluators: Evaluators = []
+    corpora = property_corpora_for_target(
+        ctx,
+        prog,
+        metadata,
+        fun_name,
+        open_targets or {fun_name},
+        constructor_names=constructor_names,
+    )
+    if corpora:
+        synthesis_metadata = dict(metadata)
+        entry = dict(metadata.get(fun_name, {}))
+        goals = list(entry.get("goals", []))
+        goals.extend(Goal(minimize=True, length=1, function=corpus.spec.name, kind="property") for corpus in corpora)
+        entry["goals"] = goals
+        synthesis_metadata[fun_name] = entry
+        property_evaluators = [make_property_fitness(corpus, _ectx_for_workers(ectx)) for corpus in corpora]
+
+    evaluators = make_evaluators(ectx, fun_name, synthesis_metadata, property_evaluators)
     assert isinstance(tyctx, TypingContext)
     assert isinstance(ty, Type)
-    tac_map = metadata.get(fun_name, {}).get("tactic_scripts")
+    tac_map = synthesis_metadata.get(fun_name, {}).get("tactic_scripts")
     steps = None
     if isinstance(tac_map, dict):
         raw = tac_map.get(hole_name)
@@ -301,7 +344,7 @@ def _synthesize_one(
     # what they mean. A `@cluster(f shape)` decorator names the output
     # featuriser `f` (e.g. a rasterised scene), else the output is the
     # candidate's own value.
-    feature_fun = _cluster_function(metadata, fun_name) or fun_name
+    feature_fun = _cluster_function(synthesis_metadata, fun_name) or fun_name
     primitives = EvalPrimitives(evaluators, _ectx_for_workers(ectx), feature_fun, replace)
     pool = EvaluationPool(replace, syn_impl.computations(primitives), budget_eval=budget_eval)
     evaluator, output_evaluator = _pool_backed(pool)
@@ -342,7 +385,7 @@ def _synthesize_one(
                 e = e.with_var(pname, v)
             return eval(sub_term, e)
 
-        metadata.setdefault(fun_name, {})["pbe_probe"] = _pbe_probe
+        synthesis_metadata.setdefault(fun_name, {})["pbe_probe"] = _pbe_probe
 
     try:
         t = syn_impl.synthesize(
@@ -351,7 +394,7 @@ def _synthesize_one(
             validate=validator,
             evaluate=evaluator,
             fun_name=fun_name,
-            metadata=metadata,
+            metadata=synthesis_metadata,
             budget=budget,
             ui=ui,
             output_value=output_evaluator,
@@ -428,6 +471,7 @@ def synthesize_holes(
     program_holes = get_holes_info(ctx, term, top, targets, refined_types=True)
 
     mapping: dict[Name, Optional[Term]] = {}
+    open_targets = {fun_name for fun_name, _ in targets}
 
     singles, mutual_groups = _partition_targets(term, targets)
 
@@ -437,7 +481,20 @@ def synthesize_holes(
         ty, tyctx = program_holes[hole_name]
         assert isinstance(tyctx, TypingContext)
         mapping[hole_name] = _synthesize_one(
-            ctx, ectx, term, fun_name, hole_name, ty, tyctx, metadata, synthesizer, budget, ui, budget_eval
+            ctx,
+            ectx,
+            term,
+            fun_name,
+            hole_name,
+            ty,
+            tyctx,
+            metadata,
+            synthesizer,
+            budget,
+            ui,
+            budget_eval,
+            constructor_names=constructor_names,
+            open_targets=open_targets,
         )
 
     for group in mutual_groups:

--- a/aeon/synthesis/modules/contata/cosynthesis.py
+++ b/aeon/synthesis/modules/contata/cosynthesis.py
@@ -652,7 +652,20 @@ def _cosynthesize_group(
             assert isinstance(tyctx, TypingContext)
             try:
                 fills[hole_name] = _synthesize_one(
-                    ctx, ectx, prog, fun_name, hole_name, ty, tyctx, metadata, synthesizer, per_budget, ui, budget_eval
+                    ctx,
+                    ectx,
+                    prog,
+                    fun_name,
+                    hole_name,
+                    ty,
+                    tyctx,
+                    metadata,
+                    synthesizer,
+                    per_budget,
+                    ui,
+                    budget_eval,
+                    constructor_names=constructor_names,
+                    open_targets={name for name, _ in members},
                 )
                 synthesised.add(hole_name)
             except Exception:

--- a/aeon/synthesis/pbt/__init__.py
+++ b/aeon/synthesis/pbt/__init__.py
@@ -9,6 +9,22 @@ generators are required.
 - :mod:`aeon.synthesis.pbt.runner` — discover, generate, check, and report.
 """
 
-from aeon.synthesis.pbt.runner import ExampleResult, PropertyResult, run_examples, run_properties
+from aeon.synthesis.pbt.runner import (
+    ExampleResult,
+    PropertyCorpus,
+    PropertyResult,
+    make_property_fitness,
+    property_corpora_for_target,
+    run_examples,
+    run_properties,
+)
 
-__all__ = ["ExampleResult", "PropertyResult", "run_examples", "run_properties"]
+__all__ = [
+    "ExampleResult",
+    "PropertyCorpus",
+    "PropertyResult",
+    "make_property_fitness",
+    "property_corpora_for_target",
+    "run_examples",
+    "run_properties",
+]

--- a/aeon/synthesis/pbt/runner.py
+++ b/aeon/synthesis/pbt/runner.py
@@ -12,11 +12,28 @@ from __future__ import annotations
 
 import signal
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass, replace as dc_replace
 
 from aeon.backend.evaluator import EvaluationContext, eval as aeon_eval
 from aeon.core.substitutions import substitution_in_type
-from aeon.core.terms import Annotation, Application, Let, Rec, Term, Var
+from aeon.core.terms import (
+    Abstraction,
+    Annotation,
+    Application,
+    Hole,
+    If,
+    ImplicitRefinementHole,
+    Let,
+    Literal,
+    Rec,
+    RefinementAbstraction,
+    RefinementApplication,
+    Term,
+    TypeAbstraction,
+    TypeApplication,
+    Var,
+)
 from aeon.core.types import (
     AbstractionType,
     RefinementPolymorphism,
@@ -135,11 +152,19 @@ def _eval_bool(program: Term, ectx: EvaluationContext, timeout: float) -> tuple[
     return result, None
 
 
-@dataclass
-class _PropertySpec:
+@dataclass(frozen=True)
+class PropertySpec:
     name: Name
-    arg_specs: list[tuple[Name, Type]]
+    arg_specs: tuple[tuple[Name, Type], ...]
     samples: int
+
+
+@dataclass(frozen=True)
+class PropertyCorpus:
+    """A property and the deterministic argument tuples used for synthesis."""
+
+    spec: PropertySpec
+    cases: tuple[tuple[Term, ...], ...]
 
 
 def _iter_top_level(core: Term):
@@ -160,7 +185,7 @@ def _iter_top_level(core: Term):
                 return
 
 
-def _collect_properties(core: Term, metadata: Metadata) -> tuple[list[_PropertySpec], list[PropertyResult]]:
+def _collect_properties(core: Term, metadata: Metadata) -> tuple[list[PropertySpec], list[PropertyResult]]:
     """Find ``@property`` functions among the program's top-level definitions and
     decompose their types. Returns runnable specs plus skip results for
     malformed properties (polymorphic, or not returning ``Bool``).
@@ -173,7 +198,7 @@ def _collect_properties(core: Term, metadata: Metadata) -> tuple[list[_PropertyS
         if isinstance(key, Name) and isinstance(entry, dict) and "property" in entry:
             config_by_name[key.name] = entry["property"] or {}
 
-    specs: list[_PropertySpec] = []
+    specs: list[PropertySpec] = []
     skips: list[PropertyResult] = []
     seen: set[str] = set()
     for name, ty in _iter_top_level(core):
@@ -190,11 +215,11 @@ def _collect_properties(core: Term, metadata: Metadata) -> tuple[list[_PropertyS
             skips.append(PropertyResult(name, passed=True, trials=0, error=f"return type must be Bool, got {ret}"))
             continue
         samples = config_by_name[name.name].get("samples") or DEFAULT_SAMPLES
-        specs.append(_PropertySpec(name, arg_specs, samples))
+        specs.append(PropertySpec(name, tuple(arg_specs), samples))
     return specs, skips
 
 
-def _shrinkable_flags(arg_specs: list[tuple[Name, Type]]) -> list[bool]:
+def _shrinkable_flags(arg_specs: tuple[tuple[Name, Type], ...]) -> list[bool]:
     """An argument is *not* shrinkable when a later argument's type refers to it:
     shrinking it could break the dependency and produce a spurious (out-of-domain)
     counterexample. Matched by name string to be robust to id differences."""
@@ -205,18 +230,14 @@ def _shrinkable_flags(arg_specs: list[tuple[Name, Type]]) -> list[bool]:
     return flags
 
 
-def _check_property(
-    spec: _PropertySpec,
+def _generate_property_cases(
+    spec: PropertySpec,
     typing_ctx: TypingContext,
     adt_ctx: TypingContext,
-    evaluation_ctx: EvaluationContext,
-    core: Term,
     metadata: Metadata,
-    constructor_types: ConstructorTypes,
-    constructor_names: set[str],
     seed: int,
-    timeout: float,
-) -> PropertyResult:
+) -> list[tuple[list[Term], list[Type]]]:
+    """Generate a property's inputs once, preserving dependent argument types."""
     from aeon.synthesis.pbt.generators import TypeSampler, is_base_type
 
     # Cache one sampler per distinct argument type. A non-dependent argument has
@@ -237,13 +258,8 @@ def _check_property(
             sampler_cache[key] = sampler
         return sampler
 
-    def evaluate(arg_terms: list[Term]) -> tuple[bool | None, str | None]:
-        call: Term = Var(spec.name)
-        for term in arg_terms:
-            call = Application(call, term)
-        return _eval_bool(_replace_tail(core, call), evaluation_ctx, timeout)
-
-    for trial in range(spec.samples):
+    cases: list[tuple[list[Term], list[Type]]] = []
+    for _ in range(spec.samples):
         chosen: list[tuple[Name, Term]] = []
         terms: list[Term] = []
         arg_tys: list[Type] = []
@@ -257,7 +273,30 @@ def _check_property(
             chosen.append((arg_name, term))
             terms.append(term)
             arg_tys.append(ty)
+        cases.append((terms, arg_tys))
+    return cases
 
+
+def _check_property(
+    spec: PropertySpec,
+    typing_ctx: TypingContext,
+    adt_ctx: TypingContext,
+    evaluation_ctx: EvaluationContext,
+    core: Term,
+    metadata: Metadata,
+    constructor_types: ConstructorTypes,
+    constructor_names: set[str],
+    seed: int,
+    timeout: float,
+) -> PropertyResult:
+    def evaluate(arg_terms: list[Term]) -> tuple[bool | None, str | None]:
+        call: Term = Var(spec.name)
+        for term in arg_terms:
+            call = Application(call, term)
+        return _eval_bool(_replace_tail(core, call), evaluation_ctx, timeout)
+
+    cases = _generate_property_cases(spec, typing_ctx, adt_ctx, metadata, seed)
+    for trial, (terms, arg_tys) in enumerate(cases):
         value, _ = evaluate(terms)
         if value is not True:
             minimized = minimize(
@@ -341,6 +380,110 @@ def _collect_constructors(core: Term, constructor_names: set[str]) -> list[Varia
     """Collect data-constructor bindings (e.g. ``List_cons``, ``List_nil``) from
     the program's top-level definitions, identified by name."""
     return [VariableBinder(name, ty) for name, ty in _iter_top_level(core) if name.name in constructor_names]
+
+
+def _top_level_values(core: Term) -> dict[Name, Term]:
+    values: dict[Name, Term] = {}
+    t = core
+    while True:
+        match t:
+            case Rec():
+                values[t.var_name] = t.var_value
+                t = t.body
+            case Let():
+                t = t.body
+            case Annotation():
+                t = t.expr
+            case _:
+                return values
+
+
+def _term_references(term: Term) -> set[Name]:
+    """Collect every value reference in a core term.
+
+    Core names have unique bound IDs, so references to local binders cannot be
+    confused with top-level synthesis targets. Traversing every term variant
+    keeps property relevance stable as elaboration introduces wrappers.
+    """
+    match term:
+        case Var(name):
+            return {name}
+        case Literal() | Hole() | ImplicitRefinementHole():
+            return set()
+        case Annotation(expr, _):
+            return _term_references(expr)
+        case Application(fun, arg):
+            return _term_references(fun) | _term_references(arg)
+        case Abstraction(_, body) | TypeAbstraction(_, _, body) | RefinementAbstraction(_, _, body):
+            return _term_references(body)
+        case Let(_, value, body) | Rec(_, _, value, body):
+            return _term_references(value) | _term_references(body)
+        case If(cond, then, otherwise):
+            return _term_references(cond) | _term_references(then) | _term_references(otherwise)
+        case TypeApplication(body, _):
+            return _term_references(body)
+        case RefinementApplication(body, refinement):
+            return _term_references(body) | _term_references(refinement)
+        case _:
+            return set()
+
+
+def property_corpora_for_target(
+    typing_ctx: TypingContext,
+    core: Term,
+    metadata: Metadata,
+    target: Name,
+    open_targets: set[Name],
+    constructor_names: set[str] | None = None,
+    seed: int = 0,
+) -> list[PropertyCorpus]:
+    """Build fixed corpora for properties that can guide one ordinary target.
+
+    A property is relevant when its core body directly references ``target``. It
+    is excluded when it also references another open synthesis target, because
+    independent one-hole synthesis cannot execute that sibling. Such relational
+    properties remain part of Contata's joint acceptance oracle.
+    """
+    from aeon.synthesis.pbt.generators import build_adt_context
+
+    specs, _ = _collect_properties(core, metadata)
+    values = _top_level_values(core)
+    names = constructor_names or set()
+    ctor_binders = _collect_constructors(core, names)
+    adt_ctx = build_adt_context(typing_ctx, ctor_binders)
+    other_targets = open_targets - {target}
+    corpora: list[PropertyCorpus] = []
+    for spec in specs:
+        body = values.get(spec.name)
+        if body is None:
+            continue
+        references = _term_references(body)
+        if target not in references or references & other_targets:
+            continue
+        cases = _generate_property_cases(spec, typing_ctx, adt_ctx, metadata, seed)
+        corpora.append(PropertyCorpus(spec, tuple(tuple(terms) for terms, _ in cases)))
+    return corpora
+
+
+def make_property_fitness(corpus: PropertyCorpus, evaluation_ctx: EvaluationContext) -> Callable[[Term], float]:
+    """Return a failure-count evaluator over one pre-generated corpus."""
+
+    def fitness(program: Term) -> float:
+        failures = 0
+        for args in corpus.cases:
+            call: Term = Var(corpus.spec.name)
+            for arg in args:
+                call = Application(call, arg)
+            try:
+                value = aeon_eval(_replace_tail(program, call), evaluation_ctx)
+            except Exception:
+                failures += 1
+                continue
+            if value is not True:
+                failures += 1
+        return float(failures)
+
+    return fitness
 
 
 def run_properties(

--- a/docs/index.md
+++ b/docs/index.md
@@ -648,8 +648,22 @@ aeon --doc  examples/pbt/examples_decorator.ae   # render them into HTML
 
 Property-based tests use the related `@property` decorator: it marks a
 `Bool`-returning function whose arguments are universally quantified and checked
-on random inputs generated from their (refinement-constrained) types under
-`--test`.
+on random inputs generated from their (refinement-constrained) types. It serves
+both testing and synthesis:
+
+- **Test** — `--test` generates the requested number of inputs, reports the first
+  failure, and shrinks it to a smaller counterexample.
+- **Synthesis specification** — when a property directly mentions a function
+  whose body is a hole, runtime-fitness synthesizers generate one deterministic
+  corpus before search and minimize the number of failing cases. The same corpus
+  is reused for every candidate, so candidate scores are comparable. Properties
+  compose with `@example` and explicit minimize/maximize objectives.
+
+A property that mentions several independently synthesized functions is not used
+as a per-function objective while the other holes remain open. Relational
+properties over a `mutual` group continue to be checked jointly by the `contata`
+co-synthesis acceptance oracle. Symbolic whole-program optimizers such as
+`cpsat` likewise do not translate sampled runtime properties.
 
 ### Unit testing (`Testing` library)
 

--- a/examples/synthesis/pell_equation.ae
+++ b/examples/synthesis/pell_equation.ae
@@ -1,0 +1,16 @@
+open Math
+open Maybe
+
+inductive Pair
+| mk (x:Int) (y:Int) :
+    {p:Pair | (px p = x) && (py p = y)}
++ px (p:Pair) : Int
++ py (p:Pair) : Int
+
+def pell_equation_solver (d:Int | d > 1) : (Maybe Pair) := ?hole
+
+@property
+def prop_pell_equation_solution (d:Int | d > 1) : Bool :=
+    (pell_equation_solver d).rec
+        (isqrt d * isqrt d = d)
+        (fun p => py p != 0 && px p * px p = d * py p * py p + 1)

--- a/tests/property_fitness_test.py
+++ b/tests/property_fitness_test.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from aeon.core.substitutions import substitution
+from aeon.core.terms import Literal, Term
+from aeon.core.types import Type, t_bool
+from aeon.decorators import Metadata
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.synthesis.api import Synthesizer
+from aeon.synthesis.entrypoint import make_program, synthesize_holes
+from aeon.synthesis.grammar.ge_synthesis import GESynthesizer
+from aeon.synthesis.identification import incomplete_functions_and_holes
+from aeon.synthesis.pbt.runner import make_property_fitness, property_corpora_for_target, run_properties
+from aeon.synthesis.uis.api import SilentSynthesisUI, SynthesisUI
+from aeon.typechecking.context import TypingContext
+from aeon.utils.name import Name
+
+from tests.driver import check_and_return_core
+
+
+class _PropertySelectingSynthesizer(Synthesizer):
+    """Try false before true and let the provided fitness choose between them."""
+
+    seen_goals: list[Any]
+    seen_scores: list[list[float]]
+
+    def synthesize(
+        self,
+        ctx: TypingContext,
+        type: Type,
+        validate: Callable[[Term], bool],
+        evaluate: Callable[[Term], list[float]],
+        fun_name: Name,
+        metadata: Metadata,
+        budget: float = 60,
+        ui: SynthesisUI = SynthesisUI(),
+        output_value: Callable[[Term], object] | None = None,
+    ) -> Term:
+        candidates = [Literal(False, t_bool), Literal(True, t_bool)]
+        assert all(validate(candidate) for candidate in candidates)
+        self.seen_goals = metadata[fun_name]["goals"]
+        self.seen_scores = [evaluate(candidate) for candidate in candidates]
+        return min(zip(self.seen_scores, candidates), key=lambda pair: pair[0])[1]
+
+
+def _corpora(source: str):
+    core, ctx, ectx, metadata = check_and_return_core(source)
+    targets = incomplete_functions_and_holes(ctx, core)
+    fun_name, holes = targets[0]
+    corpora = property_corpora_for_target(ctx, core, metadata, fun_name, {name for name, _ in targets})
+    return core, ctx, ectx, metadata, fun_name, holes[0], corpora
+
+
+def test_property_corpus_scores_failed_cases_and_is_deterministic():
+    source = """
+    def f (x : Int) : Bool := ?hole;
+    @property(12)
+    def prop_f (x : Int) : Bool := f x;
+    """
+    core, ctx, ectx, metadata, fun_name, hole_name, corpora = _corpora(source)
+    again = property_corpora_for_target(ctx, core, metadata, fun_name, {fun_name})
+
+    assert len(corpora) == 1
+    assert len(corpora[0].cases) == 12
+    assert corpora[0].cases == again[0].cases
+
+    fitness = make_property_fitness(corpora[0], ectx)
+    replace = make_program(core, hole_name)
+    assert fitness(replace(Literal(True, t_bool))) == 0.0
+    assert fitness(replace(Literal(False, t_bool))) == 12.0
+
+
+def test_property_corpus_respects_refined_dependent_arguments():
+    source = """
+    def f (n : Int) (i : {v : Int | v < n}) : Bool := ?hole;
+    @property(25)
+    def prop_f (n : Int) (i : {v : Int | v < n}) : Bool := f n i;
+    """
+    *_, corpora = _corpora(source)
+
+    assert len(corpora[0].cases) == 25
+    assert all(isinstance(n, Literal) and isinstance(i, Literal) and i.value < n.value for n, i in corpora[0].cases)
+
+
+def test_only_relevant_single_target_properties_are_selected():
+    source = """
+    def f (x : Int) : Bool := ?hf;
+    def g (x : Int) : Bool := ?hg;
+    @property(3)
+    def prop_f (x : Int) : Bool := f x;
+    @property(3)
+    def prop_g (x : Int) : Bool := g x;
+    @property(3)
+    def prop_relational (x : Int) : Bool := f x = g x;
+    """
+    core, ctx, _, metadata = check_and_return_core(source)
+    targets = incomplete_functions_and_holes(ctx, core)
+    names = {name.name: name for name, _ in targets}
+    open_targets = set(names.values())
+
+    f_corpora = property_corpora_for_target(ctx, core, metadata, names["f"], open_targets)
+    g_corpora = property_corpora_for_target(ctx, core, metadata, names["g"], open_targets)
+
+    assert [corpus.spec.name.name for corpus in f_corpora] == ["prop_f"]
+    assert [corpus.spec.name.name for corpus in g_corpora] == ["prop_g"]
+
+
+def test_property_runtime_errors_count_as_failed_cases():
+    source = """
+    def f (x : Int) : Bool := ?hole;
+    @property(4)
+    def prop_crashes (x : Int) : Bool := ignored := f x; native "1 / 0";
+    """
+    core, _, ectx, _, _, hole_name, corpora = _corpora(source)
+    fitness = make_property_fitness(corpora[0], ectx)
+
+    assert fitness(make_program(core, hole_name)(Literal(True, t_bool))) == 4.0
+
+
+def test_synthesis_receives_minimized_property_goal_and_uses_its_fitness():
+    source = """
+    def f (x : Int) : Bool := ?hole;
+    @property(8)
+    def prop_f (x : Int) : Bool := f x;
+    """
+    core, ctx, ectx, metadata = check_and_return_core(source)
+    targets = incomplete_functions_and_holes(ctx, core)
+    synthesizer = _PropertySelectingSynthesizer()
+
+    mapping = synthesize_holes(
+        ctx,
+        ectx,
+        core,
+        targets,
+        metadata,
+        synthesizer,
+        budget=1,
+        ui=SilentSynthesisUI(),
+    )
+
+    assert list(mapping.values()) == [Literal(True, t_bool)]
+    assert synthesizer.seen_scores == [[8.0], [0.0]]
+    assert len(synthesizer.seen_goals) == 1
+    assert synthesizer.seen_goals[0].kind == "property"
+    assert synthesizer.seen_goals[0].minimize is True
+
+
+def test_property_goal_composes_after_existing_objectives():
+    source = """
+    @minimize_int(if f 0 then 0 else 1)
+    def f (x : Int) : Bool := ?hole;
+    @property(5)
+    def prop_f (x : Int) : Bool := f x;
+    """
+    core, ctx, ectx, metadata = check_and_return_core(source)
+    targets = incomplete_functions_and_holes(ctx, core)
+    synthesizer = _PropertySelectingSynthesizer()
+
+    synthesize_holes(ctx, ectx, core, targets, metadata, synthesizer, budget=1, ui=SilentSynthesisUI())
+
+    assert [goal.kind for goal in synthesizer.seen_goals] == ["expression", "property"]
+    assert synthesizer.seen_scores == [[1, 5.0], [0, 0.0]]
+
+
+def test_gp_candidate_satisfies_property_fitness():
+    source = """
+    def f (x : Int) : Bool := ?hole;
+    @property(6)
+    def prop_f (x : Int) : Bool := f x;
+    """
+    core, ctx, ectx, metadata = check_and_return_core(source)
+    targets = incomplete_functions_and_holes(ctx, core)
+    mapping = synthesize_holes(
+        ctx,
+        ectx,
+        core,
+        targets,
+        metadata,
+        GESynthesizer(method="enumerative"),
+        budget=0.5,
+        ui=SilentSynthesisUI(),
+    )
+    filled = core
+    for hole_name, candidate in mapping.items():
+        assert candidate is not None
+        filled = substitution(filled, candidate, hole_name)
+
+    results = run_properties(ctx, ectx, filled, metadata)
+    assert results and all(result.passed for result in results)
+
+
+def test_adt_property_corpus_uses_constructor_values():
+    source = """
+    open Maybe
+    def f (m : (Maybe Int)) : Bool := ?hole;
+    @property(10)
+    def prop_f (m : (Maybe Int)) : Bool := f m;
+    """
+    driver = AeonDriver(
+        AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=1, no_main=True)
+    )
+    assert driver.parse(aeon_code=source, filename="<property-fitness-test>") == []
+    targets = incomplete_functions_and_holes(driver.typing_ctx, driver.core)
+    fun_name, _ = targets[0]
+    corpora = property_corpora_for_target(
+        driver.typing_ctx,
+        driver.core,
+        driver.metadata,
+        fun_name,
+        {name for name, _ in targets},
+        constructor_names=driver.constructor_names,
+    )
+
+    assert len(corpora) == 1
+    rendered = [repr(case[0]).lower() for case in corpora[0].cases]
+    assert all("maybe_just" in value or "maybe_none" in value for value in rendered)
+    assert any("maybe_just" in value for value in rendered)


### PR DESCRIPTION
## Summary

- generate one deterministic fixed input corpus for each relevant `@property` and synthesis target
- expose property failure counts as minimized fitness objectives while preserving existing goal ordering
- skip relational properties that reference another open target during independent synthesis, leaving Contata's joint property handling unchanged
- support refined/dependent inputs and ADT-generated inputs by forwarding constructor metadata
- document the behavior and add focused coverage plus a Pell equation synthesis example

## Validation

- `uv run pytest tests/property_fitness_test.py tests/pbt_test.py tests/example_decorator_test.py tests/multi_objective_fitness_test.py tests/mutual_synthesis_test.py` — 44 passed, 1 skipped
- `uvx pre-commit run --all-files` — passed
- `bash run_examples.sh` — passed
- broader targeted suite — 58 passed, 2 skipped; one unrelated environment failure because RAPL energy data at `/sys/class/powercap/intel-rapl:0/energy_uj` is not readable
- GitHub Actions test matrix is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)