### PR TITLE
Add Iterator library with hasNext-before-next typestate

### DIFF
--- a/aeon/bindings/iterator.py
+++ b/aeon/bindings/iterator.py
@@ -1,0 +1,23 @@
+"""Runtime helpers for ``libraries/Iterator.ae``."""
+
+from __future__ import annotations
+
+
+def from_array(arr):
+    # phase 0, remaining = len(arr); store elements as a list cursor.
+    return {"phase": 0, "items": list(arr), "index": 0}
+
+
+def has_next(it):
+    remaining = len(it["items"]) - it["index"]
+    if remaining > 0:
+        it = {**it, "phase": 1}
+        return (True, it)
+    it = {**it, "phase": 2}
+    return (False, it)
+
+
+def next_step(it):
+    idx = it["index"]
+    value = it["items"][idx]
+    return (value, {**it, "phase": 0, "index": idx + 1})

--- a/aeon/libraries/Iterator.ae
+++ b/aeon/libraries/Iterator.ae
@@ -1,0 +1,79 @@
+# Linear iterator protocol (LiquidJava ``Iterator`` / hasNext-before-next).
+#
+# Phases (``it_phase``):
+#   0 — must call ``has_next`` before ``next``
+#   1 — ``has_next`` returned true; ``next`` is legal
+#   2 — exhausted (``has_next`` returned false); only ``discard`` remains
+#
+# ``it_remaining`` counts unread elements. Construct with ``from_array``.
+
+open Array
+
+linear type Iterator a
+
+# After ``has_next``: flag plus recovered iterator.
+type IteratorProbe a
+
+# After ``next``: element plus recovered iterator.
+type IteratorStep a
+
+def it_phase : (it: (Iterator a)) -> Int := uninterpreted
+def it_remaining : (it: (Iterator a)) -> Int := uninterpreted
+
+def probe_has_next : (p: (IteratorProbe a)) -> Bool := uninterpreted
+def probe_remaining : (p: (IteratorProbe a)) -> Int := uninterpreted
+def step_remaining : (s: (IteratorStep a)) -> Int := uninterpreted
+
+# Consume a host array into an iterator at phase 0.
+def from_array (1 arr: (Array a)) :
+    {it: (Iterator a) |
+        it_phase it = 0 &&
+        it_remaining it = Array.size arr} :=
+    native "__import__('aeon.bindings.iterator', fromlist=['from_array']).from_array(arr)"
+
+# Probe whether more elements remain (phase 0 only).
+# If remaining > 0, recovers phase 1; otherwise phase 2.
+def has_next (1 it: {i: (Iterator a) | it_phase i = 0}) :
+    {p: (IteratorProbe a) |
+        probe_remaining p = it_remaining it &&
+        ((it_remaining it > 0 && probe_has_next p = true) ||
+         (it_remaining it = 0 && probe_has_next p = false))} :=
+    native "__import__('aeon.bindings.iterator', fromlist=['has_next']).has_next(it)"
+
+def has_next_flag (p: (IteratorProbe a)) :
+    {b: Bool | b = probe_has_next p} :=
+    native "p[0]"
+
+# Recover iterator after a true probe → phase 1, same remaining.
+def ready_iterator (p: {pr: (IteratorProbe a) | probe_has_next pr = true}) :
+    {it: (Iterator a) |
+        it_phase it = 1 &&
+        it_remaining it = probe_remaining p &&
+        it_remaining it > 0} :=
+    native "p[1]"
+
+# Recover iterator after a false probe → phase 2, remaining 0.
+def exhausted_iterator (p: {pr: (IteratorProbe a) | probe_has_next pr = false}) :
+    {it: (Iterator a) |
+        it_phase it = 2 &&
+        it_remaining it = 0 &&
+        probe_remaining p = 0} :=
+    native "p[1]"
+
+# Take the next element (phase 1 only); returns to phase 0 with remaining - 1.
+def next (1 it: {i: (Iterator a) | it_phase i = 1 && it_remaining i > 0}) :
+    {s: (IteratorStep a) | step_remaining s = it_remaining it - 1} :=
+    native "__import__('aeon.bindings.iterator', fromlist=['next_step']).next_step(it)"
+
+def next_value (s: (IteratorStep a)) : a :=
+    native "s[0]"
+
+def next_iterator (s: (IteratorStep a)) :
+    {it: (Iterator a) |
+        it_phase it = 0 &&
+        it_remaining it = step_remaining s} :=
+    native "s[1]"
+
+# Drop an exhausted iterator (phase 2).
+def discard (1 it: {i: (Iterator a) | it_phase i = 2}) : Unit :=
+    native "None"

--- a/docs/index.md
+++ b/docs/index.md
@@ -513,7 +513,7 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`, `Iterator`).
 
 ## Libraries
 
@@ -541,7 +541,7 @@ The generated files are gitignored; they are produced from source by the
 | `Array` | Linear host buffers, `size` refinements | [array.md](array) |
 | `Cuda` | Linear GPU buffers; kind/access/shape/shared/warp/status proofs | [cuda.md](cuda) |
 | `Database` | Linear sqlite3 connections/transactions | [database.md](database) |
-| `Lock` / `Reader` / `Email` / `Downloader` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
+| `Lock` / `Reader` / `Email` / `Downloader` / `Iterator` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
 | `Http` | Typed `requests` wrapper | [http.md](http) |
 | `OS` / `Subprocess` | Typed process and filesystem bindings | [os-subprocess.md](os-subprocess) |
 
@@ -560,7 +560,7 @@ Systems and I/O:
 - **Cuda** — explicit CUDA Driver API (separate from `@gpu`); memory kind, access mode, 2-D launch, shared/warp, Status
 - **Gpu** — tensor kernels imported by `@gpu`
 - **Database** — sqlite3 with linear transactions
-- **Lock**, **Reader**, **Email**, **Downloader** — typestate protocols
+- **Lock**, **Reader**, **Email**, **Downloader**, **Iterator** — typestate protocols
 - **Http**, **OS**, **Subprocess**, **Path**, **Socket**, **Sys**
 - **Json**, **Args**
 

--- a/docs/typestate-protocols.md
+++ b/docs/typestate-protocols.md
@@ -11,12 +11,14 @@ progress ghost. Each combines **linear handles** (use exactly once) with
 | [`Reader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Reader.ae) | `InputStreamReader` | open → read* → close; byte codes in `[-1, 255]` |
 | [`Email`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Email.ae) | fluent `Email` | from → to+ → body → build |
 | [`Downloader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Downloader.ae) | `Downloader` | start → monotonic update → finish at 100% |
+| [`Iterator`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Iterator.ae) | `Iterator` | hasNext before next; remaining ghost |
 
 Examples (typecheck with `--no-main`):
 [`lock_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/lock_example.ae),
 [`reader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/reader_example.ae),
 [`email_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/email_example.ae),
-[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae).
+[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae),
+[`iterator_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/iterator_example.ae).
 
 ---
 
@@ -83,6 +85,34 @@ def download (u: Unit) : Unit :=
 ```
 
 Updates must strictly increase `progress`; `finish` requires `progress = 100`.
+
+## Iterator
+
+```aeon
+open Array
+open Iterator
+
+def sum_two (u: Unit) : Int :=
+    let 1 xs := Array.append (Array.append (Array.new{Int} u) 3) 4 in
+    let 1 it0 := from_array xs in
+    let p0 := has_next it0 in
+    let 1 it1 := ready_iterator p0 in
+    let s0 := next it1 in
+    let a := next_value s0 in
+    let 1 it2 := next_iterator s0 in
+    let p1 := has_next it2 in
+    let 1 it3 := ready_iterator p1 in
+    let s1 := next it3 in
+    let b := next_value s1 in
+    let 1 it4 := next_iterator s1 in
+    let p2 := has_next it4 in
+    let 1 it5 := exhausted_iterator p2 in
+    let _ := discard it5 in
+    a + b;
+```
+
+`next` is illegal until `has_next` returns true (`ready_iterator`); after a false
+probe only `exhausted_iterator` + `discard` remain.
 
 ---
 

--- a/examples/imports/iterator_example.ae
+++ b/examples/imports/iterator_example.ae
@@ -1,0 +1,23 @@
+open Array
+open Iterator
+
+# has_next → next → has_next → discard
+def sum_two (u: Unit) : Int :=
+    let 1 xs := Array.append (Array.append (Array.new{Int} u) 3) 4 in
+    let 1 it0 := from_array xs in
+    let p0 := has_next it0 in
+    let 1 it1 := ready_iterator p0 in
+    let s0 := next it1 in
+    let a := next_value s0 in
+    let 1 it2 := next_iterator s0 in
+    let p1 := has_next it2 in
+    let 1 it3 := ready_iterator p1 in
+    let s1 := next it3 in
+    let b := next_value s1 in
+    let 1 it4 := next_iterator s1 in
+    let p2 := has_next it4 in
+    let 1 it5 := exhausted_iterator p2 in
+    let _ := discard it5 in
+    a + b;
+
+def main (args: Int) : Unit := print "ok"

--- a/tests/iterator_qtt_test.py
+++ b/tests/iterator_qtt_test.py
@@ -1,0 +1,108 @@
+"""QTT / refinement tests for Iterator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aeon.facade.api import (
+    LinearityError,
+    LinearUnusedError,
+    LiquidTypeCheckingFailedRelation,
+)
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _parse(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _errors(source: str):
+    return _parse(source)
+
+
+def _linearity_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LinearityError)]
+
+
+def _liquid_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LiquidTypeCheckingFailedRelation)]
+
+
+MAIN = """
+def main (args: Int) : Unit := print "ok";
+"""
+
+
+def test_iterator_lifecycle_typechecks():
+    src = (
+        """
+open Array
+open Iterator
+def sum_two (u: Unit) : Int :=
+    let 1 xs := Array.append (Array.append (Array.new{Int} u) 3) 4 in
+    let 1 it0 := from_array xs in
+    let p0 := has_next it0 in
+    let 1 it1 := ready_iterator p0 in
+    let s0 := next it1 in
+    let a := next_value s0 in
+    let 1 it2 := next_iterator s0 in
+    let p1 := has_next it2 in
+    let 1 it3 := ready_iterator p1 in
+    let s1 := next it3 in
+    let b := next_value s1 in
+    let 1 it4 := next_iterator s1 in
+    let p2 := has_next it4 in
+    let 1 it5 := exhausted_iterator p2 in
+    let _ := discard it5 in
+    a + b;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_iterator_next_without_has_next_is_rejected():
+    src = (
+        """
+open Array
+open Iterator
+def bad (u: Unit) : Int :=
+    let 1 xs := Array.append (Array.new{Int} u) 1 in
+    let 1 it0 := from_array xs in
+    let s0 := next it0 in
+    let v := next_value s0 in
+    let 1 it1 := next_iterator s0 in
+    let p := has_next it1 in
+    let 1 it2 := exhausted_iterator p in
+    let _ := discard it2 in
+    v;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_iterator_leak_is_rejected():
+    src = (
+        """
+open Array
+open Iterator
+def leak (u: Unit) : Unit :=
+    let 1 xs := Array.new{Int} u in
+    let 1 it := from_array xs in
+    print "ignored";
+"""
+        + MAIN
+    )
+    assert any(isinstance(e, LinearUnusedError) for e in _linearity_errors(src))
+
+
+def test_iterator_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "iterator_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []


### PR DESCRIPTION
## Summary
- Add `Iterator.ae`: linear hasNext → next → discard protocol over arrays, with `it_phase` / `it_remaining` ghosts.
- Include example, QTT tests (next-without-probe rejected), and docs updates.

## Test plan
- [x] `uv run pytest tests/iterator_qtt_test.py -q`
- [x] `uv run python -m aeon examples/imports/iterator_example.ae`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)