### PR TITLE
CUDA refinements: allocation byte-size bounds

### DIFF
--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -106,6 +106,9 @@ class _CudaDriver:
         self.cuDeviceGetAttribute = self._configure(
             self._symbol("cuDeviceGetAttribute"), [int_p, ctypes.c_int, ctypes.c_int]
         )
+        self.cuDeviceTotalMem = self._configure(
+            self._symbol("cuDeviceTotalMem_v2", "cuDeviceTotalMem"), [ctypes.POINTER(ctypes.c_size_t), ctypes.c_int]
+        )
         self.cuCtxCreate = self._configure(self._symbol("cuCtxCreate_v2", "cuCtxCreate"), [void_pp, uint, ctypes.c_int])
         self.cuCtxDestroy = self._configure(self._symbol("cuCtxDestroy_v2", "cuCtxDestroy"), [void_p])
         self.cuCtxSetCurrent = self._configure(self._symbol("cuCtxSetCurrent"), [void_p])
@@ -233,6 +236,12 @@ class Device:
                 driver.cuDeviceGetAttribute(ctypes.byref(max_threads), 1, handle.value), "cuDeviceGetAttribute"
             )
             self.max_threads_per_block = max_threads.value
+            total_mem = ctypes.c_size_t()
+            driver.check(
+                driver.cuDeviceTotalMem(ctypes.byref(total_mem), handle.value),
+                "cuDeviceTotalMem",
+            )
+            self.max_allocation = total_mem.value
         except BaseException:
             try:
                 driver.cuCtxDestroy(context)
@@ -531,6 +540,18 @@ def buffer_size(buffer: Buffer) -> int:
     return buffer.length
 
 
+def buffer_elem_size(buffer: Buffer) -> int:
+    return _ITEM_SIZE[buffer.dtype]
+
+
+def buffer_bytes(buffer: Buffer) -> int:
+    return buffer.length * _ITEM_SIZE[buffer.dtype]
+
+
+def max_allocation(device_: Device) -> int:
+    return device_.max_allocation
+
+
 def pending_device(pending: Pending) -> int:
     return pending.device.ordinal
 
@@ -560,6 +581,10 @@ def _upload(device_: Device, values: Iterable[int] | Iterable[float], dtype: _DT
         device_._activate()
         pointer = ctypes.c_uint64()
         allocation_size = max(1, len(host)) * _ITEM_SIZE[dtype]
+        if allocation_size > device_.max_allocation:
+            raise ValueError(
+                f"allocation of {allocation_size} bytes exceeds device limit {device_.max_allocation}"
+            )
         device_._driver.check(
             device_._driver.cuMemAlloc(ctypes.byref(pointer), allocation_size),
             "cuMemAlloc",

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -28,6 +28,7 @@ type Float64Download
 def device_id : (d: Device) -> Int := uninterpreted
 def num_devices : (_: Unit) -> Int := uninterpreted
 def max_threads_per_block : (d: Device) -> Int := uninterpreted
+def max_allocation : (d: Device) -> Int := uninterpreted
 def launch_device : (launch: Launch1D) -> Int := uninterpreted
 def launch_items : (launch: Launch1D) -> Int := uninterpreted
 def launch_threads : (launch: Launch1D) -> Int := uninterpreted
@@ -35,6 +36,8 @@ def launch_grid_size : (launch: Launch1D) -> Int := uninterpreted
 
 def buffer_device : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
 def buffer_size : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
+def buffer_elem_size : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
+def buffer_bytes : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
 def pending_device : (pending: (Pending a)) -> Int := uninterpreted
 def pending_size : (pending: (Pending a)) -> Int := uninterpreted
 def i32_download_device : (p: I32Download) -> Int := uninterpreted
@@ -74,14 +77,18 @@ def upload_i32 (device: Device)
     (1 values: {xs: (Array Int) | Array.size xs > 0}) :
     {buffer: (ReadyBuffer Int) |
         buffer_device buffer = device_id device &&
-        buffer_size buffer = Array.size values} :=
+        buffer_size buffer = Array.size values &&
+        buffer_bytes buffer = buffer_size buffer * 4 &&
+        buffer_bytes buffer <= max_allocation device} :=
     native "__import__('aeon.bindings.cuda', fromlist=['upload_i32']).upload_i32(device, values)"
 
 def upload_float64 (device: Device)
     (1 values: {xs: (Array Float) | Array.size xs > 0}) :
     {buffer: (ReadyBuffer Float) |
         buffer_device buffer = device_id device &&
-        buffer_size buffer = Array.size values} :=
+        buffer_size buffer = Array.size values &&
+        buffer_bytes buffer = buffer_size buffer * 8 &&
+        buffer_bytes buffer <= max_allocation device} :=
     native "__import__('aeon.bindings.cuda', fromlist=['upload_float64']).upload_float64(device, values)"
 
 # Enqueue elementwise addition.  Both inputs must be non-empty, equally sized,

--- a/tests/cuda_binding_test.py
+++ b/tests/cuda_binding_test.py
@@ -32,6 +32,16 @@ def test_num_devices_reports_available_hardware(cuda_module):
         cuda_module.device(count)
 
 
+def test_device_reports_max_allocation(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        assert cuda_module.max_allocation(device) > 0
+        assert cuda_module.buffer_bytes(cuda_module.upload_i32(device, [1, 2, 3])) == 12
+        assert cuda_module.buffer_elem_size(cuda_module.upload_i32(device, [1])) == 4
+    finally:
+        device.close()
+
+
 def test_launch_1d_validates_and_rounds_up(cuda_module):
     launch = cuda_module.Launch1D(33, 32)
     assert launch.grid_size == 2

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -83,6 +83,20 @@ def test_num_devices_is_positive():
     assert _errors(source) == []
 
 
+def test_upload_respects_allocation_byte_bound():
+    source = (
+        IMPORTS
+        + f"""
+def bounded (d: Device) : Unit :=
+    let 1 xs := {_int_array((1, 2))} in
+    let 1 buffer := upload_i32 d xs in
+    free buffer;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
 def test_open_cuda_exposes_descriptors_and_launch_measures():
     source = (
         IMPORTS


### PR DESCRIPTION
## Summary

- add `buffer_bytes`, `buffer_elem_size`, and `max_allocation` measures
- refine uploads so `buffer_bytes = size * elem_size` and `buffer_bytes <= max_allocation device`
- runtime allocation size check on upload

## Stack

Targets `cuda-refine/3-ready-buffer`. Next PR: linear downloads + streams.

## Test plan

- [x] `pytest tests/cuda_qtt_test.py tests/cuda_binding_test.py`

Made with [Cursor](https://cursor.com)