### PR TITLE
Speed up synthesis fitness evaluation

### DIFF
--- a/aeon/synthesis/entrypoint.py
+++ b/aeon/synthesis/entrypoint.py
@@ -42,6 +42,7 @@ from aeon.synthesis.api import (
     TimeoutInEvaluationException,
 )
 from aeon.synthesis.evaluation_pool import EvalPrimitives, EvaluationPool, set_program_tail
+from aeon.synthesis.fitness_eval import candidate_key, make_bundled_fitness_evaluator
 from aeon.synthesis.modules.contata.cosynthesis import (
     _cosynthesize_group,
     _joint_accepts,  # noqa: F401  — re-exported for tests/external callers.
@@ -322,9 +323,20 @@ def _synthesize_one(
         goals.extend(Goal(minimize=True, length=1, function=corpus.spec.name, kind="property") for corpus in corpora)
         entry["goals"] = goals
         synthesis_metadata[fun_name] = entry
-        property_evaluators = [make_property_fitness(corpus, _ectx_for_workers(ectx)) for corpus in corpora]
+        property_evaluators = [
+            make_property_fitness(corpus, _ectx_for_workers(ectx), target=fun_name) for corpus in corpora
+        ]
 
     evaluators = make_evaluators(ectx, fun_name, synthesis_metadata, property_evaluators)
+    dummy_prog = replace(_synthesis_dummy_literal(ty))
+    fitness_goals: list[Goal] = synthesis_metadata.get(fun_name, {}).get("goals", [])
+    bundled_fitness = make_bundled_fitness_evaluator(
+        fitness_goals,
+        _ectx_for_workers(ectx),
+        fun_name,
+        dummy_prog,
+        property_evaluators if corpora else None,
+    )
     assert isinstance(tyctx, TypingContext)
     assert isinstance(ty, Type)
     tac_map = synthesis_metadata.get(fun_name, {}).get("tactic_scripts")
@@ -345,7 +357,13 @@ def _synthesize_one(
     # featuriser `f` (e.g. a rasterised scene), else the output is the
     # candidate's own value.
     feature_fun = _cluster_function(synthesis_metadata, fun_name) or fun_name
-    primitives = EvalPrimitives(evaluators, _ectx_for_workers(ectx), feature_fun, replace)
+    primitives = EvalPrimitives(
+        evaluators,
+        _ectx_for_workers(ectx),
+        feature_fun,
+        replace,
+        bundled_fitness=bundled_fitness,
+    )
     pool = EvaluationPool(replace, syn_impl.computations(primitives), budget_eval=budget_eval)
     evaluator, output_evaluator = _pool_backed(pool)
 
@@ -364,7 +382,7 @@ def _synthesize_one(
         # and blocks on the interactive prompt. The dummy body is irrelevant:
         # the sub-terms we probe are built from the DSL components and the
         # parameters, not from the function under synthesis.
-        _dummy_prog = replace(_synthesis_dummy_literal(ty))
+        _dummy_prog = dummy_prog
         # Build the evaluation environment (all in-scope DSL bindings) ONCE,
         # rather than re-evaluating the whole def-chain for every probed
         # sub-term. Each binding is bound by evaluating it with its own name
@@ -525,10 +543,10 @@ def _pool_backed(pool: EvaluationPool) -> tuple[Callable[[Term], list[float]], C
     ``output_value`` the ``output`` one. Each candidate is run once (all its
     computations together) and the results cached, so the two callables share
     that single round-trip."""
-    cache: dict[str, dict[str, tuple[str, Any]]] = {}
+    cache: dict[int, dict[str, tuple[str, Any]]] = {}
 
     def results(term: Term) -> dict[str, tuple[str, Any]]:
-        key = str(term)
+        key = candidate_key(term)
         if key not in cache:
             cache[key] = pool.run(term)
         return cache[key]

--- a/aeon/synthesis/evaluation_pool.py
+++ b/aeon/synthesis/evaluation_pool.py
@@ -23,8 +23,9 @@ from typing import Any, Callable, Optional
 import multiprocess as mp
 
 from aeon.backend.evaluator import EvaluationContext, eval
-from aeon.core.terms import Let, Rec, Term, Var
+from aeon.core.terms import Term, Var
 from aeon.synthesis.api import InvalidIndividualException
+from aeon.synthesis.fitness_eval import memoize_fitness, set_program_tail
 from aeon.utils.name import Name
 
 # A computation maps a (candidate-substituted) program to a value. It may raise
@@ -33,14 +34,6 @@ Computation = Callable[[Term], Any]
 
 # Per-computation result statuses.
 OK, INVALID, ERROR, TIMEOUT = "ok", "invalid", "error", "timeout"
-
-
-def set_program_tail(term: Term, new_tail: Term) -> Term:
-    """Replace the innermost body of a chain of top-level ``let``/``rec``
-    bindings with ``new_tail`` (the bindings, and so everything in scope, stay)."""
-    if isinstance(term, (Let, Rec)):
-        return dataclasses.replace(term, body=set_program_tail(term.body, new_tail))
-    return new_tail
 
 
 class EvalPrimitives:
@@ -53,11 +46,13 @@ class EvalPrimitives:
         ectx: EvaluationContext,
         feature_fun: Name,
         replace: Optional[Callable[[Term], Term]] = None,
+        bundled_fitness: Optional[Computation] = None,
     ):
         self._evaluators = evaluators
         self._ectx = ectx
         self._feature_fun = feature_fun
         self._replace = replace
+        self._bundled_fitness = bundled_fitness
 
     @property
     def ectx(self) -> EvaluationContext:
@@ -77,8 +72,10 @@ class EvalPrimitives:
     @property
     def fitness(self) -> Computation:
         """Evaluate the objective(s): the list of per-goal distances."""
+        if self._bundled_fitness is not None:
+            return memoize_fitness(self._bundled_fitness)
         evaluators = self._evaluators
-        return lambda prog: [ev(prog) for ev in evaluators]
+        return memoize_fitness(lambda prog: [ev(prog) for ev in evaluators])
 
     @property
     def feature(self) -> Computation:

--- a/aeon/synthesis/fitness_eval.py
+++ b/aeon/synthesis/fitness_eval.py
@@ -1,0 +1,164 @@
+"""Shared fitness evaluation helpers: prefix pre-binding, goal bundling, memoization."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any
+
+from aeon.backend.evaluator import EvaluationContext, eval as aeon_eval
+from aeon.core.terms import Application, Let, Rec, Term, Var
+from aeon.synthesis.api import InvalidIndividualException
+from aeon.synthesis.decorators import Goal
+from aeon.synthesis.resource_meters import measure_cputime, measure_energy
+from aeon.utils.name import Name
+
+Computation = Callable[[Term], Any]
+
+# Bound duplicate-phenotype memoization during a synthesis run.
+_FITNESS_MEMO_MAX = 4096
+
+
+def set_program_tail(term: Term, new_tail: Term) -> Term:
+    """Replace the innermost body of a chain of top-level ``let``/``rec``
+    bindings with ``new_tail`` (the bindings, and so everything in scope, stay)."""
+    if isinstance(term, (Let, Rec)):
+        return dataclasses.replace(term, body=set_program_tail(term.body, new_tail))
+    return new_tail
+
+
+def candidate_key(term: Term) -> int:
+    """Stable hash for memo keys (structural, via ``Term.__hash__``)."""
+    return hash(term)
+
+
+def prebind_prefix(
+    prog: Term,
+    ectx: EvaluationContext,
+    stop_before: Name,
+) -> tuple[EvaluationContext, Term]:
+    """Evaluate static ``let``/``rec`` bindings before ``stop_before``.
+
+    Returns the extended context and the suffix starting at the ``stop_before``
+    binding (or the original program when that name is not found).
+    """
+    ctx = ectx
+    t = prog
+    while isinstance(t, (Let, Rec)):
+        if t.var_name == stop_before:
+            return ctx, t
+        bound = aeon_eval(dataclasses.replace(t, body=Var(t.var_name)), ctx)
+        ctx = ctx.with_var(t.var_name, bound)
+        t = t.body
+    return ctx, t
+
+
+def _eval_goal(
+    prog: Term,
+    prefix_ctx: EvaluationContext,
+    goal: Goal,
+    fun_name: Name,
+    ectx: EvaluationContext,
+) -> float:
+    """Evaluate one generated-helper goal, using a pre-bound prefix when possible."""
+    _, suffix = prebind_prefix(prog, ectx, fun_name)
+    program_for_fitness = set_program_tail(suffix, Var(goal.function))
+    ctx = prefix_ctx
+    try:
+        if goal.kind == "cputime":
+            return measure_cputime(lambda: aeon_eval(program_for_fitness, ctx))
+        if goal.kind == "energy":
+            return measure_energy(lambda: aeon_eval(program_for_fitness, ctx))
+        return aeon_eval(program_for_fitness, ctx)
+    except Exception:
+        raise InvalidIndividualException()
+
+
+def _collect_expression_goals(
+    suffix: Term,
+    prefix_ctx: EvaluationContext,
+    expr_functions: set[Name],
+) -> dict[Name, float]:
+    """Walk the suffix chain once, collecting expression goal values."""
+    values: dict[Name, float] = {}
+    ctx = prefix_ctx
+    t = suffix
+    while isinstance(t, (Let, Rec)):
+        try:
+            bound = aeon_eval(dataclasses.replace(t, body=Var(t.var_name)), ctx)
+        except Exception:
+            raise InvalidIndividualException()
+        ctx = ctx.with_var(t.var_name, bound)
+        if t.var_name in expr_functions:
+            values[t.var_name] = bound
+        t = t.body
+    return values
+
+
+def make_bundled_fitness_evaluator(
+    goals: list[Goal],
+    ectx: EvaluationContext,
+    fun_name: Name,
+    prefix_prog: Term,
+    property_evaluators: list[Callable[[Term], float]] | None = None,
+) -> Callable[[Term], list[float]]:
+    """Return one evaluator that scores every goal for a substituted program.
+
+    Expression goals on the suffix ``rec`` chain share a single interpreter
+    walk; ``cputime``/``energy`` and ``property`` goals fall back to their
+    own evaluation paths.
+    """
+    prefix_ctx, _ = prebind_prefix(prefix_prog, ectx, fun_name)
+    expr_functions = {g.function for g in goals if g.kind == "expression"}
+
+    def fitness(prog: Term) -> list[float]:
+        properties = iter(property_evaluators or [])
+        _, suffix = prebind_prefix(prog, ectx, fun_name)
+        expr_values = _collect_expression_goals(suffix, prefix_ctx, expr_functions) if expr_functions else {}
+        scores: list[float] = []
+        for goal in goals:
+            if goal.kind == "property":
+                prop = next(properties)
+                scores.append(prop(prog))
+            elif goal.kind == "expression":
+                if goal.function in expr_values:
+                    scores.append(expr_values[goal.function])
+                else:
+                    scores.append(_eval_goal(prog, prefix_ctx, goal, fun_name, ectx))
+            else:
+                scores.append(_eval_goal(prog, prefix_ctx, goal, fun_name, ectx))
+        return scores
+
+    return fitness
+
+
+def memoize_fitness(comp: Computation, maxsize: int = _FITNESS_MEMO_MAX) -> Computation:
+    """LRU memo keyed by ``candidate_key`` for duplicate phenotypes."""
+    cache: dict[int, Any] = {}
+    order: list[int] = []
+
+    def wrapped(prog: Term) -> Any:
+        key = candidate_key(prog)
+        hit = cache.get(key)
+        if hit is not None:
+            return hit
+        result = comp(prog)
+        if len(cache) >= maxsize and key not in cache:
+            evicted = order.pop(0)
+            cache.pop(evicted, None)
+        cache[key] = result
+        order.append(key)
+        return result
+
+    return wrapped
+
+
+def prebuild_property_calls(spec_name: Name, cases: tuple[tuple[Term, ...], ...]) -> tuple[Term, ...]:
+    """Build property application spines once for a fixed corpus."""
+    calls: list[Term] = []
+    for args in cases:
+        call: Term = Var(spec_name)
+        for arg in args:
+            call = Application(call, arg)
+        calls.append(call)
+    return tuple(calls)

--- a/aeon/synthesis/pbt/runner.py
+++ b/aeon/synthesis/pbt/runner.py
@@ -465,15 +465,34 @@ def property_corpora_for_target(
     return corpora
 
 
-def make_property_fitness(corpus: PropertyCorpus, evaluation_ctx: EvaluationContext) -> Callable[[Term], float]:
-    """Return a failure-count evaluator over one pre-generated corpus."""
+def make_property_fitness(
+    corpus: PropertyCorpus,
+    evaluation_ctx: EvaluationContext,
+    target: Name | None = None,
+) -> Callable[[Term], float]:
+    """Return a failure-count evaluator over one pre-generated corpus.
+
+    When ``target`` is the synthesised function, static prefix bindings are
+    evaluated once per candidate and pre-built call spines are reused.
+    """
+    from aeon.synthesis.fitness_eval import prebind_prefix, prebuild_property_calls, set_program_tail
+
+    calls = prebuild_property_calls(corpus.spec.name, corpus.cases)
 
     def fitness(program: Term) -> float:
         failures = 0
-        for args in corpus.cases:
-            call: Term = Var(corpus.spec.name)
-            for arg in args:
-                call = Application(call, arg)
+        if target is not None:
+            prefix_ctx, suffix = prebind_prefix(program, evaluation_ctx, target)
+            for call in calls:
+                try:
+                    value = aeon_eval(set_program_tail(suffix, call), prefix_ctx)
+                except Exception:
+                    failures += 1
+                    continue
+                if value is not True:
+                    failures += 1
+            return float(failures)
+        for call in calls:
             try:
                 value = aeon_eval(_replace_tail(program, call), evaluation_ctx)
             except Exception:


### PR DESCRIPTION
## Summary
- Add `aeon/synthesis/fitness_eval.py` with prefix pre-binding, bundled expression-goal evaluation, and LRU fitness memoization keyed by term hash.
- Wire bundled fitness through `EvaluationPool` workers so multiple `@minimize` goals share one interpreter walk on the suffix chain instead of re-evaluating the full program per goal.
- Optimize `@property` fitness by pre-building call spines and reusing prefix-bound evaluation contexts.

## Test plan
- [x] `pytest tests/synth_fitness_test.py tests/property_fitness_test.py tests/optimization_decorators_test.py`
- [x] Pre-commit on changed files


Made with [Cursor](https://cursor.com)