### PR TITLE
CUDA refinements: launch grid coverage

### DIFF
--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -519,6 +519,10 @@ def launch_threads(launch: Launch1D | tuple[Launch1D, Device]) -> int:
     return launch[0].block_size if isinstance(launch, tuple) else launch.block_size
 
 
+def launch_grid_size(launch: Launch1D | tuple[Launch1D, Device]) -> int:
+    return launch[0].grid_size if isinstance(launch, tuple) else launch.grid_size
+
+
 def buffer_device(buffer: Buffer) -> int:
     return buffer.device.ordinal
 
@@ -783,6 +787,7 @@ def _compile_vector_add_ptx(compute_capability: tuple[int, int]) -> str:
 Cuda_device = device
 Cuda_num_devices = num_devices
 Cuda_launch_1d = launch_1d
+Cuda_launch_grid_size = launch_grid_size
 Cuda_upload_i32 = upload_i32
 Cuda_upload_float64 = upload_float64
 Cuda_download_i32 = download_i32

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -30,6 +30,7 @@ def max_threads_per_block : (d: Device) -> Int := uninterpreted
 def launch_device : (launch: Launch1D) -> Int := uninterpreted
 def launch_items : (launch: Launch1D) -> Int := uninterpreted
 def launch_threads : (launch: Launch1D) -> Int := uninterpreted
+def launch_grid_size : (launch: Launch1D) -> Int := uninterpreted
 
 def buffer_device : (buffer: (Buffer a)) -> Int := uninterpreted
 def buffer_size : (buffer: (Buffer a)) -> Int := uninterpreted
@@ -62,7 +63,8 @@ def launch_1d (device: Device)
     {launch: Launch1D |
         launch_device launch = device_id device &&
         launch_items launch = items &&
-        launch_threads launch = threads} :=
+        launch_threads launch = threads &&
+        launch_grid_size launch * launch_threads launch >= launch_items launch} :=
     native "(__import__('aeon.bindings.cuda', fromlist=['launch_1d']).launch_1d(items, threads), device)"
 
 # Upload non-empty host arrays.  Upload consumes the uniquely-owned host array
@@ -90,7 +92,8 @@ def add_i32
     (1 left: {buffer: (Buffer Int) |
         buffer_size buffer > 0 &&
         buffer_device buffer = launch_device launch &&
-        buffer_size buffer = launch_items launch})
+        buffer_size buffer = launch_items launch &&
+        launch_grid_size launch * launch_threads launch >= buffer_size buffer})
     (1 right: {buffer: (Buffer Int) |
         buffer_size buffer = buffer_size left &&
         buffer_device buffer = buffer_device left}) :
@@ -104,7 +107,8 @@ def add_float64
     (1 left: {buffer: (Buffer Float) |
         buffer_size buffer > 0 &&
         buffer_device buffer = launch_device launch &&
-        buffer_size buffer = launch_items launch})
+        buffer_size buffer = launch_items launch &&
+        launch_grid_size launch * launch_threads launch >= buffer_size buffer})
     (1 right: {buffer: (Buffer Float) |
         buffer_size buffer = buffer_size left &&
         buffer_device buffer = buffer_device left}) :

--- a/tests/cuda_binding_test.py
+++ b/tests/cuda_binding_test.py
@@ -33,8 +33,10 @@ def test_num_devices_reports_available_hardware(cuda_module):
 
 
 def test_launch_1d_validates_and_rounds_up(cuda_module):
-    assert cuda_module.Launch1D(1, 1).grid_size == 1
-    assert cuda_module.Launch1D(33, 32).grid_size == 2
+    launch = cuda_module.Launch1D(33, 32)
+    assert launch.grid_size == 2
+    assert cuda_module.launch_grid_size(launch) == 2
+    assert launch.grid_size * launch.block_size >= launch.size
 
     for size, block_size in ((0, 1), (-1, 1), (1, 0), (32, 33), (2048, 1025), (True, 1)):
         with pytest.raises(ValueError):

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -89,7 +89,7 @@ def test_open_cuda_exposes_descriptors_and_launch_measures():
         + """
 def descriptors (d: Device) (l: Launch1D) : Int :=
     device_id d + max_threads_per_block d + num_devices unit
-    + launch_items l + launch_device l + launch_threads l;
+    + launch_items l + launch_device l + launch_threads l + launch_grid_size l;
 """
         + MAIN
     )
@@ -99,6 +99,20 @@ def descriptors (d: Device) (l: Launch1D) : Int :=
 # ---------------------------------------------------------------------------
 # Legal protocols
 # ---------------------------------------------------------------------------
+
+
+def test_launch_grid_covers_items_at_compile_time():
+    source = (
+        IMPORTS
+        + """
+def covered (u: Unit) : Int :=
+    let d := default_device u in
+    let launch := launch_1d d 33 1 in
+    launch_grid_size launch * launch_threads launch;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
 
 
 def test_i32_upload_add_synchronize_download_lifecycle_typechecks():

--- a/tests/public_api_test.py
+++ b/tests/public_api_test.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import aeon
+
+
+def test_public_api_parses_checks_and_runs():
+    program = aeon.parse("def answer : Int := 42;", no_main=True)
+    assert program.check() == []
+    # ``no_main`` evaluates the elaborated program tail, whose convention is
+    # the unit value represented by the interpreter as ``1``.
+    assert program.run() == 1
+
+
+def test_public_api_returns_check_errors_without_exposing_core_modules():
+    errors = aeon.check("def answer : Int := true;", no_main=True)
+    assert errors
+    assert set(aeon.__all__) == {"Program", "parse", "check", "synthesize"}
+
+
+def test_public_api_drives_native_synthesis():
+    program = aeon.synthesize("def answer : Int := ?hole;", backend="gp", budget=1, no_main=True)
+    assert program.check() == []
+
+
+def test_implementation_packages_do_not_publish_python_names():
+    import aeon.compilation
+    import aeon.elaboration
+    import aeon.optimization
+
+    assert aeon.compilation.__all__ == []
+    assert aeon.elaboration.__all__ == []
+    assert aeon.optimization.__all__ == []
+
+    import aeon.synthesis
+    import aeon.synthesis.modules.afta
+    import aeon.synthesis.modules.cata
+    import aeon.synthesis.modules.contata
+    import aeon.synthesis.modules.fta
+    import aeon.synthesis.modules.lta
+    import aeon.synthesis.modules.sygus
+    import aeon.synthesis.modules.symetric
+
+    assert aeon.synthesis.__all__ == []
+    assert aeon.synthesis.modules.afta.__all__ == []
+    assert aeon.synthesis.modules.cata.__all__ == []
+    assert aeon.synthesis.modules.contata.__all__ == []
+    assert aeon.synthesis.modules.fta.__all__ == []
+    assert aeon.synthesis.modules.lta.__all__ == []
+    assert aeon.synthesis.modules.sygus.__all__ == []
+    assert aeon.synthesis.modules.symetric.__all__ == []


### PR DESCRIPTION
## Summary

- add `launch_grid_size` and require `grid * threads >= items` on launches and kernel inputs
- prevents silent partial computation when the CUDA grid is too small

## Stack

Part of the CUDA refinement stack on top of #494. Merge after #494; next PR targets this branch.

## Test plan

- [x] `pytest tests/cuda_qtt_test.py tests/cuda_binding_test.py`

Made with [Cursor](https://cursor.com)