### PR TITLE
CUDA refinements: dtype-indexed element sizes

### DIFF
--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -92,7 +92,8 @@ def upload_i32 (device: Device)
     {buffer: (ReadyBuffer Int) |
         buffer_device buffer = device_id device &&
         buffer_size buffer = Array.size values &&
-        buffer_bytes buffer = buffer_size buffer * 4 &&
+        buffer_elem_size buffer = 4 &&
+        buffer_bytes buffer = buffer_size buffer * buffer_elem_size buffer &&
         buffer_bytes buffer <= max_allocation device} :=
     native "__import__('aeon.bindings.cuda', fromlist=['upload_i32']).upload_i32(device, values)"
 
@@ -101,7 +102,8 @@ def upload_float64 (device: Device)
     {buffer: (ReadyBuffer Float) |
         buffer_device buffer = device_id device &&
         buffer_size buffer = Array.size values &&
-        buffer_bytes buffer = buffer_size buffer * 8 &&
+        buffer_elem_size buffer = 8 &&
+        buffer_bytes buffer = buffer_size buffer * buffer_elem_size buffer &&
         buffer_bytes buffer <= max_allocation device} :=
     native "__import__('aeon.bindings.cuda', fromlist=['upload_float64']).upload_float64(device, values)"
 
@@ -114,11 +116,13 @@ def add_i32
     (stream: {s: Stream | stream_device s = launch_device launch})
     (1 left: {buffer: (ReadyBuffer Int) |
         buffer_size buffer > 0 &&
+        buffer_elem_size buffer = 4 &&
         buffer_device buffer = launch_device launch &&
         buffer_size buffer = launch_items launch &&
         launch_grid_size launch * launch_threads launch >= buffer_size buffer})
     (1 right: {buffer: (ReadyBuffer Int) |
         buffer_size buffer = buffer_size left &&
+        buffer_elem_size buffer = buffer_elem_size left &&
         buffer_device buffer = buffer_device left}) :
     {pending: (Pending Int) |
         pending_device pending = launch_device launch &&
@@ -131,11 +135,13 @@ def add_float64
     (stream: {s: Stream | stream_device s = launch_device launch})
     (1 left: {buffer: (ReadyBuffer Float) |
         buffer_size buffer > 0 &&
+        buffer_elem_size buffer = 8 &&
         buffer_device buffer = launch_device launch &&
         buffer_size buffer = launch_items launch &&
         launch_grid_size launch * launch_threads launch >= buffer_size buffer})
     (1 right: {buffer: (ReadyBuffer Float) |
         buffer_size buffer = buffer_size left &&
+        buffer_elem_size buffer = buffer_elem_size left &&
         buffer_device buffer = buffer_device left}) :
     {pending: (Pending Float) |
         pending_device pending = launch_device launch &&
@@ -147,7 +153,8 @@ def add_float64
 def synchronize (1 pending: (Pending a)) :
     {buffer: (ReadyBuffer a) |
         buffer_device buffer = pending_device pending &&
-        buffer_size buffer = pending_size pending} :=
+        buffer_size buffer = pending_size pending &&
+        buffer_bytes buffer = buffer_size buffer * buffer_elem_size buffer} :=
     native "__import__('aeon.bindings.cuda', fromlist=['synchronize']).synchronize(pending)"
 
 # Copy a completed allocation into a fresh host array while preserving the
@@ -185,7 +192,9 @@ def download_values_i32 (p: I32DownloadPair) :
 def download_buffer_i32 (p: I32DownloadPair) :
     {b: (ReadyBuffer Int) |
         buffer_device b = i32_download_pair_device p &&
-        buffer_size b = i32_download_pair_size p} :=
+        buffer_size b = i32_download_pair_size p &&
+        buffer_elem_size b = 4 &&
+        buffer_bytes b = buffer_size b * buffer_elem_size b} :=
     native "p[1]"
 
 def download_values_float64 (p: Float64DownloadPair) :
@@ -195,7 +204,9 @@ def download_values_float64 (p: Float64DownloadPair) :
 def download_buffer_float64 (p: Float64DownloadPair) :
     {b: (ReadyBuffer Float) |
         buffer_device b = float64_download_pair_device p &&
-        buffer_size b = float64_download_pair_size p} :=
+        buffer_size b = float64_download_pair_size p &&
+        buffer_elem_size b = 8 &&
+        buffer_bytes b = buffer_size b * buffer_elem_size b} :=
     native "p[1]"
 
 # Explicitly release a completed allocation or abandon pending work.

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -485,6 +485,23 @@ def invalid (u: Unit) : Unit :=
     assert _errors(source) != []
 
 
+def test_add_rejects_mismatched_element_types():
+    source = (
+        IMPORTS
+        + f"""
+def invalid (d: Device) : Unit :=
+    let stream := default_stream d in
+    let launch := launch_1d d 1 1 in
+    let 1 left := upload_float64 d ({_float_array((1.0,))}) in
+    let 1 right := upload_float64 d ({_float_array((2.0,))}) in
+    let 1 pending := add_i32 launch stream left right in
+    discard pending;
+"""
+        + MAIN
+    )
+    assert _errors(source) != []
+
+
 def test_cuda_vector_add_example_typechecks():
     example = Path(__file__).parents[1] / "examples" / "llvm" / "gpu" / "cuda_vector_add.ae"
     setup_logger()


### PR DESCRIPTION
## Summary

- track `buffer_elem_size` on uploads, kernel inputs, sync outputs, and download recovery
- i32 paths require 4-byte elements; float64 paths require 8-byte elements
- add compile-time test rejecting `add_i32` on float64 buffers

## Stack

Final PR in the CUDA refinement stack (items 1–6 from the roadmap).

## Test plan

- [x] `pytest tests/cuda_qtt_test.py tests/cuda_binding_test.py` (42 tests)

Made with [Cursor](https://cursor.com)