### PR TITLE
Add forward-only and backward-only type-directed synthesizer backends

### DIFF
--- a/aeon/__main__.py
+++ b/aeon/__main__.py
@@ -143,7 +143,9 @@ def _parse_common_arguments(parser: ArgumentParser):
         default="tdsyn_enumerative",
         help=(
             "Select a synthesizer: tdsyn_enumerative (default, type-directed BFS), tdsyn (same as tdsyn_enumerative), "
-            "tdsyn_random (type-directed random walk), tactics (random tactic search), gp, synquid, "
+            "tdsyn_random (type-directed random walk), "
+            "tdsyn_backward (type-directed, backward action only), tdsyn_forward (type-directed, forward action only), "
+            "tactics (random tactic search), gp, synquid, "
             "random_search, enumerative (grammar enumeration), hc, 1p1, smt, "
             "sygus (reduce to SyGuS and solve with cvc5), decision_tree, llm (Ollama, default qwen2.5-coder:32b), "
             "llm_<model> (per-model Ollama backends, e.g. llm_qwen2.5-coder-14b), "

--- a/aeon/lsp/server.py
+++ b/aeon/lsp/server.py
@@ -59,6 +59,8 @@ SYNTHESIZERS = sort_synthesizer_ids(
     [
         "tdsyn_enumerative",
         "tdsyn_random",
+        "tdsyn_backward",
+        "tdsyn_forward",
         "tactics",
         "gp",
         "enumerative",

--- a/aeon/synthesis/modules/synthesizerfactory.py
+++ b/aeon/synthesis/modules/synthesizerfactory.py
@@ -60,6 +60,8 @@ SYNTHESIZER_LABELS: dict[str, str] = {
     "tdsyn": "Type-directed synthesis (BFS)",
     "tdsyn_enumerative": "Type-directed synthesis (BFS)",
     "tdsyn_random": "Type-directed synthesis (Random Walk)",
+    "tdsyn_backward": "Type-directed synthesis (Backward only)",
+    "tdsyn_forward": "Type-directed synthesis (Forward only)",
     "synquid": "Synquid enumeration (Q-guided)",
     "tactics": "Tactic search (random)",
     "decision_tree": "Decision tree regression (from examples)",
@@ -98,6 +100,8 @@ SYNTHESIZER_FAMILIES: dict[str, SynthesizerFamily] = {
     "tdsyn": SynthesizerFamily.TYPE_DIRECTED,
     "tdsyn_enumerative": SynthesizerFamily.TYPE_DIRECTED,
     "tdsyn_random": SynthesizerFamily.TYPE_DIRECTED,
+    "tdsyn_backward": SynthesizerFamily.TYPE_DIRECTED,
+    "tdsyn_forward": SynthesizerFamily.TYPE_DIRECTED,
     "synquid": SynthesizerFamily.TYPE_DIRECTED,
     "tactics": SynthesizerFamily.TYPE_DIRECTED,
     # Example-driven — learn from @example / @csv_data I/O.
@@ -161,6 +165,8 @@ _BUILTIN_SYNTHESIZER_IDS = frozenset(
         "tdsyn",
         "tdsyn_enumerative",
         "tdsyn_random",
+        "tdsyn_backward",
+        "tdsyn_forward",
         "tactics",
         "lta",
         "symetric",
@@ -256,6 +262,10 @@ def make_synthesizer(module: str) -> Synthesizer | ProgramSynthesizer:
             return TDSynSynthesizer(mode="enumerative", seed=seed)
         case "tdsyn_random":
             return TDSynSynthesizer(mode="random", seed=seed)
+        case "tdsyn_backward":
+            return TDSynSynthesizer(mode="enumerative", seed=seed, direction="backward")
+        case "tdsyn_forward":
+            return TDSynSynthesizer(mode="enumerative", seed=seed, direction="forward")
         case "tactics":
             return TacticRandomSynthesizer(seed=seed)
         case "lta":

--- a/aeon/synthesis/modules/tdsyn/synthesizer.py
+++ b/aeon/synthesis/modules/tdsyn/synthesizer.py
@@ -69,17 +69,32 @@ def _peel_abstractions(ty: Type, ctx: TypingContext) -> tuple[Term, Type, Typing
 class TDSynSynthesizer(Synthesizer):
     """Type-directed synthesizer using backward and forward actions with SMT-based subtyping.
 
-    Supports both enumerative (BFS) and random exploration modes.
+    Supports both enumerative (BFS) and random exploration modes, and can be
+    restricted to a single expansion direction: ``backward`` grows terms from
+    the hole's expected type, ``forward`` grows terms from the variables in
+    scope, and ``both`` (the default) combines the two.
     Loops until the time budget is exhausted, restarting with shuffled expansion
     order on each iteration to explore different term structures.
     """
 
-    def __init__(self, mode: str = "enumerative", seed: int = 0):
+    def __init__(self, mode: str = "enumerative", seed: int = 0, direction: str = "both"):
         assert mode in ("enumerative", "random")
+        assert direction in ("both", "backward", "forward")
         self.mode = mode
         self.seed = seed
+        self.direction = direction
         self._rng = random.Random(seed)
         self._iteration = 0
+
+    def _action_fns(self) -> list[Callable]:
+        """The candidate-generating actions enabled for this synthesizer's direction."""
+        match self.direction:
+            case "backward":
+                return [backward_candidates]
+            case "forward":
+                return [forward_candidates]
+            case _:
+                return [backward_candidates, forward_candidates]
 
     def synthesize(
         self,
@@ -189,10 +204,10 @@ class TDSynSynthesizer(Synthesizer):
         hole: TypedHole,
         skip: Callable[[Name], bool],
     ) -> list[PartialAST]:
-        """Expand a single hole using backward and forward actions."""
+        """Expand a single hole using the enabled backward/forward actions."""
         results: list[PartialAST] = []
 
-        for action_fn in [backward_candidates, forward_candidates]:
+        for action_fn in self._action_fns():
             try:
                 candidates = action_fn(hole, skip)
             except Exception as e:

--- a/docs/synthesizers.md
+++ b/docs/synthesizers.md
@@ -114,6 +114,18 @@ Same expansion rules as `tdsyn`, but instead of a BFS worklist it performs indep
 
 ---
 
+### `tdsyn_backward` — Type-Directed Synthesis (Backward only)
+
+Same BFS search as `tdsyn`, but restricted to the **backward** action: candidates are derived from the hole's expected type (literals, variables and function applications whose result type matches, abstractions, if-then-else). The forward action is disabled.
+
+---
+
+### `tdsyn_forward` — Type-Directed Synthesis (Forward only)
+
+Same BFS search as `tdsyn`, but restricted to the **forward** action: candidates are built by applying in-scope functions to the variables already in scope, keeping only applications whose result type matches the hole. The backward action is disabled.
+
+---
+
 ### `tactics` — Random Tactic Search
 
 A Lean-style tactic synthesizer. The proof obligation (the hole's goal type in its typing context) is reduced step by step by repeatedly choosing a random open hole and a random tactic from:
@@ -158,6 +170,8 @@ Polymorphic library functions are kept as cyclic *template* states and finitely 
 | `llm`           | LLM generation   | Problems that are easy to describe in natural language |
 | `tdsyn` / `tdsyn_enumerative` | Type-directed BFS with SMT leaves | Tightly-typed holes where leaves reduce to arithmetic |
 | `tdsyn_random` | Type-directed random walks with SMT leaves | Wider, shallower term spaces than `tdsyn` |
+| `tdsyn_backward` | Type-directed BFS, backward action only | Goals best decomposed from the expected type |
+| `tdsyn_forward` | Type-directed BFS, forward action only | Goals best built up from the variables in scope |
 | `tactics`       | Random tactic walks (Lean-style) | Goals whose proof decomposes into tactic steps |
 | `lta`           | Component-based via Liquid Tree Automata | Reusing a library of refined functions to assemble a term |
 

--- a/tests/lsp_test.py
+++ b/tests/lsp_test.py
@@ -211,6 +211,8 @@ def test_synthesizers_list_non_empty():
 def test_synthesizers_includes_defaults():
     assert "tdsyn_enumerative" in SYNTHESIZERS
     assert "tdsyn_random" in SYNTHESIZERS
+    assert "tdsyn_backward" in SYNTHESIZERS
+    assert "tdsyn_forward" in SYNTHESIZERS
     assert "gp" in SYNTHESIZERS
     assert "enumerative" in SYNTHESIZERS
     assert "llm_qwen2.5-coder-32b" in SYNTHESIZERS
@@ -363,9 +365,10 @@ def test_run_synthesis_each_synthesizer(synthesizer, monkeypatch):
 
     # These backends need a spec the plain ``Int`` hole does not provide:
     # decision_tree needs @csv_data/@example rows; symetric needs a @minimize
-    # objective; sygus needs an SMT-expressible constraint. They legitimately
-    # produce no term here — just verify they complete without raising.
-    if synthesizer in ("decision_tree", "sygus", "symetric"):
+    # objective; sygus needs an SMT-expressible constraint; tdsyn_forward
+    # builds terms from variables in scope, and this hole has none. They
+    # legitimately produce no term here — just verify they complete without raising.
+    if synthesizer in ("decision_tree", "sygus", "symetric", "tdsyn_forward"):
         result = _run_synthesis(driver, mock_ls, "file:///test.ae", "hole", synthesizer)
         assert result is None or isinstance(result, tuple)
         return

--- a/tests/synthesizer_seed_test.py
+++ b/tests/synthesizer_seed_test.py
@@ -19,6 +19,8 @@ SEEDED_BACKENDS = [
     "tdsyn",
     "tdsyn_enumerative",
     "tdsyn_random",
+    "tdsyn_backward",
+    "tdsyn_forward",
     "tactics",
 ]
 

--- a/tests/tdsyn_direction_test.py
+++ b/tests/tdsyn_direction_test.py
@@ -90,8 +90,17 @@ def _int_hole_partial() -> tuple[PartialAST, TypedHole]:
 
 def _record_expansion_actions(synth: TDSynSynthesizer, monkeypatch) -> list[str]:
     calls: list[str] = []
-    monkeypatch.setattr(tdsyn_module, "backward_candidates", lambda hole, skip: calls.append("backward") or [])
-    monkeypatch.setattr(tdsyn_module, "forward_candidates", lambda hole, skip: calls.append("forward") or [])
+
+    def fake_backward(hole, skip):
+        calls.append("backward")
+        return []
+
+    def fake_forward(hole, skip):
+        calls.append("forward")
+        return []
+
+    monkeypatch.setattr(tdsyn_module, "backward_candidates", fake_backward)
+    monkeypatch.setattr(tdsyn_module, "forward_candidates", fake_forward)
     partial, typed_hole = _int_hole_partial()
     synth._expand_hole(partial, typed_hole, lambda name: False)
     return calls

--- a/tests/tdsyn_direction_test.py
+++ b/tests/tdsyn_direction_test.py
@@ -1,0 +1,123 @@
+"""Forward-only and backward-only variants of the type-directed synthesizer.
+
+`tdsyn_backward` expands holes only with the backward action (from the
+expected type), `tdsyn_forward` only with the forward action (from the
+variables in scope), while `tdsyn` / `tdsyn_enumerative` / `tdsyn_random`
+keep combining both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aeon.core.types import t_int
+from aeon.lsp.server import SYNTHESIZERS
+from aeon.synthesis.modules.synthesizerfactory import (
+    SynthesizerFamily,
+    is_known_synthesizer,
+    make_synthesizer,
+    synthesizer_family,
+    synthesizer_label,
+)
+from aeon.synthesis.modules.tdsyn import synthesizer as tdsyn_module
+from aeon.synthesis.modules.tdsyn.synthesizer import TDSynSynthesizer
+from aeon.synthesis.modules.tdsyn.worklist import PartialAST, TypedHole, fresh_hole
+from aeon.typechecking.context import TypingContext
+
+DIRECTIONAL_IDS = ["tdsyn_backward", "tdsyn_forward"]
+
+
+# ---------------------------------------------------------------------------
+# registration: ids, labels, families, LSP menu
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", DIRECTIONAL_IDS)
+def test_directional_backends_are_known(backend):
+    assert is_known_synthesizer(backend)
+
+
+def test_directional_backends_have_distinct_labels():
+    assert synthesizer_label("tdsyn_backward") == "Type-directed synthesis (Backward only)"
+    assert synthesizer_label("tdsyn_forward") == "Type-directed synthesis (Forward only)"
+
+
+@pytest.mark.parametrize("backend", DIRECTIONAL_IDS)
+def test_directional_backends_are_type_directed(backend):
+    assert synthesizer_family(backend) == SynthesizerFamily.TYPE_DIRECTED
+
+
+@pytest.mark.parametrize("backend", DIRECTIONAL_IDS)
+def test_directional_backends_in_lsp_menu(backend):
+    assert backend in SYNTHESIZERS
+
+
+# ---------------------------------------------------------------------------
+# make_synthesizer wiring
+# ---------------------------------------------------------------------------
+
+
+def test_make_synthesizer_backward():
+    synth = make_synthesizer("tdsyn_backward")
+    assert isinstance(synth, TDSynSynthesizer)
+    assert synth.mode == "enumerative"
+    assert synth.direction == "backward"
+
+
+def test_make_synthesizer_forward():
+    synth = make_synthesizer("tdsyn_forward")
+    assert isinstance(synth, TDSynSynthesizer)
+    assert synth.mode == "enumerative"
+    assert synth.direction == "forward"
+
+
+@pytest.mark.parametrize("backend", ["tdsyn", "tdsyn_enumerative", "tdsyn_random"])
+def test_combined_backends_keep_both_directions(backend):
+    synth = make_synthesizer(backend)
+    assert isinstance(synth, TDSynSynthesizer)
+    assert synth.direction == "both"
+
+
+# ---------------------------------------------------------------------------
+# expansion uses only the enabled action(s)
+# ---------------------------------------------------------------------------
+
+
+def _int_hole_partial() -> tuple[PartialAST, TypedHole]:
+    hole_term, typed_hole = fresh_hole(t_int, TypingContext())
+    return PartialAST(term=hole_term, holes=[typed_hole], depth=0), typed_hole
+
+
+def _record_expansion_actions(synth: TDSynSynthesizer, monkeypatch) -> list[str]:
+    calls: list[str] = []
+    monkeypatch.setattr(tdsyn_module, "backward_candidates", lambda hole, skip: calls.append("backward") or [])
+    monkeypatch.setattr(tdsyn_module, "forward_candidates", lambda hole, skip: calls.append("forward") or [])
+    partial, typed_hole = _int_hole_partial()
+    synth._expand_hole(partial, typed_hole, lambda name: False)
+    return calls
+
+
+def test_backward_only_expansion_skips_forward_action(monkeypatch):
+    assert _record_expansion_actions(TDSynSynthesizer(direction="backward"), monkeypatch) == ["backward"]
+
+
+def test_forward_only_expansion_skips_backward_action(monkeypatch):
+    assert _record_expansion_actions(TDSynSynthesizer(direction="forward"), monkeypatch) == ["forward"]
+
+
+def test_default_expansion_runs_both_actions(monkeypatch):
+    assert _record_expansion_actions(TDSynSynthesizer(), monkeypatch) == ["backward", "forward"]
+
+
+def test_backward_expansion_yields_candidates_for_int_hole():
+    partial, typed_hole = _int_hole_partial()
+    results = TDSynSynthesizer(direction="backward")._expand_hole(partial, typed_hole, lambda name: False)
+    # Backward generates literals and if-then-else even in an empty context.
+    assert results
+
+
+def test_forward_expansion_is_empty_without_scope_variables():
+    partial, typed_hole = _int_hole_partial()
+    results = TDSynSynthesizer(direction="forward")._expand_hole(partial, typed_hole, lambda name: False)
+    # Forward builds terms from variables in scope; an empty context has none.
+    assert results == []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two new synthesizer backend ids so each type-directed expansion direction is selectable on its own, including from the VS Code / LSP "Synthesize" code-action menu:

- `tdsyn_backward` — **Type-directed synthesis (Backward only)**: expands holes only with the backward action (candidates derived from the hole's expected type: literals, matching variables, applications whose return type fits, abstractions, if-then-else).
- `tdsyn_forward` — **Type-directed synthesis (Forward only)**: expands holes only with the forward action (applications built from the variables already in scope).

Both use the same BFS worklist search as `tdsyn_enumerative`. The combined `tdsyn` / `tdsyn_enumerative` / `tdsyn_random` backends still run both actions on every expansion, unchanged.

## How it differs from combined tdsyn

`TDSynSynthesizer` previously hardcoded `[backward_candidates, forward_candidates]` in `_expand_hole`. It now takes a `direction` parameter (`"both"` default, `"backward"`, `"forward"`) that selects which action(s) generate candidates. Backward-only can still complete terms via literals and SMT leaf solving; forward-only completes terms only when applications are fully saturated from scope (e.g. `! b` for a `Bool` hole with `b` in scope), so it needs variables in scope to make progress.

## Wiring

- `make_synthesizer`, `SYNTHESIZER_LABELS`, `SYNTHESIZER_FAMILIES` (Type-directed family), and the known-id set in `aeon/synthesis/modules/synthesizerfactory.py`
- CLI `-s` help text in `aeon/__main__.py`
- LSP `SYNTHESIZERS` menu list in `aeon/lsp/server.py`
- `docs/synthesizers.md` entries and comparison table
- No changes to vscode-aeon (its enum only affects the `aeon.defaultSynthesizer` setting)

## Tests

- New `tests/tdsyn_direction_test.py`: ids are known/labeled/in the Type-directed family and the LSP menu; `make_synthesizer` returns the right mode/direction; `_expand_hole` invokes only the intended action per direction (and both for the default); backward yields candidates for a bare `Int` hole while forward yields none without scope variables.
- `tests/synthesizer_seed_test.py` and `tests/lsp_test.py` extended with the new ids. In `test_run_synthesis_each_synthesizer`, `tdsyn_forward` joins the backends that legitimately produce no term for the bare `Int` hole (no variables in scope for the forward action).

CLI verification: `python -m aeon --budget 10 -s tdsyn_backward` synthesizes `10` for `{x:Int | x > 3}`, and `-s tdsyn_forward` synthesizes a forward-built term for a `Bool` hole with a `Bool` argument in scope.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55bfaa18-1f52-48a5-bc2c-a0ba39c2e640?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55bfaa18-1f52-48a5-bc2c-a0ba39c2e640&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

