### PR TITLE
Optimize Horn VC checking by avoiding redundant work

### DIFF
--- a/aeon/verification/horn.py
+++ b/aeon/verification/horn.py
@@ -544,11 +544,12 @@ def weaken(assign, c: Constraint) -> Assignment:
     assert isinstance(h, LiquidHornApplication)
     assert h.name in assign
     current_rep = assign[h.name]
+    premise = apply(assign, p)
 
     def keep(q: LiquidTerm) -> bool:
         assert isinstance(h, LiquidHornApplication)
         qp = fill_horn_arguments(h, q)
-        nc = constraint_builder(vs, imp(apply(assign, p), end(qp)))
+        nc = constraint_builder(vs, imp(premise, end(qp)))
         return smt_valid(nc)
 
     qsp = [q for q in current_rep if keep(q)]
@@ -556,12 +557,14 @@ def weaken(assign, c: Constraint) -> Assignment:
 
 
 def fixpoint(cs: list[Constraint], assign) -> Assignment:
-    ncs = [c for c in cs if not smt_valid(apply(assign, c))]
-    if not ncs:
-        return assign
-    else:
-        weakened_assignment = weaken(assign, ncs[0])
-        return fixpoint(cs, weakened_assignment)
+    # Restart after weakening: subsequent clauses must see the new assignment.
+    while True:
+        for c in cs:
+            if not smt_valid(apply(assign, c)):
+                assign = weaken(assign, c)
+                break
+        else:
+            return assign
 
 
 def solve(

--- a/examples/verification/horn_tournament.ae
+++ b/examples/verification/horn_tournament.ae
@@ -1,0 +1,22 @@
+# A larger version of examples/syntax/maxI.ae: every match instantiates
+# an abstract refinement, and later rounds depend on earlier results.
+# All scores are positive; the inferred predicates must preserve that fact.
+def maxI: (x : Int<p>) -> (y : Int<p>) -> Int<p> :=
+    fun x => fun y => if x < y then y else x;
+
+def tournament
+    (a: Int | a > 0) (b: Int | b > 0)
+    (c: Int | c > 0) (d: Int | d > 0)
+    (e: Int | e > 0) (f: Int | f > 0)
+    (g: Int | g > 0) (h: Int | h > 0)
+    : {winner: Int | winner > 0} :=
+    let ab := maxI a b in
+    let cd := maxI c d in
+    let ef := maxI e f in
+    let gh := maxI g h in
+    let left := maxI ab cd in
+    let right := maxI ef gh in
+    maxI left right;
+
+def main (_:Int) : Unit :=
+    print (tournament 3 5 2 9 4 8 1 7);

--- a/scripts/bench_horn.py
+++ b/scripts/bench_horn.py
@@ -1,0 +1,164 @@
+"""Compare Horn optimizations against a Git revision, using isolated processes.
+
+Run from the repository root:
+    .venv/bin/python scripts/bench_horn.py --baseline-ref HEAD \
+        examples/syntax/maxI.ae examples/verification/horn_tournament.ae
+
+Only fixpoint/weaken are loaded from the baseline; all other code is identical.
+Each subprocess measures a cold compilation and then a warm compilation.
+Imports and process startup are excluded. Programs are checked, never evaluated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import platform
+from pathlib import Path
+from importlib.metadata import version
+import statistics
+import subprocess
+import sys
+import time
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def worker(path: str, variant: str, baseline_ref: str) -> None:
+    sys.path.insert(0, str(ROOT))
+    from loguru import logger
+    from aeon.verification import horn, smt
+
+    logger.remove()
+    if variant == "before":
+        source = subprocess.check_output(
+            ["git", "show", f"{baseline_ref}:aeon/verification/horn.py"], cwd=ROOT, text=True
+        )
+        tree = ast.parse(source)
+        tree.body = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in {"fixpoint", "weaken"}]
+        assert len(tree.body) == 2
+        exec(compile(tree, "<baseline horn functions>", "exec"), horn.__dict__)
+
+    metrics: dict[str, float | int] = {}
+    original_solve, original_valid, original_check = horn.solve, horn.smt_valid, smt.s.check
+    original_weaken = horn.weaken
+
+    def solve(*args, **kwargs):
+        start = time.perf_counter()
+        try:
+            return original_solve(*args, **kwargs)
+        finally:
+            metrics["vc_seconds"] += time.perf_counter() - start
+
+    def valid(c):
+        metrics["smt_valid_calls"] += 1
+        return original_valid(c)
+
+    def check(*args, **kwargs):
+        metrics["z3_checks"] += 1
+        result = original_check(*args, **kwargs)
+        if result == smt.unknown:
+            metrics["unknown"] += 1
+        return result
+
+    def weaken(*args, **kwargs):
+        metrics["weaken_calls"] += 1
+        return original_weaken(*args, **kwargs)
+
+    horn.solve, horn.smt_valid, horn.weaken, smt.s.check = solve, valid, weaken, check
+    # Import after patching so callers bind to the instrumented solve.
+    from aeon.facade.driver import AeonConfig, AeonDriver
+
+    rows = []
+    for cache in ("cold", "warm"):
+        metrics.update(vc_seconds=0.0, smt_valid_calls=0, z3_checks=0, unknown=0, weaken_calls=0)
+        driver = AeonDriver(AeonConfig("gp", None, 1, no_main=True))
+        start = time.perf_counter()
+        errors = list(driver.parse(filename=path))
+        rows.append(
+            dict(metrics, cache=cache, compile_seconds=time.perf_counter() - start, errors=[str(e) for e in errors])
+        )
+        if errors:
+            raise RuntimeError(rows[-1])
+    print(json.dumps(rows))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+")
+    parser.add_argument("--baseline-ref", default="HEAD")
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--worker", choices=["before", "after"], help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.worker:
+        worker(args.paths[0], args.worker, args.baseline_ref)
+        return
+    if args.repeats < 1:
+        parser.error("--repeats must be positive")
+    baseline = subprocess.check_output(["git", "rev-parse", args.baseline_ref], cwd=ROOT, text=True).strip()
+    samples: list[dict[str, Any]] = []
+    for path in args.paths:
+        for repetition in range(args.repeats):
+            # Alternate order to reduce systematic bias from machine load.
+            order = ("before", "after") if repetition % 2 == 0 else ("after", "before")
+            for variant in order:
+                output = subprocess.check_output(
+                    [
+                        sys.executable,
+                        str(Path(__file__).resolve()),
+                        "--worker",
+                        variant,
+                        "--baseline-ref",
+                        baseline,
+                        path,
+                    ],
+                    cwd=ROOT,
+                    env={**os.environ, "PYTHONHASHSEED": "0"},
+                    text=True,
+                    timeout=120,
+                )
+                samples.extend(
+                    dict(row, path=path, variant=variant, repetition=repetition) for row in json.loads(output)
+                )
+        print(f"Finished {path}", file=sys.stderr, flush=True)
+    summary = []
+    for path in args.paths:
+        for cache in ("cold", "warm"):
+            row: dict[str, Any] = dict(path=path, cache=cache)
+            for variant in ("before", "after"):
+                group = [s for s in samples if s["path"] == path and s["cache"] == cache and s["variant"] == variant]
+                row[variant] = {
+                    key: statistics.median(s[key] for s in group)
+                    for key in (
+                        "vc_seconds",
+                        "compile_seconds",
+                        "smt_valid_calls",
+                        "z3_checks",
+                        "weaken_calls",
+                        "unknown",
+                    )
+                }
+            row["vc_speedup"] = row["before"]["vc_seconds"] / row["after"]["vc_seconds"]
+            row["compile_speedup"] = row["before"]["compile_seconds"] / row["after"]["compile_seconds"]
+            summary.append(row)
+    print(
+        json.dumps(
+            dict(
+                baseline=baseline,
+                python=sys.version,
+                platform=platform.platform(),
+                z3=version("z3-solver"),
+                repeats=args.repeats,
+                summary=summary,
+                samples=samples,
+            ),
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/horn_tournament_test.py
+++ b/tests/horn_tournament_test.py
@@ -1,0 +1,15 @@
+"""Dependent Horn assignments must preserve, but never strengthen, refinements."""
+
+from pathlib import Path
+
+import pytest
+
+from aeon.sugar.ast_helpers import st_top
+from tests.driver import check_compile
+
+
+@pytest.mark.parametrize("bound,accepted", [(0, True), (10, False)])
+def test_tournament_refinement(bound: int, accepted: bool):
+    source = (Path(__file__).resolve().parents[1] / "examples/verification/horn_tournament.ae").read_text()
+    source = source.replace("winner > 0", f"winner > {bound}")
+    assert check_compile(source, st_top) is accepted


### PR DESCRIPTION
Horn inference currently checks every clause before weakening only the first failing clause, and substitutes the same premise again for every qualifier candidate. Stop at the first failure, restart with the weakened assignment, and share the substituted premise across candidate checks. The fixpoint loop is now iterative; solver timeouts and proof criteria are unchanged.

Adds an eight-player tournament example with 14 dependent Horn clauses, acceptance/rejection regression tests, and an isolated-process benchmark that compares only the changed functions against a selected Git revision.

### Measurements

Seven alternating before/after pairs against `e6ae4b9ca946db62ce8bd234b334c2339a9123f8`, Python 3.13.14 and Z3 4.15.3 on macOS arm64. Warm means a second compilation in the same process; timings exclude imports and process startup.

- New tournament example: median warm VC time **5.18 s → 4.64 s (1.11×)**; validity calls **330 → 281**; Z3 checks **256 → 249**.
- Existing `examples/syntax/maxI.ae`: median warm VC time **258 ms → 246 ms (1.05×)**.
- The existing neural-network verification example bypasses Horn inference and has unchanged solver-call counts.

The machine was under substantial load, so wall-time ratios are provisional. Tournament warm VC samples ranged from 4.80–11.16 s before and 3.67–8.25 s after. Call-count reductions were consistent, all benchmark cases verified, and no solver `unknown` results occurred. The tournament is newly added, derived from the existing `maxI.ae` example.

Reproduce from the repository root:

```sh
.venv/bin/python scripts/bench_horn.py --baseline-ref e6ae4b9ca946db62ce8bd234b334c2339a9123f8 --repeats 7 examples/syntax/maxI.ae examples/verification/horn_tournament.ae examples/verification/nn_verification.ae
```

### Validation

- 151 targeted Horn, SMT, inference, parametric-refinement, counterexample, and recursion tests passed, including both tournament regression cases.
- `pre-commit run --all-files` passed.
- The full pytest suite was interrupted during lengthy synthesis coverage; it was not completed.
