### PR TITLE
Add CUDA kind/access/shape/shared/warp/Status refinements

### DIFF
--- a/aeon/bindings/cuda.py
+++ b/aeon/bindings/cuda.py
@@ -29,6 +29,25 @@ _DType = Literal["i32", "float64"]
 _ITEM_SIZE: dict[_DType, int] = {"i32": 4, "float64": 8}
 _KERNEL_NAME: dict[_DType, bytes] = {"i32": b"aeon_vector_add_i32", "float64": b"aeon_vector_add_float64"}
 
+# Memory kinds (refinement measures / Aeon natives).
+MEM_KIND_DEVICE = 0
+MEM_KIND_HOST_PINNED = 1
+MEM_KIND_MANAGED = 2
+MEM_KIND_HOST = 3
+
+# Access modes.
+ACCESS_READ_ONLY = 0
+ACCESS_READ_WRITE = 1
+
+# CUDA driver attribute indices used below.
+_CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
+_CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8
+_CU_DEVICE_ATTRIBUTE_WARP_SIZE = 10
+
+# Architectural defaults used when validating without a live device.
+_DEFAULT_WARP_SIZE = 32
+_MAX_THREADS_PER_BLOCK = 1024
+
 
 class CUDAError(RuntimeError):
     """Base exception for CUDA binding failures."""
@@ -235,11 +254,27 @@ class Device:
             )
             self.compute_capability = (major.value, minor.value)
             max_threads = ctypes.c_int()
-            # CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK is stable value 1.
             driver.check(
-                driver.cuDeviceGetAttribute(ctypes.byref(max_threads), 1, handle.value), "cuDeviceGetAttribute"
+                driver.cuDeviceGetAttribute(
+                    ctypes.byref(max_threads), _CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK, handle.value
+                ),
+                "cuDeviceGetAttribute",
             )
             self.max_threads_per_block = max_threads.value
+            max_shared = ctypes.c_int()
+            driver.check(
+                driver.cuDeviceGetAttribute(
+                    ctypes.byref(max_shared), _CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK, handle.value
+                ),
+                "cuDeviceGetAttribute",
+            )
+            self.max_shared_mem_per_block = max_shared.value
+            warp = ctypes.c_int()
+            driver.check(
+                driver.cuDeviceGetAttribute(ctypes.byref(warp), _CU_DEVICE_ATTRIBUTE_WARP_SIZE, handle.value),
+                "cuDeviceGetAttribute",
+            )
+            self.warp_size = warp.value
             total_mem = ctypes.c_size_t()
             driver.check(
                 driver.cuDeviceTotalMem(ctypes.byref(total_mem), handle.value),
@@ -355,6 +390,8 @@ class Launch1D:
 
     size: int
     block_size: int = 256
+    shared_bytes: int = 0
+    require_warp_multiple: bool = False
 
     def __post_init__(self) -> None:
         if isinstance(self.size, bool) or not isinstance(self.size, int) or self.size <= 0:
@@ -363,12 +400,49 @@ class Launch1D:
             raise ValueError("block size must be a positive integer")
         if self.block_size > self.size:
             raise ValueError("block size cannot exceed launch size")
-        if self.block_size > 1024:
+        if self.block_size > _MAX_THREADS_PER_BLOCK:
             raise ValueError("block size cannot exceed CUDA's architectural limit of 1024")
+        if isinstance(self.shared_bytes, bool) or not isinstance(self.shared_bytes, int) or self.shared_bytes < 0:
+            raise ValueError("shared_bytes must be a non-negative integer")
+        if not isinstance(self.require_warp_multiple, bool):
+            raise ValueError("require_warp_multiple must be a bool")
 
     @property
     def grid_size(self) -> int:
         return math.ceil(self.size / self.block_size)
+
+
+@dataclass(frozen=True)
+class Launch2D:
+    """Validated two-dimensional launch geometry."""
+
+    width: int
+    height: int
+    block_x: int
+    block_y: int
+    shared_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("width", self.width),
+            ("height", self.height),
+            ("block_x", self.block_x),
+            ("block_y", self.block_y),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"launch {name} must be a positive integer")
+        if self.block_x * self.block_y > _MAX_THREADS_PER_BLOCK:
+            raise ValueError("block_x * block_y cannot exceed CUDA's architectural limit of 1024")
+        if isinstance(self.shared_bytes, bool) or not isinstance(self.shared_bytes, int) or self.shared_bytes < 0:
+            raise ValueError("shared_bytes must be a non-negative integer")
+
+    @property
+    def grid_x(self) -> int:
+        return math.ceil(self.width / self.block_x)
+
+    @property
+    def grid_y(self) -> int:
+        return math.ceil(self.height / self.block_y)
 
 
 class Stream:
@@ -424,28 +498,56 @@ class Stream:
 class Buffer:
     """A ready, typed device allocation."""
 
-    def __init__(self, device: Device, pointer: int, length: int, dtype: _DType) -> None:
+    def __init__(
+        self,
+        device: Device,
+        pointer: int,
+        length: int,
+        dtype: _DType,
+        *,
+        mem_kind: int = MEM_KIND_DEVICE,
+        access: int = ACCESS_READ_WRITE,
+        extent_x: int | None = None,
+        extent_y: int = 1,
+    ) -> None:
+        if mem_kind not in (MEM_KIND_DEVICE, MEM_KIND_HOST_PINNED, MEM_KIND_MANAGED, MEM_KIND_HOST):
+            raise ValueError(f"unsupported mem_kind: {mem_kind}")
+        if access not in (ACCESS_READ_ONLY, ACCESS_READ_WRITE):
+            raise ValueError(f"unsupported access mode: {access}")
+        if extent_x is None:
+            extent_x = length
+        if isinstance(extent_x, bool) or not isinstance(extent_x, int) or extent_x <= 0:
+            raise ValueError("extent_x must be a positive integer")
+        if isinstance(extent_y, bool) or not isinstance(extent_y, int) or extent_y <= 0:
+            raise ValueError("extent_y must be a positive integer")
         self.device = device
         self.pointer = pointer
         self.length = length
         self.dtype = dtype
+        self.mem_kind = mem_kind
+        self.access = access
+        self.extent_x = extent_x
+        self.extent_y = extent_y
+        # Ownership transfer (e.g. as_read_only): mark ready-state consumed without cuMemFree.
+        self._transferred = False
         self._freed = False
         device._register_buffer(self)
 
     def _ensure_ready(self) -> None:
         self.device._ensure_open()
-        if self._freed:
+        if self._freed or self._transferred:
             raise CUDAStateError("CUDA buffer has been freed")
 
     def _free_from_device(self) -> None:
-        if self._freed:
+        if self._freed or self._transferred:
             return
         self.device._driver.check(self.device._driver.cuMemFree(self.pointer), "cuMemFree")
         self._freed = True
 
     def free(self) -> None:
         with self.device._lock:
-            if self._freed:
+            if self._freed or self._transferred:
+                self._freed = True
                 return
             self.device._activate()
             self._free_from_device()
@@ -549,6 +651,28 @@ class Pending:
             pass
 
 
+class Status:
+    """Linear-style completion token that must be checked or discarded."""
+
+    def __init__(self, ok: bool, code: int = 0, message: str = "") -> None:
+        self.ok = ok
+        self.code = code
+        self.message = message
+        self._consumed = False
+
+    def _ensure_live(self) -> None:
+        if self._consumed:
+            raise CUDAStateError("CUDA status has already been consumed")
+
+
+@dataclass(frozen=True, slots=True)
+class StatusBuffer:
+    """Pair of a status token and an optional ready buffer (both must be handled)."""
+
+    status: Status
+    buffer: Buffer | None
+
+
 def device(ordinal: int = 0) -> Device:
     return Device(ordinal)
 
@@ -587,8 +711,29 @@ def pending_stream(pending: Pending) -> int:
     return pending.stream.stream_id
 
 
-def launch_1d(size: int, block_size: int | None = None) -> Launch1D:
-    return Launch1D(size, min(256, size) if block_size is None else block_size)
+def launch_1d(size: int, block_size: int | None = None, shared_bytes: int = 0) -> Launch1D:
+    return Launch1D(size, min(256, size) if block_size is None else block_size, shared_bytes=shared_bytes)
+
+
+def launch_1d_warped(size: int, block_size: int | None = None, shared_bytes: int = 0) -> Launch1D:
+    """Build a Launch1D that must be a multiple of the device warp size at launch.
+
+    Without a live device, construction uses the architectural default warp size
+    (32): ``block_size`` must be a multiple of 32, or the whole launch must fit
+    in one warp (``size <= 32``). Device-side validation uses ``device.warp_size``
+    when ``require_warp_multiple`` is true.
+    """
+    resolved = min(256, size) if block_size is None else block_size
+    if size > _DEFAULT_WARP_SIZE and resolved % _DEFAULT_WARP_SIZE != 0:
+        raise ValueError(
+            f"warped launch block size {resolved} must be a multiple of {_DEFAULT_WARP_SIZE} "
+            f"when size ({size}) exceeds one warp"
+        )
+    return Launch1D(size, resolved, shared_bytes=shared_bytes, require_warp_multiple=True)
+
+
+def launch_2d(width: int, height: int, block_x: int, block_y: int, shared_bytes: int = 0) -> Launch2D:
+    return Launch2D(width, height, block_x, block_y, shared_bytes=shared_bytes)
 
 
 def device_id(device_: Device) -> int:
@@ -597,6 +742,14 @@ def device_id(device_: Device) -> int:
 
 def max_threads_per_block(device_: Device) -> int:
     return device_.max_threads_per_block
+
+
+def max_shared_mem_per_block(device_: Device) -> int:
+    return device_.max_shared_mem_per_block
+
+
+def warp_size(device_: Device) -> int:
+    return device_.warp_size
 
 
 def launch_device(launch: Launch1D | tuple[Launch1D, Device]) -> int:
@@ -617,6 +770,40 @@ def launch_grid_size(launch: Launch1D | tuple[Launch1D, Device]) -> int:
     return launch[0].grid_size if isinstance(launch, tuple) else launch.grid_size
 
 
+def launch_shared_bytes(launch: Launch1D | Launch2D | tuple[Launch1D | Launch2D, Device]) -> int:
+    return launch[0].shared_bytes if isinstance(launch, tuple) else launch.shared_bytes
+
+
+def launch2d_width(launch: Launch2D | tuple[Launch2D, Device]) -> int:
+    return launch[0].width if isinstance(launch, tuple) else launch.width
+
+
+def launch2d_height(launch: Launch2D | tuple[Launch2D, Device]) -> int:
+    return launch[0].height if isinstance(launch, tuple) else launch.height
+
+
+def launch2d_threads_x(launch: Launch2D | tuple[Launch2D, Device]) -> int:
+    return launch[0].block_x if isinstance(launch, tuple) else launch.block_x
+
+
+def launch2d_threads_y(launch: Launch2D | tuple[Launch2D, Device]) -> int:
+    return launch[0].block_y if isinstance(launch, tuple) else launch.block_y
+
+
+def launch2d_grid_x(launch: Launch2D | tuple[Launch2D, Device]) -> int:
+    return launch[0].grid_x if isinstance(launch, tuple) else launch.grid_x
+
+
+def launch2d_grid_y(launch: Launch2D | tuple[Launch2D, Device]) -> int:
+    return launch[0].grid_y if isinstance(launch, tuple) else launch.grid_y
+
+
+def launch2d_device(launch: Launch2D | tuple[Launch2D, Device]) -> int:
+    if isinstance(launch, tuple):
+        return launch[1].ordinal
+    raise ValueError("a Launch2D descriptor alone does not own a device")
+
+
 def buffer_device(buffer: Buffer) -> int:
     return buffer.device.ordinal
 
@@ -633,6 +820,47 @@ def buffer_bytes(buffer: Buffer) -> int:
     return buffer.length * _ITEM_SIZE[buffer.dtype]
 
 
+def buffer_mem_kind(buffer: Buffer) -> int:
+    return buffer.mem_kind
+
+
+def buffer_access(buffer: Buffer) -> int:
+    return buffer.access
+
+
+def buffer_extent_x(buffer: Buffer) -> int:
+    return buffer.extent_x
+
+
+def buffer_extent_y(buffer: Buffer) -> int:
+    return buffer.extent_y
+
+
+def as_read_only(buffer: Buffer) -> Buffer:
+    """Transfer ``buffer`` into a read-only handle aliasing the same allocation.
+
+    Returns a new :class:`Buffer` with ``access=ACCESS_READ_ONLY`` that owns the
+    device pointer. The input is marked transferred (``_transferred`` / ``_freed``)
+    *without* calling ``cuMemFree``, so Aeon sees the original as consumed while
+    the returned handle remains responsible for release. Prefer this over mutating
+    ``access`` in place so linear ownership stays unambiguous.
+    """
+    buffer._ensure_ready()
+    readonly = Buffer(
+        buffer.device,
+        buffer.pointer,
+        buffer.length,
+        buffer.dtype,
+        mem_kind=buffer.mem_kind,
+        access=ACCESS_READ_ONLY,
+        extent_x=buffer.extent_x,
+        extent_y=buffer.extent_y,
+    )
+    buffer._transferred = True
+    buffer._freed = True
+    return readonly
+
+
 def max_allocation(device_: Device) -> int:
     return device_.max_allocation
 
@@ -643,6 +871,28 @@ def pending_device(pending: Pending) -> int:
 
 def pending_size(pending: Pending) -> int:
     return pending._ensure_pending().length
+
+
+def status_is_ok(status: Status) -> bool:
+    status._ensure_live()
+    return status.ok
+
+
+def status_code(status: Status) -> int:
+    status._ensure_live()
+    return status.code
+
+
+def check_ok(status: Status) -> None:
+    status._ensure_live()
+    status._consumed = True
+    if not status.ok:
+        raise CUDAError(status.message or f"CUDA status error {status.code}")
+
+
+def discard_status(status: Status) -> None:
+    status._ensure_live()
+    status._consumed = True
 
 
 def _coerce_values(values: Iterable[int] | Iterable[float], dtype: _DType) -> array.array[Any]:
@@ -757,12 +1007,20 @@ def _vector_add(
         raise ValueError("CUDA stream must belong to the launch device")
     if launch.block_size > device_.max_threads_per_block:
         raise ValueError(f"block size {launch.block_size} exceeds device limit {device_.max_threads_per_block}")
+    if launch.shared_bytes > device_.max_shared_mem_per_block:
+        raise ValueError(f"shared_bytes {launch.shared_bytes} exceeds device limit {device_.max_shared_mem_per_block}")
+    if launch.require_warp_multiple:
+        warp = device_.warp_size
+        if launch.block_size > warp and launch.block_size % warp != 0:
+            raise ValueError(f"block size {launch.block_size} must be a multiple of warp size {warp}")
     for operand in (left, right):
         operand._ensure_ready()
         if operand.device is not device_:
             raise ValueError("all CUDA buffers must belong to the launch device")
         if operand.dtype != dtype:
             raise TypeError(f"expected {dtype} CUDA buffers")
+        if operand.mem_kind != MEM_KIND_DEVICE:
+            raise ValueError("kernel operands must be device buffers")
     if left.length != right.length or launch.size != left.length:
         raise ValueError("launch size and both buffer lengths must match")
 
@@ -773,7 +1031,14 @@ def _vector_add(
             device_._driver.cuMemAlloc(ctypes.byref(pointer), max(1, launch.size) * _ITEM_SIZE[dtype]),
             "cuMemAlloc",
         )
-        output = Buffer(device_, pointer.value, launch.size, dtype)
+        output = Buffer(
+            device_,
+            pointer.value,
+            launch.size,
+            dtype,
+            mem_kind=MEM_KIND_DEVICE,
+            access=ACCESS_READ_WRITE,
+        )
         try:
             if launch.size:
                 function = device_._function(dtype)
@@ -796,7 +1061,7 @@ def _vector_add(
                         launch.block_size,
                         1,
                         1,
-                        0,
+                        launch.shared_bytes,
                         ctypes.c_void_p(stream.stream_id),
                         arguments,
                         None,
@@ -819,6 +1084,42 @@ def vector_add_float64(device_: Device, launch: Launch1D, left: Buffer, right: B
 
 def synchronize(pending: Pending) -> Buffer:
     return pending.synchronize()
+
+
+def synchronize_with_status(pending: Pending) -> StatusBuffer:
+    """Like :func:`synchronize`, but returns a :class:`StatusBuffer` instead of raising.
+
+    On success the status is ok and ``buffer`` holds the ready output. On failure
+    resources are released when possible and ``buffer`` is ``None``.
+    """
+    try:
+        buffer = pending.synchronize()
+        return StatusBuffer(Status(ok=True), buffer)
+    except CUDAError as exc:
+        try:
+            pending.discard()
+        except Exception:
+            pass
+        return StatusBuffer(Status(ok=False, code=1, message=str(exc)), None)
+
+
+def status_buffer_ok(result: StatusBuffer) -> bool:
+    return result.status.ok
+
+
+def unpack_status_buffer(result: StatusBuffer) -> tuple[Status, Buffer | None]:
+    return (result.status, result.buffer)
+
+
+def status_pair_status(pair: tuple[Status, Buffer | None]) -> Status:
+    return pair[0]
+
+
+def status_pair_buffer(pair: tuple[Status, Buffer | None]) -> Buffer:
+    buffer = pair[1]
+    if buffer is None:
+        raise CUDAStateError("CUDA status buffer has no ready allocation")
+    return buffer
 
 
 def free(buffer: Buffer) -> None:
@@ -899,7 +1200,10 @@ def _compile_vector_add_ptx(compute_capability: tuple[int, int]) -> str:
 Cuda_device = device
 Cuda_num_devices = num_devices
 Cuda_launch_1d = launch_1d
+Cuda_launch_1d_warped = launch_1d_warped
+Cuda_launch_2d = launch_2d
 Cuda_launch_grid_size = launch_grid_size
+Cuda_launch_shared_bytes = launch_shared_bytes
 Cuda_upload_i32 = upload_i32
 Cuda_upload_float64 = upload_float64
 Cuda_download_i32 = download_i32
@@ -909,40 +1213,109 @@ Cuda_download_float64_result = download_float64_result
 Cuda_vector_add_i32 = vector_add_i32
 Cuda_vector_add_float64 = vector_add_float64
 Cuda_synchronize = synchronize
+Cuda_synchronize_with_status = synchronize_with_status
+Cuda_as_read_only = as_read_only
 Cuda_free = free
 Cuda_discard = discard
 Cuda_close = close
+Cuda_buffer_mem_kind = buffer_mem_kind
+Cuda_buffer_access = buffer_access
+Cuda_buffer_extent_x = buffer_extent_x
+Cuda_buffer_extent_y = buffer_extent_y
+Cuda_max_shared_mem_per_block = max_shared_mem_per_block
+Cuda_warp_size = warp_size
+Cuda_status_is_ok = status_is_ok
+Cuda_status_code = status_code
+Cuda_check_ok = check_ok
+Cuda_discard_status = discard_status
+Cuda_status_buffer_ok = status_buffer_ok
+Cuda_unpack_status_buffer = unpack_status_buffer
+Cuda_status_pair_status = status_pair_status
+Cuda_status_pair_buffer = status_pair_buffer
+Cuda_MEM_KIND_DEVICE = MEM_KIND_DEVICE
+Cuda_MEM_KIND_HOST_PINNED = MEM_KIND_HOST_PINNED
+Cuda_MEM_KIND_MANAGED = MEM_KIND_MANAGED
+Cuda_MEM_KIND_HOST = MEM_KIND_HOST
+Cuda_ACCESS_READ_ONLY = ACCESS_READ_ONLY
+Cuda_ACCESS_READ_WRITE = ACCESS_READ_WRITE
 
 __all__ = [
+    "ACCESS_READ_ONLY",
+    "ACCESS_READ_WRITE",
     "Buffer",
     "CUDAError",
     "CUDAStateError",
     "CUDAUnavailableError",
     "Device",
+    "Float64Download",
+    "I32Download",
     "Launch1D",
+    "Launch2D",
+    "MEM_KIND_DEVICE",
+    "MEM_KIND_HOST",
+    "MEM_KIND_HOST_PINNED",
+    "MEM_KIND_MANAGED",
     "Pending",
+    "Status",
+    "StatusBuffer",
+    "Stream",
+    "as_read_only",
+    "buffer_access",
+    "buffer_bytes",
     "buffer_device",
+    "buffer_elem_size",
+    "buffer_extent_x",
+    "buffer_extent_y",
+    "buffer_mem_kind",
     "buffer_size",
+    "check_ok",
     "close",
+    "create_stream",
+    "default_stream",
     "device",
     "device_id",
     "discard",
+    "discard_status",
     "download_float64",
     "download_float64_result",
     "download_i32",
     "download_i32_result",
     "free",
+    "launch2d_device",
+    "launch2d_grid_x",
+    "launch2d_grid_y",
+    "launch2d_height",
+    "launch2d_threads_x",
+    "launch2d_threads_y",
+    "launch2d_width",
     "launch_1d",
-    "num_devices",
+    "launch_1d_warped",
+    "launch_2d",
     "launch_device",
+    "launch_grid_size",
     "launch_items",
+    "launch_shared_bytes",
     "launch_threads",
+    "max_allocation",
+    "max_shared_mem_per_block",
     "max_threads_per_block",
+    "num_devices",
     "pending_device",
     "pending_size",
+    "pending_stream",
+    "status_buffer_ok",
+    "status_code",
+    "status_is_ok",
+    "status_pair_buffer",
+    "status_pair_status",
+    "stream_device",
+    "stream_id",
     "synchronize",
+    "synchronize_with_status",
+    "unpack_status_buffer",
     "upload_float64",
     "upload_i32",
     "vector_add_float64",
     "vector_add_i32",
+    "warp_size",
 ]

--- a/aeon/libraries/Cuda.ae
+++ b/aeon/libraries/Cuda.ae
@@ -16,6 +16,9 @@ type Device
 # One-dimensional launch configuration: logical item count and block size.
 type Launch1D
 
+# Two-dimensional launch configuration: width/height and block dims.
+type Launch2D
+
 # CUDA stream for ordered kernel enqueue on one device.
 type Stream
 
@@ -33,16 +36,49 @@ linear type Float64Download
 type I32DownloadPair
 type Float64DownloadPair
 
+# Linear completion token; must be ``check_ok`` or ``discard_status``.
+linear type Status
+
+# Linear pair from ``synchronize_with_status`` (status + optional ready buffer).
+linear type StatusBuffer a
+
+# Unrestricted pair after unpacking a ``StatusBuffer``.
+type StatusPair a
+
+# ── Kind / access constants ──────────────────────────────────────────────
+
+def mem_kind_device : Int := 0
+def mem_kind_host_pinned : Int := 1
+def mem_kind_managed : Int := 2
+def mem_kind_host : Int := 3
+
+def access_read_only : Int := 0
+def access_read_write : Int := 1
+
 # ── Uninterpreted measures (for refinements only) ────────────────────────
 
 def device_id : (d: Device) -> Int := uninterpreted
 def num_devices : (_: Unit) -> Int := uninterpreted
 def max_threads_per_block : (d: Device) -> Int := uninterpreted
 def max_allocation : (d: Device) -> Int := uninterpreted
+def warp_size : (d: Device) -> Int := uninterpreted
+def max_shared_mem_per_block : (d: Device) -> Int := uninterpreted
+
 def launch_device : (launch: Launch1D) -> Int := uninterpreted
 def launch_items : (launch: Launch1D) -> Int := uninterpreted
 def launch_threads : (launch: Launch1D) -> Int := uninterpreted
 def launch_grid_size : (launch: Launch1D) -> Int := uninterpreted
+def launch_shared_bytes : (launch: Launch1D) -> Int := uninterpreted
+
+def launch2d_device : (launch: Launch2D) -> Int := uninterpreted
+def launch2d_width : (launch: Launch2D) -> Int := uninterpreted
+def launch2d_height : (launch: Launch2D) -> Int := uninterpreted
+def launch2d_threads_x : (launch: Launch2D) -> Int := uninterpreted
+def launch2d_threads_y : (launch: Launch2D) -> Int := uninterpreted
+def launch2d_grid_x : (launch: Launch2D) -> Int := uninterpreted
+def launch2d_grid_y : (launch: Launch2D) -> Int := uninterpreted
+def launch2d_shared_bytes : (launch: Launch2D) -> Int := uninterpreted
+
 def stream_device : (stream: Stream) -> Int := uninterpreted
 def stream_id : (stream: Stream) -> Int := uninterpreted
 def pending_stream : (pending: (Pending a)) -> Int := uninterpreted
@@ -51,8 +87,14 @@ def buffer_device : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
 def buffer_size : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
 def buffer_elem_size : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
 def buffer_bytes : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
+def buffer_mem_kind : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
+def buffer_access : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
+def buffer_extent_x : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
+def buffer_extent_y : (buffer: (ReadyBuffer a)) -> Int := uninterpreted
+
 def pending_device : (pending: (Pending a)) -> Int := uninterpreted
 def pending_size : (pending: (Pending a)) -> Int := uninterpreted
+
 def i32_download_device : (p: I32Download) -> Int := uninterpreted
 def i32_download_size : (p: I32Download) -> Int := uninterpreted
 def i32_download_pair_device : (p: I32DownloadPair) -> Int := uninterpreted
@@ -61,6 +103,15 @@ def float64_download_device : (p: Float64Download) -> Int := uninterpreted
 def float64_download_size : (p: Float64Download) -> Int := uninterpreted
 def float64_download_pair_device : (p: Float64DownloadPair) -> Int := uninterpreted
 def float64_download_pair_size : (p: Float64DownloadPair) -> Int := uninterpreted
+
+def status_is_ok : (s: Status) -> Bool := uninterpreted
+def status_code : (s: Status) -> Int := uninterpreted
+def status_buffer_ok : (sb: (StatusBuffer a)) -> Bool := uninterpreted
+def status_buffer_device : (sb: (StatusBuffer a)) -> Int := uninterpreted
+def status_buffer_size : (sb: (StatusBuffer a)) -> Int := uninterpreted
+def status_pair_ok : (p: (StatusPair a)) -> Bool := uninterpreted
+def status_pair_device : (p: (StatusPair a)) -> Int := uninterpreted
+def status_pair_size : (p: (StatusPair a)) -> Int := uninterpreted
 
 # ── Device discovery ─────────────────────────────────────────────────────
 
@@ -72,14 +123,22 @@ def num_devices (_: Unit) :
 
 # Select a device by zero-based index.
 # id: must satisfy ``0 <= id < num_devices unit``.
-# returns: a handle whose ``device_id`` equals ``id`` with a positive block limit.
+# returns: a handle whose ``device_id`` equals ``id`` with positive warp/block limits.
 def device (id: {n: Int | n >= 0 && n < num_devices unit}) :
-    {d: Device | device_id d = id && max_threads_per_block d > 0} :=
+    {d: Device |
+        device_id d = id &&
+        max_threads_per_block d >= 1024 &&
+        warp_size d = 32 &&
+        max_shared_mem_per_block d >= 0} :=
     native "__import__('aeon.bindings.cuda', fromlist=['device']).device(id)"
 
 # Default CUDA device (device 0 when present).
 def default_device (_: Unit) :
-    {d: Device | device_id d >= 0 && max_threads_per_block d > 0} :=
+    {d: Device |
+        device_id d >= 0 &&
+        max_threads_per_block d >= 1024 &&
+        warp_size d = 32 &&
+        max_shared_mem_per_block d >= 0} :=
     native "__import__('aeon.bindings.cuda', fromlist=['device']).device()"
 
 # Default stream on ``device``.
@@ -89,26 +148,90 @@ def default_stream (device: Device) :
 
 # ── Launch configuration ─────────────────────────────────────────────────
 
-# Describe a non-empty 1-D launch on ``device``.
+# Describe a non-empty 1-D launch on ``device`` with zero shared memory.
 # device: target GPU.
 # items: logical element count (must be positive).
-# threads: block size; at most ``items`` and at most ``max_threads_per_block device``.
+# threads: block size; at most ``items``, ``max_threads_per_block``, and 1024.
 # returns: launch whose grid covers all ``items``.
 def launch_1d (device: Device)
     (items: {n: Int | n > 0})
-    (threads: {n: Int | n > 0 && n <= items && n <= max_threads_per_block device}) :
+    (threads: {n: Int | n > 0 && n <= items && n <= max_threads_per_block device && n <= 1024}) :
     {launch: Launch1D |
         launch_device launch = device_id device &&
         launch_items launch = items &&
         launch_threads launch = threads &&
-        launch_grid_size launch * launch_threads launch >= launch_items launch} :=
-    native "(__import__('aeon.bindings.cuda', fromlist=['launch_1d']).launch_1d(items, threads), device)"
+        launch_grid_size launch * launch_threads launch >= launch_items launch &&
+        launch_shared_bytes launch = 0} :=
+    native "(__import__('aeon.bindings.cuda', fromlist=['launch_1d']).launch_1d(items, threads, 0), device)"
+
+# Like ``launch_1d`` but records a shared-memory budget for the block.
+# shared: bytes of dynamic shared memory; at most ``max_shared_mem_per_block device``.
+def launch_1d_shared (device: Device)
+    (items: {n: Int | n > 0})
+    (threads: {n: Int | n > 0 && n <= items && n <= max_threads_per_block device && n <= 1024})
+    (shared: {s: Int | s >= 0 && s <= max_shared_mem_per_block device}) :
+    {launch: Launch1D |
+        launch_device launch = device_id device &&
+        launch_items launch = items &&
+        launch_threads launch = threads &&
+        launch_grid_size launch * launch_threads launch >= launch_items launch &&
+        launch_shared_bytes launch = shared} :=
+    native "(__import__('aeon.bindings.cuda', fromlist=['launch_1d']).launch_1d(items, threads, shared), device)"
+
+# Like ``launch_1d`` but requires warp-aligned block size (or a single-warp launch).
+def launch_1d_warped (device: Device)
+    (items: {n: Int | n > 0})
+    (threads: {n: Int |
+        n > 0 && n <= items && n <= max_threads_per_block device && n <= 1024 &&
+        (n <= warp_size device || n % warp_size device = 0)}) :
+    {launch: Launch1D |
+        launch_device launch = device_id device &&
+        launch_items launch = items &&
+        launch_threads launch = threads &&
+        launch_grid_size launch * launch_threads launch >= launch_items launch &&
+        launch_shared_bytes launch = 0} :=
+    native "(__import__('aeon.bindings.cuda', fromlist=['launch_1d_warped']).launch_1d_warped(items, threads, 0), device)"
+
+# Describe a non-empty 2-D launch whose grid covers ``width`` × ``height``.
+def launch_2d (device: Device)
+    (width: {n: Int | n > 0})
+    (height: {n: Int | n > 0})
+    (tx: {n: Int | n > 0 && n <= 1024})
+    (ty: {n: Int | n > 0 && n <= 1024 && tx * n <= max_threads_per_block device && tx * n <= 1024}) :
+    {launch: Launch2D |
+        launch2d_device launch = device_id device &&
+        launch2d_width launch = width &&
+        launch2d_height launch = height &&
+        launch2d_threads_x launch = tx &&
+        launch2d_threads_y launch = ty &&
+        launch2d_grid_x launch * launch2d_threads_x launch >= launch2d_width launch &&
+        launch2d_grid_y launch * launch2d_threads_y launch >= launch2d_height launch &&
+        launch2d_shared_bytes launch = 0} :=
+    native "(__import__('aeon.bindings.cuda', fromlist=['launch_2d']).launch_2d(width, height, tx, ty, 0), device)"
+
+# Like ``launch_2d`` with a shared-memory budget.
+def launch_2d_shared (device: Device)
+    (width: {n: Int | n > 0})
+    (height: {n: Int | n > 0})
+    (tx: {n: Int | n > 0 && n <= 1024})
+    (ty: {n: Int | n > 0 && n <= 1024 && tx * n <= max_threads_per_block device && tx * n <= 1024})
+    (shared: {s: Int | s >= 0 && s <= max_shared_mem_per_block device}) :
+    {launch: Launch2D |
+        launch2d_device launch = device_id device &&
+        launch2d_width launch = width &&
+        launch2d_height launch = height &&
+        launch2d_threads_x launch = tx &&
+        launch2d_threads_y launch = ty &&
+        launch2d_grid_x launch * launch2d_threads_x launch >= launch2d_width launch &&
+        launch2d_grid_y launch * launch2d_threads_y launch >= launch2d_height launch &&
+        launch2d_shared_bytes launch = shared} :=
+    native "(__import__('aeon.bindings.cuda', fromlist=['launch_2d']).launch_2d(width, height, tx, ty, shared), device)"
 
 # ── Host → device ────────────────────────────────────────────────────────
 
 # Upload a non-empty ``Int`` array; consumes the host buffer.
 # values: linear host array; size and byte budget must fit ``device``.
-# returns: ``ReadyBuffer Int`` with 4-byte elements on ``device``.
+# returns: device ``ReadyBuffer Int`` with RW access and 1-D extents.
 def upload_i32 (device: Device)
     (1 values: {xs: (Array Int) | Array.size xs > 0}) :
     {buffer: (ReadyBuffer Int) |
@@ -116,7 +239,11 @@ def upload_i32 (device: Device)
         buffer_size buffer = Array.size values &&
         buffer_elem_size buffer = 4 &&
         buffer_bytes buffer = buffer_size buffer * buffer_elem_size buffer &&
-        buffer_bytes buffer <= max_allocation device} :=
+        buffer_bytes buffer <= max_allocation device &&
+        buffer_mem_kind buffer = mem_kind_device &&
+        buffer_access buffer = access_read_write &&
+        buffer_extent_x buffer = buffer_size buffer &&
+        buffer_extent_y buffer = 1} :=
     native "__import__('aeon.bindings.cuda', fromlist=['upload_i32']).upload_i32(device, values)"
 
 # Upload a non-empty ``Float`` array as float64; consumes the host buffer.
@@ -127,13 +254,30 @@ def upload_float64 (device: Device)
         buffer_size buffer = Array.size values &&
         buffer_elem_size buffer = 8 &&
         buffer_bytes buffer = buffer_size buffer * buffer_elem_size buffer &&
-        buffer_bytes buffer <= max_allocation device} :=
+        buffer_bytes buffer <= max_allocation device &&
+        buffer_mem_kind buffer = mem_kind_device &&
+        buffer_access buffer = access_read_write &&
+        buffer_extent_x buffer = buffer_size buffer &&
+        buffer_extent_y buffer = 1} :=
     native "__import__('aeon.bindings.cuda', fromlist=['upload_float64']).upload_float64(device, values)"
+
+# Transfer a ready buffer into a read-only view of the same allocation.
+def as_read_only (1 buffer: (ReadyBuffer a)) :
+    {r: (ReadyBuffer a) |
+        buffer_device r = buffer_device buffer &&
+        buffer_size r = buffer_size buffer &&
+        buffer_elem_size r = buffer_elem_size buffer &&
+        buffer_bytes r = buffer_bytes buffer &&
+        buffer_mem_kind r = buffer_mem_kind buffer &&
+        buffer_access r = access_read_only &&
+        buffer_extent_x r = buffer_extent_x buffer &&
+        buffer_extent_y r = buffer_extent_y buffer} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['as_read_only']).as_read_only(buffer)"
 
 # ── Kernels ──────────────────────────────────────────────────────────────
 
 # Elementwise ``Int`` vector add on ``launch``'s device via ``stream``.
-# left, right: equal-sized buffers on the launch device, covering ``launch_items``.
+# left, right: equal-sized device buffers on the launch device (RO or RW).
 # returns: ``Pending Int``; inputs are consumed.
 def add_i32
     (launch: Launch1D)
@@ -143,18 +287,22 @@ def add_i32
         buffer_elem_size buffer = 4 &&
         buffer_device buffer = launch_device launch &&
         buffer_size buffer = launch_items launch &&
+        buffer_mem_kind buffer = mem_kind_device &&
+        (buffer_access buffer = access_read_only || buffer_access buffer = access_read_write) &&
         launch_grid_size launch * launch_threads launch >= buffer_size buffer})
     (1 right: {buffer: (ReadyBuffer Int) |
         buffer_size buffer = buffer_size left &&
         buffer_elem_size buffer = buffer_elem_size left &&
-        buffer_device buffer = buffer_device left}) :
+        buffer_device buffer = buffer_device left &&
+        buffer_mem_kind buffer = mem_kind_device &&
+        (buffer_access buffer = access_read_only || buffer_access buffer = access_read_write)}) :
     {pending: (Pending Int) |
         pending_device pending = launch_device launch &&
         pending_size pending = launch_items launch &&
         pending_stream pending = stream_id stream} :=
     native "__import__('aeon.bindings.cuda', fromlist=['vector_add_i32']).vector_add_i32(launch[1], launch[0], left, right, stream)"
 
-# Elementwise ``Float`` (float64) vector add; same size/device rules as ``add_i32``.
+# Elementwise ``Float`` (float64) vector add; same size/device/kind rules as ``add_i32``.
 def add_float64
     (launch: Launch1D)
     (stream: {s: Stream | stream_device s = launch_device launch})
@@ -163,11 +311,15 @@ def add_float64
         buffer_elem_size buffer = 8 &&
         buffer_device buffer = launch_device launch &&
         buffer_size buffer = launch_items launch &&
+        buffer_mem_kind buffer = mem_kind_device &&
+        (buffer_access buffer = access_read_only || buffer_access buffer = access_read_write) &&
         launch_grid_size launch * launch_threads launch >= buffer_size buffer})
     (1 right: {buffer: (ReadyBuffer Float) |
         buffer_size buffer = buffer_size left &&
         buffer_elem_size buffer = buffer_elem_size left &&
-        buffer_device buffer = buffer_device left}) :
+        buffer_device buffer = buffer_device left &&
+        buffer_mem_kind buffer = mem_kind_device &&
+        (buffer_access buffer = access_read_only || buffer_access buffer = access_read_write)}) :
     {pending: (Pending Float) |
         pending_device pending = launch_device launch &&
         pending_size pending = launch_items launch &&
@@ -176,13 +328,57 @@ def add_float64
 
 # ── Synchronization ──────────────────────────────────────────────────────
 
-# Block until ``pending`` completes; recover a ``ReadyBuffer``.
+# Block until ``pending`` completes; recover a RW device ``ReadyBuffer``.
 def synchronize (1 pending: (Pending a)) :
     {buffer: (ReadyBuffer a) |
         buffer_device buffer = pending_device pending &&
         buffer_size buffer = pending_size pending &&
-        buffer_bytes buffer = buffer_size buffer * buffer_elem_size buffer} :=
+        buffer_bytes buffer = buffer_size buffer * buffer_elem_size buffer &&
+        buffer_mem_kind buffer = mem_kind_device &&
+        buffer_access buffer = access_read_write &&
+        buffer_extent_x buffer = buffer_size buffer &&
+        buffer_extent_y buffer = 1} :=
     native "__import__('aeon.bindings.cuda', fromlist=['synchronize']).synchronize(pending)"
+
+# Like ``synchronize`` but returns a linear status token paired with the buffer.
+def synchronize_with_status (1 pending: (Pending a)) :
+    {sb: (StatusBuffer a) |
+        status_buffer_ok sb &&
+        status_buffer_device sb = pending_device pending &&
+        status_buffer_size sb = pending_size pending} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['synchronize_with_status']).synchronize_with_status(pending)"
+
+# Unpack a successful ``StatusBuffer`` into an unrestricted status/buffer pair.
+def unpack_status_buffer (1 sb: {s: (StatusBuffer a) | status_buffer_ok s}) :
+    {pair: (StatusPair a) |
+        status_pair_ok pair &&
+        status_pair_device pair = status_buffer_device sb &&
+        status_pair_size pair = status_buffer_size sb} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['unpack_status_buffer']).unpack_status_buffer(sb)"
+
+# Status half of an unpacked pair (still linear — check or discard).
+def status_pair_status (p: {pr: (StatusPair a) | status_pair_ok pr}) :
+    {s: Status | status_is_ok s} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['status_pair_status']).status_pair_status(p)"
+
+# Ready buffer half of an unpacked ok pair.
+def status_pair_buffer (p: {pr: (StatusPair a) | status_pair_ok pr}) :
+    {b: (ReadyBuffer a) |
+        buffer_device b = status_pair_device p &&
+        buffer_size b = status_pair_size p &&
+        buffer_mem_kind b = mem_kind_device &&
+        buffer_access b = access_read_write &&
+        buffer_extent_x b = buffer_size b &&
+        buffer_extent_y b = 1} :=
+    native "__import__('aeon.bindings.cuda', fromlist=['status_pair_buffer']).status_pair_buffer(p)"
+
+# Consume an ok status (runtime no-op when refinements already prove success).
+def check_ok (1 s: {st: Status | status_is_ok st}) : Unit :=
+    native "__import__('aeon.bindings.cuda', fromlist=['check_ok']).check_ok(s)"
+
+# Explicitly discard a status without checking.
+def discard_status (1 s: Status) : Unit :=
+    native "__import__('aeon.bindings.cuda', fromlist=['discard_status']).discard_status(s)"
 
 # ── Device → host ────────────────────────────────────────────────────────
 
@@ -226,7 +422,11 @@ def download_buffer_i32 (p: I32DownloadPair) :
         buffer_device b = i32_download_pair_device p &&
         buffer_size b = i32_download_pair_size p &&
         buffer_elem_size b = 4 &&
-        buffer_bytes b = buffer_size b * buffer_elem_size b} :=
+        buffer_bytes b = buffer_size b * buffer_elem_size b &&
+        buffer_mem_kind b = mem_kind_device &&
+        buffer_access b = access_read_write &&
+        buffer_extent_x b = buffer_size b &&
+        buffer_extent_y b = 1} :=
     native "p[1]"
 
 # Host snapshot from a ``Float64DownloadPair``.
@@ -240,7 +440,11 @@ def download_buffer_float64 (p: Float64DownloadPair) :
         buffer_device b = float64_download_pair_device p &&
         buffer_size b = float64_download_pair_size p &&
         buffer_elem_size b = 8 &&
-        buffer_bytes b = buffer_size b * buffer_elem_size b} :=
+        buffer_bytes b = buffer_size b * buffer_elem_size b &&
+        buffer_mem_kind b = mem_kind_device &&
+        buffer_access b = access_read_write &&
+        buffer_extent_x b = buffer_size b &&
+        buffer_extent_y b = 1} :=
     native "p[1]"
 
 # ── Release ──────────────────────────────────────────────────────────────

--- a/docs/cuda.md
+++ b/docs/cuda.md
@@ -4,8 +4,9 @@
 arrays, launch fixed elementwise kernels, synchronize, download snapshots, and
 free allocations. It is **not** imported by the `@gpu` decorator — that path uses
 [`Gpu`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Gpu.ae) and
-tensors. Use `Cuda` when you want compile-time proofs about devices, sizes, and
-byte budgets.
+tensors. Use `Cuda` when you want compile-time proofs about devices, sizes, byte
+budgets, memory kind, access mode, launch shape, shared/warp legality, and
+optional Status-aware sync.
 
 - Source: [`aeon/libraries/Cuda.ae`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Cuda.ae)
 - Examples: [`examples/llvm/gpu/`](https://github.com/alcides/aeon/tree/master/examples/llvm/gpu)
@@ -29,15 +30,17 @@ Array ──upload──► ReadyBuffer ──add──► Pending ──synchro
 | Handle | Role |
 |--------|------|
 | `Device` | Immutable CUDA device descriptor |
-| `Launch1D` | 1-D grid: item count, block size, derived grid coverage |
+| `Launch1D` / `Launch2D` | Grid descriptors (1-D items/threads; 2-D width×height + block dims) |
 | `Stream` | CUDA stream for ordered kernel enqueue |
 | `ReadyBuffer a` | Device allocation ready for kernels or download |
 | `Pending a` | In-flight kernel result (must `synchronize` or `discard`) |
+| `Status` / `StatusBuffer a` | Optional sync-with-status path (`check_ok` / `discard_status`) |
 | `I32Download` / `Float64Download` | Linear token: host snapshot + preserved buffer |
-| `*DownloadPair` | Unrestricted pair projected after `unpack_*` |
+| `*DownloadPair` / `StatusPair` | Unrestricted pairs after unpack |
 
 `discard` abandons a `Pending` without reading results. `free` releases a
-`ReadyBuffer`.
+`ReadyBuffer`. The main lifecycle above is unchanged; Status and read-only views
+are parallel APIs.
 
 ---
 
@@ -46,10 +49,19 @@ Array ──upload──► ReadyBuffer ──add──► Pending ──synchro
 The bindings prove (at compile time):
 
 - **Device bounds** — `device id` is in `[0, num_devices)`; `num_devices > 0`.
-- **Launch validity** — block size ≤ item count, ≤ hardware `max_threads_per_block`, grid covers all items.
+  Device posts also fix CUDA lower bounds: `max_threads_per_block ≥ 1024`,
+  `warp_size = 32`, `max_shared_mem_per_block ≥ 0`.
+- **Launch validity** — block size ≤ item count, ≤ `max_threads_per_block`, ≤ 1024;
+  grid covers all items (1-D) or width×height (2-D).
 - **Size matching** — binary kernels require equal non-empty buffers on the launch device, sized to `launch_items`.
 - **Byte budget** — `buffer_bytes = size × elem_size` (4 for `Int`, 8 for `Float`) ≤ `max_allocation device`.
 - **Dtype indexing** — `buffer_elem_size` is 4 or 8 for the supported upload/kernel paths.
+- **Memory kind** — uploads tag `buffer_mem_kind = mem_kind_device`; kernels require device kind on both inputs. Host/pinned/managed constants are reserved for future allocators.
+- **Access mode** — uploads and sync outputs are read-write; `as_read_only` freezes a buffer to RO while preserving device/size/kind/extents; kernels accept RO or RW inputs.
+- **Shape / extents** — 1-D uploads set `extent_x = size`, `extent_y = 1`; `Launch2D` proves grid coverage of width×height (`tx×ty ≤ 1024` and ≤ device limit). No 2-D kernels yet—descriptors prepare for them.
+- **Shared memory** — `launch_1d_shared` / `launch_2d_shared` record `0 ≤ shared ≤ max_shared_mem_per_block`; plain `launch_1d` keeps `shared_bytes = 0`.
+- **Warp legality** — `launch_1d_warped` additionally requires `threads ≤ warp_size ∨ threads % warp_size = 0`.
+- **Status** — `synchronize_with_status` yields a linear `StatusBuffer`; unpack then `check_ok` (refined-ok) or `discard_status`. Unused Status is a linearity error.
 
 Violations are type errors, not runtime surprises.
 
@@ -60,15 +72,45 @@ Violations are type errors, not runtime surprises.
 | Category | Functions |
 |----------|-----------|
 | Discovery | `num_devices`, `device`, `default_device`, `default_stream` |
-| Launch | `launch_1d` |
+| Launch | `launch_1d`, `launch_1d_shared`, `launch_1d_warped`, `launch_2d`, `launch_2d_shared` |
 | Host → device | `upload_i32`, `upload_float64` |
+| Access | `as_read_only` |
 | Kernels | `add_i32`, `add_float64` (elementwise vector add) |
-| Sync | `synchronize`, `discard` |
+| Sync | `synchronize`, `synchronize_with_status`, `discard` |
+| Status | `unpack_status_buffer`, `status_pair_*`, `check_ok`, `discard_status` |
 | Device → host | `download_i32`, `download_float64`, `unpack_*`, `download_values_*`, `download_buffer_*` |
 | Release | `free` |
 
 Aeon's surface `Float` maps to **CUDA float64** in this module; there is no silent
 float32 narrowing.
+
+### Parallel APIs (optional)
+
+Read-only view before a kernel (both inputs may be RO):
+
+```aeon
+let 1 left := as_read_only left0 in
+let 1 right := as_read_only right0 in
+let 1 pending := add_i32 launch stream left right in
+```
+
+Shared / warp-aware / 2-D launch descriptors (kernels still use 1-D `Launch1D` today):
+
+```aeon
+let l1 := launch_1d_shared d 8 4 0 in
+let lw := launch_1d_warped d 64 32 in
+let l2 := launch_2d d 33 17 16 8 in
+```
+
+Status-aware sync (must consume Status linearly):
+
+```aeon
+let 1 sb := synchronize_with_status pending in
+let pair := unpack_status_buffer sb in
+let 1 st := status_pair_status pair in
+let 1 buf := status_pair_buffer pair in
+let _ := check_ok st in
+```
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -539,7 +539,7 @@ The generated files are gitignored; they are produced from source by the
 | Module | Focus | Guide |
 |--------|-------|-------|
 | `Array` | Linear host buffers, `size` refinements | [array.md](array) |
-| `Cuda` | Linear GPU buffers, launch/size proofs | [cuda.md](cuda) |
+| `Cuda` | Linear GPU buffers; kind/access/shape/shared/warp/status proofs | [cuda.md](cuda) |
 | `Database` | Linear sqlite3 connections/transactions | [database.md](database) |
 | `Http` | Typed `requests` wrapper | [http.md](http) |
 | `OS` / `Subprocess` | Typed process and filesystem bindings | [os-subprocess.md](os-subprocess) |
@@ -556,7 +556,7 @@ Core and data:
 
 Systems and I/O:
 
-- **Cuda** — explicit CUDA Driver API (separate from `@gpu`)
+- **Cuda** — explicit CUDA Driver API (separate from `@gpu`); memory kind, access mode, 2-D launch, shared/warp, Status
 - **Gpu** — tensor kernels imported by `@gpu`
 - **Database** — sqlite3 with linear transactions
 - **Http**, **OS**, **Subprocess**, **Path**, **Socket**, **Sys**

--- a/tests/cuda_binding_test.py
+++ b/tests/cuda_binding_test.py
@@ -182,3 +182,83 @@ def test_unavailable_driver_is_reported_only_on_first_operation(cuda_module, mon
     assert cuda_module._DRIVER is None
     with pytest.raises(cuda_module.CUDAUnavailableError, match="not found"):
         cuda_module.Device()
+
+
+def test_launch_2d_grid_covers_extents(cuda_module):
+    launch = cuda_module.Launch2D(33, 17, 16, 8)
+    assert launch.grid_x == 3
+    assert launch.grid_y == 3
+    assert launch.grid_x * launch.block_x >= launch.width
+    assert launch.grid_y * launch.block_y >= launch.height
+    assert cuda_module.launch2d_grid_x(launch) == 3
+    with pytest.raises(ValueError):
+        cuda_module.Launch2D(8, 8, 64, 32)  # 2048 > 1024
+
+
+def test_launch_1d_warped_rejects_non_multiples(cuda_module):
+    with pytest.raises(ValueError):
+        cuda_module.launch_1d_warped(100, 33)
+    launch = cuda_module.launch_1d_warped(64, 32)
+    assert launch.require_warp_multiple
+    assert launch.block_size == 32
+
+
+def test_upload_tags_device_rw_extents(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        buffer = cuda_module.upload_i32(device, [1, 2, 3])
+        assert cuda_module.buffer_mem_kind(buffer) == cuda_module.MEM_KIND_DEVICE
+        assert cuda_module.buffer_access(buffer) == cuda_module.ACCESS_READ_WRITE
+        assert cuda_module.buffer_extent_x(buffer) == 3
+        assert cuda_module.buffer_extent_y(buffer) == 1
+        buffer.free()
+    finally:
+        device.close()
+
+
+def test_as_read_only_transfers_ownership(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        buffer = cuda_module.upload_i32(device, [1, 2])
+        pointer = buffer.pointer
+        readonly = cuda_module.as_read_only(buffer)
+        assert buffer._transferred and buffer._freed
+        with pytest.raises(cuda_module.CUDAStateError):
+            cuda_module.download_i32(buffer)
+        assert cuda_module.buffer_access(readonly) == cuda_module.ACCESS_READ_ONLY
+        assert readonly.pointer == pointer
+        assert cuda_module.download_i32(readonly) == [1, 2]
+        readonly.free()
+    finally:
+        device.close()
+
+
+def test_synchronize_with_status_success_path(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        left = cuda_module.upload_i32(device, [1, 2])
+        right = cuda_module.upload_i32(device, [3, 4])
+        pending = cuda_module.vector_add_i32(
+            device, cuda_module.launch_1d(2, 2), left, right, cuda_module.default_stream(device)
+        )
+        result = cuda_module.synchronize_with_status(pending)
+        assert cuda_module.status_buffer_ok(result)
+        status, buffer = cuda_module.unpack_status_buffer(result)
+        assert cuda_module.status_is_ok(status)
+        assert buffer is not None
+        assert cuda_module.download_i32(buffer) == [4, 6]
+        cuda_module.check_ok(status)
+        with pytest.raises(cuda_module.CUDAStateError):
+            cuda_module.discard_status(status)
+        buffer.free()
+    finally:
+        device.close()
+
+
+def test_device_reports_warp_and_shared_limits(cuda_module):
+    device = _cuda_device_or_skip(cuda_module)
+    try:
+        assert cuda_module.warp_size(device) > 0
+        assert cuda_module.max_shared_mem_per_block(device) >= 0
+    finally:
+        device.close()

--- a/tests/cuda_qtt_test.py
+++ b/tests/cuda_qtt_test.py
@@ -101,9 +101,13 @@ def test_open_cuda_exposes_descriptors_and_launch_measures():
     source = (
         IMPORTS
         + """
-def descriptors (d: Device) (l: Launch1D) : Int :=
+def descriptors (d: Device) (l: Launch1D) (l2: Launch2D) : Int :=
     device_id d + max_threads_per_block d + num_devices unit
-    + launch_items l + launch_device l + launch_threads l + launch_grid_size l;
+    + warp_size d + max_shared_mem_per_block d
+    + launch_items l + launch_device l + launch_threads l + launch_grid_size l
+    + launch_shared_bytes l
+    + launch2d_width l2 + launch2d_height l2 + launch2d_grid_x l2 + launch2d_grid_y l2
+    + mem_kind_device + access_read_write;
 """
         + MAIN
     )
@@ -500,6 +504,156 @@ def invalid (d: Device) : Unit :=
         + MAIN
     )
     assert _errors(source) != []
+
+
+# ---------------------------------------------------------------------------
+# Memory kind, access, shape, shared/warp, status
+# ---------------------------------------------------------------------------
+
+
+def test_upload_establishes_device_kind_rw_and_extents():
+    source = (
+        IMPORTS
+        + f"""
+def consume_device_rw (1 b: {{buffer: (ReadyBuffer Int) |
+    buffer_mem_kind buffer = mem_kind_device &&
+    buffer_access buffer = access_read_write &&
+    buffer_extent_x buffer = buffer_size buffer &&
+    buffer_extent_y buffer = 1}}) : Unit :=
+    free b;
+
+def tagged (d: Device) : Unit :=
+    let 1 buffer := upload_i32 d ({_int_array((1, 2, 3))}) in
+    consume_device_rw buffer;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_as_read_only_then_add_typechecks():
+    source = (
+        IMPORTS
+        + f"""
+def freeze_then_add (u: Unit) : Int :=
+    let d := default_device u in
+    let stream := default_stream d in
+    let launch := launch_1d d 2 1 in
+    let 1 xs := {_int_array((1, 2))} in
+    let 1 ys := {_int_array((3, 4))} in
+    let 1 left0 := upload_i32 d xs in
+    let 1 right0 := upload_i32 d ys in
+    let 1 left := as_read_only left0 in
+    let 1 right := as_read_only right0 in
+    let 1 pending := add_i32 launch stream left right in
+    let 1 ready := synchronize pending in
+    let 1 downloaded := download_i32 ready in
+    let pair := unpack_i32_download downloaded in
+    let 1 values := download_values_i32 pair in
+    let 1 next := download_buffer_i32 pair in
+    let total := Array.sum values in
+    let _ := free next in
+    total;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_leaked_read_only_buffer_is_rejected():
+    source = (
+        IMPORTS
+        + f"""
+def leak_ro (d: Device) : Int :=
+    let 1 buffer := upload_i32 d ({_int_array((1,))}) in
+    let 1 ro := as_read_only buffer in
+    0;
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUnusedError) for error in _linearity_errors(source))
+
+
+def test_launch_2d_covers_shape_at_compile_time():
+    source = (
+        IMPORTS
+        + """
+def covered (u: Unit) : Int :=
+    let d := default_device u in
+    let launch := launch_2d d 33 17 16 8 in
+    launch2d_grid_x launch * launch2d_threads_x launch
+    + launch2d_grid_y launch * launch2d_threads_y launch;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_launch_1d_shared_and_warped_typecheck():
+    source = (
+        IMPORTS
+        + """
+def shared_ok (u: Unit) : Int :=
+    let d := default_device u in
+    let launch := launch_1d_shared d 8 4 0 in
+    launch_shared_bytes launch;
+
+def warped_ok (u: Unit) : Int :=
+    let d := default_device u in
+    let launch := launch_1d_warped d 64 32 in
+    launch_threads launch;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_synchronize_with_status_requires_status_consumption():
+    source = (
+        IMPORTS
+        + f"""
+def leak_status (u: Unit) : Int :=
+    let d := default_device u in
+    let stream := default_stream d in
+    let launch := launch_1d d 1 1 in
+    let 1 left := upload_i32 d ({_int_array((1,))}) in
+    let 1 right := upload_i32 d ({_int_array((2,))}) in
+    let 1 pending := add_i32 launch stream left right in
+    let 1 sb := synchronize_with_status pending in
+    0;
+"""
+        + MAIN
+    )
+    assert any(isinstance(error, LinearUnusedError) for error in _linearity_errors(source))
+
+
+def test_synchronize_with_status_check_ok_lifecycle():
+    source = (
+        IMPORTS
+        + f"""
+def checked (u: Unit) : Int :=
+    let d := default_device u in
+    let stream := default_stream d in
+    let launch := launch_1d d 2 1 in
+    let 1 left := upload_i32 d ({_int_array((1, 2))}) in
+    let 1 right := upload_i32 d ({_int_array((3, 4))}) in
+    let 1 pending := add_i32 launch stream left right in
+    let 1 sb := synchronize_with_status pending in
+    let pair := unpack_status_buffer sb in
+    let 1 st := status_pair_status pair in
+    let 1 buf := status_pair_buffer pair in
+    let _ := check_ok st in
+    let 1 downloaded := download_i32 buf in
+    let dl := unpack_i32_download downloaded in
+    let 1 values := download_values_i32 dl in
+    let 1 next := download_buffer_i32 dl in
+    let total := Array.sum values in
+    let _ := free next in
+    total;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
 
 
 def test_cuda_vector_add_example_typechecks():


### PR DESCRIPTION
## Summary
- Extend `Cuda.ae` and the Python binding with compile-time proofs for memory kind, access mode (including `as_read_only`), 1-D extents / `Launch2D`, shared-memory launch budgets, warp-aligned launches, and a parallel Status-aware sync path.
- Keep the existing `ReadyBuffer` / `launch_1d` / `synchronize` lifecycle non-breaking; new APIs are additive (`launch_1d_shared`, `launch_1d_warped`, `synchronize_with_status`, etc.).
- Document the six constraint families in `docs/cuda.md` and update the libraries index blurb; binding + QTT tests cover the new surface.

## Test plan
- [x] `uv run pytest tests/cuda_binding_test.py tests/cuda_qtt_test.py -q`
- [x] `uv run python -m aeon --no-main examples/llvm/gpu/cuda_vector_add.ae` (GPU present)
- [x] `uvx pre-commit run --files aeon/bindings/cuda.py aeon/libraries/Cuda.ae tests/cuda_*.py docs/cuda.md docs/index.md`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)