### PR TITLE
Add Writer library for linear streaming file output

### DIFF
--- a/aeon/bindings/writer.py
+++ b/aeon/bindings/writer.py
@@ -1,0 +1,12 @@
+"""Helpers for ``libraries/Writer.ae``."""
+
+from __future__ import annotations
+
+
+def write_payload(data, writer):
+    writer.write(data)
+    # Track cumulative bytes on the handle for runtime debugging; refinements
+    # are established by posts, not by reading this attribute.
+    written = getattr(writer, "_aeon_bytes_written", 0) + len(data)
+    setattr(writer, "_aeon_bytes_written", written)
+    return writer

--- a/aeon/libraries/Writer.ae
+++ b/aeon/libraries/Writer.ae
@@ -1,0 +1,40 @@
+# Linear byte writer — open → write* → close, counterpart to ``Reader``.
+#
+# Completes the streaming I/O story: ``Path.write`` is one-shot; this API
+# exposes a live handle. ``writer_open`` tracks liveness; ``bytes_written``
+# is a ghost of cumulative payload length; ``close`` consumes the handle.
+#
+#     let 1 w0 := open_writer path in
+#     let 1 w1 := write payload w0 in
+#     close w1;
+
+linear type Writer
+
+# Opaque host payload (``bytes`` at runtime).
+type WriterPayload
+
+def writer_open : (w: Writer) -> Bool := uninterpreted
+def bytes_written : (w: Writer) -> Int := uninterpreted
+def payload_len : (p: WriterPayload) -> Int := uninterpreted
+
+# Build a payload from a non-empty string (UTF-8 bytes).
+def payload_from_string (s: {t: String | t != ""}) :
+    {p: WriterPayload | payload_len p > 0} :=
+    native "s.encode('utf-8')"
+
+# Open ``path`` for binary writing (truncates). Path must be non-empty.
+def open_writer (path: {p: String | p != ""}) :
+    {w: Writer | writer_open w = true && bytes_written w = 0} :=
+    native "open(path, 'wb')"
+
+# Append ``data`` to an open writer; increases ``bytes_written`` by ``payload_len``.
+def write (data: WriterPayload)
+    (1 w: {x: Writer | writer_open x = true}) :
+    {out: Writer |
+        writer_open out = true &&
+        bytes_written out = bytes_written w + payload_len data} :=
+    native "__import__('aeon.bindings.writer', fromlist=['write_payload']).write_payload(data, w)"
+
+# Close an open writer. Consumes the handle.
+def close (1 w: {x: Writer | writer_open x = true}) : Unit :=
+    native "w.close() or None"

--- a/docs/index.md
+++ b/docs/index.md
@@ -513,7 +513,7 @@ let numpy := native_import "numpy";
 
 For a step-by-step guide to wrapping a whole Python package — covering opaque types, designing refinements, uninterpreted functions, and the axiom-by-`native` pattern — see [Writing FFI bindings for a Python package](ffi).
 
-For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`).
+For a worked case study of taming two especially error-prone modules — turning `KeyError`, ignored exit codes, and shell injection into compile-time errors — see [Typed bindings for `os` and `subprocess`](os-subprocess). The same treatment for HTTP — mandatory timeouts, status codes you can't ignore — is in [Typed bindings for `requests`](http). For combining refinements with **linear types** (QTT) to make resource lifecycles state-safe — commit-xor-rollback, close exactly once — see [State-safe sqlite3 with `Database`](database), [linear `Array` buffers](array), [explicit CUDA device memory](cuda), and [typestate protocols](typestate-protocols) (`Lock`, `Reader`, `Email`, `Downloader`, `Writer`).
 
 ## Libraries
 
@@ -541,7 +541,7 @@ The generated files are gitignored; they are produced from source by the
 | `Array` | Linear host buffers, `size` refinements | [array.md](array) |
 | `Cuda` | Linear GPU buffers; kind/access/shape/shared/warp/status proofs | [cuda.md](cuda) |
 | `Database` | Linear sqlite3 connections/transactions | [database.md](database) |
-| `Lock` / `Reader` / `Email` / `Downloader` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
+| `Lock` / `Reader` / `Email` / `Downloader` / `Writer` | Typestate protocols (LiquidJava ports) | [typestate-protocols.md](typestate-protocols) |
 | `Http` | Typed `requests` wrapper | [http.md](http) |
 | `OS` / `Subprocess` | Typed process and filesystem bindings | [os-subprocess.md](os-subprocess) |
 
@@ -560,7 +560,7 @@ Systems and I/O:
 - **Cuda** — explicit CUDA Driver API (separate from `@gpu`); memory kind, access mode, 2-D launch, shared/warp, Status
 - **Gpu** — tensor kernels imported by `@gpu`
 - **Database** — sqlite3 with linear transactions
-- **Lock**, **Reader**, **Email**, **Downloader** — typestate protocols
+- **Lock**, **Reader**, **Email**, **Downloader**, **Writer** — typestate protocols
 - **Http**, **OS**, **Subprocess**, **Path**, **Socket**, **Sys**
 - **Json**, **Args**
 

--- a/docs/typestate-protocols.md
+++ b/docs/typestate-protocols.md
@@ -11,12 +11,14 @@ progress ghost. Each combines **linear handles** (use exactly once) with
 | [`Reader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Reader.ae) | `InputStreamReader` | open → read* → close; byte codes in `[-1, 255]` |
 | [`Email`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Email.ae) | fluent `Email` | from → to+ → body → build |
 | [`Downloader`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Downloader.ae) | `Downloader` | start → monotonic update → finish at 100% |
+| [`Writer`](https://github.com/alcides/aeon/blob/master/aeon/libraries/Writer.ae) | stream writer | open → write* → close; `bytes_written` ghost |
 
 Examples (typecheck with `--no-main`):
 [`lock_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/lock_example.ae),
 [`reader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/reader_example.ae),
 [`email_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/email_example.ae),
-[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae).
+[`downloader_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/downloader_example.ae),
+[`writer_example.ae`](https://github.com/alcides/aeon/blob/master/examples/imports/writer_example.ae).
 
 ---
 
@@ -83,6 +85,21 @@ def download (u: Unit) : Unit :=
 ```
 
 Updates must strictly increase `progress`; `finish` requires `progress = 100`.
+
+## Writer
+
+```aeon
+open Writer
+
+def write_once (path: {p: String | p != ""}) : Unit :=
+    let 1 w0 := open_writer path in
+    let payload := payload_from_string "hello" in
+    let 1 w1 := write payload w0 in
+    close w1;
+```
+
+Companion to `Reader`: linear open/write/close with a `bytes_written` ghost.
+Unlike one-shot `Path.write`, the handle must be closed exactly once.
 
 ---
 

--- a/examples/imports/writer_example.ae
+++ b/examples/imports/writer_example.ae
@@ -1,0 +1,10 @@
+open Writer
+
+# open → write → close (path is a parameter so CI need not touch disk).
+def write_once (path: {p: String | p != ""}) : Unit :=
+    let 1 w0 := open_writer path in
+    let payload := payload_from_string "hello" in
+    let 1 w1 := write payload w0 in
+    close w1;
+
+def main (args: Int) : Unit := print "ok"

--- a/tests/writer_qtt_test.py
+++ b/tests/writer_qtt_test.py
@@ -1,0 +1,85 @@
+"""QTT / refinement tests for Writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aeon.facade.api import (
+    LinearityError,
+    LinearUnusedError,
+    LiquidTypeCheckingFailedRelation,
+)
+from aeon.facade.driver import AeonConfig, AeonDriver
+from aeon.logger.logger import setup_logger
+from aeon.synthesis.uis.api import SilentSynthesisUI
+
+
+def _parse(source: str):
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    return list(AeonDriver(cfg).parse(aeon_code=source))
+
+
+def _errors(source: str):
+    return _parse(source)
+
+
+def _linearity_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LinearityError)]
+
+
+def _liquid_errors(source: str):
+    return [e for e in _parse(source) if isinstance(e, LiquidTypeCheckingFailedRelation)]
+
+
+MAIN = """
+def main (args: Int) : Unit := print "ok";
+"""
+
+
+def test_writer_lifecycle_typechecks():
+    src = (
+        """
+open Writer
+def write_once (path: {p: String | p != ""}) : Unit :=
+    let 1 w0 := open_writer path in
+    let payload := payload_from_string "hello" in
+    let 1 w1 := write payload w0 in
+    close w1;
+"""
+        + MAIN
+    )
+    assert _errors(src) == []
+
+
+def test_writer_unclosed_is_rejected():
+    src = (
+        """
+open Writer
+def leak (path: {p: String | p != ""}) : Unit :=
+    let 1 w := open_writer path in
+    print "ignored";
+"""
+        + MAIN
+    )
+    assert any(isinstance(e, LinearUnusedError) for e in _linearity_errors(src))
+
+
+def test_writer_empty_path_is_rejected():
+    src = (
+        """
+open Writer
+def bad (u: Unit) : Unit :=
+    let 1 w0 := open_writer "" in
+    close w0;
+"""
+        + MAIN
+    )
+    assert _liquid_errors(src) != []
+
+
+def test_writer_example_typechecks():
+    example = Path(__file__).parents[1] / "examples" / "imports" / "writer_example.ae"
+    setup_logger()
+    cfg = AeonConfig(synthesizer="enumerative", synthesis_ui=SilentSynthesisUI(), synthesis_budget=0, no_main=True)
+    assert AeonDriver(cfg).parse(filename=str(example)) == []


### PR DESCRIPTION
## Summary
- Add `Writer.ae`: linear open → write* → close for binary files, with `bytes_written` / `payload_len` ghosts.
- Include example, QTT tests (leak and empty-path rejected), and docs updates.

## Test plan
- [x] `uv run pytest tests/writer_qtt_test.py -q`
- [x] `uv run python -m aeon --no-main examples/imports/writer_example.ae`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)