### PR TITLE
CUDA refinements: linear downloads and streams

### DIFF
--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -113,6 +113,11 @@ class _CudaDriver:
         self.cuCtxDestroy = self._configure(self._symbol("cuCtxDestroy_v2", "cuCtxDestroy"), [void_p])
         self.cuCtxSetCurrent = self._configure(self._symbol("cuCtxSetCurrent"), [void_p])
         self.cuCtxSynchronize = self._configure(self._symbol("cuCtxSynchronize"), [])
+        self.cuStreamCreate = self._configure(
+            self._symbol("cuStreamCreate"), [ctypes.POINTER(ctypes.c_void_p), uint]
+        )
+        self.cuStreamDestroy = self._configure(self._symbol("cuStreamDestroy"), [ctypes.c_void_p])
+        self.cuStreamSynchronize = self._configure(self._symbol("cuStreamSynchronize"), [ctypes.c_void_p])
         self.cuMemAlloc = self._configure(
             self._symbol("cuMemAlloc_v2", "cuMemAlloc"), [ctypes.POINTER(ctypes.c_uint64), size_t]
         )
@@ -216,6 +221,7 @@ class Device:
         self._closed = False
         self._buffers: weakref.WeakSet[Buffer] = weakref.WeakSet()
         self._pending: weakref.WeakSet[Pending] = weakref.WeakSet()
+        self._streams: weakref.WeakSet[Stream] = weakref.WeakSet()
         self._module: ctypes.c_void_p | None = None
         self._functions: dict[_DType, ctypes.c_void_p] = {}
         self._lock = threading.RLock()
@@ -306,6 +312,11 @@ class Device:
                     pending._discard_after_device_sync()
                 except BaseException as exc:
                     error = error or exc
+            for stream in list(self._streams):
+                try:
+                    stream.close()
+                except BaseException as exc:
+                    error = error or exc
             for buffer in list(self._buffers):
                 try:
                     buffer._free_from_device()
@@ -360,6 +371,56 @@ class Launch1D:
     @property
     def grid_size(self) -> int:
         return math.ceil(self.size / self.block_size)
+
+
+class Stream:
+    """A CUDA stream owned by one device context."""
+
+    def __init__(self, device: Device, *, owned: bool, handle: int) -> None:
+        self.device = device
+        self._handle = handle
+        self._owned = owned
+        self._closed = False
+        device._streams.add(self)
+
+    @property
+    def stream_id(self) -> int:
+        return self._handle
+
+    def _ensure_open(self) -> None:
+        self.device._ensure_open()
+        if self._closed:
+            raise CUDAStateError("CUDA stream is closed")
+
+    def synchronize(self) -> None:
+        with self.device._lock:
+            self._ensure_open()
+            self.device._activate()
+            if self._handle:
+                self.device._driver.check(
+                    self.device._driver.cuStreamSynchronize(ctypes.c_void_p(self._handle)),
+                    "cuStreamSynchronize",
+                )
+            else:
+                self.device._driver.check(self.device._driver.cuCtxSynchronize(), "cuCtxSynchronize")
+
+    def close(self) -> None:
+        with self.device._lock:
+            if self._closed or not self._owned or not self._handle:
+                self._closed = True
+                return
+            self.device._activate()
+            self.device._driver.check(
+                self.device._driver.cuStreamDestroy(ctypes.c_void_p(self._handle)),
+                "cuStreamDestroy",
+            )
+            self._closed = True
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
 
 class Buffer:
@@ -419,8 +480,9 @@ class Buffer:
 class Pending:
     """The not-yet-synchronized output of an asynchronous kernel launch."""
 
-    def __init__(self, output: Buffer, inputs: tuple[Buffer, ...]) -> None:
+    def __init__(self, output: Buffer, inputs: tuple[Buffer, ...], stream: Stream) -> None:
         self.device = output.device
+        self.stream = stream
         self._output: Buffer | None = output
         self._inputs = inputs
         self._consumed = False
@@ -428,6 +490,7 @@ class Pending:
 
     def _ensure_pending(self) -> Buffer:
         self.device._ensure_open()
+        self.stream._ensure_open()
         if self._consumed or self._output is None:
             raise CUDAStateError("CUDA pending result has already been consumed")
         return self._output
@@ -435,7 +498,7 @@ class Pending:
     def synchronize(self) -> Buffer:
         with self.device._lock:
             output = self._ensure_pending()
-            self.device.synchronize()
+            self.stream.synchronize()
             inputs = self._inputs
             self._consumed = True
             self._output = None
@@ -500,6 +563,30 @@ def num_devices() -> int:
     if count.value <= 0:
         raise CUDAUnavailableError("no CUDA devices are available")
     return count.value
+
+
+def default_stream(device_: Device) -> Stream:
+    return Stream(device_, owned=False, handle=0)
+
+
+def create_stream(device_: Device) -> Stream:
+    with device_._lock:
+        device_._activate()
+        stream = ctypes.c_void_p()
+        device_._driver.check(device_._driver.cuStreamCreate(ctypes.byref(stream), 0), "cuStreamCreate")
+    return Stream(device_, owned=True, handle=stream.value or 0)
+
+
+def stream_device(stream: Stream) -> int:
+    return stream.device.ordinal
+
+
+def stream_id(stream: Stream) -> int:
+    return stream.stream_id
+
+
+def pending_stream(pending: Pending) -> int:
+    return pending.stream.stream_id
 
 
 def launch_1d(size: int, block_size: int | None = None) -> Launch1D:
@@ -667,7 +754,11 @@ def download_float64_result(buffer: Buffer) -> Float64Download:
     return Float64Download(download_float64(buffer), buffer)
 
 
-def _vector_add(device_: Device, launch: Launch1D, left: Buffer, right: Buffer, dtype: _DType) -> Pending:
+def _vector_add(
+    device_: Device, launch: Launch1D, left: Buffer, right: Buffer, dtype: _DType, stream: Stream
+) -> Pending:
+    if stream.device is not device_:
+        raise ValueError("CUDA stream must belong to the launch device")
     if launch.block_size > device_.max_threads_per_block:
         raise ValueError(f"block size {launch.block_size} exceeds device limit {device_.max_threads_per_block}")
     for operand in (left, right):
@@ -710,7 +801,7 @@ def _vector_add(device_: Device, launch: Launch1D, left: Buffer, right: Buffer, 
                         1,
                         1,
                         0,
-                        None,
+                        ctypes.c_void_p(stream.stream_id),
                         arguments,
                         None,
                     ),
@@ -719,15 +810,19 @@ def _vector_add(device_: Device, launch: Launch1D, left: Buffer, right: Buffer, 
         except BaseException:
             output.free()
             raise
-        return Pending(output, (left, right))
+        return Pending(output, (left, right), stream)
 
 
-def vector_add_i32(device_: Device, launch: Launch1D, left: Buffer, right: Buffer) -> Pending:
-    return _vector_add(device_, launch, left, right, "i32")
+def vector_add_i32(
+    device_: Device, launch: Launch1D, left: Buffer, right: Buffer, stream: Stream
+) -> Pending:
+    return _vector_add(device_, launch, left, right, "i32", stream)
 
 
-def vector_add_float64(device_: Device, launch: Launch1D, left: Buffer, right: Buffer) -> Pending:
-    return _vector_add(device_, launch, left, right, "float64")
+def vector_add_float64(
+    device_: Device, launch: Launch1D, left: Buffer, right: Buffer, stream: Stream
+) -> Pending:
+    return _vector_add(device_, launch, left, right, "float64", stream)
 
 
 def synchronize(pending: Pending) -> Buffer:

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -12,6 +12,7 @@ open Array
 # one-dimensional logical item count and CUDA block size.
 type Device
 type Launch1D
+type Stream
 
 # Device allocations that are ready for download or kernel input.  In-flight
 # results live in ``Pending`` until ``synchronize`` promotes them.
@@ -19,8 +20,10 @@ linear type ReadyBuffer a
 linear type Pending a
 
 # Host snapshot plus the live device allocation it was read from.
-type I32Download
-type Float64Download
+linear type I32Download
+linear type Float64Download
+type I32DownloadPair
+type Float64DownloadPair
 
 # Logical descriptor/resource measures.  Aeon's ``Float`` is represented by
 # this module explicitly as CUDA float64; it is never silently narrowed to
@@ -33,6 +36,9 @@ def launch_device : (launch: Launch1D) -> Int := uninterpreted
 def launch_items : (launch: Launch1D) -> Int := uninterpreted
 def launch_threads : (launch: Launch1D) -> Int := uninterpreted
 def launch_grid_size : (launch: Launch1D) -> Int := uninterpreted
+def stream_device : (stream: Stream) -> Int := uninterpreted
+def stream_id : (stream: Stream) -> Int := uninterpreted
+def pending_stream : (pending: (Pending a)) -> Int := uninterpreted
 
 def buffer_device : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
 def buffer_size : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
@@ -42,8 +48,12 @@ def pending_device : (pending: (Pending a)) -> Int := uninterpreted
 def pending_size : (pending: (Pending a)) -> Int := uninterpreted
 def i32_download_device : (p: I32Download) -> Int := uninterpreted
 def i32_download_size : (p: I32Download) -> Int := uninterpreted
+def i32_download_pair_device : (p: I32DownloadPair) -> Int := uninterpreted
+def i32_download_pair_size : (p: I32DownloadPair) -> Int := uninterpreted
 def float64_download_device : (p: Float64Download) -> Int := uninterpreted
 def float64_download_size : (p: Float64Download) -> Int := uninterpreted
+def float64_download_pair_device : (p: Float64DownloadPair) -> Int := uninterpreted
+def float64_download_pair_size : (p: Float64DownloadPair) -> Int := uninterpreted
 
 # Select an explicit CUDA device, or ask the runtime for its default device.
 def num_devices (_: Unit) :
@@ -57,6 +67,10 @@ def device (id: {n: Int | n >= 0 && n < num_devices unit}) :
 def default_device (_: Unit) :
     {d: Device | device_id d >= 0 && max_threads_per_block d > 0} :=
     native "__import__('aeon.bindings.cuda', fromlist=['device']).device()"
+
+def default_stream (device: Device) :
+    {stream: Stream | stream_device stream = device_id device} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['default_stream']).default_stream(device)"
 
 # Describe a non-empty one-dimensional launch.  A block cannot contain more
 # threads than logical items; the binding additionally enforces CUDA's
@@ -97,6 +111,7 @@ def upload_float64 (device: Device)
 # the caller synchronizes or discards it.
 def add_i32
     (launch: Launch1D)
+    (stream: {s: Stream | stream_device s = launch_device launch})
     (1 left: {buffer: (ReadyBuffer Int) |
         buffer_size buffer > 0 &&
         buffer_device buffer = launch_device launch &&
@@ -107,11 +122,13 @@ def add_i32
         buffer_device buffer = buffer_device left}) :
     {pending: (Pending Int) |
         pending_device pending = launch_device launch &&
-        pending_size pending = launch_items launch} :=
-    native "__import__('aeon.bindings.cuda', fromlist=['vector_add_i32']).vector_add_i32(launch[1], launch[0], left, right)"
+        pending_size pending = launch_items launch &&
+        pending_stream pending = stream_id stream} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['vector_add_i32']).vector_add_i32(launch[1], launch[0], left, right, stream)"
 
 def add_float64
     (launch: Launch1D)
+    (stream: {s: Stream | stream_device s = launch_device launch})
     (1 left: {buffer: (ReadyBuffer Float) |
         buffer_size buffer > 0 &&
         buffer_device buffer = launch_device launch &&
@@ -122,8 +139,9 @@ def add_float64
         buffer_device buffer = buffer_device left}) :
     {pending: (Pending Float) |
         pending_device pending = launch_device launch &&
-        pending_size pending = launch_items launch} :=
-    native "__import__('aeon.bindings.cuda', fromlist=['vector_add_float64']).vector_add_float64(launch[1], launch[0], left, right)"
+        pending_size pending = launch_items launch &&
+        pending_stream pending = stream_id stream} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['vector_add_float64']).vector_add_float64(launch[1], launch[0], left, right, stream)"
 
 # Wait for an enqueued computation and recover its completed device buffer.
 def synchronize (1 pending: (Pending a)) :
@@ -148,25 +166,37 @@ def download_float64 (1 buffer: (ReadyBuffer Float)) :
         float64_download_size result = buffer_size buffer} :=
     native "__import__('aeon.bindings.cuda', fromlist=['download_float64_result']).download_float64_result(buffer)"
 
-def download_values_i32 (p: I32Download) :
-    {xs: (Array Int) | Array.size xs = i32_download_size p} :=
-    native "p.values"
+def unpack_i32_download (1 p: I32Download) :
+    {pair: I32DownloadPair |
+        i32_download_pair_device pair = i32_download_device p &&
+        i32_download_pair_size pair = i32_download_size p} :=
+    native "(p.values, p.buffer)"
 
-def download_buffer_i32 (p: I32Download) :
+def unpack_float64_download (1 p: Float64Download) :
+    {pair: Float64DownloadPair |
+        float64_download_pair_device pair = float64_download_device p &&
+        float64_download_pair_size pair = float64_download_size p} :=
+    native "(p.values, p.buffer)"
+
+def download_values_i32 (p: I32DownloadPair) :
+    {xs: (Array Int) | Array.size xs = i32_download_pair_size p} :=
+    native "p[0]"
+
+def download_buffer_i32 (p: I32DownloadPair) :
     {b: (ReadyBuffer Int) |
-        buffer_device b = i32_download_device p &&
-        buffer_size b = i32_download_size p} :=
-    native "p.buffer"
+        buffer_device b = i32_download_pair_device p &&
+        buffer_size b = i32_download_pair_size p} :=
+    native "p[1]"
 
-def download_values_float64 (p: Float64Download) :
-    {xs: (Array Float) | Array.size xs = float64_download_size p} :=
-    native "p.values"
+def download_values_float64 (p: Float64DownloadPair) :
+    {xs: (Array Float) | Array.size xs = float64_download_pair_size p} :=
+    native "p[0]"
 
-def download_buffer_float64 (p: Float64Download) :
+def download_buffer_float64 (p: Float64DownloadPair) :
     {b: (ReadyBuffer Float) |
-        buffer_device b = float64_download_device p &&
-        buffer_size b = float64_download_size p} :=
-    native "p.buffer"
+        buffer_device b = float64_download_pair_device p &&
+        buffer_size b = float64_download_pair_size p} :=
+    native "p[1]"
 
 # Explicitly release a completed allocation or abandon pending work.
 def free (1 buffer: (ReadyBuffer a)) : Unit :=

--- a/examples/llvm/gpu/cuda_download.ae
+++ b/examples/llvm/gpu/cuda_download.ae
@@ -18,9 +18,10 @@ open Cuda
 #
 def read_once (d: Device) : Int :=
     let 1 ready := upload_i32 d (Array.append (Array.append (Array.new{Int} unit) 4) 5) in
-    let downloaded := download_i32 ready in
-    let 1 values := download_values_i32 downloaded in
-    let 1 buffer := download_buffer_i32 downloaded in
+    let 1 downloaded := download_i32 ready in
+    let pair := unpack_i32_download downloaded in
+    let 1 values := download_values_i32 pair in
+    let 1 buffer := download_buffer_i32 pair in
     let sum := Array.sum values in
     let _ := free buffer in
     sum;
@@ -31,12 +32,14 @@ def read_once (d: Device) : Int :=
 #
 def read_twice (d: Device) : Int :=
     let 1 ready0 := upload_i32 d (Array.append (Array.append (Array.new{Int} unit) 1) 2) in
-    let downloaded0 := download_i32 ready0 in
-    let 1 values0 := download_values_i32 downloaded0 in
-    let 1 ready1 := download_buffer_i32 downloaded0 in
-    let downloaded1 := download_i32 ready1 in
-    let 1 values1 := download_values_i32 downloaded1 in
-    let 1 ready2 := download_buffer_i32 downloaded1 in
+    let 1 downloaded0 := download_i32 ready0 in
+    let pair0 := unpack_i32_download downloaded0 in
+    let 1 values0 := download_values_i32 pair0 in
+    let 1 ready1 := download_buffer_i32 pair0 in
+    let 1 downloaded1 := download_i32 ready1 in
+    let pair1 := unpack_i32_download downloaded1 in
+    let 1 values1 := download_values_i32 pair1 in
+    let 1 ready2 := download_buffer_i32 pair1 in
     let first := Array.sum values0 in
     let second := Array.sum values1 in
     let _ := free ready2 in
@@ -48,17 +51,20 @@ def read_twice (d: Device) : Int :=
 #
 def download_compute_download (u: Unit) : Int :=
     let d := default_device u in
+    let stream := default_stream d in
     let launch := launch_1d d 3 1 in
     let 1 ready0 := upload_i32 d (Array.append (Array.append (Array.append (Array.new{Int} unit) 1) 2) 3) in
-    let downloaded0 := download_i32 ready0 in
-    let 1 snapshot0 := download_values_i32 downloaded0 in
-    let 1 left := download_buffer_i32 downloaded0 in
+    let 1 downloaded0 := download_i32 ready0 in
+    let pair0 := unpack_i32_download downloaded0 in
+    let 1 snapshot0 := download_values_i32 pair0 in
+    let 1 left := download_buffer_i32 pair0 in
     let 1 right := upload_i32 d (Array.append (Array.append (Array.append (Array.new{Int} unit) 10) 20) 30) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     let 1 ready1 := synchronize pending in
-    let downloaded1 := download_i32 ready1 in
-    let 1 snapshot1 := download_values_i32 downloaded1 in
-    let 1 buffer := download_buffer_i32 downloaded1 in
+    let 1 downloaded1 := download_i32 ready1 in
+    let pair1 := unpack_i32_download downloaded1 in
+    let 1 snapshot1 := download_values_i32 pair1 in
+    let 1 buffer := download_buffer_i32 pair1 in
     let _ := Array.sum snapshot0 in
     let total := Array.sum snapshot1 in
     let _ := free buffer in
@@ -68,9 +74,10 @@ def download_compute_download (u: Unit) : Int :=
 
 def read_float64 (d: Device) : Float :=
     let 1 ready := upload_float64 d (Array.append (Array.append (Array.new{Float} unit) (1.5 : Float)) (2.5 : Float)) in
-    let downloaded := download_float64 ready in
-    let 1 values := download_values_float64 downloaded in
-    let 1 buffer := download_buffer_float64 downloaded in
+    let 1 downloaded := download_float64 ready in
+    let pair := unpack_float64_download downloaded in
+    let 1 values := download_values_float64 pair in
+    let 1 buffer := download_buffer_float64 pair in
     let first := Array.get values 0 in
     let _ := free buffer in
     first;

--- a/examples/llvm/gpu/cuda_vector_add.ae
+++ b/examples/llvm/gpu/cuda_vector_add.ae
@@ -4,27 +4,29 @@ import Cuda;
 # Refined, linear CUDA lifecycle for Int vector addition.
 #
 # Host arrays and device resources are bound at multiplicity 1.  Each handle
-# is consumed exactly once by the next protocol step.  Download returns host
-# data and the preserved device buffer together:
+# is consumed exactly once by the next protocol step.  Download returns a
+# linear I32Download token that must be unpacked before freeing the buffer:
 #
-#   Array --upload--> Buffer --add--> Pending --synchronize--> Buffer
-#     --download--> I32Download --free--> Unit
+#   Array --upload--> ReadyBuffer --add--> Pending --synchronize--> ReadyBuffer
+#     --download--> I32Download --unpack--> Array + ReadyBuffer --free--> Unit
 #
 # The refinements prove at compile time that both inputs and the launch have
 # three items, share a device, and use a valid CUDA block size.  With a CUDA
 # driver/device present this prints 66 (11 + 22 + 33).
 def vector_add (u: Unit) : Int :=
     let d := Cuda.default_device u in
+    let stream := Cuda.default_stream d in
     let launch := Cuda.launch_1d d 3 1 in
     let 1 xs := Array.append (Array.append (Array.append (Array.new{Int} unit) 1) 2) 3 in
     let 1 ys := Array.append (Array.append (Array.append (Array.new{Int} unit) 10) 20) 30 in
     let 1 left := Cuda.upload_i32 d xs in
     let 1 right := Cuda.upload_i32 d ys in
-    let 1 pending := Cuda.add_i32 launch left right in
+    let 1 pending := Cuda.add_i32 launch stream left right in
     let 1 ready := Cuda.synchronize pending in
-    let downloaded := Cuda.download_i32 ready in
-    let 1 result := Cuda.download_values_i32 downloaded in
-    let 1 next := Cuda.download_buffer_i32 downloaded in
+    let 1 downloaded := Cuda.download_i32 ready in
+    let pair := Cuda.unpack_i32_download downloaded in
+    let 1 result := Cuda.download_values_i32 pair in
+    let 1 next := Cuda.download_buffer_i32 pair in
     let total := Array.sum result in
     let _ := Cuda.free next in
     total;

--- a/tests/cuda_binding_test.py
+++ b/tests/cuda_binding_test.py
@@ -71,7 +71,8 @@ def test_i32_upload_add_download_and_lifecycle(cuda_module):
     try:
         left = cuda_module.upload_i32(device, [1, -2, 3, 2**31 - 1])
         right = cuda_module.upload_i32(device, [4, 8, -3, -1])
-        pending = cuda_module.vector_add_i32(device, cuda_module.Launch1D(4, 4), left, right)
+        stream = cuda_module.default_stream(device)
+        pending = cuda_module.vector_add_i32(device, cuda_module.Launch1D(4, 4), left, right, stream)
         output = pending.synchronize()
 
         expected = [5, 6, 0, 2**31 - 2]
@@ -120,7 +121,8 @@ def test_float64_upload_add_download_and_discard(cuda_module):
     try:
         left = cuda_module.upload_float64(device, [0.5, -2.25, 1e100])
         right = cuda_module.upload_float64(device, [1.25, 0.25, -1e100])
-        pending = cuda_module.vector_add_float64(device, cuda_module.launch_1d(3), left, right)
+        stream = cuda_module.default_stream(device)
+        pending = cuda_module.vector_add_float64(device, cuda_module.launch_1d(3), left, right, stream)
         output = pending._output
         pending.discard()
         pending.discard()
@@ -142,9 +144,13 @@ def test_rejects_mismatched_buffers_without_allocating_output(cuda_module):
         ints = cuda_module.upload_i32(device, [1, 2])
         floats = cuda_module.upload_float64(device, [1.0, 2.0])
         with pytest.raises(TypeError):
-            cuda_module.vector_add_i32(device, cuda_module.launch_1d(2), ints, floats)
+            cuda_module.vector_add_i32(
+                device, cuda_module.launch_1d(2), ints, floats, cuda_module.default_stream(device)
+            )
         with pytest.raises(ValueError):
-            cuda_module.vector_add_i32(device, cuda_module.launch_1d(1), ints, ints)
+            cuda_module.vector_add_i32(
+                device, cuda_module.launch_1d(1), ints, ints, cuda_module.default_stream(device)
+            )
         ints.free()
         floats.free()
     finally:
@@ -155,7 +161,8 @@ def test_device_close_cleans_live_buffers_and_pending_results(cuda_module):
     device = _cuda_device_or_skip(cuda_module)
     left = cuda_module.upload_i32(device, [1])
     right = cuda_module.upload_i32(device, [2])
-    pending = cuda_module.vector_add_i32(device, cuda_module.launch_1d(1), left, right)
+    stream = cuda_module.default_stream(device)
+    pending = cuda_module.vector_add_i32(device, cuda_module.launch_1d(1), left, right, stream)
     output = pending._output
 
     device.close()

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -121,6 +121,7 @@ def test_launch_grid_covers_items_at_compile_time():
         + """
 def covered (u: Unit) : Int :=
     let d := default_device u in
+    let stream := default_stream d in
     let launch := launch_1d d 33 1 in
     launch_grid_size launch * launch_threads launch;
 """
@@ -135,16 +136,18 @@ def test_i32_upload_add_synchronize_download_lifecycle_typechecks():
         + f"""
 def lifecycle (u: Unit) : Int :=
     let d := default_device u in
+    let stream := default_stream d in
     let launch := launch_1d d 3 1 in
     let 1 xs := {_int_array((1, 2, 3))} in
     let 1 ys := {_int_array((10, 20, 30))} in
     let 1 left := upload_i32 d xs in
     let 1 right := upload_i32 d ys in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     let 1 ready := synchronize pending in
-    let downloaded := download_i32 ready in
-    let 1 values := download_values_i32 downloaded in
-    let 1 next := download_buffer_i32 downloaded in
+    let 1 downloaded := download_i32 ready in
+    let pair := unpack_i32_download downloaded in
+    let 1 values := download_values_i32 pair in
+    let 1 next := download_buffer_i32 pair in
     let total := Array.sum values in
     let _ := free next in
     total;
@@ -160,16 +163,18 @@ def test_float64_lifecycle_and_explicit_terminal_operations_typecheck():
         + f"""
 def lifecycle (u: Unit) : Unit :=
     let d := default_device u in
+    let stream := default_stream d in
     let launch := launch_1d d 2 1 in
     let 1 xs := {_float_array((1.5, 2.5))} in
     let 1 ys := {_float_array((3.5, 4.5))} in
     let 1 left := upload_float64 d xs in
     let 1 right := upload_float64 d ys in
-    let 1 pending := add_float64 launch left right in
+    let 1 pending := add_float64 launch stream left right in
     let 1 ready := synchronize pending in
-    let downloaded := download_float64 ready in
-    let 1 values := download_values_float64 downloaded in
-    let 1 next := download_buffer_float64 downloaded in
+    let 1 downloaded := download_float64 ready in
+    let pair := unpack_float64_download downloaded in
+    let 1 values := download_values_float64 pair in
+    let 1 next := download_buffer_float64 pair in
     let _ := Array.length values in
     let _ := free next in
     let 1 spare := upload_i32 d ({_int_array((7,))}) in
@@ -177,10 +182,11 @@ def lifecycle (u: Unit) : Unit :=
 
 def abandon (u: Unit) : Unit :=
     let d := default_device u in
+    let stream := default_stream d in
     let launch := launch_1d d 1 1 in
     let 1 left := upload_i32 d ({_int_array((1,))}) in
     let 1 right := upload_i32 d ({_int_array((2,))}) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     discard pending;
 """
         + MAIN
@@ -211,10 +217,11 @@ def test_leaked_pending_is_rejected():
         IMPORTS
         + f"""
 def leak (d: Device) : Int :=
+    let stream := default_stream d in
     let launch := launch_1d d 1 1 in
     let 1 left := upload_i32 d ({_int_array((1,))}) in
     let 1 right := upload_i32 d ({_int_array((2,))}) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     0;
 """
         + MAIN
@@ -254,10 +261,11 @@ def test_stale_input_handle_after_launch_is_rejected():
         IMPORTS
         + f"""
 def stale (d: Device) : Unit :=
+    let stream := default_stream d in
     let launch := launch_1d d 1 1 in
     let 1 left := upload_i32 d ({_int_array((1,))}) in
     let 1 right := upload_i32 d ({_int_array((2,))}) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     let _ := discard pending in
     free left;
 """
@@ -271,13 +279,16 @@ def test_download_can_be_repeated_without_nesting():
         IMPORTS
         + f"""
 def repeated (d: Device) : Int :=
+    let stream := default_stream d in
     let 1 ready0 := upload_i32 d ({_int_array((1, 2, 3))}) in
-    let downloaded0 := download_i32 ready0 in
-    let 1 values0 := download_values_i32 downloaded0 in
-    let 1 ready1 := download_buffer_i32 downloaded0 in
-    let downloaded1 := download_i32 ready1 in
-    let 1 values1 := download_values_i32 downloaded1 in
-    let 1 ready2 := download_buffer_i32 downloaded1 in
+    let 1 downloaded0 := download_i32 ready0 in
+    let pair0 := unpack_i32_download downloaded0 in
+    let 1 values0 := download_values_i32 pair0 in
+    let 1 ready1 := download_buffer_i32 pair0 in
+    let 1 downloaded1 := download_i32 ready1 in
+    let pair1 := unpack_i32_download downloaded1 in
+    let 1 values1 := download_values_i32 pair1 in
+    let 1 ready2 := download_buffer_i32 pair1 in
     let first := Array.sum values0 in
     let second := Array.sum values1 in
     let _ := free ready2 in
@@ -294,18 +305,21 @@ def test_download_preserves_size_and_device_refinements():
         + f"""
 def preserved (u: Unit) : Int :=
     let d := default_device u in
+    let stream := default_stream d in
     let launch := launch_1d d 3 1 in
     let 1 ready0 := upload_i32 d ({_int_array((1, 2, 3))}) in
-    let downloaded0 := download_i32 ready0 in
-    let 1 values0 := download_values_i32 downloaded0 in
-    let 1 ready1 := download_buffer_i32 downloaded0 in
+    let 1 downloaded0 := download_i32 ready0 in
+    let pair0 := unpack_i32_download downloaded0 in
+    let 1 values0 := download_values_i32 pair0 in
+    let 1 ready1 := download_buffer_i32 pair0 in
     let total0 := Array.sum values0 in
     let 1 other := upload_i32 d ({_int_array((4, 5, 6))}) in
-    let 1 pending := add_i32 launch ready1 other in
+    let 1 pending := add_i32 launch stream ready1 other in
     let 1 ready2 := synchronize pending in
-    let downloaded1 := download_i32 ready2 in
-    let 1 values1 := download_values_i32 downloaded1 in
-    let 1 ready3 := download_buffer_i32 downloaded1 in
+    let 1 downloaded1 := download_i32 ready2 in
+    let pair1 := unpack_i32_download downloaded1 in
+    let 1 values1 := download_values_i32 pair1 in
+    let 1 ready3 := download_buffer_i32 pair1 in
     let result := Array.sum values1 in
     let _ := free ready3 in
     result;
@@ -320,10 +334,12 @@ def test_download_result_must_free_recovered_buffer():
         IMPORTS
         + f"""
 def leak_successor (d: Device) : Int :=
+    let stream := default_stream d in
     let 1 ready := upload_i32 d ({_int_array((1,))}) in
-    let downloaded := download_i32 ready in
-    let 1 values := download_values_i32 downloaded in
-    let 1 next := download_buffer_i32 downloaded in
+    let 1 downloaded := download_i32 ready in
+    let pair := unpack_i32_download downloaded in
+    let 1 values := download_values_i32 pair in
+    let 1 next := download_buffer_i32 pair in
     Array.sum values;
 """
         + MAIN
@@ -336,10 +352,12 @@ def test_download_consumes_outer_buffer_handle():
         IMPORTS
         + f"""
 def stale (d: Device) : Unit :=
+    let stream := default_stream d in
     let 1 ready := upload_i32 d ({_int_array((1,))}) in
-    let downloaded := download_i32 ready in
-    let 1 values := download_values_i32 downloaded in
-    let 1 next := download_buffer_i32 downloaded in
+    let 1 downloaded := download_i32 ready in
+    let pair := unpack_i32_download downloaded in
+    let 1 values := download_values_i32 pair in
+    let 1 next := download_buffer_i32 pair in
     let _ := Array.sum values in
     let _ := free next in
     free ready;
@@ -354,10 +372,11 @@ def test_pending_cannot_be_downloaded_before_synchronize():
         IMPORTS
         + f"""
 def premature (d: Device) : Int :=
+    let stream := default_stream d in
     let launch := launch_1d d 1 1 in
     let 1 left := upload_i32 d ({_int_array((1,))}) in
     let 1 right := upload_i32 d ({_int_array((2,))}) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     download_i32 pending;
 """
         + MAIN
@@ -418,10 +437,11 @@ def test_add_rejects_unequal_vector_lengths():
         IMPORTS
         + f"""
 def invalid (d: Device) : Unit :=
+    let stream := default_stream d in
     let launch := launch_1d d 2 2 in
     let 1 left := upload_i32 d ({_int_array((1, 2))}) in
     let 1 right := upload_i32 d ({_int_array((3,))}) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     discard pending;
 """
         + MAIN
@@ -434,10 +454,11 @@ def test_add_rejects_launch_item_count_different_from_buffer_size():
         IMPORTS
         + f"""
 def invalid (d: Device) : Unit :=
+    let stream := default_stream d in
     let launch := launch_1d d 1 1 in
     let 1 left := upload_i32 d ({_int_array((1, 2))}) in
     let 1 right := upload_i32 d ({_int_array((3, 4))}) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     discard pending;
 """
         + MAIN
@@ -452,10 +473,11 @@ def test_add_rejects_cross_device_buffers():
 def invalid (u: Unit) : Unit :=
     let d0 := device 0 in
     let d1 := device 1 in
+    let stream := default_stream d0 in
     let launch := launch_1d d0 1 1 in
     let 1 left := upload_i32 d0 ({_int_array((1,))}) in
     let 1 right := upload_i32 d1 ({_int_array((2,))}) in
-    let 1 pending := add_i32 launch left right in
+    let 1 pending := add_i32 launch stream left right in
     discard pending;
 """
         + MAIN


### PR DESCRIPTION
## Summary

- introduce linear `I32Download` / `Float64Download` tokens with `unpack_*` accessors
- add CUDA `Stream` resources; kernel launches are stream-ordered via `pending_stream` refinements
- update examples and tests for `default_stream`, unpack flow, and stream parameters

## Stack

Targets `cuda-refine/4-byte-bounds`. Next PR: dtype-indexed element-size proofs.

## Test plan

- [x] `pytest tests/cuda_qtt_test.py tests/cuda_binding_test.py` (42 tests)

Made with [Cursor](https://cursor.com)