### PR TITLE
Add Order typestate library with total_price ghost

### DIFF
--- a/aeon/bindings/order.py
+++ b/aeon/bindings/order.py
@@ -1,0 +1,29 @@
+"""Runtime helpers for ``libraries/Order.ae``."""
+
+from __future__ import annotations
+
+
+def new_order():
+    return {"state": "empty", "total": 0, "items": [], "gift": False, "address": None}
+
+
+def add_item(name, price, order):
+    items = list(order["items"])
+    items.append((name, price))
+    return {**order, "state": "adding", "total": order["total"] + price, "items": items}
+
+
+def pay(card, order):
+    return {**order, "state": "checkout", "card": card}
+
+
+def add_gift(order):
+    return {**order, "gift": True}
+
+
+def ship(address, order):
+    return {**order, "state": "closed", "address": address}
+
+
+def finalize(order):
+    return order["total"]

--- a/aeon/libraries/Order.ae
+++ b/aeon/libraries/Order.ae
@@ -1,0 +1,70 @@
+# Shopping-order protocol with typestate + price ghost (LiquidJava ``Order``).
+#
+# States (boolean measures):
+#   empty → adding (via add_item) → checkout (via pay) → closed (via ship)
+#
+# ``total_price`` tracks the sum of item prices. ``add_gift`` is only legal
+# in checkout when ``total_price > 20``. The order handle is linear.
+
+linear type Order
+
+def empty : (o: Order) -> Bool := uninterpreted
+def adding : (o: Order) -> Bool := uninterpreted
+def checkout : (o: Order) -> Bool := uninterpreted
+def closed : (o: Order) -> Bool := uninterpreted
+def total_price : (o: Order) -> Int := uninterpreted
+
+# Fresh empty order with price 0.
+def new_order (_: Unit) :
+    {o: Order |
+        empty o = true &&
+        adding o = false &&
+        checkout o = false &&
+        closed o = false &&
+        total_price o = 0} :=
+    native "__import__('aeon.bindings.order', fromlist=['new_order']).new_order()"
+
+# Add a positively priced item (empty or adding → adding).
+def add_item (name: {s: String | s != ""})
+    (price: {p: Int | p > 0})
+    (1 o: {x: Order | empty x = true || adding x = true}) :
+    {out: Order |
+        empty out = false &&
+        adding out = true &&
+        checkout out = false &&
+        closed out = false &&
+        total_price out = total_price o + price} :=
+    native "__import__('aeon.bindings.order', fromlist=['add_item']).add_item(name, price, o)"
+
+# Pay and enter checkout (adding → checkout); price unchanged.
+def pay (card: {n: Int | n > 0})
+    (1 o: {x: Order | adding x = true}) :
+    {out: Order |
+        empty out = false &&
+        adding out = false &&
+        checkout out = true &&
+        closed out = false &&
+        total_price out = total_price o} :=
+    native "__import__('aeon.bindings.order', fromlist=['pay']).pay(card, o)"
+
+# Optional gift in checkout when the cart totals more than 20.
+def add_gift (1 o: {x: Order | checkout x = true && total_price x > 20}) :
+    {out: Order |
+        checkout out = true &&
+        closed out = false &&
+        total_price out = total_price o} :=
+    native "__import__('aeon.bindings.order', fromlist=['add_gift']).add_gift(o)"
+
+# Ship to an address (checkout → closed).
+def ship (address: {s: String | s != ""})
+    (1 o: {x: Order | checkout x = true}) :
+    {out: Order |
+        checkout out = false &&
+        closed out = true &&
+        total_price out = total_price o} :=
+    native "__import__('aeon.bindings.order', fromlist=['ship']).ship(address, o)"
+
+# Consume a closed order; returns the final total.
+def finalize (1 o: {x: Order | closed x = true}) :
+    {n: Int | n = total_price o && n >= 0} :=
+    native "__import__('aeon.bindings.order', fromlist=['finalize']).finalize(o)"

--- a/docs/index.md
+++ b/docs/index.md
@@ -513,7 +513,7 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`, `Order`).
 
 ## Libraries
 
@@ -541,7 +541,7 @@ The generated files are gitignored; they are produced from source by the
 | `Array` | Linear host buffers, `size` refinements | [array.md](array) |
 | `Cuda` | Linear GPU buffers; kind/access/shape/shared/warp/status proofs | [cuda.md](cuda) |
 | `Database` | Linear sqlite3 connections/transactions | [database.md](database) |
-| `Lock` / `Reader` / `Email` / `Downloader` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
+| `Lock` / `Reader` / `Email` / `Downloader` / `Order` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
 | `Http` | Typed `requests` wrapper | [http.md](http) |
 | `OS` / `Subprocess` | Typed process and filesystem bindings | [os-subprocess.md](os-subprocess) |
 
@@ -560,7 +560,7 @@ Systems and I/O:
 - **Cuda** — explicit CUDA Driver API (separate from `@gpu`); memory kind, access mode, 2-D launch, shared/warp, Status
 - **Gpu** — tensor kernels imported by `@gpu`
 - **Database** — sqlite3 with linear transactions
-- **Lock**, **Reader**, **Email**, **Downloader** — typestate protocols
+- **Lock**, **Reader**, **Email**, **Downloader**, **Order** — typestate protocols
 - **Http**, **OS**, **Subprocess**, **Path**, **Socket**, **Sys**
 - **Json**, **Args**
 

--- a/docs/typestate-protocols.md
+++ b/docs/typestate-protocols.md
@@ -3,7 +3,8 @@
 Four small libraries port the LiquidJava demos that fit Aeon best: a mutex,
 a streaming reader, a fluent email builder, and a download session with a
 progress ghost. Each combines **linear handles** (use exactly once) with
-**refinement measures** (legal orderings / numeric bounds).
+**refinement measures** (legal orderings / numeric bounds). An ``Order``
+module adds the classic state × price-ghost shopping protocol.
 
 | Module | LiquidJava analogue | Idea |
 |--------|---------------------|------|
@@ -11,12 +12,14 @@ progress ghost. Each combines **linear handles** (use exactly once) with
 | [`Reader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Reader.ae) | `InputStreamReader` | open → read* → close; byte codes in `[-1, 255]` |
 | [`Email`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Email.ae) | fluent `Email` | from → to+ → body → build |
 | [`Downloader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Downloader.ae) | `Downloader` | start → monotonic update → finish at 100% |
+| [`Order`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Order.ae) | gift `Order` | empty → adding → checkout → closed + `total_price` |
 
 Examples (typecheck with `--no-main`):
 [`lock_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/lock_example.ae),
 [`reader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/reader_example.ae),
 [`email_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/email_example.ae),
-[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae).
+[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae),
+[`order_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/order_example.ae).
 
 ---
 
@@ -83,6 +86,24 @@ def download (u: Unit) : Unit :=
 ```
 
 Updates must strictly increase `progress`; `finish` requires `progress = 100`.
+
+## Order
+
+```aeon
+open Order
+
+def checkout_flow (u: Unit) : Int :=
+    let 1 o0 := new_order u in
+    let 1 o1 := add_item "book" 15 o0 in
+    let 1 o2 := add_item "mug" 10 o1 in
+    let 1 o3 := pay 424242 o2 in
+    let 1 o4 := add_gift o3 in
+    let 1 o5 := ship "1 Main St" o4 in
+    finalize o5;
+```
+
+`total_price` accumulates item prices; `add_gift` requires checkout and
+`total_price > 20`. Shipping before pay, or a zero-price item, is rejected.
 
 ---
 

--- a/examples/imports/order_example.ae
+++ b/examples/imports/order_example.ae
@@ -1,0 +1,13 @@
+open Order
+
+# empty → add items → pay → (optional gift) → ship → finalize
+def checkout_flow (u: Unit) : Int :=
+    let 1 o0 := new_order u in
+    let 1 o1 := add_item "book" 15 o0 in
+    let 1 o2 := add_item "mug" 10 o1 in
+    let 1 o3 := pay 424242 o2 in
+    let 1 o4 := add_gift o3 in
+    let 1 o5 := ship "1 Main St" o4 in
+    finalize o5;
+
+def main (args: Int) : Unit := print "ok"

--- a/tests/order_qtt_test.py
+++ b/tests/order_qtt_test.py
@@ -1,0 +1,123 @@
+"""QTT / refinement tests for the Order typestate library."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aeon.facade.api import (
+    LinearityError,
+    LinearUnusedError,
+    LiquidTypeCheckingFailedRelation,
+)
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _parse(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _errors(source: str):
+    return _parse(source)
+
+
+def _linearity_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LinearityError)]
+
+
+def _liquid_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LiquidTypeCheckingFailedRelation)]
+
+
+MAIN = """
+def main (args: Int) : Unit := print "ok";
+"""
+
+
+def test_order_full_lifecycle_typechecks():
+    src = (
+        """
+open Order
+def flow (u: Unit) : Int :=
+    let 1 o0 := new_order u in
+    let 1 o1 := add_item "book" 15 o0 in
+    let 1 o2 := add_item "mug" 10 o1 in
+    let 1 o3 := pay 424242 o2 in
+    let 1 o4 := add_gift o3 in
+    let 1 o5 := ship "1 Main St" o4 in
+    finalize o5;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_order_gift_below_threshold_is_rejected():
+    src = (
+        """
+open Order
+def bad (u: Unit) : Int :=
+    let 1 o0 := new_order u in
+    let 1 o1 := add_item "pen" 5 o0 in
+    let 1 o2 := pay 1 o1 in
+    let 1 o3 := add_gift o2 in
+    let 1 o4 := ship "here" o3 in
+    finalize o4;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_order_ship_before_pay_is_rejected():
+    src = (
+        """
+open Order
+def bad (u: Unit) : Int :=
+    let 1 o0 := new_order u in
+    let 1 o1 := add_item "book" 25 o0 in
+    let 1 o2 := ship "here" o1 in
+    finalize o2;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_order_zero_price_item_is_rejected():
+    src = (
+        """
+open Order
+def bad (u: Unit) : Int :=
+    let 1 o0 := new_order u in
+    let 1 o1 := add_item "free" 0 o0 in
+    let 1 o2 := pay 1 o1 in
+    let 1 o3 := ship "here" o2 in
+    finalize o3;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_order_leak_is_rejected():
+    src = (
+        """
+open Order
+def leak (u: Unit) : Unit :=
+    let 1 o := new_order u in
+    print "ignored";
+"""
+        + MAIN
+    )
+    assert any(isinstance(e, LinearUnusedError) for e in _linearity_errors(src))
+
+
+def test_order_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "order_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []


### PR DESCRIPTION
## Summary
- Add `Order.ae`: linear shopping-order protocol (`empty → adding → checkout → closed`) with a `total_price` ghost; `add_gift` requires checkout and `total_price > 20`.
- Include example, QTT tests (illegal gift/ship/price), and docs updates.

## Test plan
- [x] `uv run pytest tests/order_qtt_test.py -q`
- [x] `uv run python -m aeon examples/imports/order_example.ae`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)