### PR TITLE
Add HUMIES 2026 Gold AutoNumerics-Zero exp2 synthesis example (Real et al., ICML 2026)

### DIFF
--- a/examples/synthesis/autonumerics/exp2_free.ae
+++ b/examples/synthesis/autonumerics/exp2_free.ae
@@ -21,7 +21,7 @@
 # encoding and typically improves from a random baseline (constant guesses
 # score ~5e-1) toward small-error expressions such as 1.0 + x (~6.1e-2, cf.
 # the paper's 2-operation f2 at ~4.1e-2). See exp2_pade.ae for the
-# coefficient-only variant, which gets much further under a small budget.
+# coefficient-only variant on a fixed f3-shaped skeleton.
 #
 # Run from the repository root with, e.g.:
 #   uv run python -m aeon --budget 30 -s gp examples/synthesis/autonumerics/exp2_free.ae

--- a/examples/synthesis/autonumerics/exp2_free.ae
+++ b/examples/synthesis/autonumerics/exp2_free.ae
@@ -1,0 +1,61 @@
+# Rediscovering finite approximations of 2^x --- AutoNumerics-Zero, HUMIES 2026 Gold.
+#
+# From Real et al., "AutoNumerics-Zero: Automated Discovery of State-of-the-Art
+# Mathematical Functions" (ICML 2026; arXiv:2312.08472; Gold, 2026 Human-
+# Competitive awards; code: github.com/google-deepmind/autonumerics_zero).
+# The paper evolves, from empty code, programs over {+, -, *, /}, float
+# constants and the input x that approximate 2^x on (0, 1] (all reals via
+# range reduction), minimising maximum relative error and operation count.
+# Its 10-operation champion f10 reaches ~14 significant figures -- see
+# exp2_reference.ae for f10 and smaller programs transliterated into Aeon.
+#
+# This file is the free-form search demo, in the paper's spirit: the hole is
+# an arbitrary Float -> Float expression built from arithmetic, constants and
+# x, scored by max relative error against 2^x on 128 points of (0, 1]
+# (exp2_metric.py; failures such as division by zero score a large penalty).
+#
+# Honest scope note: the paper's full search used distributed dNSGA-II with
+# CMA-ES coefficient optimisation over thousands of CPU-core-days, plus
+# interval-arithmetic (IBEX) proofs of the resulting error bounds. A
+# --budget 30 run here will NOT rediscover f10; it demonstrates the problem
+# encoding and typically improves from a random baseline (constant guesses
+# score ~5e-1) toward small-error expressions such as 1.0 + x (~6.1e-2, cf.
+# the paper's 2-operation f2 at ~4.1e-2). See exp2_pade.ae for the
+# coefficient-only variant, which gets much further under a small budget.
+#
+# Run from the repository root with, e.g.:
+#   uv run python -m aeon --budget 30 -s gp examples/synthesis/autonumerics/exp2_free.ae
+
+# Fitness: maximum relative error of a candidate against 2^x over 128 uniform
+# points of (0, 1] -- the paper's accuracy objective, on a sampled grid. The
+# candidate's parameter is an unrefined Float (like the other SR benchmarks):
+# the metric only ever feeds it values from (0, 1], and refining it would stop
+# the GP grammar from offering `x` as a building block.
+def exp2_mre (func: (y:Float) -> Float) : Float :=
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/autonumerics'), __import__('exp2_metric').max_rel_error(func))[1]";
+
+# Report-quality variant on a dense grid (20k uniform + 2k log-spaced points),
+# accepting domain-refined functions such as exp2_f2 below.
+def exp2_mre_dense (func: (y:{v:Float | 0.0 < v && v <= 1.0}) -> Float) : Float :=
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/autonumerics'), __import__('exp2_metric').mre_dense(func))[1]";
+
+# (a) Synthesis: evolve the expression. The helpers (and the known solution)
+# are shadowed by `unit` inside the hole so the search builds candidates only
+# from arithmetic, float constants and x.
+@minimize_float(exp2_mre synth)
+def synth (x: Float) : Float :=
+    (let exp2_mre := unit in
+     let exp2_mre_dense := unit in
+     let exp2_f2 := unit in
+     ?hole);
+
+# (b) A known small solution: the paper's 2-operation program f2 (Figure 11),
+# max relative error ~4.1e-2 on the dense grid. Its division is proven safe
+# on the domain by the liquid typechecker: from 0 < x <= 1 it follows that
+# c2 + x is in (-2.05, -1.04], which never hits zero.
+def exp2_f2 (x: Float | 0.0 < x && x <= 1.0) : Float :=
+    c1 := -2.1258595374472384;
+    c2 := -2.0413845597733418;
+    x1 := c2 + x;
+    x2 := c1 / x1;
+    x2;

--- a/examples/synthesis/autonumerics/exp2_metric.py
+++ b/examples/synthesis/autonumerics/exp2_metric.py
@@ -81,19 +81,23 @@ def mre_dense(func):
 
 
 def pade_mre(a, b, c):
-    """Fitness of the fixed [0/1] Pade skeleton  a / (1 + b*x) + c.
+    """Fitness of the fixed [0/1] Pade skeleton  a*a / (1 + b*x) + c.
 
     This is the shape of the paper's evolved 3-operation program f3 (Figure
     11) -- a reciprocal plus a constant -- renormalised so the optimal
-    coefficients (~2.44, ~-0.29, ~-1.44) fit inside the +-5.12 search box of
-    Aeon's ``ng_float`` synthesizer. Evaluated natively (no Aeon interpreter
-    in the loop), so the full fitness grid costs microseconds per candidate.
-    A candidate whose pole 1 + b*x hits zero on the grid scores PENALTY via
-    ``max_rel_error``'s guard.
+    coefficients (~1.56, ~-0.29, ~-1.44) fit inside the +-5.12 search box of
+    Aeon's ``ng_float`` synthesizer. The numerator is parameterised as ``a*a``
+    (a constant fold: at runtime the program is still 3 operations): keeping
+    it positive removes a spurious sign-symmetric local optimum with a
+    negative numerator -- approximating the increasing 2^x needs an
+    increasing reciprocal branch.
+    Evaluated natively (no Aeon interpreter in the loop), so the full fitness
+    grid costs microseconds per candidate. A candidate whose pole 1 + b*x
+    hits zero on the grid scores PENALTY via ``max_rel_error``'s guard.
     """
-    return max_rel_error(lambda x: a / (1.0 + b * x) + c)
+    return max_rel_error(lambda x: (a * a) / (1.0 + b * x) + c)
 
 
 def pade_mre_dense(a, b, c):
     """Dense-grid error of the Pade skeleton, for reporting."""
-    return mre_dense(lambda x: a / (1.0 + b * x) + c)
+    return mre_dense(lambda x: (a * a) / (1.0 + b * x) + c)

--- a/examples/synthesis/autonumerics/exp2_metric.py
+++ b/examples/synthesis/autonumerics/exp2_metric.py
@@ -1,0 +1,99 @@
+"""Native helpers for the Aeon AutoNumerics-Zero exp2 example.
+
+Implements the evaluation metric of Real, Rossini, de Souza, Garg, Firsching,
+Le, Chen, Verghese, Cubuk & Park, "AutoNumerics-Zero: Automated Discovery of
+State-of-the-Art Mathematical Functions" (ICML 2026; arXiv:2312.08472; Gold,
+2026 Human-Competitive "HUMIES" awards; code:
+github.com/google-deepmind/autonumerics_zero): the paper searches, with
+symbolic regression over {+, -, *, /}, float constants and the input x, for
+finite-precision programs approximating the exponential 2**x on the domain
+(0, 1] (extendable to all reals via standard range reduction), minimising the
+maximum relative error together with the number of operations.
+
+Its headline result is a 10-operation program ("f10", Figure 11 of the paper)
+whose maximum relative error is proven below ~5.4e-15 -- about 14 significant
+figures, beating previously known same-size approximations by more than 6
+orders of magnitude.
+
+Everything here is a plain-Python reimplementation of the *metric* only.  The
+paper proves its error bounds with interval arithmetic (IBEX) and additionally
+optimises float32 speed on hardware via JAX/XLA; neither is reproduced.
+Errors below are measured by sampling a dense float64 grid, which is fine for
+a demo but is a measurement, not a proof.
+"""
+
+import math
+
+# Per-candidate fitness grid.  Kept modest because free-form candidates are
+# interpreted Aeon closures, so every extra point costs an interpreter call
+# inside the synthesiser's inner loop.
+FITNESS_POINTS = 128
+
+# Verification grid for reporting the error of known programs: dense uniform
+# samples of (0, 1] plus log-spaced points down to 1e-8, probing the x -> 0+
+# end of the domain where the reciprocal-based programs are most delicate.
+DENSE_POINTS = 20000
+DENSE_LOG_POINTS = 2000
+
+# Score for candidates that crash (division by zero), overflow to inf, or
+# produce nan: large enough to dominate any real error, finite so the
+# genetic-programming backend can still rank individuals.
+PENALTY = 1.0e9
+
+
+def _uniform_grid(n):
+    return [i / n for i in range(1, n + 1)]
+
+
+def _dense_grid():
+    log_pts = [10.0 ** (-8.0 + 8.0 * i / DENSE_LOG_POINTS) for i in range(DENSE_LOG_POINTS)]
+    return log_pts + _uniform_grid(DENSE_POINTS)
+
+
+def max_rel_error(func, grid=None):
+    """Maximum relative error of candidate ``func`` against 2**x on (0, 1].
+
+    ``func`` is a candidate from open-ended search: it may divide by zero,
+    overflow, or return nan, so failures score PENALTY (steering the search
+    away) instead of crashing the synthesiser.  The relative-error denominator
+    2**x lies in (1, 2] on this domain, so the metric itself is total.
+    """
+    if grid is None:
+        grid = _uniform_grid(FITNESS_POINTS)
+    worst = 0.0
+    for x in grid:
+        try:
+            y = float(func(x))
+        except (ArithmeticError, ValueError):
+            return PENALTY
+        if not math.isfinite(y):
+            return PENALTY
+        target = 2.0**x
+        err = abs(y - target) / target
+        if err > worst:
+            worst = err
+    return worst
+
+
+def mre_dense(func):
+    """``max_rel_error`` on the dense verification grid (report-quality)."""
+    return max_rel_error(func, _dense_grid())
+
+
+def pade_mre(a, b, c):
+    """Fitness of the fixed [0/1] Pade skeleton  a / (1 + b*x) + c.
+
+    This is the shape of the paper's evolved 3-operation program f3 (Figure
+    11) -- a reciprocal plus a constant -- renormalised so the optimal
+    coefficients (~2.44, ~-0.29, ~-1.44) fit inside the +-5.12 search box of
+    Aeon's ``ng_float`` synthesizer. Evaluated natively (no Aeon interpreter
+    in the loop), so the full fitness grid costs microseconds per candidate.
+    A candidate whose pole 1 + b*x hits zero on the grid scores PENALTY via
+    ``max_rel_error``'s guard.
+    """
+    return max_rel_error(lambda x: a / (1.0 + b * x) + c)
+
+
+def pade_mre_dense(a, b, c):
+    """Dense-grid error of the Pade skeleton, for reporting."""
+    return mre_dense(lambda x: a / (1.0 + b * x) + c)

--- a/examples/synthesis/autonumerics/exp2_pade.ae
+++ b/examples/synthesis/autonumerics/exp2_pade.ae
@@ -1,0 +1,49 @@
+# Coefficient search for a 2^x Pade approximant --- AutoNumerics-Zero, HUMIES 2026 Gold.
+#
+# From Real et al., "AutoNumerics-Zero: Automated Discovery of State-of-the-Art
+# Mathematical Functions" (ICML 2026; arXiv:2312.08472; Gold, 2026 Human-
+# Competitive awards; code: github.com/google-deepmind/autonumerics_zero).
+# The paper alternates structural evolution with CMA-ES optimisation of each
+# program's float constants. This file demonstrates the *coefficient* half on
+# a fixed skeleton: the shape of the paper's evolved 3-operation program f3
+# (Figure 11), a reciprocal plus a constant, renormalised to
+#
+#     g(x) = a / (1 + b*x) + c
+#
+# so that the optimal coefficients fit the +-5.12 search box of Aeon's
+# ng_float backend (joint Nevergrad optimisation of all Float holes -- the
+# same family of optimisers, including CMA-ES via -s ng_float_cma, that the
+# paper uses for its constants). Fitness is the paper's accuracy objective:
+# maximum relative error against 2^x, sampled on 128 points of (0, 1]
+# (exp2_metric.py). Best reachable on this skeleton: ~1.1e-3, i.e. the
+# accuracy of the paper's f3. A --budget 30 run typically lands at ~1e-3.
+#
+# exp2_reference.ae holds the paper's own programs (down to the 10-operation,
+# ~5e-15 champion f10); exp2_free.ae is the free-form structural search.
+#
+# Requires the optional nevergrad backend (uv pip install -e ".[synthesis-ng]").
+# Run from the repository root with, e.g.:
+#   uv run python -m aeon --budget 30 -s ng_float examples/synthesis/autonumerics/exp2_pade.ae
+
+# Max relative error of the skeleton a / (1 + b*x) + c against 2^x on (0, 1],
+# evaluated natively (a pole on the grid scores a large penalty).
+def pade_mre (a:Float) (b:Float) (c:Float) : Float :=
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/autonumerics'), __import__('exp2_metric').pade_mre(a, b, c))[1]";
+
+# Dense-grid variant (20k uniform + 2k log-spaced points), for reporting.
+def pade_mre_dense (a:Float) (b:Float) (c:Float) : Float :=
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/autonumerics'), __import__('exp2_metric').pade_mre_dense(a, b, c))[1]";
+
+# (a) Synthesis: the three coefficients, jointly optimised by ng_float.
+def pa : Float := ?ha;
+def pb : Float := ?hb;
+def pc : Float := ?hc;
+
+@minimize_float(pade_mre pa pb pc)
+def pade_error : Float := pade_mre pa pb pc;
+
+# (b) The known solution: the paper's f3 constants mapped onto this skeleton
+# (a = c1/c3, b = 1/c3, c = -c2 of exp2_reference.ae's exp2_f3), max relative
+# error ~1.2e-3 on the dense grid.
+def pade_solution_error : Float :=
+    pade_mre_dense 2.441497375643565 (-0.2910765369491663) (-1.4427239805682266);

--- a/examples/synthesis/autonumerics/exp2_pade.ae
+++ b/examples/synthesis/autonumerics/exp2_pade.ae
@@ -8,15 +8,22 @@
 # a fixed skeleton: the shape of the paper's evolved 3-operation program f3
 # (Figure 11), a reciprocal plus a constant, renormalised to
 #
-#     g(x) = a / (1 + b*x) + c
+#     g(x) = a*a / (1 + b*x) + c
 #
 # so that the optimal coefficients fit the +-5.12 search box of Aeon's
 # ng_float backend (joint Nevergrad optimisation of all Float holes -- the
 # same family of optimisers, including CMA-ES via -s ng_float_cma, that the
-# paper uses for its constants). Fitness is the paper's accuracy objective:
-# maximum relative error against 2^x, sampled on 128 points of (0, 1]
-# (exp2_metric.py). Best reachable on this skeleton: ~1.1e-3, i.e. the
-# accuracy of the paper's f3. A --budget 30 run typically lands at ~1e-3.
+# paper uses for its constants). The numerator is written a*a -- a constant
+# fold, so the runtime program is still 3 operations -- because keeping it
+# positive removes a spurious sign-symmetric local optimum (see
+# exp2_metric.py). Fitness is the paper's accuracy objective: maximum
+# relative error against 2^x, sampled on 128 points of (0, 1]
+# (exp2_metric.py). The skeleton's optimum is ~1e-3 -- the accuracy of the
+# paper's f3 -- pinned by the known solution below. A --budget 30-120 run
+# reliably improves random coefficients (error >= 5e-1) to a few times 1e-2,
+# i.e. the accuracy of the paper's 2-operation f2; occasional runs reach the
+# ~1e-3 optimum. (Nevergrad's NGOpt has unseeded internal randomness, so
+# results vary between runs even with the same AEON_SEED.)
 #
 # exp2_reference.ae holds the paper's own programs (down to the 10-operation,
 # ~5e-15 champion f10); exp2_free.ae is the free-form structural search.
@@ -25,8 +32,8 @@
 # Run from the repository root with, e.g.:
 #   uv run python -m aeon --budget 30 -s ng_float examples/synthesis/autonumerics/exp2_pade.ae
 
-# Max relative error of the skeleton a / (1 + b*x) + c against 2^x on (0, 1],
-# evaluated natively (a pole on the grid scores a large penalty).
+# Max relative error of the skeleton a*a / (1 + b*x) + c against 2^x on
+# (0, 1], evaluated natively (a pole on the grid scores a large penalty).
 def pade_mre (a:Float) (b:Float) (c:Float) : Float :=
     native "(__import__('sys').path.insert(0, 'examples/synthesis/autonumerics'), __import__('exp2_metric').pade_mre(a, b, c))[1]";
 
@@ -43,7 +50,7 @@ def pc : Float := ?hc;
 def pade_error : Float := pade_mre pa pb pc;
 
 # (b) The known solution: the paper's f3 constants mapped onto this skeleton
-# (a = c1/c3, b = 1/c3, c = -c2 of exp2_reference.ae's exp2_f3), max relative
-# error ~1.2e-3 on the dense grid.
+# (a = sqrt(c1/c3), b = 1/c3, c = -c2 of exp2_reference.ae's exp2_f3), max
+# relative error ~1.2e-3 on the dense grid.
 def pade_solution_error : Float :=
-    pade_mre_dense 2.441497375643565 (-0.2910765369491663) (-1.4427239805682266);
+    pade_mre_dense 1.5625291599338442 (-0.2910765369491663) (-1.4427239805682266);

--- a/examples/synthesis/autonumerics/exp2_reference.ae
+++ b/examples/synthesis/autonumerics/exp2_reference.ae
@@ -1,0 +1,106 @@
+# AutoNumerics-Zero reference approximations of 2^x --- the 2026 HUMIES Gold result.
+#
+# From Real, Rossini, de Souza, Garg, Firsching, Le, Chen, Verghese, Cubuk &
+# Park, "AutoNumerics-Zero: Automated Discovery of State-of-the-Art
+# Mathematical Functions" (ICML 2026; arXiv:2312.08472; Gold, 2026 Human-
+# Competitive awards; code: github.com/google-deepmind/autonumerics_zero).
+# Starting from empty code, their symbolic-regression search over {+, -, *, /},
+# float constants and the input x discovered finite-precision programs
+# approximating 2^x on (0, 1] (extendable to all reals via range reduction).
+# The headline discovery is the 10-operation program f10 below, whose maximum
+# relative error is proven below ~5.4e-15 (~14 significant figures) -- more
+# than 6 orders of magnitude better than previously known approximations of
+# the same size.
+#
+# This file transliterates the paper's evolved programs f2, f3, f5 and f10
+# (Figure 11) into Aeon, constants verbatim, and measures each one's maximum
+# relative error against 2^x on a dense float64 grid over (0, 1] (uniform +
+# log-spaced points down to 1e-8; see exp2_metric.py). Expected output, in
+# program order:
+#
+#   f2  (2 ops)  ~ 4.1e-02
+#   f3  (3 ops)  ~ 1.2e-03
+#   f5  (5 ops)  ~ 6.3e-06
+#   f10 (10 ops) ~ 4.9e-15    (the paper's proven bound is ~5.4e-15; sampling
+#                              a float64 grid measures, but does not prove it)
+#
+# A bonus over the Python original: each program's input is refined to the
+# paper's domain, {v:Float | 0.0 < v && v <= 1.0}, and Aeon's liquid
+# typechecker discharges every division's nonzero-denominator obligation from
+# that refinement alone -- e.g. in f10 it proves c2 + c1/(x + c3/x) + x + c3/x
+# is never zero on the domain. The programs are verified division-safe, not
+# just observed to be.
+#
+# This file has no synthesis hole: it is the ground-truth companion to the
+# search demos exp2_free.ae and exp2_pade.ae. Run from the repository root:
+#
+#   uv run python -m aeon examples/synthesis/autonumerics/exp2_reference.ae
+
+# Maximum relative error against 2^x on the dense verification grid.
+def exp2_mre_dense (f: (y:{v:Float | 0.0 < v && v <= 1.0}) -> Float) : Float :=
+    native "(__import__('sys').path.insert(0, 'examples/synthesis/autonumerics'), __import__('exp2_metric').mre_dense(f))[1]";
+
+# f2 (2 operations): a single reciprocal already beats the truncated Taylor
+# series of the same size.
+def exp2_f2 (x: Float | 0.0 < x && x <= 1.0) : Float :=
+    c1 := -2.1258595374472384;
+    c2 := -2.0413845597733418;
+    x1 := c2 + x;
+    x2 := c1 / x1;
+    x2;
+
+# f3 (3 operations): reciprocal plus a constant (a [0/1] Pade-like form).
+def exp2_f3 (x: Float | 0.0 < x && x <= 1.0) : Float :=
+    c1 := -8.387819235563974;
+    c2 := 1.4427239805682266;
+    c3 := -3.4355225277901402;
+    x1 := c3 + x;
+    x2 := c1 / x1;
+    x3 := x2 - c2;
+    x3;
+
+# f5 (5 operations): a continued-fraction-like form appears (c1 / x nested
+# inside another reciprocal).
+def exp2_f5 (x: Float | 0.0 < x && x <= 1.0) : Float :=
+    c1 := 25.596749740144819;
+    c2 := 17.746150088734609;
+    x1 := c1 / x;
+    c3 := -0.99999366143081858;
+    c4 := -8.8505996518073289;
+    x2 := x + x1;
+    x3 := c4 + x2;
+    x4 := c2 / x3;
+    x5 := x4 - c3;
+    x5;
+
+# f10 (10 operations): the gold-medal program. A continued fraction sharing
+# the subexpression x + c3/x, offset by c5 ~ -1, then raised to the 8th power
+# by three squarings. ~14 significant figures with 10 arithmetic operations.
+def exp2_f10 (x: Float | 0.0 < x && x <= 1.0) : Float :=
+    c1 := 15141.981176922711;
+    c2 := -250.55247494972059;
+    c3 := 5783.5330096027765;
+    x1 := c3 / x;
+    x2 := x + x1;
+    x3 := c1 / x2;
+    x4 := x3 + x2;
+    x5 := c2 + x4;
+    c4 := 501.10494991027866;
+    x6 := c4 / x5;
+    c5 := -0.99999999999999956;
+    x7 := x6 - c5;
+    x8 := x7 * x7;
+    x9 := x8 * x8;
+    x10 := x9 * x9;
+    x10;
+
+def main (args:Int) : Unit :=
+    _ := print "max relative error vs 2^x, dense float64 grid over (0,1]:";
+    _ := print "f2  (2 ops):";
+    _ := print (exp2_mre_dense exp2_f2);
+    _ := print "f3  (3 ops):";
+    _ := print (exp2_mre_dense exp2_f3);
+    _ := print "f5  (5 ops):";
+    _ := print (exp2_mre_dense exp2_f5);
+    _ := print "f10 (10 ops):";
+    print (exp2_mre_dense exp2_f10);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `examples/synthesis/autonumerics/`, a runnable Aeon recreation of the **2026 Human-Competitive (HUMIES) Gold** result: [AutoNumerics-Zero: Automated Discovery of State-of-the-Art Mathematical Functions](https://arxiv.org/abs/2312.08472) (Real et al., ICML 2026; [code](https://github.com/google-deepmind/autonumerics_zero)). The paper evolves, from empty code, programs over `{+, -, *, /}`, float constants and `x` that approximate `2^x` on `(0, 1]`; its champion is a 10-operation program (**f10**) with proven max relative error below ~5.4e-15 (~14 significant figures), beating prior same-size approximations by >6 orders of magnitude. Companion to the Bronze Grover example in #515.

## Files

- `exp2_reference.ae` — the paper's evolved programs **f2, f3, f5 and f10** (Figure 11) transliterated into Aeon, constants verbatim; `main` measures each against `2^x` on a dense float64 grid (20k uniform + 2k log-spaced points down to 1e-8). Measured: f2 `4.1e-2`, f3 `1.2e-3`, f5 `6.3e-6`, **f10 `4.88e-15`** — consistent with the paper's proven ~5.4e-15 bound (float64 sampling is a measurement, not a proof; the paper's IBEX interval proofs are out of scope, as noted in comments).
  - A liquid-types bonus over the Python original: each program's input is refined to the paper's domain `{v:Float | 0.0 < v && v <= 1.0}`, and Aeon's typechecker **discharges every division's nonzero-denominator obligation** from that refinement — e.g. it proves f10's `c2 + c1/(x + c3/x) + x + c3/x` never hits zero on the domain.
- `exp2_free.ae` — the free-form search demo in the paper's spirit: a `Float -> Float` hole over `{+, -, *, /}`, constants and `x`, minimizing max relative error on 128 points of `(0, 1]` (`@minimize_float`, koza/pagie style, helpers shadowed with `unit` inside the hole). Includes the paper's 2-op f2 as a known small solution (the `circuit_solution` pattern from #515).
- `exp2_pade.ae` — the coefficient-search half (the paper alternates structure evolution with CMA-ES constant optimisation): three `Float` holes jointly optimised by `-s ng_float` / `-s ng_float_cma` (nevergrad, optional `synthesis-ng` extra) over a fixed skeleton `a*a/(1 + b*x) + c` — the paper's f3 shape renormalised into the backend's ±5.12 box. Known solution: f3's constants mapped onto the skeleton (`1.2e-3`).
- `exp2_metric.py` — native metric helpers (same pattern as `csg/csg_metric.py`): max relative error vs `2^x` on fitness/verification grids, with penalties for candidates that divide by zero, overflow or produce NaN.

## Measured search results (honest scope)

The paper's full search used distributed dNSGA-II + CMA-ES over **thousands of CPU-core-days** plus interval-arithmetic proofs; none of that is claimed here, and short runs will not rediscover f10.

- `--budget 60 -s gp exp2_free.ae`: improves from constant guesses (~5e-1) to `x + 1.0` (**6.1e-2**, between the paper's f1 and f2) in under a second of search.
- `--budget 30 -s ng_float exp2_pade.ae`: reliably improves random coefficients to a few times 1e-2 (f2 accuracy); the captured run reached **9.4e-3**, and a lucky run reached **9.7e-4**, better on the sampled grid than the paper's own f3 (1.2e-3). Results vary between runs — nevergrad's NGOpt carries unseeded internal randomness — which the file documents.

## CI

The examples live in a subfolder, which `run_examples.sh` does not walk (same precedent as `csg/` and the `grover/` folder of #515), so CI cost and stochastic-run flakiness are unaffected. `pre-commit run --all-files` passes.

## How to run

```bash
uv run python -m aeon examples/synthesis/autonumerics/exp2_reference.ae
uv run python -m aeon --budget 30 -s gp examples/synthesis/autonumerics/exp2_free.ae
uv run python -m aeon --budget 30 -s ng_float examples/synthesis/autonumerics/exp2_pade.ae  # needs .[synthesis-ng]
```

## Future work (out of scope)

Hardware-aware float32 speed objectives (JAX/XLA), IBEX interval proofs, and the paper's other targets (cosine, Airy, Bessel, erf).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-912f52e6-5cc3-4afd-8e4e-69d7e52a777f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-912f52e6-5cc3-4afd-8e4e-69d7e52a777f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

