### PR TITLE
Add HUMIES 2026 Grover-circuit synthesis example (Obidiegwu et al., GECCO'26)

### DIFF
--- a/examples/synthesis/grover/grover_circuits.ae
+++ b/examples/synthesis/grover/grover_circuits.ae
@@ -1,0 +1,80 @@
+# Evolving hardware-efficient Grover circuits --- the 2026 HUMIES Bronze result.
+#
+# From Obidiegwu, Mota Dias, Obidiegwu & Ryan, "Evolving Hardware-Efficient
+# Grover Circuits with Grammatical Evolution" (GECCO 2026; Bronze, 2026 Human-
+# Competitive awards). The paper evolves state-specific 3-qubit Grover-like
+# circuits with grammatical evolution: instead of the textbook oracle+diffuser
+# construction, the search is free to compose gates from a hardware-native set
+# and routinely discovers far shallower circuits that concentrate probability
+# on the marked basis state. Reference code: github.com/Caephas/GE-for-Grover.
+#
+# As in the paper's grammar, every candidate starts from |000> with a fixed
+# Hadamard layer on all three qubits (Grover's uniform-superposition setup);
+# the synthesised part is the gate sequence applied after that layer. The gate
+# set is the paper's non-parameterised core: x, y, z, h, s, sdg, t, tdg, cx,
+# cz, ccx (on 3 qubits the Toffoli's controls are just the non-target qubits).
+#
+# Scoring follows the paper's minimised scalar fitness (tournament mode):
+#
+#   fitness = 10 * miss + (1 - P_target) + 0.02 * gate_count
+#   miss    = 1 if P_target < 0.48 else 0
+#
+# with P_target the probability of measuring the marked state. The paper runs
+# noiseless Qiskit simulations (10k shots) and validates on ibm_torino; here
+# P_target is the exact statevector probability from grover_sim.py, a pure-
+# Python 8-amplitude simulator, so nothing beyond the repository is needed.
+# This is a noiseless reimplementation/demo, not a hardware replication.
+#
+# Run from the repository root with, e.g.:
+#   uv run python -m aeon --budget 30 -s gp examples/synthesis/grover/grover_circuits.ae
+
+open Circuit
+
+# A circuit is the gate sequence applied (left to right) after the fixed
+# initial Hadamard layer. Qubit indices follow Qiskit's little-endian
+# convention: bit i of a basis-state index is qubit i.
+inductive Circuit
+| g_end : Circuit
+| g_x   (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_y   (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_z   (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_h   (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_s   (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_sdg (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_t   (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_tdg (q: Int | q >= 0 && q <= 2) (rest: Circuit) : Circuit
+| g_cx  (cq: Int | cq >= 0 && cq <= 2) (tq: Int | tq >= 0 && tq <= 2) (rest: Circuit) : Circuit
+| g_cz  (cq: Int | cq >= 0 && cq <= 2) (tq: Int | tq >= 0 && tq <= 2) (rest: Circuit) : Circuit
+| g_ccx (tq: Int | tq >= 0 && tq <= 2) (rest: Circuit) : Circuit
+
+# The marked basis state (0..7). 0 is |000>; change it to evolve a circuit for
+# any other target, e.g. 6 marks |110> (qubit 2 = 1, qubit 1 = 1, qubit 0 = 0).
+def target_state : Int := 0;
+
+# The paper's minimised scalar fitness, from exact noiseless simulation.
+# gate_count includes the 3 fixed initial Hadamards, so for target 0 the
+# optimum is 0.12: a second H layer (3 gates) maps the superposition back to
+# |000> with P_target = 1, i.e. 10*0 + (1 - 1) + 0.02 * 6.
+def grover_fitness (c: Circuit) (target: Int) : Float :=
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/grover'), __import__('grover_sim').fitness(c, target))[1]";
+
+# Exact probability of measuring the target state, to inspect a solution.
+def p_target (c: Circuit) (target: Int) : Float :=
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/grover'), __import__('grover_sim').p_target(c, target))[1]";
+
+# (a) Synthesis: evolve the gate sequence, minimising the paper's fitness.
+# The helpers are shadowed by `unit` inside the hole so they are not offered
+# as synthesis building blocks (only Circuit constructors and Ints are).
+@minimize_float(grover_fitness circuit target_state)
+def circuit : Circuit :=
+    (let target_state := unit in
+     let grover_fitness := unit in
+     let p_target := unit in
+     let circuit_solution := unit in
+     ?hole);
+
+# (b) A known shallow optimum for target 0 (fitness 0.12, P_target = 1):
+# H is self-inverse, so a second Hadamard layer undoes the fixed one. This is
+# exactly the kind of hardware-efficient shortcut the paper's evolved circuits
+# exploit instead of the textbook oracle+diffuser Grover iteration.
+def circuit_solution : Circuit := g_h 0 (g_h 1 (g_h 2 g_end));

--- a/examples/synthesis/grover/grover_sim.py
+++ b/examples/synthesis/grover/grover_sim.py
@@ -1,0 +1,135 @@
+"""Native helpers for the Aeon HUMIES-2026 Grover-circuit benchmark.
+
+Noiseless 3-qubit statevector simulation and the scalar fitness of
+
+    Obidiegwu, Mota Dias, Obidiegwu & Ryan, "Evolving Hardware-Efficient
+    Grover Circuits with Grammatical Evolution", GECCO 2026
+    (2026 HUMIES Bronze; reference code: github.com/Caephas/GE-for-Grover).
+
+The paper evolves state-specific 3-qubit Grover-like circuits with GE and
+scores them (tournament mode, run_experiment.py of the reference code) by the
+minimised scalar
+
+    fitness = 10 * miss + (1 - P_target) + GATE_PENALTY_WEIGHT * gate_count
+    miss    = 1 if P_target < SUCCESS_THRESHOLD (0.48) else 0
+
+where P_target is the probability of measuring the target basis state. As in
+the paper's grammar, every circuit starts from |000> with a fixed Hadamard
+layer on all three qubits (Grover's uniform-superposition setup); only the
+gates after that layer are evolved. Here P_target is the *exact* statevector
+probability (the paper samples 10k shots on Qiskit's noiseless AerSimulator,
+which converges to the same value), so no Qiskit dependency is needed: a
+3-qubit state is just 8 complex amplitudes, simulated in pure Python.
+
+A Circuit value arrives from Aeon as nested tuples (one per gate, ending in
+the terminator), e.g. H(0); CX(0,1) is
+
+    ('Circuit_g_h', 0, ('Circuit_g_cx', 0, 1, ('Circuit_g_end',)))
+
+Qubit/bit convention (Qiskit little-endian): bit q of a basis-state index is
+qubit q, so target 6 = 0b110 means qubit 2 = 1, qubit 1 = 1, qubit 0 = 0.
+"""
+
+import cmath
+import math
+
+N_QUBITS = 3
+DIM = 1 << N_QUBITS
+
+SUCCESS_THRESHOLD = 0.48  # paper: miss if P_target below this
+GATE_PENALTY_WEIGHT = 0.02  # paper: lambda, per-gate parsimony pressure
+
+# A synthesised gate sequence can be arbitrarily long; evaluation is linear in
+# its length, so a generous cap keeps a single fitness call bounded without
+# affecting realistic candidates (the paper's circuits are tens of gates).
+MAX_GATES = 1024
+
+_H = 1 / math.sqrt(2)
+_SINGLE_QUBIT_GATES = {
+    "x": ((0, 1), (1, 0)),
+    "y": ((0, -1j), (1j, 0)),
+    "z": ((1, 0), (0, -1)),
+    "h": ((_H, _H), (_H, -_H)),
+    "s": ((1, 0), (0, 1j)),
+    "sdg": ((1, 0), (0, -1j)),
+    "t": ((1, 0), (0, cmath.exp(1j * math.pi / 4))),
+    "tdg": ((1, 0), (0, cmath.exp(-1j * math.pi / 4))),
+}
+
+
+def _apply_single(state, q, m):
+    """Apply a 2x2 unitary m to qubit q of the 8-amplitude state, in place."""
+    bit = 1 << q
+    for i in range(DIM):
+        if not i & bit:
+            a0, a1 = state[i], state[i | bit]
+            state[i] = m[0][0] * a0 + m[0][1] * a1
+            state[i | bit] = m[1][0] * a0 + m[1][1] * a1
+
+
+def _gate_list(circuit):
+    """Flatten the Aeon Circuit tuple chain into [(gate_name, args)]."""
+    gates = []
+    node = circuit
+    while node[0] != "Circuit_g_end" and len(gates) < MAX_GATES:
+        gates.append((node[0].removeprefix("Circuit_g_"), node[1:-1]))
+        node = node[-1]
+    return gates
+
+
+def simulate(circuit):
+    """Run the fixed Hadamard layer + evolved gates; return (state, gate_count).
+
+    gate_count includes the 3 fixed initial Hadamards, matching the paper's
+    whole-circuit gate count. A two-qubit gate whose control and target
+    coincide is a no-op but still counts, so parsimony pressure steers the
+    search away from degenerate gates.
+    """
+    state = [0j] * DIM
+    state[0] = 1 + 0j
+    for q in range(N_QUBITS):
+        _apply_single(state, q, _SINGLE_QUBIT_GATES["h"])
+
+    gates = _gate_list(circuit)
+    for name, args in gates:
+        if name in _SINGLE_QUBIT_GATES:
+            _apply_single(state, args[0], _SINGLE_QUBIT_GATES[name])
+        elif name == "cx":
+            c, t = args
+            if c != t:
+                cbit, tbit = 1 << c, 1 << t
+                for i in range(DIM):
+                    if i & cbit and not i & tbit:
+                        state[i], state[i | tbit] = state[i | tbit], state[i]
+        elif name == "cz":
+            c, t = args
+            if c != t:
+                both = (1 << c) | (1 << t)
+                for i in range(DIM):
+                    if i & both == both:
+                        state[i] = -state[i]
+        elif name == "ccx":
+            # On 3 qubits the two controls are simply the non-target qubits.
+            (t,) = args
+            tbit = 1 << t
+            controls = (DIM - 1) & ~tbit
+            for i in range(DIM):
+                if i & controls == controls and not i & tbit:
+                    state[i], state[i | tbit] = state[i | tbit], state[i]
+        else:
+            raise ValueError(f"unknown gate constructor: {name}")
+    return state, N_QUBITS + len(gates)
+
+
+def p_target(circuit, target):
+    """Exact probability of measuring basis state `target` (0..7)."""
+    state, _ = simulate(circuit)
+    return abs(state[target]) ** 2
+
+
+def fitness(circuit, target):
+    """The paper's minimised scalar fitness (0.12 is optimal for target 0)."""
+    state, gate_count = simulate(circuit)
+    p = abs(state[target]) ** 2
+    miss = 1 if p < SUCCESS_THRESHOLD else 0
+    return 10 * miss + (1 - p) + GATE_PENALTY_WEIGHT * gate_count


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Add HUMIES 2026 Grover-circuit synthesis example

Recreates the 2026 HUMIES **Bronze** result — [Obidiegwu, Mota Dias, Obidiegwu & Ryan, "Evolving Hardware-Efficient Grover Circuits with Grammatical Evolution" (GECCO 2026)](https://gpbib.cs.ucl.ac.uk/gp-html/Obidiegwu_2026_GECCO.html) ([paper PDF](https://www.egr.msu.edu/~goodman/HumiesEntries2026/Obidiegwu/Paper.pdf), [reference code](https://github.com/Caephas/GE-for-Grover)) — as an Aeon GP synthesis example. This is a noiseless reimplementation/demo of the paper's search problem, not a hardware replication (no Qiskit, no IBM QPU, no network).

## Files added

- `examples/synthesis/grover/grover_circuits.ae` — the benchmark: an inductive `Circuit` type encoding a gate sequence over the paper's non-parameterised gate set (`x y z h s sdg t tdg cx cz ccx`, qubit indices constrained to `0..2` by refinement types), a `@minimize_float` hole for the evolved gate sequence, and a known shallow optimum for reference. As in the paper's grammar, every candidate starts from |000⟩ with a fixed Hadamard layer; the synthesized part is the gate sequence after that layer. The target basis state is `target_state` (0 = |000⟩; any of 0..7 works).
- `examples/synthesis/grover/grover_sim.py` — native scoring helper (same pattern as `examples/synthesis/csg/csg_metric.py`): a pure-Python 8-amplitude statevector simulator plus the paper's minimised scalar fitness, `10 * miss + (1 − P_target) + 0.02 * gate_count` with `miss = 1` iff `P_target < 0.48`. `P_target` is the exact statevector probability (the paper's 10k-shot noiseless Aer estimate converges to the same value), so nothing beyond the repository is needed — no Qiskit dependency.

## How to run

```bash
uv run python -m aeon --budget 30 -s gp examples/synthesis/grover/grover_circuits.ae
```

## Results

A 90 s budget run reproducibly evolves `h 2; tdg 2; h 0; h 1` for target |000⟩: **P_target = 1.0 exactly** (the `tdg` acts on a qubit already in |0⟩, so it is a no-op), 7 total gates, fitness **0.14** — one redundant gate away from the global optimum 0.12 (a bare second Hadamard layer). This mirrors the paper's headline finding: evolution discovers far shallower state-preparation circuits than the textbook oracle+diffuser Grover construction (one canonical Grover iteration scores P = 25/32 ≈ 0.78 with 27 gates, fitness ≈ 0.76).

```
# best t=0.2s/90s fitness [10.89]
# best t=27.7s/90s fitness [0.64]
# best t=65.4s/90s fitness [0.14]
Synthesized holes:
?hole: Circuit_g_h 2 (Circuit_g_tdg 2 (Circuit_g_h 0 (Circuit_g_h 1 Circuit_g_end)))
```

## Verification

- Simulator validated standalone against known quantum results: double-H layer returns to |000⟩ (P = 1), one canonical Grover iteration for |000⟩ gives exactly P = 25/32, CCX truth table, unitarity of `s/sdg/t/tdg/cz`, degenerate `cx(q,q)` treated as a counted no-op.
- The Aeon↔Python FFI marshalling checked by evaluating the known solution through `native` (P = 1.0, fitness = 0.12).
- `pre-commit run --all-files` passes.
- CI unaffected: `run_examples.sh` only walks `examples/synthesis/*.ae` (not subfolders other than `image_edits`), following the existing `csg/` precedent for examples with Python helpers. A CI-style smoke run (`--no-main --budget 10`) nonetheless exits 0.

## Out of scope (as specified)

Real QPU execution (ibm_torino), the Berghegger visual-control bronze, and the AutoNumerics-Zero gold.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d866a8b-c795-43ae-b84b-c1acd936b9c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d866a8b-c795-43ae-b84b-c1acd936b9c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

