### PR TITLE
Add linear Stack and Deque with size ghosts

### DIFF
--- a/aeon/bindings/stack_deque.py
+++ b/aeon/bindings/stack_deque.py
@@ -1,0 +1,52 @@
+"""Runtime helpers for ``libraries/Stack.ae`` and ``libraries/Deque.ae``."""
+
+from __future__ import annotations
+
+from collections import deque
+
+
+def new_stack():
+    return []
+
+
+def stack_push(x, stack):
+    stack.append(x)
+    return stack
+
+
+def stack_pop(stack):
+    return (stack.pop(), stack)
+
+
+def stack_peek(stack):
+    return (stack[-1], stack)
+
+
+def new_deque():
+    return deque()
+
+
+def deque_push_back(x, d):
+    d.append(x)
+    return d
+
+
+def deque_push_front(x, d):
+    d.appendleft(x)
+    return d
+
+
+def deque_pop_back(d):
+    return (d.pop(), d)
+
+
+def deque_pop_front(d):
+    return (d.popleft(), d)
+
+
+def deque_peek_back(d):
+    return (d[-1], d)
+
+
+def deque_peek_front(d):
+    return (d[0], d)

--- a/aeon/libraries/Deque.ae
+++ b/aeon/libraries/Deque.ae
@@ -1,0 +1,73 @@
+# Linear double-ended queue with a ``size`` ghost (LiquidJava ``ArrayDeque``).
+#
+# Ends support push/pop/peek; pop and peek require ``size > 0``. The deque is
+# multiplicity-1. ``discard`` frees an empty deque.
+
+linear type Deque a
+
+type DequePop a
+type DequePeek a
+type DequeLen a
+
+def deque_size : (d: (Deque a)) -> Int := uninterpreted
+def pop_size : (p: (DequePop a)) -> Int := uninterpreted
+def peek_size : (p: (DequePeek a)) -> Int := uninterpreted
+def held_size : (l: (DequeLen a)) -> Int := uninterpreted
+
+# Empty deque. Use as ``Deque.new_deque{Int} unit``.
+def new_deque (_: Unit) :
+    {d: (Deque a) | deque_size d = 0} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['new_deque']).new_deque()"
+
+def push_back (x: a) (1 d: (Deque a)) :
+    {out: (Deque a) | deque_size out = deque_size d + 1} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['deque_push_back']).deque_push_back(x, d)"
+
+def push_front (x: a) (1 d: (Deque a)) :
+    {out: (Deque a) | deque_size out = deque_size d + 1} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['deque_push_front']).deque_push_front(x, d)"
+
+def pop_back (1 d: {q: (Deque a) | deque_size q > 0}) :
+    {p: (DequePop a) | pop_size p = deque_size d - 1} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['deque_pop_back']).deque_pop_back(d)"
+
+def pop_front (1 d: {q: (Deque a) | deque_size q > 0}) :
+    {p: (DequePop a) | pop_size p = deque_size d - 1} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['deque_pop_front']).deque_pop_front(d)"
+
+def pop_value (p: (DequePop a)) : a :=
+    native "p[0]"
+
+def pop_deque (p: (DequePop a)) :
+    {d: (Deque a) | deque_size d = pop_size p} :=
+    native "p[1]"
+
+def peek_back (1 d: {q: (Deque a) | deque_size q > 0}) :
+    {p: (DequePeek a) | peek_size p = deque_size d} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['deque_peek_back']).deque_peek_back(d)"
+
+def peek_front (1 d: {q: (Deque a) | deque_size q > 0}) :
+    {p: (DequePeek a) | peek_size p = deque_size d} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['deque_peek_front']).deque_peek_front(d)"
+
+def peek_value (p: (DequePeek a)) : a :=
+    native "p[0]"
+
+def peek_deque (p: (DequePeek a)) :
+    {d: (Deque a) | deque_size d = peek_size p} :=
+    native "p[1]"
+
+def len_of (1 d: (Deque a)) :
+    {l: (DequeLen a) | held_size l = deque_size d} :=
+    native "(len(d), d)"
+
+def len_value (l: (DequeLen a)) :
+    {n: Int | n = held_size l && n >= 0} :=
+    native "l[0]"
+
+def len_deque (l: (DequeLen a)) :
+    {d: (Deque a) | deque_size d = held_size l} :=
+    native "l[1]"
+
+def discard (1 d: {q: (Deque a) | deque_size q = 0}) : Unit :=
+    native "None"

--- a/aeon/libraries/Stack.ae
+++ b/aeon/libraries/Stack.ae
@@ -1,0 +1,69 @@
+# Linear stack with a ``size`` ghost (LiquidJava ``Stack`` exercise).
+#
+# ``push`` increases size; ``pop`` / ``peek`` require ``size > 0``. The stack
+# is multiplicity-1: each op consumes the handle and returns the next state.
+# ``discard`` frees an empty stack.
+
+linear type Stack a
+
+# Opaque tokens so ``pop`` / ``peek`` / ``len_of`` can return a value and the
+# recovered stack without breaking linearity.
+type StackPop a
+type StackPeek a
+type StackLen a
+
+def stack_size : (s: (Stack a)) -> Int := uninterpreted
+def pop_size : (p: (StackPop a)) -> Int := uninterpreted
+def peek_size : (p: (StackPeek a)) -> Int := uninterpreted
+def held_size : (l: (StackLen a)) -> Int := uninterpreted
+
+# Empty stack. Use as ``Stack.new_stack{Int} unit``.
+def new_stack (_: Unit) :
+    {s: (Stack a) | stack_size s = 0} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['new_stack']).new_stack()"
+
+# Push one element (size + 1).
+def push (x: a) (1 s: (Stack a)) :
+    {out: (Stack a) | stack_size out = stack_size s + 1} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['stack_push']).stack_push(x, s)"
+
+# Pop the top; requires a non-empty stack.
+def pop (1 s: {st: (Stack a) | stack_size st > 0}) :
+    {p: (StackPop a) | pop_size p = stack_size s - 1} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['stack_pop']).stack_pop(s)"
+
+def pop_value (p: (StackPop a)) : a :=
+    native "p[0]"
+
+def pop_stack (p: (StackPop a)) :
+    {s: (Stack a) | stack_size s = pop_size p} :=
+    native "p[1]"
+
+# Peek at the top without removing it.
+def peek (1 s: {st: (Stack a) | stack_size st > 0}) :
+    {p: (StackPeek a) | peek_size p = stack_size s} :=
+    native "__import__('aeon.bindings.stack_deque', fromlist=['stack_peek']).stack_peek(s)"
+
+def peek_value (p: (StackPeek a)) : a :=
+    native "p[0]"
+
+def peek_stack (p: (StackPeek a)) :
+    {s: (Stack a) | stack_size s = peek_size p} :=
+    native "p[1]"
+
+# Observe length and recover the stack.
+def len_of (1 s: (Stack a)) :
+    {l: (StackLen a) | held_size l = stack_size s} :=
+    native "(len(s), s)"
+
+def len_value (l: (StackLen a)) :
+    {n: Int | n = held_size l && n >= 0} :=
+    native "l[0]"
+
+def len_stack (l: (StackLen a)) :
+    {s: (Stack a) | stack_size s = held_size l} :=
+    native "l[1]"
+
+# Drop an empty stack.
+def discard (1 s: {st: (Stack a) | stack_size st = 0}) : Unit :=
+    native "None"

--- a/docs/index.md
+++ b/docs/index.md
@@ -513,7 +513,7 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`, `Stack`, `Deque`).
 
 ## Libraries
 
@@ -541,7 +541,7 @@ The generated files are gitignored; they are produced from source by the
 | `Array` | Linear host buffers, `size` refinements | [array.md](array) |
 | `Cuda` | Linear GPU buffers; kind/access/shape/shared/warp/status proofs | [cuda.md](cuda) |
 | `Database` | Linear sqlite3 connections/transactions | [database.md](database) |
-| `Lock` / `Reader` / `Email` / `Downloader` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
+| `Lock` / `Reader` / `Email` / `Downloader` / `Stack` / `Deque` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
 | `Http` | Typed `requests` wrapper | [http.md](http) |
 | `OS` / `Subprocess` | Typed process and filesystem bindings | [os-subprocess.md](os-subprocess) |
 
@@ -560,7 +560,7 @@ Systems and I/O:
 - **Cuda** — explicit CUDA Driver API (separate from `@gpu`); memory kind, access mode, 2-D launch, shared/warp, Status
 - **Gpu** — tensor kernels imported by `@gpu`
 - **Database** — sqlite3 with linear transactions
-- **Lock**, **Reader**, **Email**, **Downloader** — typestate protocols
+- **Lock**, **Reader**, **Email**, **Downloader**, **Stack**, **Deque** — typestate protocols
 - **Http**, **OS**, **Subprocess**, **Path**, **Socket**, **Sys**
 - **Json**, **Args**
 

--- a/docs/typestate-protocols.md
+++ b/docs/typestate-protocols.md
@@ -3,7 +3,8 @@
 Four small libraries port the LiquidJava demos that fit Aeon best: a mutex,
 a streaming reader, a fluent email builder, and a download session with a
 progress ghost. Each combines **linear handles** (use exactly once) with
-**refinement measures** (legal orderings / numeric bounds).
+**refinement measures** (legal orderings / numeric bounds). ``Stack`` and
+``Deque`` add size-ghost collection protocols.
 
 | Module | LiquidJava analogue | Idea |
 |--------|---------------------|------|
@@ -11,12 +12,16 @@ progress ghost. Each combines **linear handles** (use exactly once) with
 | [`Reader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Reader.ae) | `InputStreamReader` | open → read* → close; byte codes in `[-1, 255]` |
 | [`Email`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Email.ae) | fluent `Email` | from → to+ → body → build |
 | [`Downloader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Downloader.ae) | `Downloader` | start → monotonic update → finish at 100% |
+| [`Stack`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Stack.ae) | `Stack` | push/pop/peek with `size` ghost |
+| [`Deque`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Deque.ae) | `ArrayDeque` | dual-ended push/pop/peek with `size` |
 
 Examples (typecheck with `--no-main`):
 [`lock_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/lock_example.ae),
 [`reader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/reader_example.ae),
 [`email_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/email_example.ae),
-[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae).
+[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae),
+[`stack_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/stack_example.ae),
+[`deque_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/deque_example.ae).
 
 ---
 
@@ -83,6 +88,44 @@ def download (u: Unit) : Unit :=
 ```
 
 Updates must strictly increase `progress`; `finish` requires `progress = 100`.
+
+## Stack
+
+```aeon
+open Stack
+
+def demo (u: Unit) : Int :=
+    let 1 s0 := new_stack{Int} u in
+    let 1 s1 := push 7 s0 in
+    let po := pop s1 in
+    let v := pop_value po in
+    let 1 s2 := pop_stack po in
+    let _ := discard s2 in
+    v;
+```
+
+`pop` / `peek` require `stack_size > 0`; `discard` requires an empty stack.
+
+## Deque
+
+```aeon
+open Deque
+
+def demo (u: Unit) : Int :=
+    let 1 d0 := new_deque{Int} u in
+    let 1 d1 := push_back 1 d0 in
+    let 1 d2 := push_front 0 d1 in
+    let po := pop_front d2 in
+    let v := pop_value po in
+    let 1 d3 := pop_deque po in
+    let po2 := pop_back d3 in
+    let _ := pop_value po2 in
+    let 1 d4 := pop_deque po2 in
+    let _ := discard d4 in
+    v;
+```
+
+Same size discipline as `Stack`, with operations at both ends.
 
 ---
 

--- a/examples/imports/deque_example.ae
+++ b/examples/imports/deque_example.ae
@@ -1,0 +1,21 @@
+open Deque
+
+# push_back / push_front → pop_front → discard
+def demo (u: Unit) : Int :=
+    let 1 d0 := new_deque{Int} u in
+    let 1 d1 := push_back 1 d0 in
+    let 1 d2 := push_front 0 d1 in
+    let 1 d3 := push_back 2 d2 in
+    let po := pop_front d3 in
+    let front := pop_value po in
+    let 1 d4 := pop_deque po in
+    let po2 := pop_back d4 in
+    let _ := pop_value po2 in
+    let 1 d5 := pop_deque po2 in
+    let po3 := pop_front d5 in
+    let _ := pop_value po3 in
+    let 1 d6 := pop_deque po3 in
+    let _ := discard d6 in
+    front;
+
+def main (args: Int) : Unit := print "ok"

--- a/examples/imports/stack_example.ae
+++ b/examples/imports/stack_example.ae
@@ -1,0 +1,20 @@
+open Stack
+
+# push → peek → pop → discard
+def demo (u: Unit) : Int :=
+    let 1 s0 := new_stack{Int} u in
+    let 1 s1 := push 1 s0 in
+    let 1 s2 := push 2 s1 in
+    let pk := peek s2 in
+    let top := peek_value pk in
+    let 1 s3 := peek_stack pk in
+    let po := pop s3 in
+    let _ := pop_value po in
+    let 1 s4 := pop_stack po in
+    let po2 := pop s4 in
+    let _ := pop_value po2 in
+    let 1 s5 := pop_stack po2 in
+    let _ := discard s5 in
+    top;
+
+def main (args: Int) : Unit := print "ok"

--- a/tests/stack_deque_qtt_test.py
+++ b/tests/stack_deque_qtt_test.py
@@ -1,0 +1,138 @@
+"""QTT / refinement tests for Stack and Deque."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aeon.facade.api import (
+    LinearityError,
+    LinearUnusedError,
+    LiquidTypeCheckingFailedRelation,
+)
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _parse(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _errors(source: str):
+    return _parse(source)
+
+
+def _linearity_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LinearityError)]
+
+
+def _liquid_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LiquidTypeCheckingFailedRelation)]
+
+
+MAIN = """
+def main (args: Int) : Unit := print "ok";
+"""
+
+
+def test_stack_lifecycle_typechecks():
+    src = (
+        """
+open Stack
+def demo (u: Unit) : Int :=
+    let 1 s0 := new_stack{Int} u in
+    let 1 s1 := push 7 s0 in
+    let po := pop s1 in
+    let v := pop_value po in
+    let 1 s2 := pop_stack po in
+    let _ := discard s2 in
+    v;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_stack_pop_empty_is_rejected():
+    src = (
+        """
+open Stack
+def bad (u: Unit) : Int :=
+    let 1 s0 := new_stack{Int} u in
+    let po := pop s0 in
+    let v := pop_value po in
+    let 1 s1 := pop_stack po in
+    let _ := discard s1 in
+    v;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_stack_leak_is_rejected():
+    src = (
+        """
+open Stack
+def leak (u: Unit) : Unit :=
+    let 1 s := new_stack{Int} u in
+    print "ignored";
+"""
+        + MAIN
+    )
+    assert any(isinstance(e, LinearUnusedError) for e in _linearity_errors(src))
+
+
+def test_stack_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "stack_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []
+
+
+def test_deque_lifecycle_typechecks():
+    src = (
+        """
+open Deque
+def demo (u: Unit) : Int :=
+    let 1 d0 := new_deque{Int} u in
+    let 1 d1 := push_back 1 d0 in
+    let 1 d2 := push_front 0 d1 in
+    let po := pop_front d2 in
+    let v := pop_value po in
+    let 1 d3 := pop_deque po in
+    let po2 := pop_back d3 in
+    let _ := pop_value po2 in
+    let 1 d4 := pop_deque po2 in
+    let _ := discard d4 in
+    v;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_deque_pop_empty_is_rejected():
+    src = (
+        """
+open Deque
+def bad (u: Unit) : Int :=
+    let 1 d0 := new_deque{Int} u in
+    let po := pop_back d0 in
+    let v := pop_value po in
+    let 1 d1 := pop_deque po in
+    let _ := discard d1 in
+    v;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_deque_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "deque_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []


### PR DESCRIPTION
## Summary
- Add `Stack.ae` and `Deque.ae`: linear collections with a `size` ghost; pop/peek require `size > 0`; `discard` requires empty.
- Shared Python helpers in `aeon/bindings/stack_deque.py`, examples, QTT tests, and docs updates.

## Test plan
- [x] `uv run pytest tests/stack_deque_qtt_test.py -q`
- [x] `uv run python -m aeon examples/imports/stack_example.ae`
- [x] `uv run python -m aeon examples/imports/deque_example.ae`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)