### PR TITLE
Add refined CUDA resource library

### DIFF
--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -7,8 +7,10 @@ machines without an NVIDIA driver.
 
 The public objects model the lifetime used by ``Cuda.ae``: uploads produce a
 ready :class:`Buffer`, a kernel launch produces :class:`Pending`, and
-``synchronize`` turns that pending result into a ready buffer.  ``free`` and
-``discard`` are idempotent so error paths and finalizers can safely clean up.
+``synchronize`` turns that pending result into a ready buffer.  Downloads copy
+to fresh host arrays while preserving the ready buffer for subsequent downloads
+or an explicit ``free``.  ``free`` and ``discard`` are idempotent so error paths
+and finalizers can safely clean up.
 """
 
 from __future__ import annotations
@@ -574,11 +576,11 @@ def _download(buffer: Buffer, dtype: _DType) -> list[int] | list[float]:
     buffer._ensure_ready()
     if buffer.dtype != dtype:
         raise TypeError(f"expected a {dtype} CUDA buffer, got {buffer.dtype}")
-    typecode = "i" if dtype == "i32" else "d"
-    host = array.array(typecode, [0]) * buffer.length
-    with buffer.device._lock:
-        buffer.device._activate()
-        try:
+    try:
+        typecode = "i" if dtype == "i32" else "d"
+        host = array.array(typecode, [0]) * buffer.length
+        with buffer.device._lock:
+            buffer.device._activate()
             if host:
                 address, length = host.buffer_info()
                 buffer.device._driver.check(
@@ -587,11 +589,15 @@ def _download(buffer: Buffer, dtype: _DType) -> list[int] | list[float]:
                     ),
                     "cuMemcpyDtoH",
                 )
-        finally:
-            # Download is an ownership-consuming operation in Cuda.ae.  Free on
-            # transfer failure too, so an exception cannot leak device memory.
-            buffer._free_from_device()
-    return host.tolist()
+        return host.tolist()
+    except BaseException:
+        # The Aeon continuation receives no successor buffer when download
+        # fails, so release the now-unreachable allocation if possible.
+        try:
+            buffer.free()
+        except Exception:
+            pass
+        raise
 
 
 def download_i32(buffer: Buffer) -> list[int]:

--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -1,0 +1,789 @@
+"""Small, dependency-free binding to the CUDA Driver API.
+
+Importing this module does not load CUDA.  The driver is discovered and
+initialised only when :func:`device` (or another operation which needs a
+``Device``) is called.  This is intentional: Aeon must remain usable on
+machines without an NVIDIA driver.
+
+The public objects model the lifetime used by ``Cuda.ae``: uploads produce a
+ready :class:`Buffer`, a kernel launch produces :class:`Pending`, and
+``synchronize`` turns that pending result into a ready buffer.  ``free`` and
+``discard`` are idempotent so error paths and finalizers can safely clean up.
+"""
+
+from __future__ import annotations
+
+import array
+import ctypes
+import ctypes.util
+import math
+import sys
+import threading
+import weakref
+from dataclasses import dataclass
+from typing import Any, Iterable, Literal, cast
+
+_DType = Literal["i32", "float64"]
+_ITEM_SIZE: dict[_DType, int] = {"i32": 4, "float64": 8}
+_KERNEL_NAME: dict[_DType, bytes] = {"i32": b"aeon_vector_add_i32", "float64": b"aeon_vector_add_float64"}
+
+
+class CUDAError(RuntimeError):
+    """Base exception for CUDA binding failures."""
+
+
+class CUDAUnavailableError(CUDAError):
+    """Raised when the CUDA driver or a CUDA device is unavailable."""
+
+
+class CUDAStateError(CUDAError):
+    """Raised when a consumed CUDA handle is used again."""
+
+
+class _CudaDriver:
+    """Typed, lazy facade over ``libcuda``."""
+
+    def __init__(self) -> None:
+        self.lib = self._open_library()
+        self._bind_functions()
+        self._initialised = False
+        self._init_lock = threading.Lock()
+
+    @staticmethod
+    def _open_library() -> ctypes.CDLL:
+        candidates: list[str] = []
+        found = ctypes.util.find_library("cuda")
+        if found:
+            candidates.append(found)
+        if sys.platform == "win32":
+            candidates.extend(["nvcuda.dll"])
+        elif sys.platform == "darwin":
+            candidates.extend(["libcuda.dylib"])
+        else:
+            candidates.extend(["libcuda.so.1", "libcuda.so"])
+
+        errors: list[str] = []
+        for candidate in dict.fromkeys(candidates):
+            try:
+                return ctypes.CDLL(candidate)
+            except OSError as exc:
+                errors.append(str(exc))
+        detail = f" ({'; '.join(errors)})" if errors else ""
+        raise CUDAUnavailableError(f"CUDA driver library was not found{detail}")
+
+    def _symbol(self, name: str, *fallbacks: str) -> Any:
+        for candidate in (name, *fallbacks):
+            try:
+                return getattr(self.lib, candidate)
+            except AttributeError:
+                pass
+        raise CUDAUnavailableError(f"CUDA driver does not provide {name}")
+
+    @staticmethod
+    def _configure(fn: Any, argtypes: list[Any]) -> Any:
+        fn.argtypes = argtypes
+        fn.restype = ctypes.c_int
+        return fn
+
+    def _bind_functions(self) -> None:
+        void_p = ctypes.c_void_p
+        uint = ctypes.c_uint
+        size_t = ctypes.c_size_t
+        int_p = ctypes.POINTER(ctypes.c_int)
+        void_pp = ctypes.POINTER(void_p)
+
+        self.cuInit = self._configure(self._symbol("cuInit"), [uint])
+        self.cuDeviceGetCount = self._configure(self._symbol("cuDeviceGetCount"), [int_p])
+        self.cuDeviceGet = self._configure(self._symbol("cuDeviceGet"), [int_p, ctypes.c_int])
+        self.cuDeviceGetName = self._configure(
+            self._symbol("cuDeviceGetName"), [ctypes.POINTER(ctypes.c_char), ctypes.c_int, ctypes.c_int]
+        )
+        self.cuDeviceComputeCapability = self._configure(
+            self._symbol("cuDeviceComputeCapability"), [int_p, int_p, ctypes.c_int]
+        )
+        self.cuDeviceGetAttribute = self._configure(
+            self._symbol("cuDeviceGetAttribute"), [int_p, ctypes.c_int, ctypes.c_int]
+        )
+        self.cuCtxCreate = self._configure(self._symbol("cuCtxCreate_v2", "cuCtxCreate"), [void_pp, uint, ctypes.c_int])
+        self.cuCtxDestroy = self._configure(self._symbol("cuCtxDestroy_v2", "cuCtxDestroy"), [void_p])
+        self.cuCtxSetCurrent = self._configure(self._symbol("cuCtxSetCurrent"), [void_p])
+        self.cuCtxSynchronize = self._configure(self._symbol("cuCtxSynchronize"), [])
+        self.cuMemAlloc = self._configure(
+            self._symbol("cuMemAlloc_v2", "cuMemAlloc"), [ctypes.POINTER(ctypes.c_uint64), size_t]
+        )
+        self.cuMemFree = self._configure(self._symbol("cuMemFree_v2", "cuMemFree"), [ctypes.c_uint64])
+        self.cuMemcpyHtoD = self._configure(
+            self._symbol("cuMemcpyHtoD_v2", "cuMemcpyHtoD"), [ctypes.c_uint64, void_p, size_t]
+        )
+        self.cuMemcpyDtoH = self._configure(
+            self._symbol("cuMemcpyDtoH_v2", "cuMemcpyDtoH"), [void_p, ctypes.c_uint64, size_t]
+        )
+        self.cuModuleLoadData = self._configure(self._symbol("cuModuleLoadData"), [void_pp, void_p])
+        self.cuModuleUnload = self._configure(self._symbol("cuModuleUnload"), [void_p])
+        self.cuModuleGetFunction = self._configure(
+            self._symbol("cuModuleGetFunction"), [void_pp, void_p, ctypes.c_char_p]
+        )
+        self.cuLaunchKernel = self._configure(
+            self._symbol("cuLaunchKernel"),
+            [
+                void_p,
+                uint,
+                uint,
+                uint,
+                uint,
+                uint,
+                uint,
+                uint,
+                void_p,
+                void_pp,
+                void_pp,
+            ],
+        )
+        try:
+            self.cuGetErrorName = self._configure(
+                self._symbol("cuGetErrorName"), [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+            )
+            self.cuGetErrorString = self._configure(
+                self._symbol("cuGetErrorString"), [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+            )
+        except CUDAUnavailableError:
+            self.cuGetErrorName = None
+            self.cuGetErrorString = None
+
+    def initialise(self) -> None:
+        with self._init_lock:
+            if not self._initialised:
+                self.check(self.cuInit(0), "cuInit")
+                self._initialised = True
+
+    def error_text(self, result: int) -> str:
+        details: list[str] = []
+        for fn in (self.cuGetErrorName, self.cuGetErrorString):
+            if fn is None:
+                continue
+            text = ctypes.c_char_p()
+            if fn(result, ctypes.byref(text)) == 0 and text.value:
+                details.append(text.value.decode("utf-8", errors="replace"))
+        return ": ".join(details) if details else f"CUDA error {result}"
+
+    def check(self, result: int, operation: str) -> None:
+        if result != 0:
+            raise CUDAError(f"{operation} failed: {self.error_text(result)}")
+
+
+_DRIVER: _CudaDriver | None = None
+_DRIVER_LOCK = threading.Lock()
+
+
+def _driver() -> _CudaDriver:
+    global _DRIVER
+    with _DRIVER_LOCK:
+        if _DRIVER is None:
+            _DRIVER = _CudaDriver()
+        driver = _DRIVER
+    driver.initialise()
+    return driver
+
+
+class Device:
+    """An owned CUDA context for one physical device."""
+
+    def __init__(self, ordinal: int = 0) -> None:
+        if isinstance(ordinal, bool) or not isinstance(ordinal, int) or ordinal < 0:
+            raise ValueError("CUDA device ordinal must be a non-negative integer")
+        driver = _driver()
+        count = ctypes.c_int()
+        driver.check(driver.cuDeviceGetCount(ctypes.byref(count)), "cuDeviceGetCount")
+        if ordinal >= count.value:
+            raise CUDAUnavailableError(f"CUDA device {ordinal} is unavailable (found {count.value})")
+
+        handle = ctypes.c_int()
+        driver.check(driver.cuDeviceGet(ctypes.byref(handle), ordinal), "cuDeviceGet")
+        context = ctypes.c_void_p()
+        driver.check(driver.cuCtxCreate(ctypes.byref(context), 0, handle.value), "cuCtxCreate")
+
+        self.ordinal = ordinal
+        # These attributes are the runtime counterparts of Cuda.ae's measures.
+        self.device_id = ordinal
+        self._driver = driver
+        self._handle = handle.value
+        self._context = context
+        self._closed = False
+        self._buffers: weakref.WeakSet[Buffer] = weakref.WeakSet()
+        self._pending: weakref.WeakSet[Pending] = weakref.WeakSet()
+        self._module: ctypes.c_void_p | None = None
+        self._functions: dict[_DType, ctypes.c_void_p] = {}
+        self._lock = threading.RLock()
+
+        try:
+            name = ctypes.create_string_buffer(256)
+            driver.check(driver.cuDeviceGetName(name, len(name), handle.value), "cuDeviceGetName")
+            self.name = name.value.decode("utf-8", errors="replace")
+            major, minor = ctypes.c_int(), ctypes.c_int()
+            driver.check(
+                driver.cuDeviceComputeCapability(ctypes.byref(major), ctypes.byref(minor), handle.value),
+                "cuDeviceComputeCapability",
+            )
+            self.compute_capability = (major.value, minor.value)
+            max_threads = ctypes.c_int()
+            # CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK is stable value 1.
+            driver.check(
+                driver.cuDeviceGetAttribute(ctypes.byref(max_threads), 1, handle.value), "cuDeviceGetAttribute"
+            )
+            self.max_threads_per_block = max_threads.value
+        except BaseException:
+            try:
+                driver.cuCtxDestroy(context)
+            finally:
+                self._closed = True
+            raise
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise CUDAStateError("CUDA device is closed")
+
+    def _activate(self) -> None:
+        self._ensure_open()
+        self._driver.check(self._driver.cuCtxSetCurrent(self._context), "cuCtxSetCurrent")
+
+    def _register_buffer(self, buffer: Buffer) -> None:
+        self._buffers.add(buffer)
+
+    def _function(self, dtype: _DType) -> ctypes.c_void_p:
+        self._activate()
+        if dtype in self._functions:
+            return self._functions[dtype]
+        if self._module is None:
+            ptx = _compile_vector_add_ptx(self.compute_capability)
+            ptx_data = ctypes.create_string_buffer(ptx.encode("utf-8"))
+            module = ctypes.c_void_p()
+            self._driver.check(
+                self._driver.cuModuleLoadData(ctypes.byref(module), ctypes.cast(ptx_data, ctypes.c_void_p)),
+                "cuModuleLoadData",
+            )
+            self._module = module
+        function = ctypes.c_void_p()
+        self._driver.check(
+            self._driver.cuModuleGetFunction(ctypes.byref(function), self._module, _KERNEL_NAME[dtype]),
+            "cuModuleGetFunction",
+        )
+        self._functions[dtype] = function
+        return function
+
+    def synchronize(self) -> None:
+        with self._lock:
+            self._activate()
+            self._driver.check(self._driver.cuCtxSynchronize(), "cuCtxSynchronize")
+
+    def close(self) -> None:
+        """Synchronize, release children and destroy this context.
+
+        Cleanup is best-effort but the first CUDA error is re-raised after all
+        resources have had a chance to be released.
+        """
+        with self._lock:
+            if self._closed:
+                return
+            error: BaseException | None = None
+            try:
+                self._activate()
+                self._driver.check(self._driver.cuCtxSynchronize(), "cuCtxSynchronize")
+            except BaseException as exc:
+                error = exc
+            for pending in list(self._pending):
+                try:
+                    pending._discard_after_device_sync()
+                except BaseException as exc:
+                    error = error or exc
+            for buffer in list(self._buffers):
+                try:
+                    buffer._free_from_device()
+                except BaseException as exc:
+                    error = error or exc
+            if self._module is not None:
+                try:
+                    self._driver.check(self._driver.cuModuleUnload(self._module), "cuModuleUnload")
+                except BaseException as exc:
+                    error = error or exc
+                self._module = None
+                self._functions.clear()
+            try:
+                self._driver.check(self._driver.cuCtxDestroy(self._context), "cuCtxDestroy")
+            except BaseException as exc:
+                error = error or exc
+            self._closed = True
+            if error is not None:
+                raise error
+
+    def __enter__(self) -> Device:
+        self._ensure_open()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+@dataclass(frozen=True)
+class Launch1D:
+    """Validated one-dimensional launch geometry."""
+
+    size: int
+    block_size: int = 256
+
+    def __post_init__(self) -> None:
+        if isinstance(self.size, bool) or not isinstance(self.size, int) or self.size <= 0:
+            raise ValueError("launch size must be a positive integer")
+        if isinstance(self.block_size, bool) or not isinstance(self.block_size, int) or self.block_size <= 0:
+            raise ValueError("block size must be a positive integer")
+        if self.block_size > self.size:
+            raise ValueError("block size cannot exceed launch size")
+        if self.block_size > 1024:
+            raise ValueError("block size cannot exceed CUDA's architectural limit of 1024")
+
+    @property
+    def grid_size(self) -> int:
+        return math.ceil(self.size / self.block_size)
+
+
+class Buffer:
+    """A ready, typed device allocation."""
+
+    def __init__(self, device: Device, pointer: int, length: int, dtype: _DType) -> None:
+        self.device = device
+        self.pointer = pointer
+        self.length = length
+        self.dtype = dtype
+        self._freed = False
+        device._register_buffer(self)
+
+    def _ensure_ready(self) -> None:
+        self.device._ensure_open()
+        if self._freed:
+            raise CUDAStateError("CUDA buffer has been freed")
+
+    def _free_from_device(self) -> None:
+        if self._freed:
+            return
+        self.device._driver.check(self.device._driver.cuMemFree(self.pointer), "cuMemFree")
+        self._freed = True
+
+    def free(self) -> None:
+        with self.device._lock:
+            if self._freed:
+                return
+            self.device._activate()
+            self._free_from_device()
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, index: int) -> int:
+        """Expose refinement measures to the Aeon runtime."""
+        if index == 0:
+            return self.device.ordinal
+        if index == 1:
+            return self.length
+        raise IndexError(index)
+
+    def __enter__(self) -> Buffer:
+        self._ensure_ready()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.free()
+
+    def __del__(self) -> None:
+        try:
+            self.free()
+        except Exception:
+            pass
+
+
+class Pending:
+    """The not-yet-synchronized output of an asynchronous kernel launch."""
+
+    def __init__(self, output: Buffer, inputs: tuple[Buffer, ...]) -> None:
+        self.device = output.device
+        self._output: Buffer | None = output
+        self._inputs = inputs
+        self._consumed = False
+        self.device._pending.add(self)
+
+    def _ensure_pending(self) -> Buffer:
+        self.device._ensure_open()
+        if self._consumed or self._output is None:
+            raise CUDAStateError("CUDA pending result has already been consumed")
+        return self._output
+
+    def synchronize(self) -> Buffer:
+        with self.device._lock:
+            output = self._ensure_pending()
+            self.device.synchronize()
+            inputs = self._inputs
+            self._consumed = True
+            self._output = None
+            self._inputs = ()
+            try:
+                for buffer in inputs:
+                    buffer._free_from_device()
+            except BaseException:
+                # Ownership of every input and the output moved into Pending.
+                # If cleanup fails, do not expose a half-cleaned result.
+                for buffer in inputs:
+                    try:
+                        buffer._free_from_device()
+                    except Exception:
+                        pass
+                try:
+                    output._free_from_device()
+                except Exception:
+                    pass
+                raise
+            return output
+
+    def _discard_after_device_sync(self) -> None:
+        if self._consumed:
+            return
+        buffers = (*self._inputs, self._output) if self._output is not None else self._inputs
+        self._consumed = True
+        self._output = None
+        self._inputs = ()
+        error: BaseException | None = None
+        for buffer in buffers:
+            try:
+                buffer._free_from_device()
+            except BaseException as exc:
+                error = error or exc
+        if error is not None:
+            raise error
+
+    def discard(self) -> None:
+        with self.device._lock:
+            if self._consumed:
+                return
+            self.device.synchronize()
+            self._discard_after_device_sync()
+
+    def __del__(self) -> None:
+        try:
+            self.discard()
+        except Exception:
+            pass
+
+
+def device(ordinal: int = 0) -> Device:
+    return Device(ordinal)
+
+
+def launch_1d(size: int, block_size: int | None = None) -> Launch1D:
+    return Launch1D(size, min(256, size) if block_size is None else block_size)
+
+
+def device_id(device_: Device) -> int:
+    return device_.ordinal
+
+
+def max_threads_per_block(device_: Device) -> int:
+    return device_.max_threads_per_block
+
+
+def launch_device(launch: Launch1D | tuple[Launch1D, Device]) -> int:
+    if isinstance(launch, tuple):
+        return launch[1].ordinal
+    raise ValueError("a Launch1D descriptor alone does not own a device")
+
+
+def launch_items(launch: Launch1D | tuple[Launch1D, Device]) -> int:
+    return launch[0].size if isinstance(launch, tuple) else launch.size
+
+
+def launch_threads(launch: Launch1D | tuple[Launch1D, Device]) -> int:
+    return launch[0].block_size if isinstance(launch, tuple) else launch.block_size
+
+
+def buffer_device(buffer: Buffer) -> int:
+    return buffer.device.ordinal
+
+
+def buffer_size(buffer: Buffer) -> int:
+    return buffer.length
+
+
+def pending_device(pending: Pending) -> int:
+    return pending.device.ordinal
+
+
+def pending_size(pending: Pending) -> int:
+    return pending._ensure_pending().length
+
+
+def _coerce_values(values: Iterable[int] | Iterable[float], dtype: _DType) -> array.array[Any]:
+    try:
+        if dtype == "i32":
+            result = array.array("i", values)
+            if result.itemsize != 4:
+                raise CUDAError("this Python platform does not provide a 32-bit array type")
+            return result
+        result = array.array("d", values)
+        if result.itemsize != 8:
+            raise CUDAError("this Python platform does not provide a 64-bit float array type")
+        return result
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"values cannot be represented as {dtype}") from exc
+
+
+def _upload(device_: Device, values: Iterable[int] | Iterable[float], dtype: _DType) -> Buffer:
+    host = _coerce_values(values, dtype)
+    with device_._lock:
+        device_._activate()
+        pointer = ctypes.c_uint64()
+        allocation_size = max(1, len(host)) * _ITEM_SIZE[dtype]
+        device_._driver.check(
+            device_._driver.cuMemAlloc(ctypes.byref(pointer), allocation_size),
+            "cuMemAlloc",
+        )
+        buffer = Buffer(device_, pointer.value, len(host), dtype)
+        try:
+            if host:
+                address, length = host.buffer_info()
+                device_._driver.check(
+                    device_._driver.cuMemcpyHtoD(pointer.value, ctypes.c_void_p(address), length * host.itemsize),
+                    "cuMemcpyHtoD",
+                )
+        except BaseException:
+            buffer.free()
+            raise
+        return buffer
+
+
+def upload_i32(device_: Device, values: Iterable[int]) -> Buffer:
+    return _upload(device_, values, "i32")
+
+
+def upload_float64(device_: Device, values: Iterable[float]) -> Buffer:
+    return _upload(device_, values, "float64")
+
+
+def _download(buffer: Buffer, dtype: _DType) -> list[int] | list[float]:
+    buffer._ensure_ready()
+    if buffer.dtype != dtype:
+        raise TypeError(f"expected a {dtype} CUDA buffer, got {buffer.dtype}")
+    typecode = "i" if dtype == "i32" else "d"
+    host = array.array(typecode, [0]) * buffer.length
+    with buffer.device._lock:
+        buffer.device._activate()
+        try:
+            if host:
+                address, length = host.buffer_info()
+                buffer.device._driver.check(
+                    buffer.device._driver.cuMemcpyDtoH(
+                        ctypes.c_void_p(address), buffer.pointer, length * host.itemsize
+                    ),
+                    "cuMemcpyDtoH",
+                )
+        finally:
+            # Download is an ownership-consuming operation in Cuda.ae.  Free on
+            # transfer failure too, so an exception cannot leak device memory.
+            buffer._free_from_device()
+    return host.tolist()
+
+
+def download_i32(buffer: Buffer) -> list[int]:
+    return cast(list[int], _download(buffer, "i32"))
+
+
+def download_float64(buffer: Buffer) -> list[float]:
+    return cast(list[float], _download(buffer, "float64"))
+
+
+def _vector_add(device_: Device, launch: Launch1D, left: Buffer, right: Buffer, dtype: _DType) -> Pending:
+    if launch.block_size > device_.max_threads_per_block:
+        raise ValueError(f"block size {launch.block_size} exceeds device limit {device_.max_threads_per_block}")
+    for operand in (left, right):
+        operand._ensure_ready()
+        if operand.device is not device_:
+            raise ValueError("all CUDA buffers must belong to the launch device")
+        if operand.dtype != dtype:
+            raise TypeError(f"expected {dtype} CUDA buffers")
+    if left.length != right.length or launch.size != left.length:
+        raise ValueError("launch size and both buffer lengths must match")
+
+    with device_._lock:
+        device_._activate()
+        pointer = ctypes.c_uint64()
+        device_._driver.check(
+            device_._driver.cuMemAlloc(ctypes.byref(pointer), max(1, launch.size) * _ITEM_SIZE[dtype]),
+            "cuMemAlloc",
+        )
+        output = Buffer(device_, pointer.value, launch.size, dtype)
+        try:
+            if launch.size:
+                function = device_._function(dtype)
+                left_arg = ctypes.c_uint64(left.pointer)
+                right_arg = ctypes.c_uint64(right.pointer)
+                output_arg = ctypes.c_uint64(output.pointer)
+                size_arg = ctypes.c_int32(launch.size)
+                arguments = (ctypes.c_void_p * 4)(
+                    ctypes.addressof(left_arg),
+                    ctypes.addressof(right_arg),
+                    ctypes.addressof(output_arg),
+                    ctypes.addressof(size_arg),
+                )
+                device_._driver.check(
+                    device_._driver.cuLaunchKernel(
+                        function,
+                        launch.grid_size,
+                        1,
+                        1,
+                        launch.block_size,
+                        1,
+                        1,
+                        0,
+                        None,
+                        arguments,
+                        None,
+                    ),
+                    "cuLaunchKernel",
+                )
+        except BaseException:
+            output.free()
+            raise
+        return Pending(output, (left, right))
+
+
+def vector_add_i32(device_: Device, launch: Launch1D, left: Buffer, right: Buffer) -> Pending:
+    return _vector_add(device_, launch, left, right, "i32")
+
+
+def vector_add_float64(device_: Device, launch: Launch1D, left: Buffer, right: Buffer) -> Pending:
+    return _vector_add(device_, launch, left, right, "float64")
+
+
+def synchronize(pending: Pending) -> Buffer:
+    return pending.synchronize()
+
+
+def free(buffer: Buffer) -> None:
+    buffer.free()
+
+
+def discard(pending: Pending) -> None:
+    pending.discard()
+
+
+def close(device_: Device) -> None:
+    device_.close()
+
+
+def _compile_vector_add_ptx(compute_capability: tuple[int, int]) -> str:
+    """Generate the two fixed vector-add kernels and compile them to PTX."""
+    try:
+        import llvmlite.binding as llvm
+        import llvmlite.ir as ir
+    except ImportError as exc:
+        raise CUDAUnavailableError("llvmlite is required to generate CUDA kernels") from exc
+
+    module = ir.Module(name="aeon_cuda_vector_add")
+    module.triple = "nvptx64-nvidia-cuda"
+    module.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64-S128-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32"
+    i32 = ir.IntType(32)
+    tid = ir.Function(module, ir.FunctionType(i32, []), name="llvm.nvvm.read.ptx.sreg.tid.x")
+    ctaid = ir.Function(module, ir.FunctionType(i32, []), name="llvm.nvvm.read.ptx.sreg.ctaid.x")
+    ntid = ir.Function(module, ir.FunctionType(i32, []), name="llvm.nvvm.read.ptx.sreg.ntid.x")
+
+    kernels: list[Any] = []
+    for dtype_value, element in (("i32", i32), ("float64", ir.DoubleType())):
+        dtype = cast(_DType, dtype_value)
+        pointer = ir.PointerType(element, addrspace=1)
+        kernel = ir.Function(
+            module,
+            ir.FunctionType(ir.VoidType(), [pointer, pointer, pointer, i32]),
+            name=_KERNEL_NAME[dtype].decode("ascii"),
+        )
+        left, right, output, size = kernel.args
+        block = kernel.append_basic_block("entry")
+        body = kernel.append_basic_block("body")
+        done = kernel.append_basic_block("done")
+        builder = ir.IRBuilder(block)
+        index = builder.add(builder.mul(builder.call(ctaid, []), builder.call(ntid, [])), builder.call(tid, []))
+        builder.cbranch(builder.icmp_signed("<", index, size), body, done)
+        builder.position_at_end(body)
+        left_value = builder.load(builder.gep(left, [index]))
+        right_value = builder.load(builder.gep(right, [index]))
+        value = builder.add(left_value, right_value) if dtype == "i32" else builder.fadd(left_value, right_value)
+        builder.store(value, builder.gep(output, [index]))
+        builder.branch(done)
+        builder.position_at_end(done)
+        builder.ret_void()
+        kernels.append(kernel)
+
+    annotations = module.add_named_metadata("nvvm.annotations")
+    for kernel in kernels:
+        annotations.add(module.add_metadata([kernel, "kernel", ir.Constant(i32, 1)]))
+
+    try:
+        llvm.initialize_all_targets()
+        llvm.initialize_all_asmprinters()
+        parsed = llvm.parse_assembly(str(module))
+        parsed.verify()
+        target = llvm.Target.from_triple(module.triple)
+        major, minor = compute_capability
+        machine = target.create_target_machine(cpu=f"sm_{major}{minor}", opt=2)
+        return str(machine.emit_assembly(parsed))
+    except Exception as exc:
+        raise CUDAError(
+            f"NVPTX compilation failed for sm_{compute_capability[0]}{compute_capability[1]}: {exc}"
+        ) from exc
+
+
+# Names used by native expressions in Cuda.ae.  Keeping these aliases here also
+# makes the Python binding convenient to exercise without the Aeon evaluator.
+Cuda_device = device
+Cuda_launch_1d = launch_1d
+Cuda_upload_i32 = upload_i32
+Cuda_upload_float64 = upload_float64
+Cuda_download_i32 = download_i32
+Cuda_download_float64 = download_float64
+Cuda_vector_add_i32 = vector_add_i32
+Cuda_vector_add_float64 = vector_add_float64
+Cuda_synchronize = synchronize
+Cuda_free = free
+Cuda_discard = discard
+Cuda_close = close
+
+__all__ = [
+    "Buffer",
+    "CUDAError",
+    "CUDAStateError",
+    "CUDAUnavailableError",
+    "Device",
+    "Launch1D",
+    "Pending",
+    "buffer_device",
+    "buffer_size",
+    "close",
+    "device",
+    "device_id",
+    "discard",
+    "download_float64",
+    "download_i32",
+    "free",
+    "launch_1d",
+    "launch_device",
+    "launch_items",
+    "launch_threads",
+    "max_threads_per_block",
+    "pending_device",
+    "pending_size",
+    "synchronize",
+    "upload_float64",
+    "upload_i32",
+    "vector_add_float64",
+    "vector_add_i32",
+]

--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -483,6 +483,16 @@ def device(ordinal: int = 0) -> Device:
     return Device(ordinal)
 
 
+def num_devices() -> int:
+    """Return the number of visible CUDA devices without creating a context."""
+    driver = _driver()
+    count = ctypes.c_int()
+    driver.check(driver.cuDeviceGetCount(ctypes.byref(count)), "cuDeviceGetCount")
+    if count.value <= 0:
+        raise CUDAUnavailableError("no CUDA devices are available")
+    return count.value
+
+
 def launch_1d(size: int, block_size: int | None = None) -> Launch1D:
     return Launch1D(size, min(256, size) if block_size is None else block_size)
 
@@ -771,6 +781,7 @@ def _compile_vector_add_ptx(compute_capability: tuple[int, int]) -> str:
 # Names used by native expressions in Cuda.ae.  Keeping these aliases here also
 # makes the Python binding convenient to exercise without the Aeon evaluator.
 Cuda_device = device
+Cuda_num_devices = num_devices
 Cuda_launch_1d = launch_1d
 Cuda_upload_i32 = upload_i32
 Cuda_upload_float64 = upload_float64
@@ -805,6 +816,7 @@ __all__ = [
     "download_i32_result",
     "free",
     "launch_1d",
+    "num_devices",
     "launch_device",
     "launch_items",
     "launch_threads",

--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -591,8 +591,8 @@ def _download(buffer: Buffer, dtype: _DType) -> list[int] | list[float]:
                 )
         return host.tolist()
     except BaseException:
-        # The Aeon continuation receives no successor buffer when download
-        # fails, so release the now-unreachable allocation if possible.
+        # The Aeon caller receives no buffer handle when download fails, so
+        # release the now-unreachable allocation if possible.
         try:
             buffer.free()
         except Exception:
@@ -600,12 +600,32 @@ def _download(buffer: Buffer, dtype: _DType) -> list[int] | list[float]:
         raise
 
 
+@dataclass(frozen=True, slots=True)
+class I32Download:
+    values: list[int]
+    buffer: Buffer
+
+
+@dataclass(frozen=True, slots=True)
+class Float64Download:
+    values: list[float]
+    buffer: Buffer
+
+
 def download_i32(buffer: Buffer) -> list[int]:
     return cast(list[int], _download(buffer, "i32"))
 
 
+def download_i32_result(buffer: Buffer) -> I32Download:
+    return I32Download(download_i32(buffer), buffer)
+
+
 def download_float64(buffer: Buffer) -> list[float]:
     return cast(list[float], _download(buffer, "float64"))
+
+
+def download_float64_result(buffer: Buffer) -> Float64Download:
+    return Float64Download(download_float64(buffer), buffer)
 
 
 def _vector_add(device_: Device, launch: Launch1D, left: Buffer, right: Buffer, dtype: _DType) -> Pending:
@@ -755,7 +775,9 @@ Cuda_launch_1d = launch_1d
 Cuda_upload_i32 = upload_i32
 Cuda_upload_float64 = upload_float64
 Cuda_download_i32 = download_i32
+Cuda_download_i32_result = download_i32_result
 Cuda_download_float64 = download_float64
+Cuda_download_float64_result = download_float64_result
 Cuda_vector_add_i32 = vector_add_i32
 Cuda_vector_add_float64 = vector_add_float64
 Cuda_synchronize = synchronize
@@ -778,7 +800,9 @@ __all__ = [
     "device_id",
     "discard",
     "download_float64",
+    "download_float64_result",
     "download_i32",
+    "download_i32_result",
     "free",
     "launch_1d",
     "launch_device",

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -3,8 +3,8 @@
 # This module is separate from ``Gpu`` and is never imported implicitly by
 # ``@gpu``.  ``Buffer`` and ``Pending`` are linear resources: every uploaded or
 # computed allocation must eventually be freed, synchronized, or discarded
-# exactly once.  Downloads preserve the allocation and pass its ownership to a
-# fresh linear ``Buffer`` binding.
+# exactly once.  Downloads copy to a fresh host array and return a
+# ``DownloadResult`` pairing the snapshot with the preserved allocation.
 
 open Array
 
@@ -16,6 +16,10 @@ type Launch1D
 # Device allocations and enqueued computations are uniquely owned.
 linear type Buffer a
 linear type Pending a
+
+# Host snapshot plus the live device allocation it was read from.
+type I32Download
+type Float64Download
 
 # Logical descriptor/resource measures.  Aeon's ``Float`` is represented by
 # this module explicitly as CUDA float64; it is never silently narrowed to
@@ -30,6 +34,10 @@ def buffer_device : (buffer: (Buffer a)) -> Int := uninterpreted
 def buffer_size : (buffer: (Buffer a)) -> Int := uninterpreted
 def pending_device : (pending: (Pending a)) -> Int := uninterpreted
 def pending_size : (pending: (Pending a)) -> Int := uninterpreted
+def i32_download_device : (p: I32Download) -> Int := uninterpreted
+def i32_download_size : (p: I32Download) -> Int := uninterpreted
+def float64_download_device : (p: Float64Download) -> Int := uninterpreted
+def float64_download_size : (p: Float64Download) -> Int := uninterpreted
 
 # Select an explicit CUDA device, or ask the runtime for its default device.
 def device (id: {n: Int | n >= 0}) :
@@ -108,29 +116,40 @@ def synchronize (1 pending: (Pending a)) :
     native "__import__('aeon.bindings.cuda', fromlist=['synchronize']).synchronize(pending)"
 
 # Copy a completed allocation into a fresh host array while preserving the
-# device allocation.  Ownership of ``buffer`` moves to the callback as
-# ``next``; the callback can download it again and must eventually free it.
-# Continuation passing prevents an unrestricted result wrapper from projecting
-# multiple linear aliases for the same allocation.
-def download_i32
-    (1 buffer: (Buffer Int))
-    (1 continuation:
-        (1 values: {xs: (Array Int) | Array.size xs = buffer_size buffer}) ->
-        (1 next: {b: (Buffer Int) |
-            buffer_device b = buffer_device buffer &&
-            buffer_size b = buffer_size buffer}) ->
-        r) : r :=
-    native "continuation(__import__('aeon.bindings.cuda', fromlist=['download_i32']).download_i32(buffer))(buffer)"
+# device allocation.  The input buffer is consumed.  The returned host array
+# is linear like any other ``Array``; use ``download_buffer_*`` to recover the
+# live GPU allocation and eventually ``free`` it.
+def download_i32 (1 buffer: (Buffer Int)) :
+    {result: I32Download |
+        i32_download_device result = buffer_device buffer &&
+        i32_download_size result = buffer_size buffer} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['download_i32_result']).download_i32_result(buffer)"
 
-def download_float64
-    (1 buffer: (Buffer Float))
-    (1 continuation:
-        (1 values: {xs: (Array Float) | Array.size xs = buffer_size buffer}) ->
-        (1 next: {b: (Buffer Float) |
-            buffer_device b = buffer_device buffer &&
-            buffer_size b = buffer_size buffer}) ->
-        r) : r :=
-    native "continuation(__import__('aeon.bindings.cuda', fromlist=['download_float64']).download_float64(buffer))(buffer)"
+def download_float64 (1 buffer: (Buffer Float)) :
+    {result: Float64Download |
+        float64_download_device result = buffer_device buffer &&
+        float64_download_size result = buffer_size buffer} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['download_float64_result']).download_float64_result(buffer)"
+
+def download_values_i32 (p: I32Download) :
+    {xs: (Array Int) | Array.size xs = i32_download_size p} :=
+    native "p.values"
+
+def download_buffer_i32 (p: I32Download) :
+    {b: (Buffer Int) |
+        buffer_device b = i32_download_device p &&
+        buffer_size b = i32_download_size p} :=
+    native "p.buffer"
+
+def download_values_float64 (p: Float64Download) :
+    {xs: (Array Float) | Array.size xs = float64_download_size p} :=
+    native "p.values"
+
+def download_buffer_float64 (p: Float64Download) :
+    {b: (Buffer Float) |
+        buffer_device b = float64_download_device p &&
+        buffer_size b = float64_download_size p} :=
+    native "p.buffer"
 
 # Explicitly release a completed allocation or abandon pending work.
 def free (1 buffer: (Buffer a)) : Unit :=

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -25,6 +25,7 @@ type Float64Download
 # this module explicitly as CUDA float64; it is never silently narrowed to
 # float32.
 def device_id : (d: Device) -> Int := uninterpreted
+def num_devices : (_: Unit) -> Int := uninterpreted
 def max_threads_per_block : (d: Device) -> Int := uninterpreted
 def launch_device : (launch: Launch1D) -> Int := uninterpreted
 def launch_items : (launch: Launch1D) -> Int := uninterpreted
@@ -40,7 +41,11 @@ def float64_download_device : (p: Float64Download) -> Int := uninterpreted
 def float64_download_size : (p: Float64Download) -> Int := uninterpreted
 
 # Select an explicit CUDA device, or ask the runtime for its default device.
-def device (id: {n: Int | n >= 0}) :
+def num_devices (_: Unit) :
+    {n: Int | n > 0} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['num_devices']).num_devices()"
+
+def device (id: {n: Int | n >= 0 && n < num_devices unit}) :
     {d: Device | device_id d = id && max_threads_per_block d > 0} :=
     native "__import__('aeon.bindings.cuda', fromlist=['device']).device(id)"
 

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -1,0 +1,123 @@
+# Explicit CUDA device-buffer API.
+#
+# This module is separate from ``Gpu`` and is never imported implicitly by
+# ``@gpu``.  ``Buffer`` and ``Pending`` are linear resources: every uploaded or
+# computed allocation must eventually be downloaded/freed, synchronized, or
+# discarded exactly once.
+
+open Array
+
+# Immutable descriptors.  A launch belongs to one device and describes a
+# one-dimensional logical item count and CUDA block size.
+type Device
+type Launch1D
+
+# Device allocations and enqueued computations are uniquely owned.
+linear type Buffer a
+linear type Pending a
+
+# Logical descriptor/resource measures.  Aeon's ``Float`` is represented by
+# this module explicitly as CUDA float64; it is never silently narrowed to
+# float32.
+def device_id : (d: Device) -> Int := uninterpreted
+def max_threads_per_block : (d: Device) -> Int := uninterpreted
+def launch_device : (launch: Launch1D) -> Int := uninterpreted
+def launch_items : (launch: Launch1D) -> Int := uninterpreted
+def launch_threads : (launch: Launch1D) -> Int := uninterpreted
+
+def buffer_device : (buffer: (Buffer a)) -> Int := uninterpreted
+def buffer_size : (buffer: (Buffer a)) -> Int := uninterpreted
+def pending_device : (pending: (Pending a)) -> Int := uninterpreted
+def pending_size : (pending: (Pending a)) -> Int := uninterpreted
+
+# Select an explicit CUDA device, or ask the runtime for its default device.
+def device (id: {n: Int | n >= 0}) :
+    {d: Device | device_id d = id && max_threads_per_block d > 0} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['device']).device(id)"
+
+def default_device (_: Unit) :
+    {d: Device | device_id d >= 0 && max_threads_per_block d > 0} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['device']).device()"
+
+# Describe a non-empty one-dimensional launch.  A block cannot contain more
+# threads than logical items; the binding additionally enforces CUDA's
+# hardware-specific maximum block size.
+def launch_1d (device: Device)
+    (items: {n: Int | n > 0})
+    (threads: {n: Int | n > 0 && n <= items && n <= max_threads_per_block device}) :
+    {launch: Launch1D |
+        launch_device launch = device_id device &&
+        launch_items launch = items &&
+        launch_threads launch = threads} :=
+    native "(__import__('aeon.bindings.cuda', fromlist=['launch_1d']).launch_1d(items, threads), device)"
+
+# Upload non-empty host arrays.  Upload consumes the uniquely-owned host array
+# and returns a uniquely-owned device allocation of the same size.
+def upload_i32 (device: Device)
+    (1 values: {xs: (Array Int) | Array.size xs > 0}) :
+    {buffer: (Buffer Int) |
+        buffer_device buffer = device_id device &&
+        buffer_size buffer = Array.size values} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['upload_i32']).upload_i32(device, values)"
+
+def upload_float64 (device: Device)
+    (1 values: {xs: (Array Float) | Array.size xs > 0}) :
+    {buffer: (Buffer Float) |
+        buffer_device buffer = device_id device &&
+        buffer_size buffer = Array.size values} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['upload_float64']).upload_float64(device, values)"
+
+# Enqueue elementwise addition.  Both inputs must be non-empty, equally sized,
+# resident on the launch's device, and cover exactly the launch's item count.
+# The input allocations are consumed and ownership moves to ``Pending`` until
+# the caller synchronizes or discards it.
+def add_i32
+    (launch: Launch1D)
+    (1 left: {buffer: (Buffer Int) |
+        buffer_size buffer > 0 &&
+        buffer_device buffer = launch_device launch &&
+        buffer_size buffer = launch_items launch})
+    (1 right: {buffer: (Buffer Int) |
+        buffer_size buffer = buffer_size left &&
+        buffer_device buffer = buffer_device left}) :
+    {pending: (Pending Int) |
+        pending_device pending = launch_device launch &&
+        pending_size pending = launch_items launch} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['vector_add_i32']).vector_add_i32(launch[1], launch[0], left, right)"
+
+def add_float64
+    (launch: Launch1D)
+    (1 left: {buffer: (Buffer Float) |
+        buffer_size buffer > 0 &&
+        buffer_device buffer = launch_device launch &&
+        buffer_size buffer = launch_items launch})
+    (1 right: {buffer: (Buffer Float) |
+        buffer_size buffer = buffer_size left &&
+        buffer_device buffer = buffer_device left}) :
+    {pending: (Pending Float) |
+        pending_device pending = launch_device launch &&
+        pending_size pending = launch_items launch} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['vector_add_float64']).vector_add_float64(launch[1], launch[0], left, right)"
+
+# Wait for an enqueued computation and recover its completed device buffer.
+def synchronize (1 pending: (Pending a)) :
+    {buffer: (Buffer a) |
+        buffer_device buffer = pending_device pending &&
+        buffer_size buffer = pending_size pending} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['synchronize']).synchronize(pending)"
+
+# Copy a completed allocation to the host, consuming the device allocation.
+def download_i32 (1 buffer: (Buffer Int)) :
+    {values: (Array Int) | Array.size values = buffer_size buffer} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['download_i32']).download_i32(buffer)"
+
+def download_float64 (1 buffer: (Buffer Float)) :
+    {values: (Array Float) | Array.size values = buffer_size buffer} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['download_float64']).download_float64(buffer)"
+
+# Explicitly release a completed allocation or abandon pending work.
+def free (1 buffer: (Buffer a)) : Unit :=
+    native "__import__('aeon.bindings.cuda', fromlist=['free']).free(buffer)"
+
+def discard (1 pending: (Pending a)) : Unit :=
+    native "__import__('aeon.bindings.cuda', fromlist=['discard']).discard(pending)"

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -2,8 +2,9 @@
 #
 # This module is separate from ``Gpu`` and is never imported implicitly by
 # ``@gpu``.  ``Buffer`` and ``Pending`` are linear resources: every uploaded or
-# computed allocation must eventually be downloaded/freed, synchronized, or
-# discarded exactly once.
+# computed allocation must eventually be freed, synchronized, or discarded
+# exactly once.  Downloads preserve the allocation and pass its ownership to a
+# fresh linear ``Buffer`` binding.
 
 open Array
 
@@ -106,14 +107,30 @@ def synchronize (1 pending: (Pending a)) :
         buffer_size buffer = pending_size pending} :=
     native "__import__('aeon.bindings.cuda', fromlist=['synchronize']).synchronize(pending)"
 
-# Copy a completed allocation to the host, consuming the device allocation.
-def download_i32 (1 buffer: (Buffer Int)) :
-    {values: (Array Int) | Array.size values = buffer_size buffer} :=
-    native "__import__('aeon.bindings.cuda', fromlist=['download_i32']).download_i32(buffer)"
+# Copy a completed allocation into a fresh host array while preserving the
+# device allocation.  Ownership of ``buffer`` moves to the callback as
+# ``next``; the callback can download it again and must eventually free it.
+# Continuation passing prevents an unrestricted result wrapper from projecting
+# multiple linear aliases for the same allocation.
+def download_i32
+    (1 buffer: (Buffer Int))
+    (1 continuation:
+        (1 values: {xs: (Array Int) | Array.size xs = buffer_size buffer}) ->
+        (1 next: {b: (Buffer Int) |
+            buffer_device b = buffer_device buffer &&
+            buffer_size b = buffer_size buffer}) ->
+        r) : r :=
+    native "continuation(__import__('aeon.bindings.cuda', fromlist=['download_i32']).download_i32(buffer))(buffer)"
 
-def download_float64 (1 buffer: (Buffer Float)) :
-    {values: (Array Float) | Array.size values = buffer_size buffer} :=
-    native "__import__('aeon.bindings.cuda', fromlist=['download_float64']).download_float64(buffer)"
+def download_float64
+    (1 buffer: (Buffer Float))
+    (1 continuation:
+        (1 values: {xs: (Array Float) | Array.size xs = buffer_size buffer}) ->
+        (1 next: {b: (Buffer Float) |
+            buffer_device b = buffer_device buffer &&
+            buffer_size b = buffer_size buffer}) ->
+        r) : r :=
+    native "continuation(__import__('aeon.bindings.cuda', fromlist=['download_float64']).download_float64(buffer))(buffer)"
 
 # Explicitly release a completed allocation or abandon pending work.
 def free (1 buffer: (Buffer a)) : Unit :=

--- a/aeon/llvm/pipeline.py
+++ b/aeon/llvm/pipeline.py
@@ -59,8 +59,9 @@ class MultiBackendPipeline(LLVMPipeline):
         return "cpu"
 
     def compile(self, program: Term):
-        self._initialize_cuda_backend()
         discovered_targets = self._find_compilation_targets(program)
+        if any(self._get_target_for_function(target_id) == "cuda" for target_id in discovered_targets):
+            self._initialize_cuda_backend()
 
         for target_id, target_body in discovered_targets.items():
             target_name = self._get_target_for_function(target_id)

--- a/examples/llvm/gpu/cuda_download.ae
+++ b/examples/llvm/gpu/cuda_download.ae
@@ -1,0 +1,83 @@
+import Array;
+import Cuda;
+
+open Cuda
+
+# Examples of the explicit ``Cuda`` download API.
+#
+# ``download_i32`` / ``download_float64`` copy device memory to a fresh host
+# ``Array`` while preserving the GPU ``Buffer``.  Access both parts through
+# ``download_values_*`` and ``download_buffer_*``, then ``free`` the buffer.
+# Host arrays are linear (``let 1 xs := ...``); GPU buffers are too.
+
+# -- 1. Single download ---------------------------------------------------
+#
+#   Buffer --download_i32--> I32Download
+#              |-- download_values_i32 --> Array Int   (host snapshot)
+#              +-- download_buffer_i32 --> Buffer Int  (live allocation)
+#
+def read_once (d: Device) : Int :=
+    let 1 ready := upload_i32 d (Array.append (Array.append (Array.new{Int} unit) 4) 5) in
+    let downloaded := download_i32 ready in
+    let 1 values := download_values_i32 downloaded in
+    let 1 buffer := download_buffer_i32 downloaded in
+    let sum := Array.sum values in
+    let _ := free buffer in
+    sum;
+
+# -- 2. Repeated downloads (no nested callbacks) ---------------------------
+#
+# The preserved buffer can be downloaded again to obtain another host snapshot.
+#
+def read_twice (d: Device) : Int :=
+    let 1 ready0 := upload_i32 d (Array.append (Array.append (Array.new{Int} unit) 1) 2) in
+    let downloaded0 := download_i32 ready0 in
+    let 1 values0 := download_values_i32 downloaded0 in
+    let 1 ready1 := download_buffer_i32 downloaded0 in
+    let downloaded1 := download_i32 ready1 in
+    let 1 values1 := download_values_i32 downloaded1 in
+    let 1 ready2 := download_buffer_i32 downloaded1 in
+    let first := Array.sum values0 in
+    let second := Array.sum values1 in
+    let _ := free ready2 in
+    first + second;
+
+# -- 3. Download, reuse buffer in a kernel, download again ----------------
+#
+# After the first download the GPU allocation stays valid for further kernels.
+#
+def download_compute_download (u: Unit) : Int :=
+    let d := default_device u in
+    let launch := launch_1d d 3 1 in
+    let 1 ready0 := upload_i32 d (Array.append (Array.append (Array.append (Array.new{Int} unit) 1) 2) 3) in
+    let downloaded0 := download_i32 ready0 in
+    let 1 snapshot0 := download_values_i32 downloaded0 in
+    let 1 left := download_buffer_i32 downloaded0 in
+    let 1 right := upload_i32 d (Array.append (Array.append (Array.append (Array.new{Int} unit) 10) 20) 30) in
+    let 1 pending := add_i32 launch left right in
+    let 1 ready1 := synchronize pending in
+    let downloaded1 := download_i32 ready1 in
+    let 1 snapshot1 := download_values_i32 downloaded1 in
+    let 1 buffer := download_buffer_i32 downloaded1 in
+    let _ := Array.sum snapshot0 in
+    let total := Array.sum snapshot1 in
+    let _ := free buffer in
+    total;
+
+# -- 4. float64 variant ----------------------------------------------------
+
+def read_float64 (d: Device) : Float :=
+    let 1 ready := upload_float64 d (Array.append (Array.append (Array.new{Float} unit) (1.5 : Float)) (2.5 : Float)) in
+    let downloaded := download_float64 ready in
+    let 1 values := download_values_float64 downloaded in
+    let 1 buffer := download_buffer_float64 downloaded in
+    let first := Array.get values 0 in
+    let _ := free buffer in
+    first;
+
+def main (args: Int) : Unit :=
+    let d := default_device unit in
+    let _ := print (read_once d) in
+    let _ := print (read_twice d) in
+    let _ := print (download_compute_download unit) in
+    print (read_float64 d);

--- a/examples/llvm/gpu/cuda_vector_add.ae
+++ b/examples/llvm/gpu/cuda_vector_add.ae
@@ -1,0 +1,26 @@
+import Array;
+import Cuda;
+
+# Refined, linear CUDA lifecycle for Int vector addition.
+#
+# Host arrays and device resources are bound at multiplicity 1.  Each handle
+# is consumed exactly once by the next protocol step:
+#
+#   Array --upload--> Buffer --add--> Pending --synchronize--> Buffer --download--> Array
+#
+# The refinements prove at compile time that both inputs and the launch have
+# three items, share a device, and use a valid CUDA block size.  With a CUDA
+# driver/device present this prints 66 (11 + 22 + 33).
+def vector_add (u: Unit) : Int :=
+    let d := Cuda.default_device u in
+    let launch := Cuda.launch_1d d 3 1 in
+    let 1 xs := Array.append (Array.append (Array.append (Array.new{Int} unit) 1) 2) 3 in
+    let 1 ys := Array.append (Array.append (Array.append (Array.new{Int} unit) 10) 20) 30 in
+    let 1 left := Cuda.upload_i32 d xs in
+    let 1 right := Cuda.upload_i32 d ys in
+    let 1 pending := Cuda.add_i32 launch left right in
+    let 1 ready := Cuda.synchronize pending in
+    let 1 result := Cuda.download_i32 ready in
+    Array.sum result;
+
+def main (args: Int) : Unit := print (vector_add unit);

--- a/examples/llvm/gpu/cuda_vector_add.ae
+++ b/examples/llvm/gpu/cuda_vector_add.ae
@@ -4,9 +4,12 @@ import Cuda;
 # Refined, linear CUDA lifecycle for Int vector addition.
 #
 # Host arrays and device resources are bound at multiplicity 1.  Each handle
-# is consumed exactly once by the next protocol step:
+# is consumed exactly once by the next protocol step.  Download produces a
+# fresh host snapshot and transfers ownership to a new Buffer binding, which
+# can be downloaded again or explicitly freed:
 #
-#   Array --upload--> Buffer --add--> Pending --synchronize--> Buffer --download--> Array
+#   Array --upload--> Buffer --add--> Pending --synchronize--> Buffer
+#                                                        --download--> Array + Buffer --free--> Unit
 #
 # The refinements prove at compile time that both inputs and the launch have
 # three items, share a device, and use a valid CUDA block size.  With a CUDA
@@ -20,7 +23,9 @@ def vector_add (u: Unit) : Int :=
     let 1 right := Cuda.upload_i32 d ys in
     let 1 pending := Cuda.add_i32 launch left right in
     let 1 ready := Cuda.synchronize pending in
-    let 1 result := Cuda.download_i32 ready in
-    Array.sum result;
+    Cuda.download_i32 ready (fun result => fun next =>
+        let total := Array.sum result in
+        let _ := Cuda.free next in
+        total);
 
 def main (args: Int) : Unit := print (vector_add unit);

--- a/examples/llvm/gpu/cuda_vector_add.ae
+++ b/examples/llvm/gpu/cuda_vector_add.ae
@@ -4,12 +4,11 @@ import Cuda;
 # Refined, linear CUDA lifecycle for Int vector addition.
 #
 # Host arrays and device resources are bound at multiplicity 1.  Each handle
-# is consumed exactly once by the next protocol step.  Download produces a
-# fresh host snapshot and transfers ownership to a new Buffer binding, which
-# can be downloaded again or explicitly freed:
+# is consumed exactly once by the next protocol step.  Download returns host
+# data and the preserved device buffer together:
 #
 #   Array --upload--> Buffer --add--> Pending --synchronize--> Buffer
-#                                                        --download--> Array + Buffer --free--> Unit
+#     --download--> I32Download --free--> Unit
 #
 # The refinements prove at compile time that both inputs and the launch have
 # three items, share a device, and use a valid CUDA block size.  With a CUDA
@@ -23,9 +22,11 @@ def vector_add (u: Unit) : Int :=
     let 1 right := Cuda.upload_i32 d ys in
     let 1 pending := Cuda.add_i32 launch left right in
     let 1 ready := Cuda.synchronize pending in
-    Cuda.download_i32 ready (fun result => fun next =>
-        let total := Array.sum result in
-        let _ := Cuda.free next in
-        total);
+    let downloaded := Cuda.download_i32 ready in
+    let 1 result := Cuda.download_values_i32 downloaded in
+    let 1 next := Cuda.download_buffer_i32 downloaded in
+    let total := Array.sum result in
+    let _ := Cuda.free next in
+    total;
 
 def main (args: Int) : Unit := print (vector_add unit);

--- a/tests/cuda_binding_test.py
+++ b/tests/cuda_binding_test.py
@@ -22,6 +22,16 @@ def test_import_does_not_initialize_cuda(cuda_module):
     assert cuda_module._DRIVER is None
 
 
+def test_num_devices_reports_available_hardware(cuda_module):
+    try:
+        count = cuda_module.num_devices()
+    except cuda_module.CUDAError as exc:
+        pytest.skip(f"CUDA hardware is unavailable: {exc}")
+    assert count > 0
+    with pytest.raises(cuda_module.CUDAUnavailableError):
+        cuda_module.device(count)
+
+
 def test_launch_1d_validates_and_rounds_up(cuda_module):
     assert cuda_module.Launch1D(1, 1).grid_size == 1
     assert cuda_module.Launch1D(33, 32).grid_size == 2

--- a/tests/cuda_binding_test.py
+++ b/tests/cuda_binding_test.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import gc
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def cuda_module():
+    sys.modules.pop("aeon.bindings.cuda", None)
+    module = importlib.import_module("aeon.bindings.cuda")
+    yield module
+    driver = module._DRIVER
+    module._DRIVER = None
+    del driver
+    gc.collect()
+
+
+def test_import_does_not_initialize_cuda(cuda_module):
+    assert cuda_module._DRIVER is None
+
+
+def test_launch_1d_validates_and_rounds_up(cuda_module):
+    assert cuda_module.Launch1D(1, 1).grid_size == 1
+    assert cuda_module.Launch1D(33, 32).grid_size == 2
+
+    for size, block_size in ((0, 1), (-1, 1), (1, 0), (32, 33), (2048, 1025), (True, 1)):
+        with pytest.raises(ValueError):
+            cuda_module.Launch1D(size, block_size)
+
+
+def test_ptx_contains_fixed_vector_add_kernels(cuda_module):
+    ptx = cuda_module._compile_vector_add_ptx((8, 6))
+    assert ".visible .entry aeon_vector_add_i32" in ptx
+    assert ".visible .entry aeon_vector_add_float64" in ptx
+
+
+def _cuda_device_or_skip(cuda_module):
+    try:
+        return cuda_module.Device()
+    except cuda_module.CUDAError as exc:
+        pytest.skip(f"CUDA hardware is unavailable: {exc}")
+
+
+def test_i32_upload_add_download_and_lifecycle(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        left = cuda_module.upload_i32(device, [1, -2, 3, 2**31 - 1])
+        right = cuda_module.upload_i32(device, [4, 8, -3, -1])
+        pending = cuda_module.vector_add_i32(device, cuda_module.Launch1D(4, 4), left, right)
+        output = pending.synchronize()
+
+        assert cuda_module.download_i32(output) == [5, 6, 0, 2**31 - 2]
+        with pytest.raises(cuda_module.CUDAStateError):
+            cuda_module.download_i32(output)
+        with pytest.raises(cuda_module.CUDAStateError):
+            pending.synchronize()
+
+        left.free()
+        left.free()
+        with pytest.raises(cuda_module.CUDAStateError):
+            cuda_module.download_i32(left)
+        assert right._freed
+        output.free()
+    finally:
+        device.close()
+        device.close()
+
+
+def test_float64_upload_add_download_and_discard(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        left = cuda_module.upload_float64(device, [0.5, -2.25, 1e100])
+        right = cuda_module.upload_float64(device, [1.25, 0.25, -1e100])
+        pending = cuda_module.vector_add_float64(device, cuda_module.launch_1d(3), left, right)
+        output = pending._output
+        pending.discard()
+        pending.discard()
+
+        assert output is not None
+        with pytest.raises(cuda_module.CUDAStateError):
+            cuda_module.download_float64(output)
+        with pytest.raises(cuda_module.CUDAStateError):
+            pending.synchronize()
+        assert left._freed
+        assert right._freed
+    finally:
+        device.close()
+
+
+def test_rejects_mismatched_buffers_without_allocating_output(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        ints = cuda_module.upload_i32(device, [1, 2])
+        floats = cuda_module.upload_float64(device, [1.0, 2.0])
+        with pytest.raises(TypeError):
+            cuda_module.vector_add_i32(device, cuda_module.launch_1d(2), ints, floats)
+        with pytest.raises(ValueError):
+            cuda_module.vector_add_i32(device, cuda_module.launch_1d(1), ints, ints)
+        ints.free()
+        floats.free()
+    finally:
+        device.close()
+
+
+def test_device_close_cleans_live_buffers_and_pending_results(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    left = cuda_module.upload_i32(device, [1])
+    right = cuda_module.upload_i32(device, [2])
+    pending = cuda_module.vector_add_i32(device, cuda_module.launch_1d(1), left, right)
+    output = pending._output
+
+    device.close()
+
+    assert left._freed
+    assert right._freed
+    assert output is not None and output._freed
+    with pytest.raises(cuda_module.CUDAStateError):
+        pending.synchronize()
+
+
+def test_unavailable_driver_is_reported_only_on_first_operation(cuda_module, monkeypatch):
+    def unavailable():
+        raise OSError("no CUDA")
+
+    monkeypatch.setattr(cuda_module.ctypes.util, "find_library", lambda name: None)
+    monkeypatch.setattr(cuda_module.ctypes, "CDLL", lambda name: unavailable())
+
+    assert cuda_module._DRIVER is None
+    with pytest.raises(cuda_module.CUDAUnavailableError, match="not found"):
+        cuda_module.Device()

--- a/tests/cuda_binding_test.py
+++ b/tests/cuda_binding_test.py
@@ -52,9 +52,13 @@ def test_i32_upload_add_download_and_lifecycle(cuda_module):
         pending = cuda_module.vector_add_i32(device, cuda_module.Launch1D(4, 4), left, right)
         output = pending.synchronize()
 
-        assert cuda_module.download_i32(output) == [5, 6, 0, 2**31 - 2]
-        with pytest.raises(cuda_module.CUDAStateError):
-            cuda_module.download_i32(output)
+        expected = [5, 6, 0, 2**31 - 2]
+        first = cuda_module.download_i32(output)
+        second = cuda_module.download_i32(output)
+        assert first == expected
+        assert second == expected
+        assert first is not second
+        assert not output._freed
         with pytest.raises(cuda_module.CUDAStateError):
             pending.synchronize()
 
@@ -63,9 +67,29 @@ def test_i32_upload_add_download_and_lifecycle(cuda_module):
         with pytest.raises(cuda_module.CUDAStateError):
             cuda_module.download_i32(left)
         assert right._freed
+
+        output.free()
+        with pytest.raises(cuda_module.CUDAStateError):
+            cuda_module.download_i32(output)
         output.free()
     finally:
         device.close()
+        device.close()
+
+
+def test_download_failure_releases_buffer(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        buffer = cuda_module.upload_i32(device, [1])
+
+        def fail_copy(*args):
+            raise cuda_module.CUDAError("copy failed")
+
+        device._driver.cuMemcpyDtoH = fail_copy
+        with pytest.raises(cuda_module.CUDAError, match="copy failed"):
+            cuda_module.download_i32(buffer)
+        assert buffer._freed
+    finally:
         device.close()
 
 

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -71,9 +71,15 @@ def test_import_cuda_keeps_api_qualified():
 import Cuda;
 
 def selected (u: Unit) : Int := Cuda.device_id (Cuda.default_device u);
+def count (u: Unit) : Int := Cuda.num_devices u;
 """
         + MAIN
     )
+    assert _errors(source) == []
+
+
+def test_num_devices_is_positive():
+    source = IMPORTS + "def count (u: Unit) : {n: Int | n > 0} := num_devices u;" + MAIN
     assert _errors(source) == []
 
 
@@ -82,7 +88,8 @@ def test_open_cuda_exposes_descriptors_and_launch_measures():
         IMPORTS
         + """
 def descriptors (d: Device) (l: Launch1D) : Int :=
-    device_id d + max_threads_per_block d + launch_items l + launch_device l + launch_threads l;
+    device_id d + max_threads_per_block d + num_devices unit
+    + launch_items l + launch_device l + launch_threads l;
 """
         + MAIN
     )

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -107,15 +107,17 @@ def lifecycle (u: Unit) : Int :=
     let 1 right := upload_i32 d ys in
     let 1 pending := add_i32 launch left right in
     let 1 ready := synchronize pending in
-    let 1 values := download_i32 ready in
-    Array.sum values;
+    download_i32 ready (fun values => fun next =>
+        let total := Array.sum values in
+        let _ := free next in
+        total);
 """
         + MAIN
     )
     assert _errors(source) == []
 
 
-def test_float64_lifecycle_and_terminal_operations_typecheck():
+def test_float64_lifecycle_and_explicit_terminal_operations_typecheck():
     source = (
         IMPORTS
         + f"""
@@ -128,10 +130,11 @@ def lifecycle (u: Unit) : Unit :=
     let 1 right := upload_float64 d ys in
     let 1 pending := add_float64 launch left right in
     let 1 ready := synchronize pending in
-    let 1 values := download_float64 ready in
-    let _ := Array.length values in
-    let 1 spare := upload_i32 d ({_int_array((7,))}) in
-    free spare;
+    download_float64 ready (fun values => fun next =>
+        let _ := Array.length values in
+        let _ := free next in
+        let 1 spare := upload_i32 d ({_int_array((7,))}) in
+        free spare);
 
 def abandon (u: Unit) : Unit :=
     let d := default_device u in
@@ -224,6 +227,76 @@ def stale (d: Device) : Unit :=
     assert any(isinstance(error, LinearUsedTooManyTimesError) for error in _linearity_errors(source))
 
 
+def test_download_can_thread_ownership_more_than_once():
+    source = (
+        IMPORTS
+        + f"""
+def repeated (d: Device) : Int :=
+    let 1 ready0 := upload_i32 d ({_int_array((1, 2, 3))}) in
+    download_i32 ready0 (fun values0 => fun ready1 =>
+        let first := Array.sum values0 in
+        download_i32 ready1 (fun values1 => fun ready2 =>
+            let second := Array.sum values1 in
+            let _ := free ready2 in
+            first + second));
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_download_preserves_size_and_device_refinements():
+    source = (
+        IMPORTS
+        + f"""
+def preserved (u: Unit) : Int :=
+    let d := default_device u in
+    let launch := launch_1d d 3 1 in
+    let 1 ready0 := upload_i32 d ({_int_array((1, 2, 3))}) in
+    download_i32 ready0 (fun values0 => fun ready1 =>
+        let total0 := Array.sum values0 in
+        let 1 other := upload_i32 d ({_int_array((4, 5, 6))}) in
+        let 1 pending := add_i32 launch ready1 other in
+        let 1 ready2 := synchronize pending in
+        download_i32 ready2 (fun values1 => fun ready3 =>
+            let result := Array.sum values1 in
+            let _ := free ready3 in
+            result));
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_download_callback_must_consume_successor_buffer():
+    source = (
+        IMPORTS
+        + f"""
+def leak_successor (d: Device) : Int :=
+    let 1 ready := upload_i32 d ({_int_array((1,))}) in
+    download_i32 ready (fun values => fun next => Array.sum values);
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUnusedError) for error in _linearity_errors(source))
+
+
+def test_download_consumes_outer_buffer_handle():
+    source = (
+        IMPORTS
+        + f"""
+def stale (d: Device) : Unit :=
+    let 1 ready := upload_i32 d ({_int_array((1,))}) in
+    download_i32 ready (fun values => fun next =>
+        let _ := Array.sum values in
+        let _ := free next in
+        free ready);
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUsedTooManyTimesError) for error in _linearity_errors(source))
+
+
 def test_pending_cannot_be_downloaded_before_synchronize():
     source = (
         IMPORTS
@@ -233,8 +306,10 @@ def premature (d: Device) : Int :=
     let 1 left := upload_i32 d ({_int_array((1,))}) in
     let 1 right := upload_i32 d ({_int_array((2,))}) in
     let 1 pending := add_i32 launch left right in
-    let 1 values := download_i32 pending in
-    Array.sum values;
+    download_i32 pending (fun values => fun next =>
+        let total := Array.sum values in
+        let _ := free next in
+        total);
 """
         + MAIN
     )

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -107,10 +107,12 @@ def lifecycle (u: Unit) : Int :=
     let 1 right := upload_i32 d ys in
     let 1 pending := add_i32 launch left right in
     let 1 ready := synchronize pending in
-    download_i32 ready (fun values => fun next =>
-        let total := Array.sum values in
-        let _ := free next in
-        total);
+    let downloaded := download_i32 ready in
+    let 1 values := download_values_i32 downloaded in
+    let 1 next := download_buffer_i32 downloaded in
+    let total := Array.sum values in
+    let _ := free next in
+    total;
 """
         + MAIN
     )
@@ -130,11 +132,13 @@ def lifecycle (u: Unit) : Unit :=
     let 1 right := upload_float64 d ys in
     let 1 pending := add_float64 launch left right in
     let 1 ready := synchronize pending in
-    download_float64 ready (fun values => fun next =>
-        let _ := Array.length values in
-        let _ := free next in
-        let 1 spare := upload_i32 d ({_int_array((7,))}) in
-        free spare);
+    let downloaded := download_float64 ready in
+    let 1 values := download_values_float64 downloaded in
+    let 1 next := download_buffer_float64 downloaded in
+    let _ := Array.length values in
+    let _ := free next in
+    let 1 spare := upload_i32 d ({_int_array((7,))}) in
+    free spare;
 
 def abandon (u: Unit) : Unit :=
     let d := default_device u in
@@ -227,18 +231,22 @@ def stale (d: Device) : Unit :=
     assert any(isinstance(error, LinearUsedTooManyTimesError) for error in _linearity_errors(source))
 
 
-def test_download_can_thread_ownership_more_than_once():
+def test_download_can_be_repeated_without_nesting():
     source = (
         IMPORTS
         + f"""
 def repeated (d: Device) : Int :=
     let 1 ready0 := upload_i32 d ({_int_array((1, 2, 3))}) in
-    download_i32 ready0 (fun values0 => fun ready1 =>
-        let first := Array.sum values0 in
-        download_i32 ready1 (fun values1 => fun ready2 =>
-            let second := Array.sum values1 in
-            let _ := free ready2 in
-            first + second));
+    let downloaded0 := download_i32 ready0 in
+    let 1 values0 := download_values_i32 downloaded0 in
+    let 1 ready1 := download_buffer_i32 downloaded0 in
+    let downloaded1 := download_i32 ready1 in
+    let 1 values1 := download_values_i32 downloaded1 in
+    let 1 ready2 := download_buffer_i32 downloaded1 in
+    let first := Array.sum values0 in
+    let second := Array.sum values1 in
+    let _ := free ready2 in
+    first + second;
 """
         + MAIN
     )
@@ -253,28 +261,35 @@ def preserved (u: Unit) : Int :=
     let d := default_device u in
     let launch := launch_1d d 3 1 in
     let 1 ready0 := upload_i32 d ({_int_array((1, 2, 3))}) in
-    download_i32 ready0 (fun values0 => fun ready1 =>
-        let total0 := Array.sum values0 in
-        let 1 other := upload_i32 d ({_int_array((4, 5, 6))}) in
-        let 1 pending := add_i32 launch ready1 other in
-        let 1 ready2 := synchronize pending in
-        download_i32 ready2 (fun values1 => fun ready3 =>
-            let result := Array.sum values1 in
-            let _ := free ready3 in
-            result));
+    let downloaded0 := download_i32 ready0 in
+    let 1 values0 := download_values_i32 downloaded0 in
+    let 1 ready1 := download_buffer_i32 downloaded0 in
+    let total0 := Array.sum values0 in
+    let 1 other := upload_i32 d ({_int_array((4, 5, 6))}) in
+    let 1 pending := add_i32 launch ready1 other in
+    let 1 ready2 := synchronize pending in
+    let downloaded1 := download_i32 ready2 in
+    let 1 values1 := download_values_i32 downloaded1 in
+    let 1 ready3 := download_buffer_i32 downloaded1 in
+    let result := Array.sum values1 in
+    let _ := free ready3 in
+    result;
 """
         + MAIN
     )
     assert _errors(source) == []
 
 
-def test_download_callback_must_consume_successor_buffer():
+def test_download_result_must_free_recovered_buffer():
     source = (
         IMPORTS
         + f"""
 def leak_successor (d: Device) : Int :=
     let 1 ready := upload_i32 d ({_int_array((1,))}) in
-    download_i32 ready (fun values => fun next => Array.sum values);
+    let downloaded := download_i32 ready in
+    let 1 values := download_values_i32 downloaded in
+    let 1 next := download_buffer_i32 downloaded in
+    Array.sum values;
 """
         + MAIN
     )
@@ -287,10 +302,12 @@ def test_download_consumes_outer_buffer_handle():
         + f"""
 def stale (d: Device) : Unit :=
     let 1 ready := upload_i32 d ({_int_array((1,))}) in
-    download_i32 ready (fun values => fun next =>
-        let _ := Array.sum values in
-        let _ := free next in
-        free ready);
+    let downloaded := download_i32 ready in
+    let 1 values := download_values_i32 downloaded in
+    let 1 next := download_buffer_i32 downloaded in
+    let _ := Array.sum values in
+    let _ := free next in
+    free ready;
 """
         + MAIN
     )
@@ -306,10 +323,7 @@ def premature (d: Device) : Int :=
     let 1 left := upload_i32 d ({_int_array((1,))}) in
     let 1 right := upload_i32 d ({_int_array((2,))}) in
     let 1 pending := add_i32 launch left right in
-    download_i32 pending (fun values => fun next =>
-        let total := Array.sum values in
-        let _ := free next in
-        total);
+    download_i32 pending;
 """
         + MAIN
     )
@@ -416,6 +430,13 @@ def invalid (u: Unit) : Unit :=
 
 def test_cuda_vector_add_example_typechecks():
     example = Path(__file__).parents[1] / "examples" / "llvm" / "gpu" / "cuda_vector_add.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []
+
+
+def test_cuda_download_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "llvm" / "gpu" / "cuda_download.ae"
     setup_logger()
     cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
     assert AeonDriver(cfg).parse(filename=str(example)) == []

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -1,0 +1,346 @@
+"""Compile-time protocol tests for the explicit ``Cuda`` module.
+
+These tests do not initialize CUDA or require a GPU.  They exercise module
+scoping, the QTT ownership discipline of ``Buffer``/``Pending``, and the
+refinements connecting devices, launch configurations, and vector sizes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aeon.facade.api import (
+    LinearityError,
+    LinearTypeNotBoundLinearlyError,
+    LinearUnusedError,
+    LinearUsedTooManyTimesError,
+)
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+MAIN = '\ndef main (args: Int) : Unit := print "ok";\n'
+IMPORTS = """
+open Array
+open Cuda
+"""
+
+
+def _errors(source: str):
+    """Compile ``source`` without evaluating native CUDA operations."""
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _linearity_errors(source: str):
+    return [error for error in _errors(source) if isinstance(error, LinearityError)]
+
+
+def _int_array(values: tuple[int, ...]) -> str:
+    expression = "Array.new{Int} unit"
+    for value in values:
+        expression = f"Array.append ({expression}) {value}"
+    return expression
+
+
+def _float_array(values: tuple[float, ...]) -> str:
+    expression = "Array.new{Float} unit"
+    for value in values:
+        expression = f"Array.append ({expression}) ({value} : Float)"
+    return expression
+
+
+# ---------------------------------------------------------------------------
+# Module scoping
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_names_are_not_in_the_global_prelude():
+    device_errors = [str(error) for error in _errors("def probe (u: Unit) : Int := device_id u;" + MAIN)]
+    default_errors = [str(error) for error in _errors("def probe (u: Unit) : Int := default_device u;" + MAIN)]
+    assert any("device_id" in error and "does not exist" in error for error in device_errors), device_errors
+    assert any("default_device" in error and "does not exist" in error for error in default_errors), default_errors
+
+
+def test_import_cuda_keeps_api_qualified():
+    source = (
+        """
+import Cuda;
+
+def selected (u: Unit) : Int := Cuda.device_id (Cuda.default_device u);
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_open_cuda_exposes_descriptors_and_launch_measures():
+    source = (
+        IMPORTS
+        + """
+def descriptors (d: Device) (l: Launch1D) : Int :=
+    device_id d + max_threads_per_block d + launch_items l + launch_device l + launch_threads l;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Legal protocols
+# ---------------------------------------------------------------------------
+
+
+def test_i32_upload_add_synchronize_download_lifecycle_typechecks():
+    source = (
+        IMPORTS
+        + f"""
+def lifecycle (u: Unit) : Int :=
+    let d := default_device u in
+    let launch := launch_1d d 3 1 in
+    let 1 xs := {_int_array((1, 2, 3))} in
+    let 1 ys := {_int_array((10, 20, 30))} in
+    let 1 left := upload_i32 d xs in
+    let 1 right := upload_i32 d ys in
+    let 1 pending := add_i32 launch left right in
+    let 1 ready := synchronize pending in
+    let 1 values := download_i32 ready in
+    Array.sum values;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_float64_lifecycle_and_terminal_operations_typecheck():
+    source = (
+        IMPORTS
+        + f"""
+def lifecycle (u: Unit) : Unit :=
+    let d := default_device u in
+    let launch := launch_1d d 2 1 in
+    let 1 xs := {_float_array((1.5, 2.5))} in
+    let 1 ys := {_float_array((3.5, 4.5))} in
+    let 1 left := upload_float64 d xs in
+    let 1 right := upload_float64 d ys in
+    let 1 pending := add_float64 launch left right in
+    let 1 ready := synchronize pending in
+    let 1 values := download_float64 ready in
+    let _ := Array.length values in
+    let 1 spare := upload_i32 d ({_int_array((7,))}) in
+    free spare;
+
+def abandon (u: Unit) : Unit :=
+    let d := default_device u in
+    let launch := launch_1d d 1 1 in
+    let 1 left := upload_i32 d ({_int_array((1,))}) in
+    let 1 right := upload_i32 d ({_int_array((2,))}) in
+    let 1 pending := add_i32 launch left right in
+    discard pending;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+# ---------------------------------------------------------------------------
+# QTT ownership failures
+# ---------------------------------------------------------------------------
+
+
+def test_leaked_buffer_is_rejected():
+    source = (
+        IMPORTS
+        + f"""
+def leak (d: Device) : Int :=
+    let 1 buffer := upload_i32 d ({_int_array((1,))}) in
+    0;
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUnusedError) for error in _linearity_errors(source))
+
+
+def test_leaked_pending_is_rejected():
+    source = (
+        IMPORTS
+        + f"""
+def leak (d: Device) : Int :=
+    let launch := launch_1d d 1 1 in
+    let 1 left := upload_i32 d ({_int_array((1,))}) in
+    let 1 right := upload_i32 d ({_int_array((2,))}) in
+    let 1 pending := add_i32 launch left right in
+    0;
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUnusedError) for error in _linearity_errors(source))
+
+
+def test_linear_result_requires_a_multiplicity_one_binder():
+    source = (
+        IMPORTS
+        + f"""
+def bad_binder (d: Device) : Unit :=
+    let buffer := upload_i32 d ({_int_array((1,))}) in
+    free buffer;
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearTypeNotBoundLinearlyError) for error in _linearity_errors(source))
+
+
+def test_double_free_is_rejected():
+    source = (
+        IMPORTS
+        + f"""
+def double_free (d: Device) : Unit :=
+    let 1 buffer := upload_i32 d ({_int_array((1,))}) in
+    let _ := free buffer in
+    free buffer;
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUsedTooManyTimesError) for error in _linearity_errors(source))
+
+
+def test_stale_input_handle_after_launch_is_rejected():
+    source = (
+        IMPORTS
+        + f"""
+def stale (d: Device) : Unit :=
+    let launch := launch_1d d 1 1 in
+    let 1 left := upload_i32 d ({_int_array((1,))}) in
+    let 1 right := upload_i32 d ({_int_array((2,))}) in
+    let 1 pending := add_i32 launch left right in
+    let _ := discard pending in
+    free left;
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUsedTooManyTimesError) for error in _linearity_errors(source))
+
+
+def test_pending_cannot_be_downloaded_before_synchronize():
+    source = (
+        IMPORTS
+        + f"""
+def premature (d: Device) : Int :=
+    let launch := launch_1d d 1 1 in
+    let 1 left := upload_i32 d ({_int_array((1,))}) in
+    let 1 right := upload_i32 d ({_int_array((2,))}) in
+    let 1 pending := add_i32 launch left right in
+    let 1 values := download_i32 pending in
+    Array.sum values;
+"""
+        + MAIN
+    )
+    errors = _errors(source)
+    assert errors
+    assert not any(isinstance(error, LinearityError) for error in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# Refinement-protocol failures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "let d := device (-1) in device_id d",
+        "let d := default_device unit in let launch := launch_1d d (-1) 1 in launch_items launch",
+        "let d := default_device unit in let launch := launch_1d d 0 1 in launch_items launch",
+        "let d := default_device unit in let launch := launch_1d d 1 0 in launch_threads launch",
+        "let d := default_device unit in let launch := launch_1d d 1 2 in launch_threads launch",
+    ],
+    ids=("negative-device", "negative-items", "zero-items", "zero-threads", "threads-above-items"),
+)
+def test_invalid_device_or_launch_dimensions_are_rejected(body: str):
+    source = IMPORTS + f"def invalid (u: Unit) : Int := {body};" + MAIN
+    assert _errors(source) != []
+
+
+def test_threads_above_device_limit_are_rejected():
+    source = (
+        IMPORTS
+        + """
+def invalid (d: Device) (items: {n: Int | n > max_threads_per_block d}) : Launch1D :=
+    launch_1d d items items;
+"""
+        + MAIN
+    )
+    assert _errors(source) != []
+
+
+def test_empty_upload_is_rejected():
+    source = (
+        IMPORTS
+        + """
+def invalid (d: Device) : Unit :=
+    let 1 buffer := upload_i32 d (Array.new{Int} unit) in
+    free buffer;
+"""
+        + MAIN
+    )
+    assert _errors(source) != []
+
+
+def test_add_rejects_unequal_vector_lengths():
+    source = (
+        IMPORTS
+        + f"""
+def invalid (d: Device) : Unit :=
+    let launch := launch_1d d 2 2 in
+    let 1 left := upload_i32 d ({_int_array((1, 2))}) in
+    let 1 right := upload_i32 d ({_int_array((3,))}) in
+    let 1 pending := add_i32 launch left right in
+    discard pending;
+"""
+        + MAIN
+    )
+    assert _errors(source) != []
+
+
+def test_add_rejects_launch_item_count_different_from_buffer_size():
+    source = (
+        IMPORTS
+        + f"""
+def invalid (d: Device) : Unit :=
+    let launch := launch_1d d 1 1 in
+    let 1 left := upload_i32 d ({_int_array((1, 2))}) in
+    let 1 right := upload_i32 d ({_int_array((3, 4))}) in
+    let 1 pending := add_i32 launch left right in
+    discard pending;
+"""
+        + MAIN
+    )
+    assert _errors(source) != []
+
+
+def test_add_rejects_cross_device_buffers():
+    source = (
+        IMPORTS
+        + f"""
+def invalid (u: Unit) : Unit :=
+    let d0 := device 0 in
+    let d1 := device 1 in
+    let launch := launch_1d d0 1 1 in
+    let 1 left := upload_i32 d0 ({_int_array((1,))}) in
+    let 1 right := upload_i32 d1 ({_int_array((2,))}) in
+    let 1 pending := add_i32 launch left right in
+    discard pending;
+"""
+        + MAIN
+    )
+    assert _errors(source) != []
+
+
+def test_cuda_vector_add_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "llvm" / "gpu" / "cuda_vector_add.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []


### PR DESCRIPTION
## Summary

- add an explicit `Cuda.ae` standard-library module with linear `Buffer` and `Pending` resources
- encode buffer sizes, device identity, launch dimensions, and synchronization state with dependent refinements
- add a lazy CUDA Driver API binding with `i32` and `float64` transfers and fixed vector-add kernels
- make downloads reusable: each call returns host data and the preserved GPU buffer through accessor functions (no nested callbacks)
- require the final ready buffer to be explicitly consumed by `Cuda.free`
- initialize the existing LLVM CUDA backend only when a program actually contains a CUDA compilation target
- add compile-time ownership/refinement tests, real CUDA integration tests, and usage examples

## Download API

`download_i32` / `download_float64` consume a ready `Buffer` and return an opaque `I32Download` / `Float64Download` handle. Split it with the accessors, then free the recovered buffer:

```aeon
let downloaded := download_i32 ready in
let 1 values := download_values_i32 downloaded in   -- linear host Array
let 1 buffer := download_buffer_i32 downloaded in   -- linear GPU Buffer
let total := Array.sum values in
let _ := free buffer in
total
```

Repeated downloads are flat — no continuation passing:

```aeon
let downloaded0 := download_i32 ready0 in
let 1 values0 := download_values_i32 downloaded0 in
let 1 ready1 := download_buffer_i32 downloaded0 in
let downloaded1 := download_i32 ready1 in
let 1 values1 := download_values_i32 downloaded1 in
let 1 ready2 := download_buffer_i32 downloaded1 in
let _ := free ready2 in
Array.sum values0 + Array.sum values1
```

After a download the GPU allocation can be reused in another kernel before a second download:

```aeon
let downloaded0 := download_i32 ready0 in
let 1 snapshot0 := download_values_i32 downloaded0 in
let 1 left := download_buffer_i32 downloaded0 in
let 1 pending := add_i32 launch left right in
let 1 ready1 := synchronize pending in
let downloaded1 := download_i32 ready1 in
let 1 snapshot1 := download_values_i32 downloaded1 in
let 1 buffer := download_buffer_i32 downloaded1 in
let _ := free buffer in
Array.sum snapshot1
```

See `examples/llvm/gpu/cuda_download.ae` for all four patterns (single download, repeated download, download → kernel → download, float64) and `examples/llvm/gpu/cuda_vector_add.ae` for the end-to-end vector-add workflow.

## Safety model

```text
Array --upload--> Buffer --add--> Pending --synchronize--> Buffer
                                                        --download--> I32Download
                                                              |-- download_values_* --> Array
                                                              +-- download_buffer_* --> Buffer --free--> Unit
```

Each successful download copies to a fresh host `Array` while preserving the device allocation. Host arrays and GPU buffers are both linear and must be consumed exactly once. The final buffer must be freed; dropping it or reusing a stale handle is rejected statically.

Inputs to vector addition must have equal non-zero lengths, reside on the launch device, and match the launch item count. Pending computations remain linear, preventing leaks, stale-handle reuse, double-free, and download before synchronization. A CUDA copy failure performs best-effort cleanup.

## Test plan

- [x] `uv run pytest tests/cuda_binding_test.py tests/cuda_qtt_test.py -q`
- [x] `examples/llvm/gpu/cuda_vector_add.ae` and `examples/llvm/gpu/cuda_download.ae` type-check
- [ ] `uv run python -m aeon examples/llvm/gpu/cuda_vector_add.ae` — prints `66` with a CUDA device present
- [ ] `uv run python -m aeon examples/llvm/gpu/cuda_download.ae` — runs all download demos with a CUDA device present