### PR TITLE
Add ForkJoin library for refinement-safe parallel computation

### DIFF
--- a/aeon/bindings/forkjoin.py
+++ b/aeon/bindings/forkjoin.py
@@ -1,0 +1,87 @@
+"""Python bindings for the Aeon ``ForkJoin`` library.
+
+Wraps ``concurrent.futures.ThreadPoolExecutor`` so Aeon programs can fork
+independent thunks, join their futures, and shut the pool down. Handle
+ownership (exactly-once join / shutdown) is enforced by Aeon linear types in
+``ForkJoin.ae``; this module only implements the runtime side.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from typing import Any, Callable
+
+
+def pool(workers: int) -> ThreadPoolExecutor:
+    """Create a thread pool with a positive worker count."""
+    return ThreadPoolExecutor(max_workers=workers)
+
+
+def fork(pool_: ThreadPoolExecutor, task: Callable[[Any], Any]) -> tuple[ThreadPoolExecutor, Future[Any]]:
+    """Submit ``task`` (an Aeon ``Unit -> a`` thunk) and return ``(pool, future)``."""
+    future = pool_.submit(task, None)
+    return (pool_, future)
+
+
+def fork2(
+    pool_: ThreadPoolExecutor,
+    left: Callable[[Any], Any],
+    right: Callable[[Any], Any],
+) -> tuple[ThreadPoolExecutor, Future[Any], Future[Any]]:
+    """Submit two independent thunks; return ``(pool, left_future, right_future)``."""
+    fl = pool_.submit(left, None)
+    fr = pool_.submit(right, None)
+    return (pool_, fl, fr)
+
+
+def invoke(pool_: ThreadPoolExecutor, task: Callable[[Any], Any]) -> tuple[ThreadPoolExecutor, Any]:
+    """Run ``task`` on the pool and wait; return ``(pool, result)``."""
+    result = pool_.submit(task, None).result()
+    return (pool_, result)
+
+
+def join(future: Future[Any]) -> Any:
+    """Block until ``future`` completes and return its result."""
+    return future.result()
+
+
+def join_timeout(seconds: float, future: Future[Any]) -> Any:
+    """Like :func:`join` but abort after a positive ``seconds`` timeout."""
+    return future.result(timeout=seconds)
+
+
+def join2(left: Future[Any], right: Future[Any]) -> tuple[Any, Any]:
+    """Wait for both futures (in parallel completion order) and return ``(left, right)``."""
+    wait((left, right))
+    return (left.result(), right.result())
+
+
+def shutdown(pool_: ThreadPoolExecutor) -> None:
+    """Shut the pool down, waiting for in-flight work. Consumes the pool handle."""
+    pool_.shutdown(wait=True)
+    return None
+
+
+def parallel2(
+    workers: int,
+    left: Callable[[Any], Any],
+    right: Callable[[Any], Any],
+) -> tuple[Any, Any]:
+    """One-shot: create a pool, run two thunks in parallel, join, shut down."""
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        fl = ex.submit(left, None)
+        fr = ex.submit(right, None)
+        wait((fl, fr))
+        return (fl.result(), fr.result())
+
+
+def par_map(workers: int, f: Callable[[Any], Any], xs: list[Any]) -> list[Any]:
+    """Map ``f`` over ``xs`` with a temporary pool; length is preserved."""
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        return list(ex.map(f, xs))
+
+
+def halves(xs: list[Any]) -> tuple[list[Any], list[Any]]:
+    """Split a non-trivial array into two non-empty contiguous halves."""
+    mid = len(xs) // 2
+    return (xs[:mid], xs[mid:])

--- a/aeon/libraries/ForkJoin.ae
+++ b/aeon/libraries/ForkJoin.ae
@@ -1,0 +1,181 @@
+# Safe-by-construction fork/join parallelism via ``concurrent.futures``.
+#
+# Raw thread pools are easy to misuse in three ways this library closes:
+#
+#   1. **Forgotten joins / double joins (linearity).** A ``Future`` is a
+#      multiplicity-1 handle: you must ``join`` it exactly once. Dropping a
+#      future leaks unfinished work; joining twice races on a spent handle.
+#      Both are compile errors (``LinearUnusedError`` /
+#      ``LinearUsedTooManyTimesError``).
+#
+#   2. **Leaked pools (linearity).** A ``Pool`` is likewise linear: every
+#      ``pool`` must eventually reach ``shutdown``. Forgetting to shut down
+#      leaves worker threads alive; shutting down twice is rejected.
+#
+#   3. **Bogus worker counts and lost sizes (refinements).** Pool creation
+#      demands ``workers > 0`` (and a small upper bound). ``par_map`` proves
+#      the output length equals the input length. ``halves`` proves both
+#      pieces are non-empty and cover the original array — the invariant
+#      that makes divide-and-conquer parallel recursion safe to type-check.
+#
+# Linearity also prevents *data races on unique buffers*: a linear ``Array``
+# cannot be captured by two forked thunks unless you ``Array.copy`` first, so
+# parallel tasks never alias the same unique resource.
+#
+# Narrative guide: ``docs/forkjoin.md``. HTML reference:
+# ``aeon --doc libraries/ForkJoin.ae``.
+
+open Array
+
+# ── Opaque handles ───────────────────────────────────────────────────────
+
+# Thread pool. Linear: create with ``pool``, thread through ``fork`` /
+# ``fork2`` / ``invoke``, finish with ``shutdown``.
+linear type Pool
+
+# Pending asynchronous result. Linear: must be ``join``ed exactly once.
+linear type Future a
+
+# Result of ``fork``: packages the (still-open) pool with the new future so
+# both can be projected and the pool threaded onward.
+type Forked a
+
+# Result of ``fork2``: pool plus the two independent futures.
+type Forked2 a b
+
+# Result of ``invoke``: pool plus the computed value.
+type Invoked a
+
+# Result of ``join2`` / ``parallel2``: an unrestricted pair of values.
+type Joined2 a b
+
+# Result of ``halves``: two contiguous non-empty pieces of an array.
+type Halves a
+
+# ── Uninterpreted measures (refinement logic only) ───────────────────────
+
+# Worker count of a pool / forked wrapper.
+def pool_workers : (p: Pool) -> Int := uninterpreted
+def forked_workers : (f: (Forked a)) -> Int := uninterpreted
+def forked2_workers : (f: (Forked2 a b)) -> Int := uninterpreted
+def invoked_workers : (i: (Invoked a)) -> Int := uninterpreted
+
+# Sizes carried by ``halves`` so the split covers the original array.
+def half_left_size : (h: (Halves a)) -> Int := uninterpreted
+def half_right_size : (h: (Halves a)) -> Int := uninterpreted
+
+# ── Pool lifecycle ───────────────────────────────────────────────────────
+
+# Create a thread pool.
+# workers: must be positive and at most 64 (a compile-time sanity bound).
+# returns: a linear pool whose ``pool_workers`` measure equals ``workers``.
+def pool (workers: {n: Int | n > 0 && n <= 64}) :
+    {p: Pool | pool_workers p = workers} :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['pool']).pool(workers)"
+
+# Shut the pool down, waiting for in-flight work. Consumes the handle.
+def shutdown (1 p: Pool) : Unit :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['shutdown']).shutdown(p)"
+
+# ── Fork / join ──────────────────────────────────────────────────────────
+
+# Submit ``task`` (a ``Unit -> a`` thunk) to ``p``. Consumes the pool and
+# returns a ``Forked`` wrapper; project with ``forked_pool`` / ``forked_future``.
+def fork (1 p: Pool) (task: (_: Unit) -> a) :
+    {f: (Forked a) | forked_workers f = pool_workers p} :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['fork']).fork(p, task)"
+
+# Recover the pool from a ``fork`` result, with its worker count intact.
+def forked_pool (f: (Forked a)) :
+    {p: Pool | pool_workers p = forked_workers f} :=
+    native "f[0]"
+
+# Recover the linear future from a ``fork`` result. Bind it to ``let 1``.
+def forked_future (f: (Forked a)) : (Future a) :=
+    native "f[1]"
+
+# Submit two independent thunks. Project with ``forked2_pool`` /
+# ``forked2_left`` / ``forked2_right``.
+def fork2 (1 p: Pool) (left: (_: Unit) -> a) (right: (_: Unit) -> b) :
+    {f: (Forked2 a b) | forked2_workers f = pool_workers p} :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['fork2']).fork2(p, left, right)"
+
+def forked2_pool (f: (Forked2 a b)) :
+    {p: Pool | pool_workers p = forked2_workers f} :=
+    native "f[0]"
+
+def forked2_left (f: (Forked2 a b)) : (Future a) :=
+    native "f[1]"
+
+def forked2_right (f: (Forked2 a b)) : (Future b) :=
+    native "f[2]"
+
+# Run ``task`` on the pool and wait; keep the pool for further work.
+def invoke (1 p: Pool) (task: (_: Unit) -> a) :
+    {i: (Invoked a) | invoked_workers i = pool_workers p} :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['invoke']).invoke(p, task)"
+
+def invoked_pool (i: (Invoked a)) :
+    {p: Pool | pool_workers p = invoked_workers i} :=
+    native "i[0]"
+
+def invoked_value (i: (Invoked a)) : a :=
+    native "i[1]"
+
+# Block until ``future`` completes; consumes the future.
+def join (1 future: (Future a)) : a :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['join']).join(future)"
+
+# Like ``join`` but aborts after a positive timeout (seconds).
+def join_timeout (seconds: {s: Float | s > 0.0}) (1 future: (Future a)) : a :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['join_timeout']).join_timeout(seconds, future)"
+
+# Wait for both futures and return their results as a ``Joined2``.
+def join2 (1 left: (Future a)) (1 right: (Future b)) : (Joined2 a b) :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['join2']).join2(left, right)"
+
+def joined_fst (j: (Joined2 a b)) : a :=
+    native "j[0]"
+
+def joined_snd (j: (Joined2 a b)) : b :=
+    native "j[1]"
+
+# ── One-shot helpers ─────────────────────────────────────────────────────
+
+# Create a pool, run two thunks in parallel, join both, shut down.
+# workers: must be positive and at most 64.
+# returns: both results packaged in a ``Joined2``.
+def parallel2 (workers: {n: Int | n > 0 && n <= 64})
+              (left: (_: Unit) -> a)
+              (right: (_: Unit) -> b) : (Joined2 a b) :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['parallel2']).parallel2(workers, left, right)"
+
+# Map ``f`` over a linear array using a temporary pool of ``workers`` threads.
+# Preserves length: the result has the same ``size`` as the input.
+def par_map (workers: {n: Int | n > 0 && n <= 64})
+            (f: (x: {v:a | p v}) -> {w:b | q w})
+            (1 xs: (Array a)) :
+    {ys: (Array b) | size ys = size xs} :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['par_map']).par_map(workers, f, xs)"
+
+# ── Divide-and-conquer splitting ─────────────────────────────────────────
+
+# Split a non-trivial linear array into two non-empty contiguous halves.
+# The refinements guarantee coverage: ``left + right = original`` and both
+# sides have size ≥ 1 — exactly the precondition recursive parallel forks need.
+def halves (1 xs: {arr: (Array a) | size arr >= 2}) :
+    {h: (Halves a) |
+        half_left_size h + half_right_size h = size xs &&
+        half_left_size h >= 1 &&
+        half_right_size h >= 1} :=
+    native "__import__('aeon.bindings.forkjoin', fromlist=['halves']).halves(xs)"
+
+# Left half; length pinned to ``half_left_size``.
+def half_left (h: (Halves a)) :
+    {xs: (Array a) | size xs = half_left_size h && size xs >= 1} :=
+    native "h[0]"
+
+# Right half; length pinned to ``half_right_size``.
+def half_right (h: (Halves a)) :
+    {xs: (Array a) | size xs = half_right_size h && size xs >= 1} :=
+    native "h[1]"

--- a/docs/forkjoin.md
+++ b/docs/forkjoin.md
@@ -1,0 +1,150 @@
+# `ForkJoin`: refinement-safe parallel computation
+
+`ForkJoin.ae` wraps Python's `concurrent.futures.ThreadPoolExecutor` so **fork**,
+**join**, and **shutdown** are checked by the compiler. It combines Aeon's two
+static disciplines:
+
+- **Linear types (QTT)** — a `Future` must be joined exactly once; a `Pool` must
+  be shut down exactly once.
+- **Liquid refinements** — worker counts are positive, `par_map` preserves
+  length, and `halves` proves a split covers the original array with two
+  non-empty pieces.
+
+Together these make a common class of parallel bugs unrepresentable: forgotten
+joins, leaked pools, zero-sized worker pools, and divide-and-conquer splits that
+drop or duplicate work. Linearity also blocks data races on unique buffers —
+you cannot capture the same linear `Array` in two forked thunks without an
+explicit `Array.copy`.
+
+- Source: [`aeon/libraries/ForkJoin.ae`](https://github.com/alcides/aeon/blob/master/aeon/libraries/ForkJoin.ae)
+- Bindings: [`aeon/bindings/forkjoin.py`](https://github.com/alcides/aeon/blob/master/aeon/bindings/forkjoin.py)
+- Examples: [`examples/ffi/forkjoin_example.ae`](https://github.com/alcides/aeon/blob/master/examples/ffi/forkjoin_example.ae),
+  [`examples/ffi/forkjoin_divide.ae`](https://github.com/alcides/aeon/blob/master/examples/ffi/forkjoin_divide.ae)
+- Generated reference: [stdlib/ForkJoin.html](stdlib/ForkJoin.html) (from `aeon --doc`)
+
+For the general FFI recipe (`native`, opaque types, uninterpreted measures), see
+[Writing FFI bindings for a Python package](ffi).
+
+---
+
+## How refinements make parallelism safer
+
+| Risk in raw `ThreadPoolExecutor` | Aeon static check |
+|---|---|
+| `max_workers=0` / negative | `pool` / `parallel2` / `par_map` require `{n: Int \| n > 0 && n ≤ 64}` |
+| Submit and forget a future | `Future a` is linear → `LinearUnusedError` without `join` |
+| `future.result()` twice | linear future already consumed → `LinearUsedTooManyTimesError` |
+| Forget `shutdown()` | linear `Pool` unused → `LinearUnusedError` |
+| Parallel map silently changes length | `par_map` returns `{ys: Array b \| size ys = size xs}` |
+| Recursive split drops an element | `halves` proves `left + right = original` and both ≥ 1 |
+| Two tasks mutate the same buffer | linear `Array` cannot be shared across forks without `copy` |
+
+Refinements talk about *values* (counts, sizes); linearity talks about
+*ownership*. Safe parallel code needs both: sizes that compose under fork/join,
+and handles that cannot be aliased or leaked.
+
+---
+
+## Resource lifecycle
+
+```
+pool ──fork──► Forked ──forked_pool──► Pool ──…──► shutdown
+                 │
+                 └──forked_future──► Future ──join──► value
+```
+
+Or the two-task path:
+
+```
+pool ──fork2──► Forked2 ──forked2_pool──► Pool ──shutdown──► Unit
+                   │
+                   ├──forked2_left──► Future a ─┐
+                   │                             ├──join2──► Joined2
+                   └──forked2_right─► Future b ─┘
+```
+
+| Handle | Role |
+|--------|------|
+| `Pool` | Linear thread pool; thread through forks, finish with `shutdown` |
+| `Future a` | Linear pending result; must `join` (or `join_timeout`) exactly once |
+| `Forked a` / `Forked2 a b` | Unrestricted wrappers that reintroduce the pool + future(s) |
+| `Invoked a` | Pool + value after `invoke` (fork+join in one step) |
+| `Joined2 a b` | Unrestricted pair after `join2` / `parallel2` |
+| `Halves a` | Two non-empty contiguous pieces for divide-and-conquer |
+
+Bind every linear result with `let 1`:
+
+```aeon
+def const21 (u: Unit) : Int := 21;
+
+def demo (_: Unit) : Int :=
+    let 1 p0 := ForkJoin.pool 4 in
+    let f := ForkJoin.fork p0 const21 in
+    let 1 p1 := ForkJoin.forked_pool f in
+    let 1 fut := ForkJoin.forked_future f in
+    let v := ForkJoin.join fut in
+    let _ := ForkJoin.shutdown p1 in
+    v * 2;
+```
+
+---
+
+## One-shot helpers
+
+When you do not need to keep the pool open:
+
+```aeon
+def twenty (u: Unit) : Int := 20;
+def twenty_two (v: Unit) : Int := 22;
+def square (x: Int) : Int := x * x;
+
+# Two independent thunks; pool create/join/shutdown is internal.
+def both (_: Unit) : Int :=
+    let j := ForkJoin.parallel2 2 twenty twenty_two in
+    ForkJoin.joined_fst j + ForkJoin.joined_snd j;
+
+# Length-preserving parallel map over a linear array.
+def squares (1 xs: (Array Int)) : {ys: (Array Int) | Array.size ys = Array.size xs} :=
+    ForkJoin.par_map 4 square xs;
+```
+
+---
+
+## Divide-and-conquer with size proofs
+
+`halves` is the refinement-level contract for splitting work:
+
+```aeon
+def halves (1 xs: {arr: (Array a) | Array.size arr >= 2}) :
+    {h: Halves a |
+        half_left_size h + half_right_size h = Array.size xs &&
+        half_left_size h >= 1 &&
+        half_right_size h >= 1}
+```
+
+After projecting `half_left` / `half_right`, the solver knows each piece is
+non-empty and that the sizes sum to the original — so recursive parallel
+forks can re-establish the same preconditions on smaller arrays without
+runtime bounds checks.
+
+---
+
+## Minimal example
+
+```aeon
+import Array;
+import ForkJoin;
+
+def work (u: Unit) : Int := 6 * 7;
+def inc (x: Int) : Int := x + 1;
+
+def main (_: Int) : Unit :=
+    let 1 xs0 := ((Array.new{Int} unit).append 1).append 2 in
+    let 1 xs1 := Array.append xs0 3 in
+    let 1 ys := ForkJoin.par_map 2 inc xs1 in
+    let j := ForkJoin.parallel2 2 work work in
+    print (ForkJoin.joined_fst j + ForkJoin.joined_snd j);
+```
+
+Violations (zero workers, unjoined future, unshutdown pool, single-element
+`halves`) are type errors, not runtime surprises.

--- a/docs/index.md
+++ b/docs/index.md
@@ -526,7 +526,7 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Writer`, `Email`, `Downloader`, `Order`, `Stack`, `Deque`, `Iterator`).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Writer`, `Email`, `Downloader`, `Order`, `Stack`, `Deque`, `Iterator`). The same pairing for **safe parallel computation** — join/shutdown exactly once, positive worker counts, size-preserving `par_map`, proven `halves` splits — is in [Fork/Join parallelism with `ForkJoin`](forkjoin).
 
 ## Libraries
 
@@ -554,6 +554,7 @@ The generated files are gitignored; they are produced from source by the
 | `Array` | Linear host buffers, `size` refinements | [array.md](array) |
 | `Cuda` | Linear GPU buffers; kind/access/shape/shared/warp/status proofs | [cuda.md](cuda) |
 | `Database` | Linear sqlite3 connections/transactions | [database.md](database) |
+| `ForkJoin` | Linear pool/futures, safe parallel splits | [forkjoin.md](forkjoin) |
 | `Lock` / `Reader` / `Writer` / `Email` / `Downloader` / `Order` / `Stack` / `Deque` / `Iterator` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
 | `Http` | Typed `requests` wrapper | [http.md](http) |
 | `OS` / `Subprocess` | Typed process and filesystem bindings | [os-subprocess.md](os-subprocess) |
@@ -573,6 +574,7 @@ Systems and I/O:
 - **Cuda** — explicit CUDA Driver API (separate from `@gpu`); memory kind, access mode, 2-D launch, shared/warp, Status
 - **Gpu** — tensor kernels imported by `@gpu`
 - **Database** — sqlite3 with linear transactions
+- **ForkJoin** — thread pools with linear futures and size-safe splits
 - **Lock**, **Reader**, **Writer**, **Email**, **Downloader**, **Order**, **Stack**, **Deque**, **Iterator** — typestate protocols
 - **Http**, **OS**, **Subprocess**, **Path**, **Socket**, **Sys**
 - **Json**, **Args**

--- a/examples/ffi/forkjoin_divide.ae
+++ b/examples/ffi/forkjoin_divide.ae
@@ -1,0 +1,33 @@
+import Array;
+import ForkJoin;
+
+# Divide-and-conquer sketch: split with halves (size coverage proved),
+# measure each half, then fork2 pure length thunks and join.
+#
+# The interesting static facts:
+#   * halves requires size >= 2 and proves left + right = original, both >= 1
+#   * pool / fork2 thread a linear Pool that must reach shutdown
+#   * the two Futures from fork2 must each be joined exactly once
+
+def ret (n: Int) (u: Unit) : Int := n;
+
+def parallel_lengths (1 xs: {a: (Array Int) | Array.size a >= 2}) : Int :=
+    let h := ForkJoin.halves xs in
+    let 1 left := ForkJoin.half_left h in
+    let 1 right := ForkJoin.half_right h in
+    let l := Array.length left in
+    let r := Array.length right in
+    let 1 p0 := ForkJoin.pool 2 in
+    let f := ForkJoin.fork2 p0 (ret l) (ret r) in
+    let 1 p1 := ForkJoin.forked2_pool f in
+    let 1 fl := ForkJoin.forked2_left f in
+    let 1 fr := ForkJoin.forked2_right f in
+    let j := ForkJoin.join2 fl fr in
+    let _ := ForkJoin.shutdown p1 in
+    ForkJoin.joined_fst j + ForkJoin.joined_snd j;
+
+def main (_: Int) : Unit :=
+    let 1 xs0 := ((Array.new{Int} unit).append 10).append 20 in
+    let 1 xs1 := Array.append xs0 30 in
+    let 1 xs2 := Array.append xs1 40 in
+    print (parallel_lengths xs2);

--- a/examples/ffi/forkjoin_example.ae
+++ b/examples/ffi/forkjoin_example.ae
@@ -1,0 +1,25 @@
+import Array;
+import ForkJoin;
+
+# Minimal ForkJoin demo: one-shot parallel2 + length-preserving par_map.
+#
+# Refinements guarantee workers > 0 and that par_map keeps Array.size.
+# Linearity is discharged inside the helpers (they create and shut down
+# their own pools), so the caller only sees unrestricted Joined2 values
+# and a fresh linear array result.
+
+def left (u: Unit) : Int := 20;
+
+def right (u: Unit) : Int := 22;
+
+def inc (x: Int) : Int := x + 1;
+
+def main (_: Int) : Unit :=
+    let j := ForkJoin.parallel2 2 left right in
+    let sum := ForkJoin.joined_fst j + ForkJoin.joined_snd j in
+    let 1 xs0 := ((Array.new{Int} unit).append 1).append 2 in
+    let 1 xs1 := Array.append xs0 3 in
+    let 1 ys := ForkJoin.par_map 2 inc xs1 in
+    let n := Array.length ys in
+    let _ := print sum in
+    print n;

--- a/tests/forkjoin_test.py
+++ b/tests/forkjoin_test.py
@@ -1,0 +1,271 @@
+"""Compile-time and runtime tests for the ``ForkJoin`` library.
+
+Covers module scoping, QTT ownership of ``Pool`` / ``Future``, refinement
+guards on worker counts and ``halves``, and a small end-to-end run of the
+one-shot helpers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aeon.facade.api import (
+    LinearityError,
+    LinearUnusedError,
+    LinearUsedTooManyTimesError,
+)
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+MAIN = '\ndef main (args: Int) : Unit := print "ok";\n'
+IMPORTS = """
+open Array
+open ForkJoin
+"""
+
+
+def _errors(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _linearity_errors(source: str):
+    return [error for error in _errors(source) if isinstance(error, LinearityError)]
+
+
+def _run(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0)
+    driver = AeonDriver(cfg)
+    errs = list(driver.parse(aeon_code=source))
+    assert errs == [], errs
+    return driver.run()
+
+
+# ---------------------------------------------------------------------------
+# Module scoping
+# ---------------------------------------------------------------------------
+
+
+def test_forkjoin_names_are_not_in_the_global_prelude():
+    errors = [str(error) for error in _errors("def probe (u: Unit) : Int := pool_workers u;" + MAIN)]
+    assert any("pool_workers" in error and "does not exist" in error for error in errors), errors
+
+
+def test_import_forkjoin_keeps_api_qualified():
+    source = (
+        """
+import ForkJoin;
+
+def open_and_close (u: Unit) : Unit :=
+    let 1 p := ForkJoin.pool 2 in
+    ForkJoin.shutdown p;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+def test_open_forkjoin_lifecycle_typechecks():
+    source = (
+        IMPORTS
+        + """
+def const21 (x: Unit) : Int := 21;
+def demo (u: Unit) : Int :=
+    let 1 p0 := pool 2 in
+    let f := fork p0 const21 in
+    let 1 p1 := forked_pool f in
+    let 1 fut := forked_future f in
+    let v := join fut in
+    let _ := shutdown p1 in
+    v;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Linearity: Pool and Future
+# ---------------------------------------------------------------------------
+
+
+def test_unjoined_future_errors():
+    source = (
+        IMPORTS
+        + """
+def const1 (x: Unit) : Int := 1;
+def leak (u: Unit) : Unit :=
+    let 1 p0 := pool 2 in
+    let f := fork p0 const1 in
+    let 1 p1 := forked_pool f in
+    let 1 fut := forked_future f in
+    shutdown p1;
+"""
+        + MAIN
+    )
+    errs = _linearity_errors(source)
+    assert any(isinstance(e, LinearUnusedError) for e in errs), errs
+
+
+def test_double_join_errors():
+    source = (
+        IMPORTS
+        + """
+def const1 (x: Unit) : Int := 1;
+def twice (u: Unit) : Int :=
+    let 1 p0 := pool 2 in
+    let f := fork p0 const1 in
+    let 1 p1 := forked_pool f in
+    let 1 fut := forked_future f in
+    let a := join fut in
+    let b := join fut in
+    let _ := shutdown p1 in
+    a + b;
+"""
+        + MAIN
+    )
+    errs = _linearity_errors(source)
+    assert any(isinstance(e, LinearUsedTooManyTimesError) for e in errs), errs
+
+
+def test_unshutdown_pool_errors():
+    source = (
+        IMPORTS
+        + """
+def leak_pool (u: Unit) : Int :=
+    let 1 p := pool 2 in
+    0;
+"""
+        + MAIN
+    )
+    errs = _linearity_errors(source)
+    assert any(isinstance(e, LinearUnusedError) for e in errs), errs
+
+
+def test_double_shutdown_errors():
+    source = (
+        IMPORTS
+        + """
+def twice_shutdown (u: Unit) : Unit :=
+    let 1 p := pool 2 in
+    let _ := shutdown p in
+    shutdown p;
+"""
+        + MAIN
+    )
+    errs = _linearity_errors(source)
+    assert any(isinstance(e, LinearUsedTooManyTimesError) for e in errs), errs
+
+
+# ---------------------------------------------------------------------------
+# Refinements
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("workers", [0, -1, 65])
+def test_invalid_worker_counts_are_rejected(workers: int):
+    source = (
+        IMPORTS
+        + f"""
+def bad (u: Unit) : Unit :=
+    let 1 p := pool {workers} in
+    shutdown p;
+"""
+        + MAIN
+    )
+    errs = _errors(source)
+    assert errs, f"expected refinement failure for workers={workers}"
+
+
+def test_halves_rejects_singleton_array():
+    source = (
+        IMPORTS
+        + """
+def bad (u: Unit) : Int :=
+    let 1 xs := (Array.new{Int} unit).append 1 in
+    let h := halves xs in
+    let 1 left := half_left h in
+    Array.length left;
+"""
+        + MAIN
+    )
+    errs = _errors(source)
+    assert errs, "singleton halves should fail to prove size >= 2"
+
+
+def test_halves_and_par_map_typecheck():
+    source = (
+        IMPORTS
+        + """
+def sq (x: Int) : Int := x * x;
+def ok (u: Unit) : Int :=
+    let 1 xs0 := ((Array.new{Int} unit).append 1).append 2 in
+    let 1 xs1 := Array.append xs0 3 in
+    let h := halves xs1 in
+    let 1 left := half_left h in
+    let 1 right := half_right h in
+    let 1 mapped := par_map 2 sq left in
+    Array.length mapped + Array.length right;
+"""
+        + MAIN
+    )
+    assert _errors(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Runtime
+# ---------------------------------------------------------------------------
+
+
+def test_parallel2_and_par_map_run():
+    source = """
+open Array
+open ForkJoin
+
+def left (x: Unit) : Int := 20;
+def right (y: Unit) : Int := 22;
+def inc (x: Int) : Int := x + 1;
+
+def main (_: Int) : Int :=
+    let j := parallel2 2 left right in
+    let 1 xs0 := ((Array.new{Int} unit).append 1).append 2 in
+    let 1 xs1 := Array.append xs0 3 in
+    let 1 ys := par_map 2 inc xs1 in
+    joined_fst j + joined_snd j + Array.length ys;
+"""
+    assert _run(source) == 45
+
+
+def test_fork_join_shutdown_run():
+    source = """
+open ForkJoin
+
+def const21 (x: Unit) : Int := 21;
+
+def main (_: Int) : Int :=
+    let 1 p0 := pool 2 in
+    let f := fork p0 const21 in
+    let 1 p1 := forked_pool f in
+    let 1 fut := forked_future f in
+    let v := join fut in
+    let _ := shutdown p1 in
+    v * 2;
+"""
+    assert _run(source) == 42
+
+
+def test_example_files_typecheck_and_run():
+    root = Path(__file__).resolve().parents[1] / "examples" / "ffi"
+    for name in ("forkjoin_example.ae", "forkjoin_divide.ae"):
+        source = (root / name).read_text()
+        setup_logger()
+        cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0)
+        driver = AeonDriver(cfg)
+        errs = list(driver.parse(aeon_code=source))
+        assert errs == [], (name, errs)
+        driver.run()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a standard-library **`ForkJoin`** module that wraps `concurrent.futures.ThreadPoolExecutor` with Aeon’s linear types and liquid refinements, so common parallel bugs become type errors.

### What’s included

- `aeon/libraries/ForkJoin.ae` — surface API (`pool`, `fork`/`fork2`, `join`/`join2`, `shutdown`, `parallel2`, `par_map`, `halves`)
- `aeon/bindings/forkjoin.py` — Python runtime
- `docs/forkjoin.md` — narrative guide (linked from `docs/index.md`)
- Examples under `examples/ffi/`
- `tests/forkjoin_test.py` — scoping, linearity, refinements, and runtime checks

## How refinements enable safe parallel computation

Raw thread pools fail in ways that are hard to see in review. This library makes those failures **unrepresentable** by pairing refinements (what values are legal) with linearity (who owns a handle):

| Parallel risk | Static guarantee |
|---|---|
| `max_workers ≤ 0` | `pool` / `parallel2` / `par_map` require `{n: Int \| n > 0 && n ≤ 64}` |
| Fire-and-forget futures | `Future a` is linear → must `join` exactly once |
| Double-`result()` / use-after-join | second use → `LinearUsedTooManyTimesError` |
| Forgotten `shutdown()` | linear `Pool` → must reach `shutdown` |
| Parallel map changes length | `par_map` returns `{ys: Array b \| size ys = size xs}` |
| Divide-and-conquer drops/duplicates work | `halves` proves `left + right = original` and both sides `≥ 1` |
| Data races on unique buffers | a linear `Array` cannot be captured by two forks without `Array.copy` |

**Refinements** discharge the numeric / structural invariants (worker counts, size preservation, split coverage). **Linearity** discharges the protocol (join once, shut down once, no aliasing). Together they are the library’s model of *safe parallel computation*: forks may run concurrently, but ownership and size proofs still compose under join.

See `docs/forkjoin.md` for the lifecycle diagrams and worked examples.

## Test plan

- [x] `pytest tests/forkjoin_test.py -v` (15 passed)
- [x] `python -m aeon examples/ffi/forkjoin_example.ae` → prints `42` then `3`
- [x] `python -m aeon examples/ffi/forkjoin_divide.ae` → prints `4`
- [x] `pre-commit run` on touched files
- [ ] Rebased onto latest `master`; waiting for CI on `c1ca68f1`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36bd1c17-c4f2-42cd-9a50-583a9a5532ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36bd1c17-c4f2-42cd-9a50-583a9a5532ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

