### PR TITLE
Add Lock, Reader, Email, and Downloader typestate protocols

### DIFF
--- a/aeon/bindings/downloader.py
+++ b/aeon/bindings/downloader.py
@@ -1,0 +1,19 @@
+"""Runtime helpers for ``libraries/Downloader.ae``."""
+
+from __future__ import annotations
+
+
+def new_downloader():
+    return {"state": "created", "progress": 0}
+
+
+def start(session):
+    return {"state": "downloading", "progress": 0}
+
+
+def update(session, percentage):
+    return {"state": "downloading", "progress": percentage}
+
+
+def finish(session):
+    return {"state": "completed", "progress": 100}

--- a/aeon/bindings/email.py
+++ b/aeon/bindings/email.py
@@ -1,0 +1,31 @@
+"""Runtime helpers for ``libraries/Email.ae`` fluent drafts."""
+
+from __future__ import annotations
+
+
+def new_email():
+    return {"phase": 1, "sender": None, "to": [], "subject": "", "body": None}
+
+
+def set_from(sender, draft):
+    return {**draft, "phase": 2, "sender": sender}
+
+
+def add_to(receiver, draft):
+    receivers = list(draft["to"])
+    receivers.append(receiver)
+    return {**draft, "phase": 3, "to": receivers}
+
+
+def set_subject(subject, draft):
+    return {**draft, "subject": subject}
+
+
+def set_body(body, draft):
+    return {**draft, "phase": 4, "body": body}
+
+
+def build(draft):
+    receivers = ", ".join(draft["to"])
+    subject = draft["subject"] or "(no subject)"
+    return f"From: {draft['sender']}\nTo: {receivers}\nSubject: {subject}\n\n{draft['body']}"

--- a/aeon/bindings/reader.py
+++ b/aeon/bindings/reader.py
@@ -1,0 +1,11 @@
+"""Helpers for ``libraries/Reader.ae``."""
+
+from __future__ import annotations
+
+
+def read_step(reader):
+    """Read one byte; return ``(code, reader)`` with ``code == -1`` at EOF."""
+    data = reader.read(1)
+    if not data:
+        return (-1, reader)
+    return (data[0], reader)

--- a/aeon/libraries/Downloader.ae
+++ b/aeon/libraries/Downloader.ae
@@ -1,0 +1,54 @@
+# Download session with typestate + progress ghost (LiquidJava ``Downloader``).
+#
+# States:
+#   created → start → downloading → (update)* → finish → completed
+#
+# ``progress`` is a ghost measure in ``[0, 100]``. Updates must strictly
+# increase it; ``finish`` requires ``progress = 100``.
+
+linear type Downloader
+
+def created : (d: Downloader) -> Bool := uninterpreted
+def downloading : (d: Downloader) -> Bool := uninterpreted
+def completed : (d: Downloader) -> Bool := uninterpreted
+def progress : (d: Downloader) -> Int := uninterpreted
+
+# Fresh session at 0% in the created state.
+def new_downloader (_: Unit) :
+    {d: Downloader |
+        created d = true &&
+        downloading d = false &&
+        completed d = false &&
+        progress d = 0} :=
+    native "__import__('aeon.bindings.downloader', fromlist=['new_downloader']).new_downloader()"
+
+# Begin downloading (created → downloading), progress stays 0.
+def start (1 d: {x: Downloader | created x = true && progress x = 0}) :
+    {out: Downloader |
+        created out = false &&
+        downloading out = true &&
+        completed out = false &&
+        progress out = 0} :=
+    native "__import__('aeon.bindings.downloader', fromlist=['start']).start(d)"
+
+# Monotonic progress update while downloading. ``p`` must exceed current
+# progress and be at most 100.
+def update (1 d: {x: Downloader | downloading x = true})
+    (p: {n: Int | n > progress d && n <= 100}) :
+    {out: Downloader |
+        downloading out = true &&
+        completed out = false &&
+        progress out = p} :=
+    native "__import__('aeon.bindings.downloader', fromlist=['update']).update(d, p)"
+
+# Complete only at 100%.
+def finish (1 d: {x: Downloader | downloading x = true && progress x = 100}) :
+    {out: Downloader |
+        downloading out = false &&
+        completed out = true &&
+        progress out = 100} :=
+    native "__import__('aeon.bindings.downloader', fromlist=['finish']).finish(d)"
+
+# Consume a completed session.
+def discard (1 d: {x: Downloader | completed x = true}) : Unit :=
+    native "None"

--- a/aeon/libraries/Email.ae
+++ b/aeon/libraries/Email.ae
@@ -1,0 +1,48 @@
+# Fluent email builder with ordered typestate (LiquidJava ``Email`` demo).
+#
+# Acceptable construction order:
+#   new → set_from → add_to (+ optional set_subject) → set_body → build
+#
+# Phases (measure ``email_phase``):
+#   1 empty · 2 sender set · 3 receivers · 4 body set
+#
+# The draft is linear: each step consumes the previous handle so you cannot
+# skip stages or build twice.
+
+linear type EmailDraft
+
+def email_phase : (e: EmailDraft) -> Int := uninterpreted
+
+# Start with an empty draft (phase 1).
+def new_email (_: Unit) :
+    {e: EmailDraft | email_phase e = 1} :=
+    native "__import__('aeon.bindings.email', fromlist=['new_email']).new_email()"
+
+# Record the sender (phase 1 → 2). Must be non-empty.
+def set_from (sender: {s: String | s != ""})
+    (1 e: {d: EmailDraft | email_phase d = 1}) :
+    {out: EmailDraft | email_phase out = 2} :=
+    native "__import__('aeon.bindings.email', fromlist=['set_from']).set_from(sender, e)"
+
+# Add a recipient (phase 2 or 3 → 3). At least one ``add_to`` is required
+# before ``set_body``.
+def add_to (receiver: {s: String | s != ""})
+    (1 e: {d: EmailDraft | email_phase d = 2 || email_phase d = 3}) :
+    {out: EmailDraft | email_phase out = 3} :=
+    native "__import__('aeon.bindings.email', fromlist=['add_to']).add_to(receiver, e)"
+
+# Optional subject; stays in phase 3.
+def set_subject (subject: String)
+    (1 e: {d: EmailDraft | email_phase d = 3}) :
+    {out: EmailDraft | email_phase out = 3} :=
+    native "__import__('aeon.bindings.email', fromlist=['set_subject']).set_subject(subject, e)"
+
+# Set the body (phase 3 → 4).
+def set_body (body: {s: String | s != ""})
+    (1 e: {d: EmailDraft | email_phase d = 3}) :
+    {out: EmailDraft | email_phase out = 4} :=
+    native "__import__('aeon.bindings.email', fromlist=['set_body']).set_body(body, e)"
+
+# Consume a complete draft and produce the rendered email text.
+def build (1 e: {d: EmailDraft | email_phase d = 4}) : String :=
+    native "__import__('aeon.bindings.email', fromlist=['build']).build(e)"

--- a/aeon/libraries/Lock.ae
+++ b/aeon/libraries/Lock.ae
@@ -1,0 +1,38 @@
+# Linear (QTT) mutex — Python ``threading.Lock`` with locked/unlocked typestate.
+#
+# Inspired by LiquidJava's ``ReentrantLock`` external refinements. A lock is a
+# unique linear handle: you must ``acquire`` before the critical section and
+# ``release`` before destroying it. The ``lock_held`` measure tracks state so
+# double-acquire / unlock-while-free are compile-time errors.
+#
+#     let 1 l0 := new_lock unit in
+#     let 1 l1 := acquire l0 in
+#     # critical section
+#     let 1 l2 := release l1 in
+#     destroy l2;
+
+linear type Lock
+
+def threading : Unit := native_import "threading"
+
+# True exactly when this handle is in the locked state.
+def lock_held : (l: Lock) -> Bool := uninterpreted
+
+# Fresh unlocked mutex. Takes ``Unit`` so each call allocates a new lock.
+def new_lock (_: Unit) :
+    {l: Lock | lock_held l = false} :=
+    native "threading.Lock()"
+
+# Acquire an unlocked lock; returns the same lock in the held state.
+def acquire (1 l: {x: Lock | lock_held x = false}) :
+    {out: Lock | lock_held out = true} :=
+    native "(l.acquire(), l)[1]"
+
+# Release a held lock; returns an unlocked handle for reuse or ``destroy``.
+def release (1 l: {x: Lock | lock_held x = true}) :
+    {out: Lock | lock_held out = false} :=
+    native "(l.release(), l)[1]"
+
+# Drop an unlocked lock. Consumes the handle so it cannot be used again.
+def destroy (1 l: {x: Lock | lock_held x = false}) : Unit :=
+    native "None"

--- a/aeon/libraries/Reader.ae
+++ b/aeon/libraries/Reader.ae
@@ -1,0 +1,46 @@
+# Linear (QTT) byte reader — open → read* → close, inspired by LiquidJava's
+# ``InputStreamReader`` refinements.
+#
+# Unlike ``Path.read`` (one-shot whole-file), this API exposes a streaming
+# handle. ``reader_open`` tracks whether the stream is still live; ``read``
+# returns a code in ``[-1, 255]`` (``-1`` = EOF) and threads the open reader;
+# ``close`` consumes it.
+#
+#     let 1 r0 := open_reader path in
+#     let step := read r0 in
+#     let code := read_code step in
+#     let 1 r1 := read_reader step in
+#     close r1;
+
+linear type Reader
+
+# Unrestricted token after ``read``: byte/EOF code plus the live reader.
+type ReaderStep
+
+def reader_open : (r: Reader) -> Bool := uninterpreted
+def step_code : (s: ReaderStep) -> Int := uninterpreted
+
+# Open ``path`` for binary reading. Path must be non-empty.
+def open_reader (path: {p: String | p != ""}) :
+    {r: Reader | reader_open r = true} :=
+    native "open(path, 'rb')"
+
+# Read one byte from an open reader. Returns ``-1`` at EOF, else ``0..255``.
+# Consumes the reader and recovers it via ``read_reader``.
+def read (1 r: {x: Reader | reader_open x = true}) :
+    {s: ReaderStep |
+        step_code s >= (0 - 1) &&
+        step_code s <= 255} :=
+    native "__import__('aeon.bindings.reader', fromlist=['read_step']).read_step(r)"
+
+def read_code (s: ReaderStep) :
+    {n: Int | n = step_code s && n >= (0 - 1) && n <= 255} :=
+    native "s[0]"
+
+def read_reader (s: ReaderStep) :
+    {r: Reader | reader_open r = true} :=
+    native "s[1]"
+
+# Close an open reader. Consumes the handle.
+def close (1 r: {x: Reader | reader_open x = true}) : Unit :=
+    native "r.close() or None"

--- a/docs/index.md
+++ b/docs/index.md
@@ -513,7 +513,7 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), and [explicit CUDA device memory](cuda).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`).
 
 ## Libraries
 
@@ -541,6 +541,7 @@ The generated files are gitignored; they are produced from source by the
 | `Array` | Linear host buffers, `size` refinements | [array.md](array) |
 | `Cuda` | Linear GPU buffers, launch/size proofs | [cuda.md](cuda) |
 | `Database` | Linear sqlite3 connections/transactions | [database.md](database) |
+| `Lock` / `Reader` / `Email` / `Downloader` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
 | `Http` | Typed `requests` wrapper | [http.md](http) |
 | `OS` / `Subprocess` | Typed process and filesystem bindings | [os-subprocess.md](os-subprocess) |
 
@@ -559,6 +560,7 @@ Systems and I/O:
 - **Cuda** — explicit CUDA Driver API (separate from `@gpu`)
 - **Gpu** — tensor kernels imported by `@gpu`
 - **Database** — sqlite3 with linear transactions
+- **Lock**, **Reader**, **Email**, **Downloader** — typestate protocols
 - **Http**, **OS**, **Subprocess**, **Path**, **Socket**, **Sys**
 - **Json**, **Args**
 

--- a/docs/typestate-protocols.md
+++ b/docs/typestate-protocols.md
@@ -1,0 +1,93 @@
+# Typestate protocols from LiquidJava, in Aeon
+
+Four small libraries port the LiquidJava demos that fit Aeon best: a mutex,
+a streaming reader, a fluent email builder, and a download session with a
+progress ghost. Each combines **linear handles** (use exactly once) with
+**refinement measures** (legal orderings / numeric bounds).
+
+| Module | LiquidJava analogue | Idea |
+|--------|---------------------|------|
+| [`Lock`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Lock.ae) | `ReentrantLock` | unlocked ↔ locked; destroy only when free |
+| [`Reader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Reader.ae) | `InputStreamReader` | open → read* → close; byte codes in `[-1, 255]` |
+| [`Email`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Email.ae) | fluent `Email` | from → to+ → body → build |
+| [`Downloader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Downloader.ae) | `Downloader` | start → monotonic update → finish at 100% |
+
+Examples (typecheck with `--no-main`):
+[`lock_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/lock_example.ae),
+[`reader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/reader_example.ae),
+[`email_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/email_example.ae),
+[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae).
+
+---
+
+## Lock
+
+```aeon
+open Lock
+
+def critical (u: Unit) : Unit :=
+    let 1 l0 := new_lock u in
+    let 1 l1 := acquire l0 in
+    let 1 l2 := release l1 in
+    destroy l2;
+```
+
+`acquire` requires `lock_held = false`; `release` / `destroy` require the
+matching state. Leaking or double-acquiring a held lock is rejected.
+
+## Reader
+
+```aeon
+open Reader
+
+def read_once (path: {p: String | p != ""}) : Int :=
+    let 1 r0 := open_reader path in
+    let step := read r0 in
+    let code := read_code step in
+    let 1 r1 := read_reader step in
+    let _ := close r1 in
+    code;
+```
+
+Unlike one-shot `Path.read`, the linear `Reader` must be closed. Each `read`
+returns a `ReaderStep` (code + recovered open handle).
+
+## Email
+
+```aeon
+open Email
+
+def compose (u: Unit) : String :=
+    let 1 e0 := new_email u in
+    let 1 e1 := set_from "alice@example.com" e0 in
+    let 1 e2 := add_to "bob@example.com" e1 in
+    let 1 e3 := set_body "Hi Bob," e2 in
+    build e3;
+```
+
+`email_phase` enforces the builder order. Building before `set_body`, or
+setting the sender twice, does not type-check.
+
+## Downloader
+
+```aeon
+open Downloader
+
+def download (u: Unit) : Unit :=
+    let 1 d0 := new_downloader u in
+    let 1 d1 := start d0 in
+    let 1 d2 := update d1 40 in
+    let 1 d3 := update d2 100 in
+    let 1 d4 := finish d3 in
+    discard d4;
+```
+
+Updates must strictly increase `progress`; `finish` requires `progress = 100`.
+
+---
+
+## Related reading
+
+- [State-safe `Database`](database.md) — Conn/Txn typestate
+- [Linear `Socket`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Socket.ae) — bind/connect/close
+- [LiquidJava examples](https://github.com/liquid-java/liquidjava-examples) — original Java demos

--- a/examples/imports/downloader_example.ae
+++ b/examples/imports/downloader_example.ae
@@ -1,0 +1,12 @@
+open Downloader
+
+# Progress session: start → update → finish → discard.
+def download (u: Unit) : Unit :=
+    let 1 d0 := new_downloader u in
+    let 1 d1 := start d0 in
+    let 1 d2 := update d1 40 in
+    let 1 d3 := update d2 100 in
+    let 1 d4 := finish d3 in
+    discard d4;
+
+def main (args: Int) : Unit := print "ok"

--- a/examples/imports/email_example.ae
+++ b/examples/imports/email_example.ae
@@ -1,0 +1,12 @@
+open Email
+
+# Fluent builder: from → to → subject → body → build.
+def compose (u: Unit) : String :=
+    let 1 e0 := new_email u in
+    let 1 e1 := set_from "alice@example.com" e0 in
+    let 1 e2 := add_to "bob@example.com" e1 in
+    let 1 e3 := set_subject "Hello" e2 in
+    let 1 e4 := set_body "Hi Bob," e3 in
+    build e4;
+
+def main (args: Int) : Unit := print "ok"

--- a/examples/imports/lock_example.ae
+++ b/examples/imports/lock_example.ae
@@ -1,0 +1,11 @@
+open Lock
+
+# Linear mutex lifecycle: new → acquire → release → destroy.
+# Wrapped in a function so --no-main typechecks without racing threads.
+def critical (u: Unit) : Unit :=
+    let 1 l0 := new_lock u in
+    let 1 l1 := acquire l0 in
+    let 1 l2 := release l1 in
+    destroy l2;
+
+def main (args: Int) : Unit := print "ok"

--- a/examples/imports/reader_example.ae
+++ b/examples/imports/reader_example.ae
@@ -1,0 +1,13 @@
+open Reader
+
+# Streaming reader lifecycle: open → read → close.
+# Path is a parameter so CI typechecks without touching the filesystem.
+def read_once (path: {p: String | p != ""}) : Int :=
+    let 1 r0 := open_reader path in
+    let step := read r0 in
+    let code := read_code step in
+    let 1 r1 := read_reader step in
+    let _ := close r1 in
+    code;
+
+def main (args: Int) : Unit := print "ok"

--- a/tests/liquidjava_protocols_test.py
+++ b/tests/liquidjava_protocols_test.py
@@ -1,0 +1,246 @@
+"""QTT / refinement tests for Lock, Reader, Email, and Downloader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aeon.facade.api import (
+    LinearityError,
+    LinearUnusedError,
+    LiquidTypeCheckingFailedRelation,
+)
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _parse(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _errors(source: str):
+    return _parse(source)
+
+
+def _linearity_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LinearityError)]
+
+
+def _liquid_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LiquidTypeCheckingFailedRelation)]
+
+
+MAIN = """
+def main (args: Int) : Unit := print "ok";
+"""
+
+
+# ── Lock ──────────────────────────────────────────────────────────────────
+
+
+def test_lock_lifecycle_typechecks():
+    src = (
+        """
+open Lock
+def critical (u: Unit) : Unit :=
+    let 1 l0 := new_lock u in
+    let 1 l1 := acquire l0 in
+    let 1 l2 := release l1 in
+    destroy l2;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_lock_leak_is_rejected():
+    src = (
+        """
+open Lock
+def leak (u: Unit) : Unit :=
+    let 1 l := new_lock u in
+    print "ignored";
+"""
+        + MAIN
+    )
+    assert any(isinstance(e, LinearUnusedError) for e in _linearity_errors(src))
+
+
+def test_lock_double_acquire_is_rejected():
+    src = (
+        """
+open Lock
+def bad (u: Unit) : Unit :=
+    let 1 l0 := new_lock u in
+    let 1 l1 := acquire l0 in
+    let 1 l2 := acquire l1 in
+    let 1 l3 := release l2 in
+    destroy l3;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_lock_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "lock_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []
+
+
+# ── Reader ────────────────────────────────────────────────────────────────
+
+
+def test_reader_lifecycle_typechecks():
+    src = (
+        """
+open Reader
+def once (path: {p: String | p != ""}) : Int :=
+    let 1 r0 := open_reader path in
+    let step := read r0 in
+    let code := read_code step in
+    let 1 r1 := read_reader step in
+    let _ := close r1 in
+    code;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_reader_unclosed_is_rejected():
+    src = (
+        """
+open Reader
+def leak (path: {p: String | p != ""}) : Unit :=
+    let 1 r := open_reader path in
+    print "ignored";
+"""
+        + MAIN
+    )
+    assert any(isinstance(e, LinearUnusedError) for e in _linearity_errors(src))
+
+
+def test_reader_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "reader_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []
+
+
+# ── Email ─────────────────────────────────────────────────────────────────
+
+
+def test_email_fluent_build_typechecks():
+    src = (
+        """
+open Email
+def compose (u: Unit) : String :=
+    let 1 e0 := new_email u in
+    let 1 e1 := set_from "a@x.com" e0 in
+    let 1 e2 := add_to "b@x.com" e1 in
+    let 1 e3 := set_body "hi" e2 in
+    build e3;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_email_build_without_body_is_rejected():
+    src = (
+        """
+open Email
+def bad (u: Unit) : String :=
+    let 1 e0 := new_email u in
+    let 1 e1 := set_from "a@x.com" e0 in
+    let 1 e2 := add_to "b@x.com" e1 in
+    build e2;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_email_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "email_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []
+
+
+# ── Downloader ────────────────────────────────────────────────────────────
+
+
+def test_downloader_lifecycle_typechecks():
+    src = (
+        """
+open Downloader
+def download (u: Unit) : Unit :=
+    let 1 d0 := new_downloader u in
+    let 1 d1 := start d0 in
+    let 1 d2 := update d1 50 in
+    let 1 d3 := update d2 100 in
+    let 1 d4 := finish d3 in
+    discard d4;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_downloader_finish_before_100_is_rejected():
+    src = (
+        """
+open Downloader
+def bad (u: Unit) : Unit :=
+    let 1 d0 := new_downloader u in
+    let 1 d1 := start d0 in
+    let 1 d2 := update d1 50 in
+    let 1 d3 := finish d2 in
+    discard d3;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_downloader_non_monotonic_update_is_rejected():
+    src = (
+        """
+open Downloader
+def bad (u: Unit) : Unit :=
+    let 1 d0 := new_downloader u in
+    let 1 d1 := start d0 in
+    let 1 d2 := update d1 80 in
+    let 1 d3 := update d2 40 in
+    let 1 d4 := update d3 100 in
+    let 1 d5 := finish d4 in
+    discard d5;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_downloader_leak_is_rejected():
+    src = (
+        """
+open Downloader
+def leak (u: Unit) : Unit :=
+    let 1 d := new_downloader u in
+    print "ignored";
+"""
+        + MAIN
+    )
+    assert any(isinstance(e, LinearUnusedError) for e in _linearity_errors(src))
+
+
+def test_downloader_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "downloader_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []


### PR DESCRIPTION
## Summary
- Add four LiquidJava-inspired libraries: `Lock` (mutex typestate), `Reader` (streaming InputStreamReader-style open/read/close), `Email` (ordered fluent builder), and `Downloader` (state + monotonic progress ghost).
- Include import examples, QTT/refinement tests for happy paths and illegal orderings, and a short guide in `docs/typestate-protocols.md`.

## Test plan
- [x] `uv run pytest tests/liquidjava_protocols_test.py -q`
- [x] Run `lock` / `email` / `downloader` examples; `--no-main` on `reader_example.ae`
- [x] `uvx pre-commit run --files` on touched paths
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)